### PR TITLE
feat: TurboQuant KV cache quantization

### DIFF
--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -91,7 +91,11 @@ class ExperimentalSettings(BaseSettings):
         _VALID_METHODS = {"turboquant"}
         _VALID_BITS = {"2", "4"}
         parts = v.split(":", 1)
-        if len(parts) != 2 or parts[0] not in _VALID_METHODS or parts[1] not in _VALID_BITS:
+        if (
+            len(parts) != 2
+            or parts[0] not in _VALID_METHODS
+            or parts[1] not in _VALID_BITS
+        ):
             raise ValueError(
                 f"Invalid kv_cache_quant={v!r}. "
                 f"Expected '<method>:<bits>' where method is one of {_VALID_METHODS} "

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -83,6 +83,22 @@ class ExperimentalSettings(BaseSettings):
     # TurboQuant KV cache quantization (e.g. "turboquant:4", "turboquant:2")
     kv_cache_quant: str | None = None
 
+    @field_validator("kv_cache_quant")
+    @classmethod
+    def validate_kv_cache_quant(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        _VALID_METHODS = {"turboquant"}
+        _VALID_BITS = {"2", "4"}
+        parts = v.split(":", 1)
+        if len(parts) != 2 or parts[0] not in _VALID_METHODS or parts[1] not in _VALID_BITS:
+            raise ValueError(
+                f"Invalid kv_cache_quant={v!r}. "
+                f"Expected '<method>:<bits>' where method is one of {_VALID_METHODS} "
+                f"and bits is one of {_VALID_BITS}."
+            )
+        return v
+
     # Flash MoE (SSD-based expert offloading for MoE models)
     flash_moe: bool = False
     flash_moe_cache_budget_experts: Annotated[int, Field(ge=0)] = 48  # per layer

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -80,6 +80,9 @@ class ExperimentalSettings(BaseSettings):
     flash_speculative_draft_model: str | None = None
     flash_speculative_tokens: Annotated[int, Field(gt=0)] = 4
 
+    # TurboQuant KV cache quantization (e.g. "turboquant:4", "turboquant:2")
+    kv_cache_quant: str | None = None
+
     # Flash MoE (SSD-based expert offloading for MoE models)
     flash_moe: bool = False
     flash_moe_cache_budget_experts: Annotated[int, Field(ge=0)] = 48  # per layer

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -925,7 +925,7 @@ async def _stream_completion(
                 # No usable prefix — free old cache and create fresh
                 lm.prompt_cache_store.remove(cache_id)
                 kv_quant = experimental.kv_cache_quant
-                if kv_quant and kv_quant.startswith("turboquant:"):
+                if kv_quant is not None:
                     bits = int(kv_quant.split(":")[1])
                     new_cache = _make_turboquant_prompt_cache(
                         lm.model, bits, is_vlm=lm.is_vlm

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -18,7 +18,7 @@ from olmlx.engine.model_manager import (
     ModelManager,
     parse_keep_alive,
 )
-from olmlx.config import settings
+from olmlx.config import experimental, settings
 from olmlx.utils import memory as memory_utils
 
 try:
@@ -700,6 +700,14 @@ def _get_model_for_cache(model: Any, is_vlm: bool) -> Any:
     return model
 
 
+def _make_turboquant_prompt_cache(model: Any, bits: int, is_vlm: bool = False) -> list:
+    """Create a TurboQuant-compressed prompt cache for the model."""
+    from olmlx.engine.turboquant_cache import make_turboquant_cache
+
+    cache_model = _get_model_for_cache(model, is_vlm)
+    return make_turboquant_cache(cache_model, bits=bits)
+
+
 def _extract_images(messages: list[dict]) -> list[str] | None:
     """Extract image URLs/paths from message content."""
     images = []
@@ -916,8 +924,15 @@ async def _stream_completion(
             else:
                 # No usable prefix — free old cache and create fresh
                 lm.prompt_cache_store.remove(cache_id)
-                cache_model = _get_model_for_cache(lm.model, lm.is_vlm)
-                new_cache = make_prompt_cache(cache_model)
+                kv_quant = experimental.kv_cache_quant
+                if kv_quant and kv_quant.startswith("turboquant:"):
+                    bits = int(kv_quant.split(":")[1])
+                    new_cache = _make_turboquant_prompt_cache(
+                        lm.model, bits, is_vlm=lm.is_vlm
+                    )
+                else:
+                    cache_model = _get_model_for_cache(lm.model, lm.is_vlm)
+                    new_cache = make_prompt_cache(cache_model)
                 gen_kwargs["prompt_cache"] = new_cache
                 cache_creation_tokens = len(prompt_tokens)
                 logger.info(

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -47,6 +47,13 @@ _FALLBACK_EXCEPTIONS = (
 )
 
 
+def _is_serializable_cache(cache: list) -> bool:
+    """Check if a cache list can be serialized with mlx-lm's save_prompt_cache."""
+    from olmlx.engine.turboquant_cache import TurboQuantKVCache
+
+    return not any(isinstance(c, TurboQuantKVCache) for c in cache)
+
+
 class ModelLoadTimeoutError(TimeoutError):
     """Raised when model loading exceeds OLMLX_MODEL_LOAD_TIMEOUT."""
 
@@ -102,6 +109,13 @@ class PromptCacheStore:
     def _save_to_disk(self, cache_id: str, state: CachedPromptState) -> None:
         """Save a cache entry to disk."""
         if not self._disk_enabled:
+            return
+        # TurboQuant caches use a custom format incompatible with safetensors
+        if state.cache and not _is_serializable_cache(state.cache):
+            logger.debug(
+                "Skipping disk save for '%s': cache uses non-serializable format (TurboQuant)",
+                cache_id,
+            )
             return
         try:
             disk_dir = self._disk_dir()

--- a/olmlx/engine/turboquant.py
+++ b/olmlx/engine/turboquant.py
@@ -122,10 +122,10 @@ def turboquant_quantize(
     head_dim = x.shape[-1]
     codebook = get_codebook(bits, head_dim)
 
-    # Compute and store vector norms
-    norms = mx.sqrt(mx.sum(x * x, axis=-1, keepdims=True))
+    # Compute norms in float32 to avoid overflow (float16 max ~65504)
+    norms = mx.sqrt(mx.sum(x.astype(mx.float32) ** 2, axis=-1, keepdims=True))
     # Normalize to unit sphere (avoid division by zero)
-    x_norm = x / mx.maximum(norms, mx.array(1e-8))
+    x_norm = x / mx.maximum(norms.astype(x.dtype), mx.array(1e-8, dtype=x.dtype))
 
     # Rotate: y = x_norm @ Πᵀ  (equivalent to Π @ x_norm per vector)
     y = x_norm @ rotation.matrix.T

--- a/olmlx/engine/turboquant.py
+++ b/olmlx/engine/turboquant.py
@@ -1,0 +1,130 @@
+"""TurboQuant: data-oblivious vector quantization for KV cache compression.
+
+Implements TurboQuant_mse from https://arxiv.org/abs/2504.19874.
+Algorithm: random rotation → scalar quantization per coordinate → inverse rotation.
+"""
+
+import mlx.core as mx
+import numpy as np
+
+# Standard Gaussian N(0,1) Lloyd-Max centroids.
+# For dimension d, scale by 1/sqrt(d) to get the codebook for the
+# Beta distribution that arises from random rotation on the unit sphere.
+GAUSSIAN_CODEBOOKS: dict[int, list[float]] = {
+    2: [
+        -1.5104176085,
+        -0.4527800346,
+        0.4527800346,
+        1.5104176085,
+    ],
+    4: [
+        -2.732589571,
+        -2.0690172265,
+        -1.618046386,
+        -1.2562311973,
+        -0.9423404565,
+        -0.6567591185,
+        -0.3880482995,
+        -0.1283950299,
+        0.1283950299,
+        0.3880482995,
+        0.6567591185,
+        0.9423404565,
+        1.2562311973,
+        1.618046386,
+        2.0690172265,
+        2.732589571,
+    ],
+}
+
+# Cache scaled codebooks keyed by (bits, dim)
+_codebook_cache: dict[tuple[int, int], mx.array] = {}
+
+
+def get_codebook(bits: int, dim: int) -> mx.array:
+    """Return Lloyd-Max codebook scaled for the given dimension."""
+    if bits not in GAUSSIAN_CODEBOOKS:
+        raise ValueError(
+            f"TurboQuant supports {sorted(GAUSSIAN_CODEBOOKS.keys())}-bit, got {bits}"
+        )
+    key = (bits, dim)
+    if key not in _codebook_cache:
+        centroids = mx.array(GAUSSIAN_CODEBOOKS[bits], dtype=mx.float32)
+        _codebook_cache[key] = centroids / mx.sqrt(mx.array(float(dim)))
+    return _codebook_cache[key]
+
+
+class TurboQuantRotation:
+    """Per-layer orthogonal rotation matrix via QR decomposition."""
+
+    def __init__(self, head_dim: int, seed: int):
+        rng = np.random.RandomState(seed)
+        random_matrix = rng.randn(head_dim, head_dim).astype(np.float32)
+        q, _ = np.linalg.qr(random_matrix)
+        self.matrix: mx.array = mx.array(q)
+
+
+def turboquant_quantize(
+    x: mx.array,
+    rotation: TurboQuantRotation,
+    bits: int,
+) -> tuple[mx.array, mx.array]:
+    """Quantize vectors using TurboQuant_mse.
+
+    Args:
+        x: Input tensor of shape (B, n_heads, seq_len, head_dim).
+        rotation: Rotation matrix for this layer.
+        bits: Quantization bit-width (2 or 4).
+
+    Returns:
+        (indices, norms): indices as uint8 (B, n_heads, seq_len, head_dim),
+                          norms as float16 (B, n_heads, seq_len, 1).
+    """
+    head_dim = x.shape[-1]
+    codebook = get_codebook(bits, head_dim)
+
+    # Compute and store vector norms
+    norms = mx.sqrt(mx.sum(x * x, axis=-1, keepdims=True))
+    # Normalize to unit sphere (avoid division by zero)
+    x_norm = x / mx.maximum(norms, mx.array(1e-8))
+
+    # Rotate: y = x_norm @ Πᵀ  (equivalent to Π @ x_norm per vector)
+    y = x_norm @ rotation.matrix.T
+
+    # Scalar quantize: find nearest centroid per coordinate
+    # codebook shape: (n_centroids,) → broadcast against y
+    # distances shape: (..., head_dim, n_centroids)
+    distances = mx.abs(mx.expand_dims(y, -1) - codebook)
+    indices = mx.argmin(distances, axis=-1).astype(mx.uint8)
+
+    return indices, norms.astype(mx.float16)
+
+
+def turboquant_dequantize(
+    indices: mx.array,
+    norms: mx.array,
+    rotation: TurboQuantRotation,
+    bits: int,
+) -> mx.array:
+    """Dequantize TurboQuant_mse encoded vectors.
+
+    Args:
+        indices: Quantized indices of shape (B, n_heads, seq_len, head_dim).
+        norms: Vector norms of shape (B, n_heads, seq_len, 1).
+        rotation: Rotation matrix used during quantization.
+        bits: Quantization bit-width (2 or 4).
+
+    Returns:
+        Reconstructed tensor of shape (B, n_heads, seq_len, head_dim).
+    """
+    head_dim = indices.shape[-1]
+    codebook = get_codebook(bits, head_dim)
+
+    # Lookup centroids
+    y_hat = codebook[indices.astype(mx.uint32)]
+
+    # Inverse rotate: x_hat = y_hat @ Π
+    x_hat = y_hat @ rotation.matrix
+
+    # Rescale by original norms
+    return x_hat * norms.astype(x_hat.dtype)

--- a/olmlx/engine/turboquant.py
+++ b/olmlx/engine/turboquant.py
@@ -116,7 +116,8 @@ def turboquant_quantize(
         bits: Quantization bit-width (2 or 4).
 
     Returns:
-        (packed_indices, norms): bit-packed indices as uint8, norms as float16.
+        (packed_indices, norms): bit-packed indices as uint8, norms as float32
+            (float32 to avoid overflow for vectors with L2-norm > 65504).
     """
     head_dim = x.shape[-1]
     codebook = get_codebook(bits, head_dim)
@@ -139,7 +140,6 @@ def turboquant_quantize(
         better = d < best_dist
         best_idx = mx.where(better, mx.array(ci, dtype=mx.uint8), best_idx)
         best_dist = mx.minimum(best_dist, d)
-    mx.eval(best_idx)
 
     return pack_indices(best_idx, bits), norms
 

--- a/olmlx/engine/turboquant.py
+++ b/olmlx/engine/turboquant.py
@@ -139,8 +139,9 @@ def turboquant_quantize(
         better = d < best_dist
         best_idx = mx.where(better, mx.array(ci, dtype=mx.uint8), best_idx)
         best_dist = mx.minimum(best_dist, d)
+    mx.eval(best_idx)
 
-    return pack_indices(best_idx, bits), norms.astype(mx.float16)
+    return pack_indices(best_idx, bits), norms
 
 
 def turboquant_dequantize(
@@ -148,6 +149,7 @@ def turboquant_dequantize(
     norms: mx.array,
     rotation: TurboQuantRotation,
     bits: int,
+    dtype: mx.Dtype | None = None,
 ) -> mx.array:
     """Dequantize TurboQuant_mse encoded vectors.
 
@@ -171,4 +173,5 @@ def turboquant_dequantize(
     x_hat = y_hat @ rotation.matrix
 
     # Rescale by original norms
-    return x_hat * norms.astype(x_hat.dtype)
+    result = x_hat * norms.astype(x_hat.dtype)
+    return result.astype(dtype) if dtype is not None else result

--- a/olmlx/engine/turboquant.py
+++ b/olmlx/engine/turboquant.py
@@ -90,24 +90,16 @@ def unpack_indices(packed: mx.array, bits: int, head_dim: int) -> mx.array:
     if bits == 4:
         low = packed & 0xF
         high = (packed >> 4) & 0xF
-        # Interleave: [low0, high0, low1, high1, ...]
-        shape = packed.shape[:-1] + (head_dim,)
-        result = mx.zeros(shape, dtype=mx.uint8)
-        result[..., 0::2] = low
-        result[..., 1::2] = high
-        return result
+        # Interleave via stack + reshape: [low0, high0, low1, high1, ...]
+        parts = mx.stack([low, high], axis=-1)  # (..., packed_dim, 2)
+        return parts.reshape(packed.shape[:-1] + (head_dim,)).astype(mx.uint8)
     elif bits == 2:
         i0 = packed & 0x3
         i1 = (packed >> 2) & 0x3
         i2 = (packed >> 4) & 0x3
         i3 = (packed >> 6) & 0x3
-        shape = packed.shape[:-1] + (head_dim,)
-        result = mx.zeros(shape, dtype=mx.uint8)
-        result[..., 0::4] = i0
-        result[..., 1::4] = i1
-        result[..., 2::4] = i2
-        result[..., 3::4] = i3
-        return result
+        parts = mx.stack([i0, i1, i2, i3], axis=-1)  # (..., packed_dim, 4)
+        return parts.reshape(packed.shape[:-1] + (head_dim,)).astype(mx.uint8)
     raise ValueError(f"Unsupported bits={bits}")
 
 

--- a/olmlx/engine/turboquant.py
+++ b/olmlx/engine/turboquant.py
@@ -64,6 +64,53 @@ class TurboQuantRotation:
         self.matrix: mx.array = mx.array(q)
 
 
+def pack_indices(indices: mx.array, bits: int) -> mx.array:
+    """Pack quantized indices into bytes.
+
+    4-bit: 2 indices per byte (low/high nibble).
+    2-bit: 4 indices per byte.
+    """
+    if bits == 4:
+        # Pack pairs: low nibble = even indices, high nibble = odd indices
+        low = indices[..., 0::2] & 0xF
+        high = (indices[..., 1::2] & 0xF) << 4
+        return (low | high).astype(mx.uint8)
+    elif bits == 2:
+        # Pack quads: bits 0-1 = idx[0], bits 2-3 = idx[1], etc.
+        i0 = indices[..., 0::4] & 0x3
+        i1 = (indices[..., 1::4] & 0x3) << 2
+        i2 = (indices[..., 2::4] & 0x3) << 4
+        i3 = (indices[..., 3::4] & 0x3) << 6
+        return (i0 | i1 | i2 | i3).astype(mx.uint8)
+    raise ValueError(f"Unsupported bits={bits}")
+
+
+def unpack_indices(packed: mx.array, bits: int, head_dim: int) -> mx.array:
+    """Unpack bit-packed indices back to one-per-element uint8."""
+    if bits == 4:
+        low = packed & 0xF
+        high = (packed >> 4) & 0xF
+        # Interleave: [low0, high0, low1, high1, ...]
+        shape = packed.shape[:-1] + (head_dim,)
+        result = mx.zeros(shape, dtype=mx.uint8)
+        result[..., 0::2] = low
+        result[..., 1::2] = high
+        return result
+    elif bits == 2:
+        i0 = packed & 0x3
+        i1 = (packed >> 2) & 0x3
+        i2 = (packed >> 4) & 0x3
+        i3 = (packed >> 6) & 0x3
+        shape = packed.shape[:-1] + (head_dim,)
+        result = mx.zeros(shape, dtype=mx.uint8)
+        result[..., 0::4] = i0
+        result[..., 1::4] = i1
+        result[..., 2::4] = i2
+        result[..., 3::4] = i3
+        return result
+    raise ValueError(f"Unsupported bits={bits}")
+
+
 def turboquant_quantize(
     x: mx.array,
     rotation: TurboQuantRotation,
@@ -77,8 +124,7 @@ def turboquant_quantize(
         bits: Quantization bit-width (2 or 4).
 
     Returns:
-        (indices, norms): indices as uint8 (B, n_heads, seq_len, head_dim),
-                          norms as float16 (B, n_heads, seq_len, 1).
+        (packed_indices, norms): bit-packed indices as uint8, norms as float16.
     """
     head_dim = x.shape[-1]
     codebook = get_codebook(bits, head_dim)
@@ -91,17 +137,22 @@ def turboquant_quantize(
     # Rotate: y = x_norm @ Πᵀ  (equivalent to Π @ x_norm per vector)
     y = x_norm @ rotation.matrix.T
 
-    # Scalar quantize: find nearest centroid per coordinate
-    # codebook shape: (n_centroids,) → broadcast against y
-    # distances shape: (..., head_dim, n_centroids)
-    distances = mx.abs(mx.expand_dims(y, -1) - codebook)
-    indices = mx.argmin(distances, axis=-1).astype(mx.uint8)
+    # Scalar quantize: find nearest centroid per coordinate.
+    # Iterate over centroids to avoid materializing the full distances tensor
+    # which would be (B, heads, seq, head_dim, n_centroids) — OOM on long prefills.
+    best_idx = mx.zeros(y.shape, dtype=mx.uint8)
+    best_dist = mx.full(y.shape, float("inf"))
+    for ci in range(len(codebook)):
+        d = mx.abs(y - codebook[ci])
+        better = d < best_dist
+        best_idx = mx.where(better, mx.array(ci, dtype=mx.uint8), best_idx)
+        best_dist = mx.minimum(best_dist, d)
 
-    return indices, norms.astype(mx.float16)
+    return pack_indices(best_idx, bits), norms.astype(mx.float16)
 
 
 def turboquant_dequantize(
-    indices: mx.array,
+    packed_indices: mx.array,
     norms: mx.array,
     rotation: TurboQuantRotation,
     bits: int,
@@ -109,7 +160,7 @@ def turboquant_dequantize(
     """Dequantize TurboQuant_mse encoded vectors.
 
     Args:
-        indices: Quantized indices of shape (B, n_heads, seq_len, head_dim).
+        packed_indices: Bit-packed quantized indices.
         norms: Vector norms of shape (B, n_heads, seq_len, 1).
         rotation: Rotation matrix used during quantization.
         bits: Quantization bit-width (2 or 4).
@@ -117,10 +168,11 @@ def turboquant_dequantize(
     Returns:
         Reconstructed tensor of shape (B, n_heads, seq_len, head_dim).
     """
-    head_dim = indices.shape[-1]
+    head_dim = rotation.matrix.shape[0]
     codebook = get_codebook(bits, head_dim)
 
-    # Lookup centroids
+    # Unpack indices and lookup centroids
+    indices = unpack_indices(packed_indices, bits, head_dim)
     y_hat = codebook[indices.astype(mx.uint32)]
 
     # Inverse rotate: x_hat = y_hat @ Π

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -25,9 +25,9 @@ logger = logging.getLogger(__name__)
 class TurboQuantKVCache(_BaseCache):
     """KV cache with TurboQuant compression.
 
-    Stores only bit-packed indices and float16 norms. Dequantizes the
-    full cache on each ``update_and_fetch`` call — this is O(n) per step,
-    matching the cost of attention itself.
+    Stores only bit-packed indices and float32 norms. Dequantizes the
+    full cache on each ``update_and_fetch`` call — O(n · head_dim²) per
+    step due to the rotation matrix multiply.
     """
 
     step = 256
@@ -114,6 +114,13 @@ class TurboQuantKVCache(_BaseCache):
             dtype=input_dtype,
         )
         return k_out, v_out
+
+    @property
+    def state(self):
+        raise NotImplementedError(
+            "TurboQuantKVCache does not support serialization. "
+            "Disable disk cache offload when using TurboQuant."
+        )
 
     def is_trimmable(self):
         return True

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -177,7 +177,9 @@ def make_turboquant_cache(model: Any, bits: int) -> list[TurboQuantKVCache]:
     for i in range(num_layers):
         rot_k = TurboQuantRotation(head_dim=head_dim, seed=i * 2)
         rot_v = TurboQuantRotation(head_dim=head_dim, seed=i * 2 + 1)
-        caches.append(TurboQuantKVCache(bits=bits, rotation_key=rot_k, rotation_value=rot_v))
+        caches.append(
+            TurboQuantKVCache(bits=bits, rotation_key=rot_k, rotation_value=rot_v)
+        )
 
     logger.info(
         "Created TurboQuant KV cache: %d layers, %d-bit, head_dim=%d",

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -63,7 +63,7 @@ class TurboQuantKVCache(_BaseCache):
 
         # Allocate or expand buffers
         if self._key_indices is None or (prev + num_steps) > self._key_indices.shape[2]:
-            new_steps = (self.step + num_steps - 1) // self.step * self.step
+            new_steps = (num_steps + self.step - 1) // self.step * self.step
             idx_shape = (B, n_heads, new_steps, packed_dim)
             nrm_shape = (B, n_heads, new_steps, 1)
 
@@ -121,6 +121,11 @@ class TurboQuantKVCache(_BaseCache):
     def trim(self, n: int) -> int:
         n = min(self.offset, n)
         self.offset -= n
+        if self.offset == 0:
+            self._key_indices = None
+            self._key_norms = None
+            self._value_indices = None
+            self._value_norms = None
         return n
 
     def make_mask(self, *args, **kwargs):

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -40,16 +40,25 @@ class TurboQuantKVCache(_BaseCache):
         self.bits = bits
         self.rotation_key = rotation_key
         self.rotation_value = rotation_value
+        # Quantized storage (compact)
         self._key_indices: mx.array | None = None
         self._key_norms: mx.array | None = None
         self._value_indices: mx.array | None = None
         self._value_norms: mx.array | None = None
+        # Dequantized cache (avoids O(n^2) re-dequantization)
+        self._keys_deq: mx.array | None = None
+        self._values_deq: mx.array | None = None
         self.offset = 0
 
     def update_and_fetch(
         self, keys: mx.array, values: mx.array
     ) -> tuple[mx.array, mx.array]:
-        """Quantize new K/V, append to store, dequantize all and return."""
+        """Quantize new K/V, append to store, return dequantized cache.
+
+        Only the new tokens are dequantized each call — the previously
+        dequantized prefix is reused, making per-step cost O(new_tokens)
+        instead of O(total_tokens).
+        """
         B, n_heads, num_steps, head_dim = keys.shape
         prev = self.offset
 
@@ -57,11 +66,16 @@ class TurboQuantKVCache(_BaseCache):
         k_idx, k_nrm = turboquant_quantize(keys, self.rotation_key, self.bits)
         v_idx, v_nrm = turboquant_quantize(values, self.rotation_value, self.bits)
 
-        # Allocate or expand buffers
+        # Dequantize only the new tokens
+        k_new_deq = turboquant_dequantize(k_idx, k_nrm, self.rotation_key, self.bits)
+        v_new_deq = turboquant_dequantize(v_idx, v_nrm, self.rotation_value, self.bits)
+
+        # Allocate or expand quantized buffers
         if self._key_indices is None or (prev + num_steps) > self._key_indices.shape[2]:
             new_steps = (self.step + num_steps - 1) // self.step * self.step
             idx_shape = (B, n_heads, new_steps, head_dim)
             nrm_shape = (B, n_heads, new_steps, 1)
+            deq_shape = (B, n_heads, new_steps, head_dim)
 
             if self._key_indices is not None:
                 if prev % self.step != 0:
@@ -69,6 +83,8 @@ class TurboQuantKVCache(_BaseCache):
                     self._key_norms = self._key_norms[..., :prev, :]
                     self._value_indices = self._value_indices[..., :prev, :]
                     self._value_norms = self._value_norms[..., :prev, :]
+                    self._keys_deq = self._keys_deq[..., :prev, :]
+                    self._values_deq = self._values_deq[..., :prev, :]
                 self._key_indices = mx.concatenate(
                     [self._key_indices, mx.zeros(idx_shape, dtype=mx.uint8)], axis=2
                 )
@@ -81,33 +97,33 @@ class TurboQuantKVCache(_BaseCache):
                 self._value_norms = mx.concatenate(
                     [self._value_norms, mx.zeros(nrm_shape, dtype=mx.float16)], axis=2
                 )
+                self._keys_deq = mx.concatenate(
+                    [self._keys_deq, mx.zeros(deq_shape, dtype=keys.dtype)], axis=2
+                )
+                self._values_deq = mx.concatenate(
+                    [self._values_deq, mx.zeros(deq_shape, dtype=values.dtype)], axis=2
+                )
             else:
                 self._key_indices = mx.zeros(idx_shape, dtype=mx.uint8)
                 self._key_norms = mx.zeros(nrm_shape, dtype=mx.float16)
                 self._value_indices = mx.zeros(idx_shape, dtype=mx.uint8)
                 self._value_norms = mx.zeros(nrm_shape, dtype=mx.float16)
+                self._keys_deq = mx.zeros(deq_shape, dtype=keys.dtype)
+                self._values_deq = mx.zeros(deq_shape, dtype=values.dtype)
 
-        # Store quantized data
+        # Store quantized data and dequantized cache
         self.offset += num_steps
         self._key_indices[..., prev : self.offset, :] = k_idx
         self._key_norms[..., prev : self.offset, :] = k_nrm
         self._value_indices[..., prev : self.offset, :] = v_idx
         self._value_norms[..., prev : self.offset, :] = v_nrm
+        self._keys_deq[..., prev : self.offset, :] = k_new_deq
+        self._values_deq[..., prev : self.offset, :] = v_new_deq
 
-        # Dequantize full cache and return
-        k_out = turboquant_dequantize(
-            self._key_indices[..., : self.offset, :],
-            self._key_norms[..., : self.offset, :],
-            self.rotation_key,
-            self.bits,
+        return (
+            self._keys_deq[..., : self.offset, :],
+            self._values_deq[..., : self.offset, :],
         )
-        v_out = turboquant_dequantize(
-            self._value_indices[..., : self.offset, :],
-            self._value_norms[..., : self.offset, :],
-            self.rotation_value,
-            self.bits,
-        )
-        return k_out, v_out
 
     def is_trimmable(self):
         return True
@@ -124,14 +140,38 @@ class TurboQuantKVCache(_BaseCache):
         return self._key_indices is None
 
 
+def _detect_head_dim(model: Any) -> int:
+    """Detect head_dim from model args or K projection layer shape.
+
+    Handles models where head_dim != hidden_size // num_attention_heads
+    (e.g. Gemma 3, Phi-3/4).
+    """
+    # Prefer explicit head_dim from model args
+    head_dim = getattr(model.args, "head_dim", None)
+    if head_dim is not None:
+        return head_dim
+
+    # Derive from K projection weight shape: k_proj.weight is (n_kv_heads * head_dim, hidden_size)
+    try:
+        layer = model.layers[0]
+        k_proj = layer.self_attn.k_proj
+        weight = k_proj.weight
+        if isinstance(weight, mx.array):
+            kv_out_dim = weight.shape[0]
+            n_kv_heads = getattr(model.args, "num_key_value_heads", None)
+            if n_kv_heads:
+                return kv_out_dim // n_kv_heads
+    except (AttributeError, IndexError):
+        pass
+
+    # Last resort: hidden_size // num_attention_heads
+    return model.args.hidden_size // model.args.num_attention_heads
+
+
 def make_turboquant_cache(model: Any, bits: int) -> list[TurboQuantKVCache]:
     """Create a list of TurboQuantKVCache objects, one per model layer."""
     num_layers = len(model.layers)
-
-    try:
-        head_dim = model.args.head_dim
-    except AttributeError:
-        head_dim = model.args.hidden_size // model.args.num_attention_heads
+    head_dim = _detect_head_dim(model)
 
     caches = []
     for i in range(num_layers):

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -124,7 +124,7 @@ class TurboQuantKVCache(_BaseCache):
         return create_attention_mask(*args, offset=self.offset, **kwargs)
 
     def empty(self):
-        return self._key_indices is None
+        return self._key_indices is None or self.offset == 0
 
 
 def _detect_head_dim(model: Any) -> int:

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -1,7 +1,7 @@
 """TurboQuant KV cache: drop-in replacement for mlx-lm's KVCache.
 
-Stores quantized key/value vectors using TurboQuant_mse and dequantizes
-on fetch, providing transparent memory compression.
+Stores bit-packed quantized key/value vectors using TurboQuant_mse and
+dequantizes on fetch, providing transparent memory compression.
 """
 
 from __future__ import annotations
@@ -25,8 +25,9 @@ logger = logging.getLogger(__name__)
 class TurboQuantKVCache(_BaseCache):
     """KV cache with TurboQuant compression.
 
-    Quantizes K/V vectors on store and dequantizes on fetch.
-    Implements the same interface as mlx-lm's KVCache.
+    Stores only bit-packed indices and float16 norms. Dequantizes the
+    full cache on each ``update_and_fetch`` call — this is O(n) per step,
+    matching the cost of attention itself.
     """
 
     step = 256
@@ -40,42 +41,30 @@ class TurboQuantKVCache(_BaseCache):
         self.bits = bits
         self.rotation_key = rotation_key
         self.rotation_value = rotation_value
-        # Quantized storage (compact)
         self._key_indices: mx.array | None = None
         self._key_norms: mx.array | None = None
         self._value_indices: mx.array | None = None
         self._value_norms: mx.array | None = None
-        # Dequantized cache (avoids O(n^2) re-dequantization)
-        self._keys_deq: mx.array | None = None
-        self._values_deq: mx.array | None = None
         self.offset = 0
 
     def update_and_fetch(
         self, keys: mx.array, values: mx.array
     ) -> tuple[mx.array, mx.array]:
-        """Quantize new K/V, append to store, return dequantized cache.
-
-        Only the new tokens are dequantized each call — the previously
-        dequantized prefix is reused, making per-step cost O(new_tokens)
-        instead of O(total_tokens).
-        """
+        """Quantize new K/V, append to store, dequantize all and return."""
         B, n_heads, num_steps, head_dim = keys.shape
         prev = self.offset
 
-        # Quantize incoming tokens
+        # Quantize incoming tokens (returns bit-packed indices)
         k_idx, k_nrm = turboquant_quantize(keys, self.rotation_key, self.bits)
         v_idx, v_nrm = turboquant_quantize(values, self.rotation_value, self.bits)
 
-        # Dequantize only the new tokens
-        k_new_deq = turboquant_dequantize(k_idx, k_nrm, self.rotation_key, self.bits)
-        v_new_deq = turboquant_dequantize(v_idx, v_nrm, self.rotation_value, self.bits)
+        packed_dim = k_idx.shape[-1]  # head_dim // (8 // bits)
 
-        # Allocate or expand quantized buffers
+        # Allocate or expand buffers
         if self._key_indices is None or (prev + num_steps) > self._key_indices.shape[2]:
             new_steps = (self.step + num_steps - 1) // self.step * self.step
-            idx_shape = (B, n_heads, new_steps, head_dim)
+            idx_shape = (B, n_heads, new_steps, packed_dim)
             nrm_shape = (B, n_heads, new_steps, 1)
-            deq_shape = (B, n_heads, new_steps, head_dim)
 
             if self._key_indices is not None:
                 if prev % self.step != 0:
@@ -83,8 +72,6 @@ class TurboQuantKVCache(_BaseCache):
                     self._key_norms = self._key_norms[..., :prev, :]
                     self._value_indices = self._value_indices[..., :prev, :]
                     self._value_norms = self._value_norms[..., :prev, :]
-                    self._keys_deq = self._keys_deq[..., :prev, :]
-                    self._values_deq = self._values_deq[..., :prev, :]
                 self._key_indices = mx.concatenate(
                     [self._key_indices, mx.zeros(idx_shape, dtype=mx.uint8)], axis=2
                 )
@@ -97,33 +84,33 @@ class TurboQuantKVCache(_BaseCache):
                 self._value_norms = mx.concatenate(
                     [self._value_norms, mx.zeros(nrm_shape, dtype=mx.float16)], axis=2
                 )
-                self._keys_deq = mx.concatenate(
-                    [self._keys_deq, mx.zeros(deq_shape, dtype=keys.dtype)], axis=2
-                )
-                self._values_deq = mx.concatenate(
-                    [self._values_deq, mx.zeros(deq_shape, dtype=values.dtype)], axis=2
-                )
             else:
                 self._key_indices = mx.zeros(idx_shape, dtype=mx.uint8)
                 self._key_norms = mx.zeros(nrm_shape, dtype=mx.float16)
                 self._value_indices = mx.zeros(idx_shape, dtype=mx.uint8)
                 self._value_norms = mx.zeros(nrm_shape, dtype=mx.float16)
-                self._keys_deq = mx.zeros(deq_shape, dtype=keys.dtype)
-                self._values_deq = mx.zeros(deq_shape, dtype=values.dtype)
 
-        # Store quantized data and dequantized cache
+        # Store quantized data
         self.offset += num_steps
         self._key_indices[..., prev : self.offset, :] = k_idx
         self._key_norms[..., prev : self.offset, :] = k_nrm
         self._value_indices[..., prev : self.offset, :] = v_idx
         self._value_norms[..., prev : self.offset, :] = v_nrm
-        self._keys_deq[..., prev : self.offset, :] = k_new_deq
-        self._values_deq[..., prev : self.offset, :] = v_new_deq
 
-        return (
-            self._keys_deq[..., : self.offset, :],
-            self._values_deq[..., : self.offset, :],
+        # Dequantize full cache and return
+        k_out = turboquant_dequantize(
+            self._key_indices[..., : self.offset, :],
+            self._key_norms[..., : self.offset, :],
+            self.rotation_key,
+            self.bits,
         )
+        v_out = turboquant_dequantize(
+            self._value_indices[..., : self.offset, :],
+            self._value_norms[..., : self.offset, :],
+            self.rotation_value,
+            self.bits,
+        )
+        return k_out, v_out
 
     def is_trimmable(self):
         return True
@@ -165,7 +152,13 @@ def _detect_head_dim(model: Any) -> int:
         pass
 
     # Last resort: hidden_size // num_attention_heads
-    return model.args.hidden_size // model.args.num_attention_heads
+    try:
+        return model.args.hidden_size // model.args.num_attention_heads
+    except AttributeError as e:
+        raise RuntimeError(
+            f"TurboQuant: cannot detect head_dim for this model architecture. "
+            f"Missing attribute: {e}"
+        ) from e
 
 
 def make_turboquant_cache(model: Any, bits: int) -> list[TurboQuantKVCache]:

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -1,0 +1,148 @@
+"""TurboQuant KV cache: drop-in replacement for mlx-lm's KVCache.
+
+Stores quantized key/value vectors using TurboQuant_mse and dequantizes
+on fetch, providing transparent memory compression.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import mlx.core as mx
+
+from mlx_lm.models.cache import _BaseCache, create_attention_mask
+
+from olmlx.engine.turboquant import (
+    TurboQuantRotation,
+    turboquant_dequantize,
+    turboquant_quantize,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TurboQuantKVCache(_BaseCache):
+    """KV cache with TurboQuant compression.
+
+    Quantizes K/V vectors on store and dequantizes on fetch.
+    Implements the same interface as mlx-lm's KVCache.
+    """
+
+    step = 256
+
+    def __init__(
+        self,
+        bits: int,
+        rotation_key: TurboQuantRotation,
+        rotation_value: TurboQuantRotation,
+    ):
+        self.bits = bits
+        self.rotation_key = rotation_key
+        self.rotation_value = rotation_value
+        self._key_indices: mx.array | None = None
+        self._key_norms: mx.array | None = None
+        self._value_indices: mx.array | None = None
+        self._value_norms: mx.array | None = None
+        self.offset = 0
+
+    def update_and_fetch(
+        self, keys: mx.array, values: mx.array
+    ) -> tuple[mx.array, mx.array]:
+        """Quantize new K/V, append to store, dequantize all and return."""
+        B, n_heads, num_steps, head_dim = keys.shape
+        prev = self.offset
+
+        # Quantize incoming tokens
+        k_idx, k_nrm = turboquant_quantize(keys, self.rotation_key, self.bits)
+        v_idx, v_nrm = turboquant_quantize(values, self.rotation_value, self.bits)
+
+        # Allocate or expand buffers
+        if self._key_indices is None or (prev + num_steps) > self._key_indices.shape[2]:
+            new_steps = (self.step + num_steps - 1) // self.step * self.step
+            idx_shape = (B, n_heads, new_steps, head_dim)
+            nrm_shape = (B, n_heads, new_steps, 1)
+
+            if self._key_indices is not None:
+                if prev % self.step != 0:
+                    self._key_indices = self._key_indices[..., :prev, :]
+                    self._key_norms = self._key_norms[..., :prev, :]
+                    self._value_indices = self._value_indices[..., :prev, :]
+                    self._value_norms = self._value_norms[..., :prev, :]
+                self._key_indices = mx.concatenate(
+                    [self._key_indices, mx.zeros(idx_shape, dtype=mx.uint8)], axis=2
+                )
+                self._key_norms = mx.concatenate(
+                    [self._key_norms, mx.zeros(nrm_shape, dtype=mx.float16)], axis=2
+                )
+                self._value_indices = mx.concatenate(
+                    [self._value_indices, mx.zeros(idx_shape, dtype=mx.uint8)], axis=2
+                )
+                self._value_norms = mx.concatenate(
+                    [self._value_norms, mx.zeros(nrm_shape, dtype=mx.float16)], axis=2
+                )
+            else:
+                self._key_indices = mx.zeros(idx_shape, dtype=mx.uint8)
+                self._key_norms = mx.zeros(nrm_shape, dtype=mx.float16)
+                self._value_indices = mx.zeros(idx_shape, dtype=mx.uint8)
+                self._value_norms = mx.zeros(nrm_shape, dtype=mx.float16)
+
+        # Store quantized data
+        self.offset += num_steps
+        self._key_indices[..., prev : self.offset, :] = k_idx
+        self._key_norms[..., prev : self.offset, :] = k_nrm
+        self._value_indices[..., prev : self.offset, :] = v_idx
+        self._value_norms[..., prev : self.offset, :] = v_nrm
+
+        # Dequantize full cache and return
+        k_out = turboquant_dequantize(
+            self._key_indices[..., : self.offset, :],
+            self._key_norms[..., : self.offset, :],
+            self.rotation_key,
+            self.bits,
+        )
+        v_out = turboquant_dequantize(
+            self._value_indices[..., : self.offset, :],
+            self._value_norms[..., : self.offset, :],
+            self.rotation_value,
+            self.bits,
+        )
+        return k_out, v_out
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n: int) -> int:
+        n = min(self.offset, n)
+        self.offset -= n
+        return n
+
+    def make_mask(self, *args, **kwargs):
+        return create_attention_mask(*args, offset=self.offset, **kwargs)
+
+    def empty(self):
+        return self._key_indices is None
+
+
+def make_turboquant_cache(model: Any, bits: int) -> list[TurboQuantKVCache]:
+    """Create a list of TurboQuantKVCache objects, one per model layer."""
+    num_layers = len(model.layers)
+
+    try:
+        head_dim = model.args.head_dim
+    except AttributeError:
+        head_dim = model.args.hidden_size // model.args.num_attention_heads
+
+    caches = []
+    for i in range(num_layers):
+        rot_k = TurboQuantRotation(head_dim=head_dim, seed=i * 2)
+        rot_v = TurboQuantRotation(head_dim=head_dim, seed=i * 2 + 1)
+        caches.append(TurboQuantKVCache(bits=bits, rotation_key=rot_k, rotation_value=rot_v))
+
+    logger.info(
+        "Created TurboQuant KV cache: %d layers, %d-bit, head_dim=%d",
+        num_layers,
+        bits,
+        head_dim,
+    )
+    return caches

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -52,6 +52,7 @@ class TurboQuantKVCache(_BaseCache):
     ) -> tuple[mx.array, mx.array]:
         """Quantize new K/V, append to store, dequantize all and return."""
         B, n_heads, num_steps, head_dim = keys.shape
+        input_dtype = keys.dtype
         prev = self.offset
 
         # Quantize incoming tokens (returns bit-packed indices)
@@ -76,19 +77,19 @@ class TurboQuantKVCache(_BaseCache):
                     [self._key_indices, mx.zeros(idx_shape, dtype=mx.uint8)], axis=2
                 )
                 self._key_norms = mx.concatenate(
-                    [self._key_norms, mx.zeros(nrm_shape, dtype=mx.float16)], axis=2
+                    [self._key_norms, mx.zeros(nrm_shape, dtype=mx.float32)], axis=2
                 )
                 self._value_indices = mx.concatenate(
                     [self._value_indices, mx.zeros(idx_shape, dtype=mx.uint8)], axis=2
                 )
                 self._value_norms = mx.concatenate(
-                    [self._value_norms, mx.zeros(nrm_shape, dtype=mx.float16)], axis=2
+                    [self._value_norms, mx.zeros(nrm_shape, dtype=mx.float32)], axis=2
                 )
             else:
                 self._key_indices = mx.zeros(idx_shape, dtype=mx.uint8)
-                self._key_norms = mx.zeros(nrm_shape, dtype=mx.float16)
+                self._key_norms = mx.zeros(nrm_shape, dtype=mx.float32)
                 self._value_indices = mx.zeros(idx_shape, dtype=mx.uint8)
-                self._value_norms = mx.zeros(nrm_shape, dtype=mx.float16)
+                self._value_norms = mx.zeros(nrm_shape, dtype=mx.float32)
 
         # Store quantized data
         self.offset += num_steps
@@ -97,18 +98,20 @@ class TurboQuantKVCache(_BaseCache):
         self._value_indices[..., prev : self.offset, :] = v_idx
         self._value_norms[..., prev : self.offset, :] = v_nrm
 
-        # Dequantize full cache and return
+        # Dequantize full cache and return in the original dtype
         k_out = turboquant_dequantize(
             self._key_indices[..., : self.offset, :],
             self._key_norms[..., : self.offset, :],
             self.rotation_key,
             self.bits,
+            dtype=input_dtype,
         )
         v_out = turboquant_dequantize(
             self._value_indices[..., : self.offset, :],
             self._value_norms[..., : self.offset, :],
             self.rotation_value,
             self.bits,
+            dtype=input_dtype,
         )
         return k_out, v_out
 
@@ -121,7 +124,8 @@ class TurboQuantKVCache(_BaseCache):
         return n
 
     def make_mask(self, *args, **kwargs):
-        return create_attention_mask(*args, offset=self.offset, **kwargs)
+        kwargs["offset"] = self.offset
+        return create_attention_mask(*args, **kwargs)
 
     def empty(self):
         return self._key_indices is None or self.offset == 0
@@ -165,6 +169,13 @@ def make_turboquant_cache(model: Any, bits: int) -> list[TurboQuantKVCache]:
     """Create a list of TurboQuantKVCache objects, one per model layer."""
     num_layers = len(model.layers)
     head_dim = _detect_head_dim(model)
+
+    packing_factor = 8 // bits
+    if head_dim % packing_factor != 0:
+        raise ValueError(
+            f"TurboQuant {bits}-bit requires head_dim divisible by {packing_factor}, "
+            f"got head_dim={head_dim}"
+        )
 
     caches = []
     for i in range(num_layers):

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -319,6 +319,35 @@ class TestTurboQuantKVCache:
         # For N=1, mask should be None (single token attention)
         assert mask is None
 
+    def test_prefix_stability(self):
+        """Dequantized prefix should be identical across consecutive fetches.
+
+        This verifies the O(n) incremental dequantization — the prefix
+        portion of the returned tensors must not change when new tokens
+        are appended.
+        """
+        cache = self._make_cache(bits=4, head_dim=64)
+
+        # Prefill 16 tokens
+        k1 = mx.random.normal((1, 4, 16, 64))
+        v1 = mx.random.normal((1, 4, 16, 64))
+        k_out1, v_out1 = cache.update_and_fetch(k1, v1)
+
+        # Append 1 token
+        k2 = mx.random.normal((1, 4, 1, 64))
+        v2 = mx.random.normal((1, 4, 1, 64))
+        k_out2, v_out2 = cache.update_and_fetch(k2, v2)
+
+        # First 16 tokens of second fetch should match first fetch exactly
+        np.testing.assert_array_equal(
+            np.array(k_out2[..., :16, :]),
+            np.array(k_out1),
+        )
+        np.testing.assert_array_equal(
+            np.array(v_out2[..., :16, :]),
+            np.array(v_out1),
+        )
+
     def test_fetch_after_trim_returns_correct_length(self):
         """After trim, next fetch should return trimmed + new tokens."""
         cache = self._make_cache(bits=4, head_dim=64)
@@ -393,22 +422,38 @@ class TestMakeTurboQuantCache:
         r1 = np.array(cache[1].rotation_key.matrix)
         assert not np.allclose(r0, r1)
 
-    def test_head_dim_fallback(self):
-        """When model.args.head_dim is missing, derive from hidden_size / num_attention_heads."""
+    def test_head_dim_fallback_from_k_proj(self):
+        """When model.args.head_dim is missing, derive from k_proj weight shape."""
         from unittest.mock import MagicMock
 
         from olmlx.engine.turboquant_cache import make_turboquant_cache
 
         class FakeArgs:
-            hidden_size = 512
-            num_attention_heads = 8
+            # Gemma 3 style: head_dim not in args, and hidden_size // num_heads is wrong
+            num_key_value_heads = 4
 
         model = MagicMock()
-        model.layers = [MagicMock() for _ in range(1)]
+        layer = MagicMock()
+        # k_proj output dim = num_kv_heads * head_dim = 4 * 64 = 256
+        layer.self_attn.k_proj.weight = mx.zeros((256, 512))
+        model.layers = [layer]
         model.args = FakeArgs()
 
         cache = make_turboquant_cache(model, bits=4)
         assert cache[0].rotation_key.matrix.shape == (64, 64)
+
+    def test_head_dim_from_args(self):
+        """When model.args.head_dim is present, use it directly."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.turboquant_cache import make_turboquant_cache
+
+        model = MagicMock()
+        model.layers = [MagicMock() for _ in range(1)]
+        model.args.head_dim = 128
+
+        cache = make_turboquant_cache(model, bits=4)
+        assert cache[0].rotation_key.matrix.shape == (128, 128)
 
 
 # ---------------------------------------------------------------------------
@@ -441,6 +486,44 @@ class TestKvCacheQuantConfig:
 
         s = ExperimentalSettings(_env_file=None)
         assert s.kv_cache_quant == "turboquant:2"
+
+    def test_invalid_bits_rejected(self, monkeypatch):
+        """Unsupported bit-width should fail at config validation time."""
+        from pydantic import ValidationError
+
+        from olmlx.config import ExperimentalSettings
+
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_KV_CACHE_QUANT", "turboquant:3")
+        with pytest.raises(ValidationError):
+            ExperimentalSettings(_env_file=None)
+
+    def test_missing_bits_rejected(self, monkeypatch):
+        """Malformed value without bits should fail at config validation."""
+        from pydantic import ValidationError
+
+        from olmlx.config import ExperimentalSettings
+
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_KV_CACHE_QUANT", "turboquant:")
+        with pytest.raises(ValidationError):
+            ExperimentalSettings(_env_file=None)
+
+    def test_unknown_method_rejected(self, monkeypatch):
+        from pydantic import ValidationError
+
+        from olmlx.config import ExperimentalSettings
+
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_KV_CACHE_QUANT", "foo:4")
+        with pytest.raises(ValidationError):
+            ExperimentalSettings(_env_file=None)
+
+    def test_bare_string_rejected(self, monkeypatch):
+        from pydantic import ValidationError
+
+        from olmlx.config import ExperimentalSettings
+
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_KV_CACHE_QUANT", "turboquant")
+        with pytest.raises(ValidationError):
+            ExperimentalSettings(_env_file=None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -46,9 +46,7 @@ class TestCodebook:
 
         cb = get_codebook(bits=2, dim=128)
         expected = mx.array(GAUSSIAN_CODEBOOKS[2]) / mx.sqrt(mx.array(128.0))
-        np.testing.assert_allclose(
-            np.array(cb), np.array(expected), atol=1e-6
-        )
+        np.testing.assert_allclose(np.array(cb), np.array(expected), atol=1e-6)
 
 
 class TestRotation:
@@ -61,9 +59,7 @@ class TestRotation:
         rot = TurboQuantRotation(head_dim=128, seed=42)
         product = rot.matrix @ rot.matrix.T
         identity = mx.eye(128)
-        np.testing.assert_allclose(
-            np.array(product), np.array(identity), atol=1e-5
-        )
+        np.testing.assert_allclose(np.array(product), np.array(identity), atol=1e-5)
 
     def test_deterministic(self):
         """Same seed should produce same rotation."""
@@ -301,11 +297,13 @@ class TestTurboQuantKVCache:
         # Check relative MSE
         k_mse = float(mx.mean((keys - k_out) ** 2))
         k_var = float(mx.mean(keys**2))
-        assert k_mse / k_var < 0.05, f"Key 4-bit relative MSE too high: {k_mse/k_var}"
+        assert k_mse / k_var < 0.05, f"Key 4-bit relative MSE too high: {k_mse / k_var}"
 
         v_mse = float(mx.mean((values - v_out) ** 2))
         v_var = float(mx.mean(values**2))
-        assert v_mse / v_var < 0.05, f"Value 4-bit relative MSE too high: {v_mse/v_var}"
+        assert v_mse / v_var < 0.05, (
+            f"Value 4-bit relative MSE too high: {v_mse / v_var}"
+        )
 
     def test_make_mask(self):
         """make_mask should delegate to create_attention_mask."""
@@ -469,7 +467,11 @@ class TestKvCacheQuantConfig:
 
         s = ExperimentalSettings(
             _env_file=None,
-            **{k: v.default for k, v in ExperimentalSettings.model_fields.items() if v.default is not None and k != "kv_cache_quant"},
+            **{
+                k: v.default
+                for k, v in ExperimentalSettings.model_fields.items()
+                if v.default is not None and k != "kv_cache_quant"
+            },
         )
         assert s.kv_cache_quant is None
 

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -93,6 +93,28 @@ class TestQuantizeDequantize:
         x = np.random.randn(*shape).astype(np.float32)
         return mx.array(x)
 
+    def test_pack_unpack_4bit(self):
+        """4-bit pack/unpack should roundtrip perfectly."""
+        from olmlx.engine.turboquant import pack_indices, unpack_indices
+
+        indices = mx.array([0, 15, 3, 12, 7, 8, 1, 14], dtype=mx.uint8).reshape(
+            1, 1, 1, 8
+        )
+        packed = pack_indices(indices, bits=4)
+        assert packed.shape == (1, 1, 1, 4)
+        unpacked = unpack_indices(packed, bits=4, head_dim=8)
+        np.testing.assert_array_equal(np.array(unpacked), np.array(indices))
+
+    def test_pack_unpack_2bit(self):
+        """2-bit pack/unpack should roundtrip perfectly."""
+        from olmlx.engine.turboquant import pack_indices, unpack_indices
+
+        indices = mx.array([0, 3, 1, 2, 3, 0, 2, 1], dtype=mx.uint8).reshape(1, 1, 1, 8)
+        packed = pack_indices(indices, bits=2)
+        assert packed.shape == (1, 1, 1, 2)
+        unpacked = unpack_indices(packed, bits=2, head_dim=8)
+        np.testing.assert_array_equal(np.array(unpacked), np.array(indices))
+
     def test_roundtrip_mse_4bit(self):
         """4-bit roundtrip should have low MSE."""
         from olmlx.engine.turboquant import (
@@ -143,12 +165,27 @@ class TestQuantizeDequantize:
         x = self._random_vectors((1, 4, 32, 64))
 
         indices, norms = turboquant_quantize(x, rot, bits=4)
-        assert indices.shape == (1, 4, 32, 64)
+        # 4-bit: 2 indices per byte → head_dim // 2
+        assert indices.shape == (1, 4, 32, 32)
         assert indices.dtype == mx.uint8
         assert norms.shape == (1, 4, 32, 1)
 
         x_hat = turboquant_dequantize(indices, norms, rot, bits=4)
         assert x_hat.shape == x.shape
+
+    def test_output_shapes_2bit(self):
+        from olmlx.engine.turboquant import (
+            TurboQuantRotation,
+            turboquant_quantize,
+        )
+
+        rot = TurboQuantRotation(head_dim=64, seed=0)
+        x = self._random_vectors((1, 4, 32, 64))
+
+        indices, norms = turboquant_quantize(x, rot, bits=2)
+        # 2-bit: 4 indices per byte → head_dim // 4
+        assert indices.shape == (1, 4, 32, 16)
+        assert indices.dtype == mx.uint8
 
     def test_batch_dimensions(self):
         """Should handle batch>1 and multiple heads."""
@@ -316,35 +353,6 @@ class TestTurboQuantKVCache:
         mask = cache.make_mask(N=1, return_array=True, window_size=None)
         # For N=1, mask should be None (single token attention)
         assert mask is None
-
-    def test_prefix_stability(self):
-        """Dequantized prefix should be identical across consecutive fetches.
-
-        This verifies the O(n) incremental dequantization — the prefix
-        portion of the returned tensors must not change when new tokens
-        are appended.
-        """
-        cache = self._make_cache(bits=4, head_dim=64)
-
-        # Prefill 16 tokens
-        k1 = mx.random.normal((1, 4, 16, 64))
-        v1 = mx.random.normal((1, 4, 16, 64))
-        k_out1, v_out1 = cache.update_and_fetch(k1, v1)
-
-        # Append 1 token
-        k2 = mx.random.normal((1, 4, 1, 64))
-        v2 = mx.random.normal((1, 4, 1, 64))
-        k_out2, v_out2 = cache.update_and_fetch(k2, v2)
-
-        # First 16 tokens of second fetch should match first fetch exactly
-        np.testing.assert_array_equal(
-            np.array(k_out2[..., :16, :]),
-            np.array(k_out1),
-        )
-        np.testing.assert_array_equal(
-            np.array(v_out2[..., :16, :]),
-            np.array(v_out1),
-        )
 
     def test_fetch_after_trim_returns_correct_length(self):
         """After trim, next fetch should return trimmed + new tokens."""

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -1,0 +1,518 @@
+"""Tests for TurboQuant KV cache quantization."""
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Core algorithm tests
+# ---------------------------------------------------------------------------
+
+
+class TestCodebook:
+    """Tests for precomputed Lloyd-Max codebooks."""
+
+    def test_codebook_has_2_and_4_bit(self):
+        from olmlx.engine.turboquant import GAUSSIAN_CODEBOOKS
+
+        assert 2 in GAUSSIAN_CODEBOOKS
+        assert 4 in GAUSSIAN_CODEBOOKS
+
+    def test_codebook_count(self):
+        from olmlx.engine.turboquant import GAUSSIAN_CODEBOOKS
+
+        assert len(GAUSSIAN_CODEBOOKS[2]) == 4
+        assert len(GAUSSIAN_CODEBOOKS[4]) == 16
+
+    def test_codebook_symmetry(self):
+        """Centroids should be symmetric around 0."""
+        from olmlx.engine.turboquant import GAUSSIAN_CODEBOOKS
+
+        for bits in [2, 4]:
+            c = np.array(GAUSSIAN_CODEBOOKS[bits])
+            np.testing.assert_allclose(c, -c[::-1], atol=1e-6)
+
+    def test_codebook_sorted(self):
+        from olmlx.engine.turboquant import GAUSSIAN_CODEBOOKS
+
+        for bits in [2, 4]:
+            c = GAUSSIAN_CODEBOOKS[bits]
+            assert all(c[i] < c[i + 1] for i in range(len(c) - 1))
+
+    def test_scaled_codebook(self):
+        """get_codebook should return centroids scaled by 1/sqrt(dim)."""
+        from olmlx.engine.turboquant import GAUSSIAN_CODEBOOKS, get_codebook
+
+        cb = get_codebook(bits=2, dim=128)
+        expected = mx.array(GAUSSIAN_CODEBOOKS[2]) / mx.sqrt(mx.array(128.0))
+        np.testing.assert_allclose(
+            np.array(cb), np.array(expected), atol=1e-6
+        )
+
+
+class TestRotation:
+    """Tests for per-layer rotation matrices."""
+
+    def test_orthogonality(self):
+        """Π @ Πᵀ should be identity."""
+        from olmlx.engine.turboquant import TurboQuantRotation
+
+        rot = TurboQuantRotation(head_dim=128, seed=42)
+        product = rot.matrix @ rot.matrix.T
+        identity = mx.eye(128)
+        np.testing.assert_allclose(
+            np.array(product), np.array(identity), atol=1e-5
+        )
+
+    def test_deterministic(self):
+        """Same seed should produce same rotation."""
+        from olmlx.engine.turboquant import TurboQuantRotation
+
+        r1 = TurboQuantRotation(head_dim=64, seed=7)
+        r2 = TurboQuantRotation(head_dim=64, seed=7)
+        np.testing.assert_array_equal(np.array(r1.matrix), np.array(r2.matrix))
+
+    def test_per_layer_different(self):
+        """Different seeds should produce different rotations."""
+        from olmlx.engine.turboquant import TurboQuantRotation
+
+        r1 = TurboQuantRotation(head_dim=64, seed=0)
+        r2 = TurboQuantRotation(head_dim=64, seed=1)
+        assert not np.allclose(np.array(r1.matrix), np.array(r2.matrix))
+
+    def test_shape(self):
+        from olmlx.engine.turboquant import TurboQuantRotation
+
+        rot = TurboQuantRotation(head_dim=128, seed=0)
+        assert rot.matrix.shape == (128, 128)
+
+
+class TestQuantizeDequantize:
+    """Tests for quantize/dequantize roundtrip."""
+
+    def _random_vectors(self, shape, seed=0):
+        """Generate random vectors with varying norms (like real KV vectors)."""
+        np.random.seed(seed)
+        x = np.random.randn(*shape).astype(np.float32)
+        return mx.array(x)
+
+    def test_roundtrip_mse_4bit(self):
+        """4-bit roundtrip should have low MSE."""
+        from olmlx.engine.turboquant import (
+            TurboQuantRotation,
+            turboquant_dequantize,
+            turboquant_quantize,
+        )
+
+        rot = TurboQuantRotation(head_dim=128, seed=0)
+        x = self._random_vectors((1, 1, 16, 128))
+
+        indices, norms = turboquant_quantize(x, rot, bits=4)
+        x_hat = turboquant_dequantize(indices, norms, rot, bits=4)
+
+        # Relative MSE should be small for 4-bit
+        mse = float(mx.mean((x - x_hat) ** 2))
+        var = float(mx.mean(x**2))
+        relative_mse = mse / var
+        assert relative_mse < 0.05, f"4-bit relative MSE {relative_mse} too high"
+
+    def test_roundtrip_mse_2bit(self):
+        """2-bit roundtrip has higher MSE but still bounded."""
+        from olmlx.engine.turboquant import (
+            TurboQuantRotation,
+            turboquant_dequantize,
+            turboquant_quantize,
+        )
+
+        rot = TurboQuantRotation(head_dim=128, seed=0)
+        x = self._random_vectors((1, 1, 16, 128))
+
+        indices, norms = turboquant_quantize(x, rot, bits=2)
+        x_hat = turboquant_dequantize(indices, norms, rot, bits=2)
+
+        mse = float(mx.mean((x - x_hat) ** 2))
+        var = float(mx.mean(x**2))
+        relative_mse = mse / var
+        assert relative_mse < 0.25, f"2-bit relative MSE {relative_mse} too high"
+
+    def test_output_shapes(self):
+        from olmlx.engine.turboquant import (
+            TurboQuantRotation,
+            turboquant_dequantize,
+            turboquant_quantize,
+        )
+
+        rot = TurboQuantRotation(head_dim=64, seed=0)
+        x = self._random_vectors((1, 4, 32, 64))
+
+        indices, norms = turboquant_quantize(x, rot, bits=4)
+        assert indices.shape == (1, 4, 32, 64)
+        assert indices.dtype == mx.uint8
+        assert norms.shape == (1, 4, 32, 1)
+
+        x_hat = turboquant_dequantize(indices, norms, rot, bits=4)
+        assert x_hat.shape == x.shape
+
+    def test_batch_dimensions(self):
+        """Should handle batch>1 and multiple heads."""
+        from olmlx.engine.turboquant import (
+            TurboQuantRotation,
+            turboquant_dequantize,
+            turboquant_quantize,
+        )
+
+        rot = TurboQuantRotation(head_dim=64, seed=0)
+        x = self._random_vectors((2, 8, 10, 64))
+
+        indices, norms = turboquant_quantize(x, rot, bits=2)
+        x_hat = turboquant_dequantize(indices, norms, rot, bits=2)
+
+        assert x_hat.shape == x.shape
+
+    def test_single_token(self):
+        """Should work with seq_len=1 (decoding step)."""
+        from olmlx.engine.turboquant import (
+            TurboQuantRotation,
+            turboquant_dequantize,
+            turboquant_quantize,
+        )
+
+        rot = TurboQuantRotation(head_dim=128, seed=0)
+        x = self._random_vectors((1, 8, 1, 128))
+
+        indices, norms = turboquant_quantize(x, rot, bits=4)
+        x_hat = turboquant_dequantize(indices, norms, rot, bits=4)
+
+        assert x_hat.shape == x.shape
+
+    def test_norm_preservation(self):
+        """Dequantized vectors should approximately preserve input norms."""
+        from olmlx.engine.turboquant import (
+            TurboQuantRotation,
+            turboquant_dequantize,
+            turboquant_quantize,
+        )
+
+        rot = TurboQuantRotation(head_dim=128, seed=0)
+        x = self._random_vectors((1, 1, 100, 128))
+
+        indices, norms = turboquant_quantize(x, rot, bits=4)
+        x_hat = turboquant_dequantize(indices, norms, rot, bits=4)
+
+        orig_norms = mx.sqrt(mx.sum(x**2, axis=-1))
+        recon_norms = mx.sqrt(mx.sum(x_hat**2, axis=-1))
+
+        # Norms should be close (within 20%)
+        ratio = np.array(recon_norms / orig_norms)
+        assert np.all(ratio > 0.7) and np.all(ratio < 1.3)
+
+
+# ---------------------------------------------------------------------------
+# TurboQuantKVCache tests
+# ---------------------------------------------------------------------------
+
+
+class TestTurboQuantKVCache:
+    """Tests for the KV cache wrapper."""
+
+    def _make_cache(self, bits=4, head_dim=64):
+        from olmlx.engine.turboquant import TurboQuantRotation
+        from olmlx.engine.turboquant_cache import TurboQuantKVCache
+
+        rot_k = TurboQuantRotation(head_dim=head_dim, seed=0)
+        rot_v = TurboQuantRotation(head_dim=head_dim, seed=1)
+        return TurboQuantKVCache(bits=bits, rotation_key=rot_k, rotation_value=rot_v)
+
+    def test_update_and_fetch_basic(self):
+        """First update should store and return data."""
+        cache = self._make_cache(bits=4, head_dim=64)
+        keys = mx.random.normal((1, 4, 8, 64))
+        values = mx.random.normal((1, 4, 8, 64))
+
+        k_out, v_out = cache.update_and_fetch(keys, values)
+
+        assert k_out.shape == (1, 4, 8, 64)
+        assert v_out.shape == (1, 4, 8, 64)
+        assert cache.offset == 8
+
+    def test_sequential_updates(self):
+        """Multiple updates should accumulate tokens."""
+        cache = self._make_cache(bits=4, head_dim=64)
+
+        # Prefill: 16 tokens
+        k1 = mx.random.normal((1, 4, 16, 64))
+        v1 = mx.random.normal((1, 4, 16, 64))
+        k_out, v_out = cache.update_and_fetch(k1, v1)
+        assert k_out.shape == (1, 4, 16, 64)
+        assert cache.offset == 16
+
+        # Decode: 1 token at a time
+        k2 = mx.random.normal((1, 4, 1, 64))
+        v2 = mx.random.normal((1, 4, 1, 64))
+        k_out, v_out = cache.update_and_fetch(k2, v2)
+        assert k_out.shape == (1, 4, 17, 64)
+        assert v_out.shape == (1, 4, 17, 64)
+        assert cache.offset == 17
+
+    def test_trim(self):
+        """Trim should reduce offset."""
+        cache = self._make_cache(bits=4, head_dim=64)
+        keys = mx.random.normal((1, 4, 32, 64))
+        values = mx.random.normal((1, 4, 32, 64))
+        cache.update_and_fetch(keys, values)
+
+        trimmed = cache.trim(10)
+        assert trimmed == 10
+        assert cache.offset == 22
+
+    def test_trim_clamps_to_offset(self):
+        """Trim more than offset should clamp."""
+        cache = self._make_cache(bits=4, head_dim=64)
+        keys = mx.random.normal((1, 4, 5, 64))
+        values = mx.random.normal((1, 4, 5, 64))
+        cache.update_and_fetch(keys, values)
+
+        trimmed = cache.trim(100)
+        assert trimmed == 5
+        assert cache.offset == 0
+
+    def test_is_trimmable(self):
+        cache = self._make_cache()
+        assert cache.is_trimmable()
+
+    def test_empty(self):
+        cache = self._make_cache()
+        assert cache.empty()
+
+        keys = mx.random.normal((1, 4, 1, 64))
+        values = mx.random.normal((1, 4, 1, 64))
+        cache.update_and_fetch(keys, values)
+        assert not cache.empty()
+
+    def test_reconstruction_quality(self):
+        """Dequantized cache should be close to original (4-bit)."""
+        cache = self._make_cache(bits=4, head_dim=128)
+        keys = mx.random.normal((1, 8, 32, 128))
+        values = mx.random.normal((1, 8, 32, 128))
+
+        k_out, v_out = cache.update_and_fetch(keys, values)
+
+        # Check relative MSE
+        k_mse = float(mx.mean((keys - k_out) ** 2))
+        k_var = float(mx.mean(keys**2))
+        assert k_mse / k_var < 0.05, f"Key 4-bit relative MSE too high: {k_mse/k_var}"
+
+        v_mse = float(mx.mean((values - v_out) ** 2))
+        v_var = float(mx.mean(values**2))
+        assert v_mse / v_var < 0.05, f"Value 4-bit relative MSE too high: {v_mse/v_var}"
+
+    def test_make_mask(self):
+        """make_mask should delegate to create_attention_mask."""
+        cache = self._make_cache()
+        keys = mx.random.normal((1, 4, 10, 64))
+        values = mx.random.normal((1, 4, 10, 64))
+        cache.update_and_fetch(keys, values)
+
+        # Should not raise — just verify it's callable
+        mask = cache.make_mask(N=1, return_array=True, window_size=None)
+        # For N=1, mask should be None (single token attention)
+        assert mask is None
+
+    def test_fetch_after_trim_returns_correct_length(self):
+        """After trim, next fetch should return trimmed + new tokens."""
+        cache = self._make_cache(bits=4, head_dim=64)
+
+        # Add 20 tokens
+        k1 = mx.random.normal((1, 4, 20, 64))
+        v1 = mx.random.normal((1, 4, 20, 64))
+        cache.update_and_fetch(k1, v1)
+
+        # Trim 5
+        cache.trim(5)
+        assert cache.offset == 15
+
+        # Add 3 more
+        k2 = mx.random.normal((1, 4, 3, 64))
+        v2 = mx.random.normal((1, 4, 3, 64))
+        k_out, v_out = cache.update_and_fetch(k2, v2)
+
+        assert k_out.shape == (1, 4, 18, 64)
+        assert cache.offset == 18
+
+
+# ---------------------------------------------------------------------------
+# make_turboquant_cache tests
+# ---------------------------------------------------------------------------
+
+
+class TestMakeTurboQuantCache:
+    """Tests for the factory function that creates per-layer caches."""
+
+    def test_creates_correct_number_of_layers(self):
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.turboquant_cache import make_turboquant_cache
+
+        model = MagicMock()
+        model.layers = [MagicMock() for _ in range(4)]
+        # head_dim from model.args
+        model.args.head_dim = 64
+
+        cache = make_turboquant_cache(model, bits=4)
+        assert len(cache) == 4
+
+    def test_each_layer_is_turboquant_cache(self):
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.turboquant_cache import (
+            TurboQuantKVCache,
+            make_turboquant_cache,
+        )
+
+        model = MagicMock()
+        model.layers = [MagicMock() for _ in range(2)]
+        model.args.head_dim = 64
+
+        cache = make_turboquant_cache(model, bits=4)
+        for c in cache:
+            assert isinstance(c, TurboQuantKVCache)
+
+    def test_per_layer_different_rotations(self):
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.turboquant_cache import make_turboquant_cache
+
+        model = MagicMock()
+        model.layers = [MagicMock() for _ in range(2)]
+        model.args.head_dim = 64
+
+        cache = make_turboquant_cache(model, bits=4)
+        # Different layers should have different rotation matrices
+        r0 = np.array(cache[0].rotation_key.matrix)
+        r1 = np.array(cache[1].rotation_key.matrix)
+        assert not np.allclose(r0, r1)
+
+    def test_head_dim_fallback(self):
+        """When model.args.head_dim is missing, derive from hidden_size / num_attention_heads."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.turboquant_cache import make_turboquant_cache
+
+        class FakeArgs:
+            hidden_size = 512
+            num_attention_heads = 8
+
+        model = MagicMock()
+        model.layers = [MagicMock() for _ in range(1)]
+        model.args = FakeArgs()
+
+        cache = make_turboquant_cache(model, bits=4)
+        assert cache[0].rotation_key.matrix.shape == (64, 64)
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+class TestKvCacheQuantConfig:
+    """Tests for the kv_cache_quant experimental setting."""
+
+    def test_default_is_none(self):
+        from olmlx.config import ExperimentalSettings
+
+        s = ExperimentalSettings(
+            _env_file=None,
+            **{k: v.default for k, v in ExperimentalSettings.model_fields.items() if v.default is not None and k != "kv_cache_quant"},
+        )
+        assert s.kv_cache_quant is None
+
+    def test_turboquant_4(self, monkeypatch):
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_KV_CACHE_QUANT", "turboquant:4")
+        from olmlx.config import ExperimentalSettings
+
+        s = ExperimentalSettings(_env_file=None)
+        assert s.kv_cache_quant == "turboquant:4"
+
+    def test_turboquant_2(self, monkeypatch):
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_KV_CACHE_QUANT", "turboquant:2")
+        from olmlx.config import ExperimentalSettings
+
+        s = ExperimentalSettings(_env_file=None)
+        assert s.kv_cache_quant == "turboquant:2"
+
+
+# ---------------------------------------------------------------------------
+# Integration: _make_turboquant_prompt_cache
+# ---------------------------------------------------------------------------
+
+
+class TestInferenceIntegration:
+    """Tests for TurboQuant integration in inference.py."""
+
+    def test_make_turboquant_prompt_cache_creates_turboquant(self):
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.inference import _make_turboquant_prompt_cache
+        from olmlx.engine.turboquant_cache import TurboQuantKVCache
+
+        model = MagicMock()
+        model.layers = [MagicMock() for _ in range(2)]
+        model.args.head_dim = 64
+
+        cache = _make_turboquant_prompt_cache(model, bits=4)
+        assert len(cache) == 2
+        assert all(isinstance(c, TurboQuantKVCache) for c in cache)
+
+    def test_make_turboquant_prompt_cache_bits(self):
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.inference import _make_turboquant_prompt_cache
+
+        model = MagicMock()
+        model.layers = [MagicMock() for _ in range(1)]
+        model.args.head_dim = 64
+
+        cache_4 = _make_turboquant_prompt_cache(model, bits=4)
+        assert cache_4[0].bits == 4
+
+        cache_2 = _make_turboquant_prompt_cache(model, bits=2)
+        assert cache_2[0].bits == 2
+
+
+class TestBitsValidation:
+    """Validate that unsupported bit-widths raise clear errors."""
+
+    def test_invalid_bits_raises(self):
+        from olmlx.engine.turboquant import get_codebook
+
+        with pytest.raises(ValueError, match="TurboQuant supports"):
+            get_codebook(bits=3, dim=128)
+
+    def test_valid_bits_no_error(self):
+        from olmlx.engine.turboquant import get_codebook
+
+        get_codebook(bits=2, dim=128)
+        get_codebook(bits=4, dim=128)
+
+
+class TestDiskCacheGuard:
+    """Verify TurboQuant caches are not saved to disk."""
+
+    def test_turboquant_cache_not_serializable(self):
+        from olmlx.engine.model_manager import _is_serializable_cache
+        from olmlx.engine.turboquant import TurboQuantRotation
+        from olmlx.engine.turboquant_cache import TurboQuantKVCache
+
+        rot = TurboQuantRotation(head_dim=64, seed=0)
+        cache = [TurboQuantKVCache(bits=4, rotation_key=rot, rotation_value=rot)]
+        assert not _is_serializable_cache(cache)
+
+    def test_standard_cache_serializable(self):
+        from mlx_lm.models.cache import KVCache
+
+        from olmlx.engine.model_manager import _is_serializable_cache
+
+        cache = [KVCache()]
+        assert _is_serializable_cache(cache)


### PR DESCRIPTION
## Summary

- Implement TurboQuant_mse (arxiv 2504.19874) for KV cache compression during inference
- Support 2-bit (~7.5x compression) and 4-bit (~3.9x compression) with minimal quality loss (<5% relative MSE at 4-bit)
- Integrate as drop-in `TurboQuantKVCache` replacing mlx-lm's `KVCache` — no changes to attention code needed

## Design

**Algorithm:** normalize vectors → rotate via per-layer orthogonal matrix (QR decomposition) → scalar quantize each coordinate using precomputed Lloyd-Max codebooks → store compact indices + norms. Dequantize on fetch via centroid lookup → inverse rotation → rescale.

**New files:**
- `olmlx/engine/turboquant.py` — core algorithm (codebooks, rotation, quantize/dequantize)
- `olmlx/engine/turboquant_cache.py` — `TurboQuantKVCache` class + `make_turboquant_cache` factory
- `tests/test_turboquant.py` — 37 tests

**Modified files:**
- `olmlx/config.py` — `kv_cache_quant` experimental setting
- `olmlx/engine/inference.py` — cache creation integration
- `olmlx/engine/model_manager.py` — disk cache offload guard for non-serializable caches

**Usage:** `OLMLX_EXPERIMENTAL_KV_CACHE_QUANT=turboquant:4 uv run olmlx`

Closes #111

## Test plan

- [x] 37 unit tests covering codebooks, rotation matrices, quantize/dequantize roundtrip quality, cache operations, config parsing, integration, validation, and disk cache guard
- [x] Full test suite passes (1347 tests, 0 failures)
- [ ] Manual test: run server with `OLMLX_EXPERIMENTAL_KV_CACHE_QUANT=turboquant:4`, send multi-turn chat, verify coherent responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)