### PR TITLE
fix: support Qwen3-Next MoE architecture in Flash-MoE

### DIFF
--- a/olmlx/engine/flash/flash_moe_model.py
+++ b/olmlx/engine/flash/flash_moe_model.py
@@ -96,6 +96,12 @@ class _FlashMoEQwen3Next(nn.Module):
         self.top_k = original_moe.top_k
         self.norm_topk_prob = original_moe.norm_topk_prob
         self._flash_moe = flash_moe
+        if not hasattr(original_moe, "shared_expert"):
+            raise ValueError(
+                f"Qwen3-Next MoE detection matched on shared_expert_gate but "
+                f"{type(original_moe).__name__} has no 'shared_expert' attribute. "
+                "Unexpected architecture — disable Flash-MoE or file a bug."
+            )
         self.shared_expert = original_moe.shared_expert
         self.shared_expert_gate = original_moe.shared_expert_gate
 
@@ -106,7 +112,8 @@ class _FlashMoEQwen3Next(nn.Module):
         inds = mx.argpartition(gates, kth=-k, axis=-1)[..., -k:]
         scores = mx.take_along_axis(gates, inds, axis=-1)
         if self.norm_topk_prob:
-            scores = scores / scores.sum(axis=-1, keepdims=True)
+            denom = scores.sum(axis=-1, keepdims=True)
+            scores = scores / mx.maximum(denom, mx.array(1e-9, dtype=denom.dtype))
 
         y = self._flash_moe(x, inds, scores)
         y = y.astype(x.dtype)
@@ -207,13 +214,29 @@ def _replace_moe_layers(
         if getattr(moe_module, "shared_expert_gate", None) is not None and isinstance(
             getattr(moe_module, "gate", None), nn.Linear
         ):
-            # Qwen3-Next style: plain nn.Linear gate + shared_expert + shared_expert_gate
+            # Qwen3-Next style (mlx_lm Qwen3NextSparseMoeBlock):
+            # plain nn.Linear gate + shared_expert + shared_expert_gate
+            logger.debug(
+                "Layer %d: detected Qwen3-Next MoE (%s)",
+                layer_idx,
+                type(moe_module).__name__,
+            )
             replacement = _FlashMoEQwen3Next(moe_module, flash_moe)
         elif hasattr(moe_module, "gate"):
             # DeepSeek-V3 / Kimi-K2.5 style: gate returns (inds, scores)
+            logger.debug(
+                "Layer %d: detected DeepSeek-style MoE (%s)",
+                layer_idx,
+                type(moe_module).__name__,
+            )
             replacement = _FlashMoEDeepSeek(moe_module, flash_moe)
         else:
             # gpt-oss style (has router + experts)
+            logger.debug(
+                "Layer %d: detected gpt-oss MoE (%s)",
+                layer_idx,
+                type(moe_module).__name__,
+            )
             replacement = _FlashMoEGptOss(moe_module, flash_moe)
 
         # Delete original SwitchGLU weights before replacing

--- a/tests/test_flash_moe_model.py
+++ b/tests/test_flash_moe_model.py
@@ -399,6 +399,22 @@ class TestFlashMoeQwen3Next:
             assert hasattr(mlp, "shared_expert")
             assert hasattr(mlp, "shared_expert_gate")
 
+    def test_frees_switch_mlp_weights(self, model_and_store):
+        """Original SwitchGLU weights should be deleted after wrapping."""
+        model, store, hidden, inter, experts, num_experts_per_tok = model_and_store
+
+        from olmlx.engine.flash.flash_moe_model import FlashMoeModelWrapper
+
+        moe_layer_indices = [1, 2]
+        wrapped = FlashMoeModelWrapper(
+            model, store, moe_layer_indices, hidden, inter, experts, num_experts_per_tok
+        )
+
+        for i in [1, 2]:
+            mlp = wrapped.layers[i].mlp
+            assert not hasattr(mlp, "switch_mlp")
+            assert not hasattr(mlp, "experts")
+
     def test_qwen3_next_forward_pass(self, model_and_store):
         """Forward pass through Qwen3-Next Flash-MoE wrapper produces valid output."""
         model, store, hidden, inter, experts, num_experts_per_tok = model_and_store
@@ -418,4 +434,28 @@ class TestFlashMoeQwen3Next:
         assert result.shape == (1, 4, hidden)
         # Numerical correctness: no NaN/Inf and experts actually contribute
         assert mx.all(mx.isfinite(result)).item(), "Output contains NaN or Inf"
+        assert not mx.array_equal(result, x), "Output unchanged — experts had no effect"
+
+    def test_qwen3_next_norm_topk_prob(self, model_and_store):
+        """Forward pass with norm_topk_prob=True should produce finite output."""
+        model, store, hidden, inter, experts, num_experts_per_tok = model_and_store
+
+        from olmlx.engine.flash.flash_moe_model import FlashMoeModelWrapper
+
+        moe_layer_indices = [1, 2]
+        wrapped = FlashMoeModelWrapper(
+            model, store, moe_layer_indices, hidden, inter, experts, num_experts_per_tok
+        )
+
+        # Enable norm_topk_prob on the wrapped layer
+        wrapped.layers[1].mlp.norm_topk_prob = True
+
+        mx.random.seed(42)
+        x = mx.random.normal((1, 4, hidden))
+        result = wrapped.layers[1].mlp(x)
+        mx.eval(result)
+        assert result.shape == (1, 4, hidden)
+        assert mx.all(mx.isfinite(result)).item(), (
+            "Output contains NaN or Inf with norm_topk_prob=True"
+        )
         assert not mx.array_equal(result, x), "Output unchanged — experts had no effect"


### PR DESCRIPTION
## Summary

- Qwen3-Next's `SparseMoeBlock` uses a plain `nn.Linear` gate that returns raw logits, unlike DeepSeek-V3 which returns `(inds, scores)`. This caused `_FlashMoEDeepSeek` to crash with "not enough values to unpack (expected 2, got 1)" when loading models like `mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit`.
- Add `_FlashMoEQwen3Next` wrapper that handles argpartition topk selection, `norm_topk_prob`, and preserves `shared_expert` / `shared_expert_gate` in RAM.
- Detection uses `shared_expert_gate` as the discriminator, checked before the DeepSeek `gate` check.

## Test plan

- [x] New `TestFlashMoeQwen3Next` tests: layer replacement detection and forward pass
- [x] All 100 existing flash tests still pass
- [ ] Manual: `OLMLX_EXPERIMENTAL_FLASH_MOE=true olmlx serve` with `Qwen3-Next-80B-A3B-Instruct-4bit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)