### PR TITLE
Fix #9: Atomic JSON writes in registry

### DIFF
--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -11,6 +11,7 @@ def _atomic_write_json(data: dict, path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(suffix=".tmp", dir=path.parent)
     try:
+        os.fchmod(fd, 0o644)
         with os.fdopen(fd, "w") as f:
             fd = -1  # ownership transferred to the file object
             json.dump(data, f, indent=2)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,6 +1,8 @@
 """Tests for olmlx.engine.registry."""
 
 import json
+import os
+import stat
 from unittest.mock import patch
 
 import pytest
@@ -124,3 +126,9 @@ class TestAtomicWriteJson:
             with pytest.raises(IOError, match="disk full"):
                 _atomic_write_json({"new": True}, target)
         assert json.loads(target.read_text()) == original
+
+    def test_atomic_write_json_file_permissions(self, tmp_path):
+        target = tmp_path / "data.json"
+        _atomic_write_json({"a": 1}, target)
+        mode = stat.S_IMODE(os.stat(target).st_mode)
+        assert mode == 0o644


### PR DESCRIPTION
## Summary
- Replace direct `open(path, "w")` + `json.dump()` in `_save_mappings()` and `_save_aliases()` with atomic write-to-temp-file + `os.replace()` pattern
- Extract shared `_atomic_write_json()` helper that cleans up temp files on failure and preserves existing files
- Add 4 tests covering: valid write, no leftover temp files, cleanup on failure, and preservation of original on failure

## Test plan
- [x] All 20 registry tests pass (`uv run pytest tests/test_registry.py -v`)
- [x] Lint clean (`uv run ruff check --fix && uv run ruff format`)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)