### PR TITLE
Fix #52: Trim KV cache instead of invalidating when over token limit

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -578,7 +578,6 @@ async def _stream_completion(
                     )
                 except Exception:
                     lm.prompt_cache_state = None
-                    gen_kwargs.pop("prompt_cache", None)
                     prompt_cache = None
                     gc.collect()
                     mx.clear_cache()

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -1228,6 +1228,82 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
         assert lm.prompt_cache_state.tokens == [10, 20, 30]
 
     @pytest.mark.asyncio
+    async def test_trim_none_id_limit_smaller_than_prompt(self, mock_manager):
+        """When max_cache_tokens < len(prompt), only a prefix of prompt is stored."""
+        from olmlx.engine.inference import generate_chat
+        from olmlx.engine.model_manager import CachedPromptState
+
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.tokenizer.apply_chat_template = MagicMock(return_value="prompt")
+        lm.tokenizer.bos_token = None
+        lm.tokenizer.encode = MagicMock(return_value=[10, 20, 30, 40, 50])
+
+        # 5 prompt + 3 gen steps (all None-ID) = 8, limit = 3
+        stream_tokens = [
+            StreamToken(
+                text="",
+                token=None,
+                prompt_tokens=5,
+                generation_tokens=i + 1,
+                prompt_tps=100.0,
+                generation_tps=50.0,
+            )
+            for i in range(3)
+        ]
+        # Need at least one non-None token for text output
+        stream_tokens[-1] = StreamToken(
+            text="x",
+            token=200,
+            prompt_tokens=5,
+            generation_tokens=3,
+            prompt_tps=100.0,
+            generation_tps=50.0,
+        )
+        mock_stream = _make_mock_stream(stream_tokens)
+
+        mock_cache_obj = [MagicMock()]
+        mock_make_cache = MagicMock(return_value=mock_cache_obj)
+        mock_trim = MagicMock()
+
+        mock_mx = MagicMock()
+        with (
+            patch("olmlx.engine.inference.mx", mock_mx),
+            patch(
+                "olmlx.engine.inference.async_mlx_stream",
+                return_value=mock_stream,
+            ),
+            patch(
+                "olmlx.engine.inference.make_prompt_cache",
+                mock_make_cache,
+            ),
+            patch(
+                "olmlx.engine.inference.trim_prompt_cache",
+                mock_trim,
+            ),
+            patch("olmlx.engine.inference.settings") as mock_settings,
+        ):
+            mock_settings.prompt_cache = True
+            mock_settings.prompt_cache_max_tokens = 3
+            mock_settings.default_keep_alive = "5m"
+            gen = await generate_chat(
+                mock_manager,
+                "qwen3",
+                [{"role": "user", "content": "hi"}],
+                stream=True,
+            )
+            async for chunk in gen:
+                pass
+
+        # actual_total = 5 + 3 = 8 > limit 3
+        # trim_amount = 8 - 3 = 5 → KV depth = 3 (pure prompt prefix)
+        # extra = 3 - 5 = -2 → no second trim needed
+        # stored_tokens = [10, 20, 30, 40, 50][:3] = [10, 20, 30]
+        mock_trim.assert_called_once_with(mock_cache_obj, 5)
+        assert lm.prompt_cache_state is not None
+        assert isinstance(lm.prompt_cache_state, CachedPromptState)
+        assert lm.prompt_cache_state.tokens == [10, 20, 30]
+
+    @pytest.mark.asyncio
     async def test_cache_invalidated_on_trim_exception(self, mock_manager):
         """If trim_prompt_cache raises, cache is invalidated but response completes."""
         from olmlx.engine.inference import generate_chat


### PR DESCRIPTION
## Summary

- When `prompt + generated tokens > prompt_cache_max_tokens`, **trim** the KV cache to the limit instead of invalidating it entirely. The next request reuses the trimmed prefix as a cache hit, avoiding full 60-120s re-prefills.
- Add debug logging for cache miss diagnosis and a fallback prefix matcher for edge cases where `common_prefix` returns 0 despite matching tokens.
- Update tests: rename `TestCacheInvalidatedWhenExceedsTokenLimit` → `TestCacheTrimmedWhenExceedsTokenLimit` with 3 test cases (trim amount, prefix correctness, reusability on next request).

## Test plan

- [x] All 3 new trim tests pass (`test_cache_trimmed_when_over_limit`, `test_trimmed_tokens_are_prefix`, `test_trimmed_cache_reusable_on_next_request`)
- [x] Full test suite passes (635 tests)
- [x] Ruff check + format clean
- [ ] Manual test: run a multi-turn conversation that exceeds `prompt_cache_max_tokens` and verify logs show "Cache trimmed" instead of "Cache invalidated"

🤖 Generated with [Claude Code](https://claude.com/claude-code)