### PR TITLE
Fix #47: Stop filtering tool calls by name

### DIFF
--- a/olmlx/engine/tool_parser.py
+++ b/olmlx/engine/tool_parser.py
@@ -263,15 +263,12 @@ def _try_bare_json(text: str) -> tuple[list[dict], str]:
 def parse_model_output(
     text: str,
     has_tools: bool,
-    tool_names: set[str] | None = None,
 ) -> tuple[str, str, list[dict]]:
     """Parse raw model output into (thinking_text, visible_text, tool_use_blocks).
 
     Args:
         text: Raw model output text.
         has_tools: Whether tools were provided in the request.
-        tool_names: Set of valid tool names. If provided, parsed tool calls
-            with unknown names are dropped and a warning is logged.
     """
     thinking = ""
 
@@ -297,41 +294,7 @@ def parse_model_output(
             if tool_uses:
                 break
 
-        # Filter out tool calls with unknown names
-        if tool_uses and tool_names:
-            kept = []
-            dropped = []
-            for tu in tool_uses:
-                if tu["name"] in tool_names:
-                    kept.append(tu)
-                else:
-                    dropped.append(tu)
-                    logger.warning(
-                        "Dropping parsed tool call '%s' — not in provided tool set: %s",
-                        tu["name"],
-                        tool_names,
-                    )
-            if dropped:
-                logger.warning(
-                    "Filtered %d of %d parsed tool call(s) with unknown names",
-                    len(dropped),
-                    len(tool_uses),
-                )
-            tool_uses = kept
-
-            # For shared-span formats (Mistral/DeepSeek), a dropped call's
-            # raw text is unavoidably lost when a sibling call is kept (the
-            # whole block is stripped).
-            kept_span_set = {tu.get("_span") for tu in kept if "_span" in tu}
-            for tu in dropped:
-                if tu.get("_span") in kept_span_set:
-                    logger.warning(
-                        "Raw text for dropped call '%s' is lost — shares a span "
-                        "with a kept call (Mistral/DeepSeek shared-block format)",
-                        tu["name"],
-                    )
-
-        # Strip matched spans from text for kept tool calls.
+        # Strip matched spans from text for tool calls.
         # For formats where multiple calls share one span (Mistral/DeepSeek),
         # the span is stripped if any call was kept — the dropped call's raw
         # text is unavoidably lost since it's embedded in the same block.

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -302,7 +302,7 @@ def _emit_content_block(
     return events
 
 
-async def _stream_buffered_with_tools(result, tool_names):
+async def _stream_buffered_with_tools(result):
     """Buffer full output, parse tools, yield SSE strings. Yields a final dict with metadata."""
     full_text = ""
     output_tokens = 0
@@ -328,7 +328,6 @@ async def _stream_buffered_with_tools(result, tool_names):
     thinking, visible_text, tool_uses = parse_model_output(
         full_text,
         True,
-        tool_names=tool_names,
     )
 
     if tool_uses:
@@ -624,7 +623,6 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
     options = _build_options(req)
     tools = _convert_tools(req)
     has_tools = bool(tools)
-    tool_names = {t["function"]["name"] for t in tools} if tools else None
     msg_id = _make_msg_id()
     logger.debug("Converted %d messages, %d tools", len(messages), len(tools or []))
 
@@ -656,7 +654,7 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
             path = None
             try:
                 path = (
-                    _stream_buffered_with_tools(result, tool_names)
+                    _stream_buffered_with_tools(result)
                     if has_tools
                     else _stream_thinking_state_machine(result)
                 )
@@ -777,7 +775,6 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
         thinking, visible_text, tool_uses = parse_model_output(
             text,
             has_tools,
-            tool_names=tool_names,
         )
 
         content_blocks = []

--- a/tests/test_tool_parser.py
+++ b/tests/test_tool_parser.py
@@ -435,47 +435,16 @@ class TestParseModelOutput:
         assert len(tools) == 0
         assert "<tool_call>" in visible
 
-    def test_tool_name_filtering(self):
-        text = '<tool_call>{"name": "unknown_func", "arguments": {}}</tool_call>'
-        thinking, visible, tools = parse_model_output(
-            text,
-            has_tools=True,
-            tool_names={"search", "get_weather"},
-        )
-        # Unknown tool names are filtered out; original text is restored
-        assert len(tools) == 0
-        assert "unknown_func" in visible
-
-    def test_tool_name_filtering_keeps_valid(self):
+    def test_unknown_tool_names_not_filtered(self):
+        """Unknown tool names should be returned as-is, not filtered out."""
         text = (
             '<tool_call>{"name": "search", "arguments": {"q": "test"}}</tool_call>'
-            '<tool_call>{"name": "unknown", "arguments": {}}</tool_call>'
+            '<tool_call>{"name": "TodoWrite", "arguments": {"todos": []}}</tool_call>'
         )
-        thinking, visible, tools = parse_model_output(
-            text,
-            has_tools=True,
-            tool_names={"search", "get_weather"},
-        )
-        assert len(tools) == 1
+        thinking, visible, tools = parse_model_output(text, has_tools=True)
+        assert len(tools) == 2
         assert tools[0]["name"] == "search"
-        # Dropped call's raw text is preserved in visible_text
-        assert "unknown" in visible
-
-    def test_tool_name_filtering_mistral_shared_span(self):
-        """Mistral calls share one span — block is stripped if any call is kept.
-
-        For formats where all calls share one span (Mistral/DeepSeek), the
-        entire block is removed when at least one call passes the filter.
-        The dropped call's raw text is unavoidably lost.
-        """
-        text = '[TOOL_CALLS] [{"name": "search", "arguments": {}}, {"name": "bad_tool", "arguments": {}}]'
-        _, visible, tools = parse_model_output(
-            text, has_tools=True, tool_names={"search"}
-        )
-        assert len(tools) == 1
-        assert tools[0]["name"] == "search"
-        # Shared span is stripped because at least one call was kept
-        assert visible == ""
+        assert tools[1]["name"] == "TodoWrite"
 
     def test_qwen_format_priority(self):
         """Qwen format should be tried first and win."""


### PR DESCRIPTION
## Summary
- Removed `tool_names` parameter from `parse_model_output()` and deleted the filtering block that dropped tool calls with unknown names
- Removed `tool_names` construction and passing from all callers in the Anthropic router
- Replaced three filtering tests with one test confirming unknown tool names are returned as-is

Closes #47

## Context
When a local model generated tool calls for tools not in the provided set (e.g. `TodoWrite`), the parser silently dropped them. This caused Claude Code to stall: the response said "let me update the todo" but contained no `tool_use` block, and `stop_reason` was `"end_turn"` instead of `"tool_use"`. Claude Code handles unknown tool errors gracefully (sends back a `tool_result` with an error), so we should let all tool calls through.

## Test plan
- [x] `uv run pytest tests/test_tool_parser.py tests/test_routers_anthropic.py -v` — 145 passed
- [x] `uv run pytest` — full suite 689 passed
- [x] `uv run ruff check --fix && uv run ruff format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)