### PR TITLE
Fix #54: Map Claude model names to local models

### DIFF
--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Annotated, Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -21,6 +21,17 @@ class Settings(BaseSettings):
     prompt_cache_max_tokens: Annotated[int, Field(gt=0)] | None = 32768
     cors_origins: list[str] = ["http://localhost:*", "http://127.0.0.1:*"]
     anthropic_models: dict[str, str] = {}
+
+    @field_validator("anthropic_models")
+    @classmethod
+    def validate_anthropic_model_keys(cls, v: dict[str, str]) -> dict[str, str]:
+        for key in v:
+            if "-" in key or ":" in key:
+                raise ValueError(
+                    f"anthropic_models key {key!r} must be a single segment "
+                    "(no dashes or colons)"
+                )
+        return v
 
 
 settings = Settings()

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -22,22 +22,17 @@ logger = logging.getLogger(__name__)
 
 
 def _build_anthropic_model_map() -> list[tuple[str, str]]:
-    """Pre-sort anthropic_models by key length descending, filtering invalid entries."""
-    entries = []
-    for family, local_model in settings.anthropic_models.items():
-        key = family.strip().lower()
-        value = local_model.strip()
-        if not key or not value:
-            continue
-        if "-" in key or ":" in key:
-            logger.warning(
-                "Skipping anthropic_models key %r: keys must be single segments "
-                "(no dashes or colons)",
-                family,
-            )
-            continue
-        entries.append((key, value))
-    return sorted(entries, key=lambda x: len(x[0]), reverse=True)
+    """Pre-sort anthropic_models by key length descending, filtering invalid entries.
+
+    Keys with dashes/colons are rejected by the Settings validator; this only
+    filters empty/whitespace entries that slip through.
+    """
+    entries = [
+        (family.strip().lower(), local_model.strip())
+        for family, local_model in settings.anthropic_models.items()
+        if family.strip() and local_model.strip()
+    ]
+    return sorted(entries, key=lambda x: (-len(x[0]), x[0]))
 
 
 _anthropic_model_map = _build_anthropic_model_map()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,3 +66,19 @@ class TestSettings:
             "haiku": "qwen3:latest",
             "sonnet": "qwen3-8b:latest",
         }
+
+    def test_anthropic_models_rejects_dash_in_key(self, monkeypatch):
+        monkeypatch.setenv(
+            "OLMLX_ANTHROPIC_MODELS",
+            '{"claude-sonnet": "qwen3:latest"}',
+        )
+        with pytest.raises(ValidationError, match="single segment"):
+            Settings()
+
+    def test_anthropic_models_rejects_colon_in_key(self, monkeypatch):
+        monkeypatch.setenv(
+            "OLMLX_ANTHROPIC_MODELS",
+            '{"sonnet:latest": "qwen3:latest"}',
+        )
+        with pytest.raises(ValidationError, match="single segment"):
+            Settings()

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -1271,6 +1271,19 @@ class TestResolveAnthropicModel:
         with patch(MAP_PATCH, [("sonnet", "long-match"), ("son", "short-match")]):
             assert _resolve_anthropic_model("claude-sonnet-4-6") == "long-match"
 
+    def test_equal_length_keys_sorted_alphabetically(self):
+        """Equal-length keys use alphabetical order for deterministic tie-breaking."""
+        from olmlx.routers.anthropic import _build_anthropic_model_map
+
+        with patch("olmlx.routers.anthropic.settings") as mock_settings:
+            mock_settings.anthropic_models = {
+                "llama": "llama-model",
+                "haiku": "haiku-model",
+            }
+            result = _build_anthropic_model_map()
+            # Both 5 chars — alphabetical: haiku before llama
+            assert result == [("haiku", "haiku-model"), ("llama", "llama-model")]
+
     def test_empty_value_skipped(self):
         """_build_anthropic_model_map filters out empty values at build time."""
         from olmlx.routers.anthropic import _build_anthropic_model_map
@@ -1304,14 +1317,6 @@ class TestResolveAnthropicModel:
 
         with patch("olmlx.routers.anthropic.settings") as mock_settings:
             mock_settings.anthropic_models = {"sonnet": "   "}
-            assert _build_anthropic_model_map() == []
-
-    def test_multi_segment_key_excluded(self):
-        """Keys containing - or : can never match a single segment; exclude them."""
-        from olmlx.routers.anthropic import _build_anthropic_model_map
-
-        with patch("olmlx.routers.anthropic.settings") as mock_settings:
-            mock_settings.anthropic_models = {"claude-sonnet": "qwen3:latest"}
             assert _build_anthropic_model_map() == []
 
 


### PR DESCRIPTION
## Summary
- Add `anthropic_models` config field (`OLMLX_ANTHROPIC_MODELS` JSON env var) mapping Claude model family keywords to local MLX model names
- Add `_resolve_anthropic_model()` in the Anthropic router with case-insensitive family keyword matching (e.g. "sonnet" in "claude-sonnet-4-6")
- Apply resolution in both `/v1/messages` and `/v1/messages/count_tokens` endpoints; responses still echo the original Claude model name

## Test plan
- [x] 2 config tests (default empty dict, JSON env var parsing)
- [x] 6 unit tests for resolver (no mapping, haiku/sonnet/opus mapping, case insensitivity, no-match fallthrough)
- [x] 3 integration tests (non-streaming, streaming, count_tokens all resolve correctly and echo original model name)
- [x] Full test suite passes (624 tests)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)