### PR TITLE
Fix KV cache estimate AttributeError for VLM models

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -219,7 +219,17 @@ def _estimate_kv_cache_bytes(model: Any, num_tokens: int) -> int:
     """
     if num_tokens <= 0:
         return 0
-    args = model.args
+    # mlx-lm text models: model.args
+    # mlx-vlm vision-language models: model.language_model.args
+    args = getattr(model, "args", None)
+    if args is None:
+        lang_model = getattr(model, "language_model", None)
+        if lang_model is not None:
+            args = getattr(lang_model, "args", None)
+    if args is None:
+        raise AttributeError(
+            "Model has no 'args' attribute (checked model.args and model.language_model.args)"
+        )
     num_layers = args.num_hidden_layers
     num_heads = args.num_attention_heads
     num_kv_heads = getattr(args, "num_key_value_heads", num_heads)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1375,6 +1375,25 @@ class TestEstimateKvCacheBytes:
         result = _estimate_kv_cache_bytes(model, 100)
         assert result == 26_214_400
 
+    def test_vlm_fallback_to_language_model_args(self):
+        """Falls back to model.language_model.args for VLM models."""
+        model = MagicMock(spec=[])
+        model.language_model = MagicMock(spec=[])
+        model.language_model.args = self._make_model_args(
+            num_hidden_layers=32,
+            num_attention_heads=32,
+            num_key_value_heads=8,
+            hidden_size=4096,
+        )
+        result = _estimate_kv_cache_bytes(model, 1000)
+        assert result == 131_072_000
+
+    def test_raises_when_no_args_found(self):
+        """Raises AttributeError when model has no discoverable args."""
+        model = MagicMock(spec=[])
+        with pytest.raises(AttributeError, match="no 'args' attribute"):
+            _estimate_kv_cache_bytes(model, 1000)
+
 
 class TestKvCachePreflightCheck:
     """Tests for the pre-flight KV cache memory check in _stream_completion."""


### PR DESCRIPTION
## Summary
- VLM models loaded via mlx-vlm (e.g. `mlx-community/Qwen3.5-35B-A3B-4bit`) store their config at `model.language_model.args`, not `model.args`
- `_estimate_kv_cache_bytes` now checks `model.args` first, then falls back to `model.language_model.args`
- This enables the KV cache pre-flight OOM check for VLM models, which was previously silently skipped

## Test plan
- [x] Existing `TestEstimateKvCacheBytes` tests pass (text models with `model.args`)
- [x] New test for VLM fallback to `model.language_model.args`
- [x] New test for clear `AttributeError` when no args found

🤖 Generated with [Claude Code](https://claude.com/claude-code)