### PR TITLE
fix: support MiniMax block_sparse_moe in Flash-MoE

### DIFF
--- a/olmlx/engine/flash/flash_moe_model.py
+++ b/olmlx/engine/flash/flash_moe_model.py
@@ -116,6 +116,42 @@ class _FlashMoEQwen3Next(nn.Module):
         return y + shared_y
 
 
+class _FlashMoEMiniMax(nn.Module):
+    """Replacement MoE layer for MiniMax-style models.
+
+    Gate is nn.Linear returning logits; uses sigmoid scoring with
+    e_score_correction_bias for expert selection.
+    """
+
+    def __init__(self, original_moe, flash_moe: FlashMoE):
+        super().__init__()
+        if getattr(original_moe, "sharding_group", None) is not None:
+            raise NotImplementedError(
+                "Flash-MoE does not support distributed tensor parallelism. "
+                "Each rank loads all needed experts, so all_sum would produce "
+                "incorrect results. Disable distributed or Flash-MoE."
+            )
+        self.gate = original_moe.gate
+        self.num_experts_per_tok = original_moe.num_experts_per_tok
+        self.e_score_correction_bias = original_moe.e_score_correction_bias
+        self._flash_moe = flash_moe
+
+    def __call__(self, x):
+        gates = self.gate(x.astype(mx.float32))
+        scores = mx.sigmoid(gates)
+        orig_scores = scores
+        scores = scores + self.e_score_correction_bias
+
+        k = self.num_experts_per_tok
+        inds = mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+        scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+        scores = scores / (mx.sum(scores, axis=-1, keepdims=True) + 1e-20)
+        scores = scores.astype(x.dtype)
+
+        y = self._flash_moe(x, inds, scores)
+        return y.astype(x.dtype)
+
+
 class FlashMoeModelWrapper(nn.Module):
     """Wraps an mlx-lm model for Flash-MoE inference.
 
@@ -166,6 +202,21 @@ class FlashMoeModelWrapper(nn.Module):
         return self._model.args
 
 
+def _find_moe_module(layer: nn.Module) -> tuple[str, nn.Module]:
+    """Find the MoE module on a decoder layer.
+
+    Returns (attr_name, module) — the attribute may be 'mlp' (DeepSeek,
+    Qwen3-Next, gpt-oss) or 'block_sparse_moe' (MiniMax).
+    """
+    for attr in ("block_sparse_moe", "mlp"):
+        mod = getattr(layer, attr, None)
+        if mod is not None:
+            return attr, mod
+    raise AttributeError(
+        f"Layer {layer} has neither 'mlp' nor 'block_sparse_moe' attribute"
+    )
+
+
 def _replace_moe_layers(
     model: nn.Module,
     weight_store: FlashMoeWeightStore,
@@ -181,7 +232,7 @@ def _replace_moe_layers(
 
     for layer_idx in moe_layer_indices:
         layer = layers[layer_idx]
-        moe_module = layer.mlp
+        moe_attr, moe_module = _find_moe_module(layer)
 
         # Extract activation function from the original SwitchGLU before we delete it
         activation = None
@@ -203,12 +254,13 @@ def _replace_moe_layers(
         )
 
         # Detect router style and create appropriate replacement.
-        # Qwen3-Next: gate is a linear layer (nn.Linear or QuantizedLinear) returning logits; we apply softmax.
-        # DeepSeek-V3: gate is a custom module returning (inds, scores) directly.
         gate = getattr(moe_module, "gate", None)
         if hasattr(moe_module, "shared_expert_gate") and gate is not None:
             # Qwen3-Next style: linear gate + shared_expert + shared_expert_gate
             replacement = _FlashMoEQwen3Next(moe_module, flash_moe)
+        elif hasattr(moe_module, "e_score_correction_bias") and gate is not None:
+            # MiniMax style: sigmoid gate + correction bias
+            replacement = _FlashMoEMiniMax(moe_module, flash_moe)
         elif gate is not None:
             # DeepSeek-V3 / Kimi-K2.5 style: gate returns (inds, scores)
             replacement = _FlashMoEDeepSeek(moe_module, flash_moe)
@@ -226,8 +278,8 @@ def _replace_moe_layers(
                 delattr(moe_module, attr)
                 break
 
-        # Replace the entire mlp module
-        layer.mlp = replacement
+        # Replace the MoE module on the layer
+        setattr(layer, moe_attr, replacement)
         replaced += 1
 
     gc.collect()

--- a/olmlx/engine/flash/flash_moe_model.py
+++ b/olmlx/engine/flash/flash_moe_model.py
@@ -213,7 +213,7 @@ def _find_moe_module(layer: nn.Module) -> tuple[str, nn.Module]:
     Returns (attr_name, module) — the attribute may be 'mlp' (DeepSeek,
     Qwen3-Next, gpt-oss) or 'block_sparse_moe' (MiniMax).
     """
-    for attr in ("block_sparse_moe", "mlp"):
+    for attr in ("mlp", "block_sparse_moe"):
         mod = getattr(layer, attr, None)
         if mod is not None:
             return attr, mod
@@ -259,17 +259,20 @@ def _replace_moe_layers(
         )
 
         # Detect router style and create appropriate replacement.
+        # Structural checks use gate type: nn.Linear (or QuantizedLinear)
+        # returns logits; custom gate modules return (inds, scores) directly.
         gate = getattr(moe_module, "gate", None)
-        if hasattr(moe_module, "shared_expert_gate") and gate is not None:
+        gate_is_linear = isinstance(gate, (nn.Linear,)) or (
+            hasattr(nn, "QuantizedLinear") and isinstance(gate, nn.QuantizedLinear)
+        )
+        if hasattr(moe_module, "shared_expert_gate") and gate_is_linear:
             # Qwen3-Next style: linear gate + shared_expert + shared_expert_gate
             replacement = _FlashMoEQwen3Next(moe_module, flash_moe)
-        elif hasattr(moe_module, "e_score_correction_bias") and gate is not None:
-            # MiniMax style: sigmoid gate + correction bias.
-            # DeepSeek V3 also has e_score_correction_bias but on its MoEGate
-            # submodule (moe_module.gate), not the MoE block itself.
+        elif gate_is_linear and hasattr(moe_module, "e_score_correction_bias"):
+            # MiniMax style: linear gate with sigmoid scoring + correction bias
             replacement = _FlashMoEMiniMax(moe_module, flash_moe)
         elif gate is not None:
-            # DeepSeek-V3 / Kimi-K2.5 style: gate returns (inds, scores)
+            # DeepSeek-V3 / Kimi-K2.5 style: custom gate returns (inds, scores)
             replacement = _FlashMoEDeepSeek(moe_module, flash_moe)
         else:
             # gpt-oss style (has router + experts)

--- a/olmlx/engine/flash/flash_moe_model.py
+++ b/olmlx/engine/flash/flash_moe_model.py
@@ -135,6 +135,8 @@ class _FlashMoEMiniMax(nn.Module):
         self.num_experts_per_tok = original_moe.num_experts_per_tok
         self.e_score_correction_bias = original_moe.e_score_correction_bias
         self._flash_moe = flash_moe
+        if hasattr(original_moe, "shared_experts"):
+            self.shared_experts = original_moe.shared_experts
 
     def __call__(self, x):
         gates = self.gate(x.astype(mx.float32))
@@ -149,7 +151,10 @@ class _FlashMoEMiniMax(nn.Module):
         scores = scores.astype(x.dtype)
 
         y = self._flash_moe(x, inds, scores)
-        return y.astype(x.dtype)
+        y = y.astype(x.dtype)
+        if hasattr(self, "shared_experts"):
+            y = y + self.shared_experts(x)
+        return y
 
 
 class FlashMoeModelWrapper(nn.Module):
@@ -259,7 +264,9 @@ def _replace_moe_layers(
             # Qwen3-Next style: linear gate + shared_expert + shared_expert_gate
             replacement = _FlashMoEQwen3Next(moe_module, flash_moe)
         elif hasattr(moe_module, "e_score_correction_bias") and gate is not None:
-            # MiniMax style: sigmoid gate + correction bias
+            # MiniMax style: sigmoid gate + correction bias.
+            # DeepSeek V3 also has e_score_correction_bias but on its MoEGate
+            # submodule (moe_module.gate), not the MoE block itself.
             replacement = _FlashMoEMiniMax(moe_module, flash_moe)
         elif gate is not None:
             # DeepSeek-V3 / Kimi-K2.5 style: gate returns (inds, scores)

--- a/olmlx/engine/flash/moe_bundler.py
+++ b/olmlx/engine/flash/moe_bundler.py
@@ -170,9 +170,23 @@ def _try_load_tensor(
 def _detect_expert_prefix(
     model_dir: Path, sample_layer: int, index: dict | None
 ) -> str:
-    """Detect whether expert weights use 'switch_mlp' or 'experts' prefix."""
-    for prefix in ("switch_mlp", "experts"):
-        name = f"model.layers.{sample_layer}.mlp.{prefix}.gate_proj.weight"
+    """Detect the full MoE weight prefix for expert projections.
+
+    Returns the prefix from ``model.layers.{i}.`` up to and including the
+    expert container, e.g. ``mlp.switch_mlp`` or ``block_sparse_moe.switch_mlp``.
+    """
+    # Try all known (moe_module, expert_container) combinations
+    _MOE_MODULES = ("mlp", "block_sparse_moe")
+    _EXPERT_CONTAINERS = ("switch_mlp", "experts")
+
+    candidates = [
+        f"{mod}.{cont}"
+        for mod in _MOE_MODULES
+        for cont in _EXPERT_CONTAINERS
+    ]
+
+    for prefix in candidates:
+        name = f"model.layers.{sample_layer}.{prefix}.gate_proj.weight"
         # Check index first (fast, no I/O)
         if index and name in index.get("weight_map", {}):
             return prefix
@@ -186,14 +200,14 @@ def _detect_expert_prefix(
         if sf_key not in _shard_cache:
             _shard_cache[sf_key] = mx.load(sf_key)
         tensors = _shard_cache[sf_key]
-        for prefix in ("switch_mlp", "experts"):
-            name = f"model.layers.{sample_layer}.mlp.{prefix}.gate_proj.weight"
+        for prefix in candidates:
+            name = f"model.layers.{sample_layer}.{prefix}.gate_proj.weight"
             if name in tensors:
                 return prefix
 
     raise ValueError(
         f"Cannot find expert weights for layer {sample_layer} "
-        f"(tried switch_mlp and experts prefixes)"
+        f"(tried prefixes: {', '.join(candidates)})"
     )
 
 
@@ -360,11 +374,11 @@ def bundle_moe_experts(
     layouts: dict[int, MoeExpertLayout] = {}
 
     try:
-        # Detect expert weight prefix: "switch_mlp" (DeepSeek-V3) or "experts" (gpt-oss)
+        # Detect expert weight prefix, e.g. "mlp.switch_mlp" or "block_sparse_moe.switch_mlp"
         expert_prefix = _detect_expert_prefix(model_dir, moe_layers[0], index)
 
         # Process first MoE layer to determine component manifest
-        first_prefix = f"model.layers.{moe_layers[0]}.mlp.{expert_prefix}"
+        first_prefix = f"model.layers.{moe_layers[0]}.{expert_prefix}"
         _, manifest = _collect_all_projections(model_dir, first_prefix, index)
         expert_byte_size = sum(entry["nbytes"] for entry in manifest)
 
@@ -379,7 +393,7 @@ def bundle_moe_experts(
             group_size = quant_config.get("group_size", 32)
             quant_mode = quant_config.get("mode", "affine")
         for layer_idx in moe_layers:
-            prefix = f"model.layers.{layer_idx}.mlp.{expert_prefix}"
+            prefix = f"model.layers.{layer_idx}.{expert_prefix}"
 
             all_components, layer_manifest = _collect_all_projections(
                 model_dir, prefix, index

--- a/olmlx/engine/flash/moe_bundler.py
+++ b/olmlx/engine/flash/moe_bundler.py
@@ -180,9 +180,7 @@ def _detect_expert_prefix(
     _EXPERT_CONTAINERS = ("switch_mlp", "experts")
 
     candidates = [
-        f"{mod}.{cont}"
-        for mod in _MOE_MODULES
-        for cont in _EXPERT_CONTAINERS
+        f"{mod}.{cont}" for mod in _MOE_MODULES for cont in _EXPERT_CONTAINERS
     ]
 
     for prefix in candidates:

--- a/tests/test_flash_moe_bundler.py
+++ b/tests/test_flash_moe_bundler.py
@@ -430,3 +430,210 @@ class TestBundleMoeExperts:
 
         assert 0 in layouts
         assert layouts[0].num_experts == experts
+
+
+def _make_synthetic_minimax_moe_weights(
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    num_moe_layers: int,
+    tmp_path: Path,
+    quantized: bool = False,
+) -> Path:
+    """Create synthetic safetensors with MiniMax-style block_sparse_moe naming.
+
+    MiniMax uses block_sparse_moe instead of mlp as the MoE module name:
+      model.layers.{l}.block_sparse_moe.switch_mlp.gate_proj.weight
+    """
+    from safetensors.numpy import save_file
+
+    rng = np.random.RandomState(42)
+    tensors = {}
+
+    for layer in range(num_moe_layers):
+        prefix = f"model.layers.{layer}.block_sparse_moe"
+
+        # Router weights
+        tensors[f"{prefix}.gate.weight"] = rng.randn(num_experts, hidden_size).astype(
+            np.float16
+        )
+
+        if not quantized:
+            tensors[f"{prefix}.switch_mlp.gate_proj.weight"] = rng.randn(
+                num_experts, intermediate_size, hidden_size
+            ).astype(np.float16)
+            tensors[f"{prefix}.switch_mlp.up_proj.weight"] = rng.randn(
+                num_experts, intermediate_size, hidden_size
+            ).astype(np.float16)
+            tensors[f"{prefix}.switch_mlp.down_proj.weight"] = rng.randn(
+                num_experts, hidden_size, intermediate_size
+            ).astype(np.float16)
+        else:
+            group_size = 32
+            bits = 4
+            gate_packed_dim = hidden_size * bits // 32
+            down_packed_dim = intermediate_size * bits // 32
+
+            for proj, out_dim, packed_dim, in_dim in [
+                ("gate_proj", intermediate_size, gate_packed_dim, hidden_size),
+                ("up_proj", intermediate_size, gate_packed_dim, hidden_size),
+                ("down_proj", hidden_size, down_packed_dim, intermediate_size),
+            ]:
+                tensors[f"{prefix}.switch_mlp.{proj}.weight"] = rng.randint(
+                    0, 2**31, (num_experts, out_dim, packed_dim)
+                ).astype(np.uint32)
+                tensors[f"{prefix}.switch_mlp.{proj}.scales"] = rng.randn(
+                    num_experts, out_dim, in_dim // group_size
+                ).astype(np.float16)
+                tensors[f"{prefix}.switch_mlp.{proj}.biases"] = rng.randn(
+                    num_experts, out_dim, in_dim // group_size
+                ).astype(np.float16)
+
+    # Non-MLP weights
+    tensors["model.embed_tokens.weight"] = rng.randn(100, hidden_size).astype(
+        np.float16
+    )
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    save_file(tensors, str(model_dir / "model.safetensors"))
+
+    # MiniMax config: all layers are MoE, no moe_layer_freq
+    config = {
+        "hidden_size": hidden_size,
+        "intermediate_size": intermediate_size,
+        "num_hidden_layers": num_moe_layers,
+        "num_local_experts": num_experts,
+        "num_experts_per_tok": 2,
+        "model_type": "minimax_m2",
+    }
+    if quantized:
+        config["quantization"] = {"bits": 4, "group_size": 32}
+    (model_dir / "config.json").write_text(json.dumps(config))
+
+    return model_dir
+
+
+class TestBundleMiniMaxMoeExperts:
+    """Test bundler with MiniMax-style block_sparse_moe weight naming."""
+
+    def test_detect_block_sparse_moe_prefix(self, tmp_path):
+        """Should detect block_sparse_moe.switch_mlp as the expert prefix."""
+        hidden, inter, experts = 64, 32, 4
+        model_dir = _make_synthetic_minimax_moe_weights(
+            hidden, inter, experts, 1, tmp_path
+        )
+
+        from olmlx.engine.flash.moe_bundler import bundle_moe_experts
+
+        layouts = bundle_moe_experts(model_dir, tmp_path / "flash_moe")
+
+        assert 0 in layouts
+        assert layouts[0].num_experts == experts
+
+    def test_bundle_preserves_minimax_expert_data(self, tmp_path):
+        """Bundled data should match original block_sparse_moe weights."""
+        hidden, inter, experts = 64, 32, 8
+        model_dir = _make_synthetic_minimax_moe_weights(
+            hidden, inter, experts, 1, tmp_path
+        )
+        output_dir = tmp_path / "flash_moe"
+
+        from safetensors.numpy import load_file
+
+        from olmlx.engine.flash.moe_bundler import bundle_moe_experts
+
+        original = load_file(str(model_dir / "model.safetensors"))
+        gate_w = original[
+            "model.layers.0.block_sparse_moe.switch_mlp.gate_proj.weight"
+        ]
+
+        layouts = bundle_moe_experts(model_dir, output_dir)
+        layout = layouts[0]
+
+        expert_idx = 3
+        expert_offset = int(layout.offsets[expert_idx])
+        with open(layout.file_path, "rb") as f:
+            f.seek(expert_offset)
+            raw = f.read(inter * hidden * 2)  # gate_proj float16
+
+        gate_read = np.frombuffer(raw, dtype=np.float16).reshape(inter, hidden)
+        np.testing.assert_array_equal(gate_read, gate_w[expert_idx])
+
+    def test_bundle_quantized_minimax(self, tmp_path):
+        """Quantized MiniMax model should bundle correctly."""
+        hidden, inter, experts = 64, 32, 4
+        model_dir = _make_synthetic_minimax_moe_weights(
+            hidden, inter, experts, 1, tmp_path, quantized=True
+        )
+        output_dir = tmp_path / "flash_moe"
+
+        from olmlx.engine.flash.moe_bundler import (
+            MOE_HEADER_SIZE,
+            bundle_moe_experts,
+            parse_moe_header,
+        )
+
+        layouts = bundle_moe_experts(model_dir, output_dir)
+        layout = layouts[0]
+
+        with open(layout.file_path, "rb") as f:
+            header = parse_moe_header(f.read(MOE_HEADER_SIZE))
+        assert header["is_quantized"] is True
+        assert header["bits"] == 4
+
+    def test_bundle_sharded_minimax(self, tmp_path):
+        """Should handle sharded MiniMax models via safetensors index."""
+        from safetensors.numpy import save_file
+
+        hidden, inter, experts = 64, 32, 4
+        rng = np.random.RandomState(99)
+
+        model_dir = tmp_path / "sharded_model"
+        model_dir.mkdir()
+
+        # Shard 1: gate_proj
+        shard1 = {
+            "model.layers.0.block_sparse_moe.switch_mlp.gate_proj.weight": rng.randn(
+                experts, inter, hidden
+            ).astype(np.float16),
+            "model.layers.0.block_sparse_moe.gate.weight": rng.randn(
+                experts, hidden
+            ).astype(np.float16),
+        }
+        save_file(shard1, str(model_dir / "model-00001-of-00002.safetensors"))
+
+        # Shard 2: up_proj and down_proj
+        shard2 = {
+            "model.layers.0.block_sparse_moe.switch_mlp.up_proj.weight": rng.randn(
+                experts, inter, hidden
+            ).astype(np.float16),
+            "model.layers.0.block_sparse_moe.switch_mlp.down_proj.weight": rng.randn(
+                experts, hidden, inter
+            ).astype(np.float16),
+        }
+        save_file(shard2, str(model_dir / "model-00002-of-00002.safetensors"))
+
+        # Index
+        weight_map = {k: "model-00001-of-00002.safetensors" for k in shard1}
+        weight_map.update({k: "model-00002-of-00002.safetensors" for k in shard2})
+        (model_dir / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": weight_map})
+        )
+
+        # Config
+        config = {
+            "hidden_size": hidden,
+            "intermediate_size": inter,
+            "num_hidden_layers": 1,
+            "num_local_experts": experts,
+            "num_experts_per_tok": 2,
+            "model_type": "minimax_m2",
+        }
+        (model_dir / "config.json").write_text(json.dumps(config))
+
+        from olmlx.engine.flash.moe_bundler import bundle_moe_experts
+
+        layouts = bundle_moe_experts(model_dir, tmp_path / "flash_moe")
+        assert 0 in layouts
+        assert layouts[0].num_experts == experts

--- a/tests/test_flash_moe_bundler.py
+++ b/tests/test_flash_moe_bundler.py
@@ -544,9 +544,7 @@ class TestBundleMiniMaxMoeExperts:
         from olmlx.engine.flash.moe_bundler import bundle_moe_experts
 
         original = load_file(str(model_dir / "model.safetensors"))
-        gate_w = original[
-            "model.layers.0.block_sparse_moe.switch_mlp.gate_proj.weight"
-        ]
+        gate_w = original["model.layers.0.block_sparse_moe.switch_mlp.gate_proj.weight"]
 
         layouts = bundle_moe_experts(model_dir, output_dir)
         layout = layouts[0]

--- a/tests/test_flash_moe_model.py
+++ b/tests/test_flash_moe_model.py
@@ -412,3 +412,184 @@ class TestFlashMoeQwen3Next:
         result = wrapped.layers[1].mlp(x)
         mx.eval(result)
         assert result.shape == (1, 4, hidden)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic MiniMax-like model (block_sparse_moe instead of mlp)
+# ---------------------------------------------------------------------------
+
+
+class _MockMiniMaxSparseMoeBlock(nn.Module):
+    """Mock MiniMaxSparseMoeBlock — sigmoid routing with correction bias."""
+
+    def __init__(
+        self, hidden_size, intermediate_size, num_experts, num_experts_per_tok
+    ):
+        super().__init__()
+        self.num_experts_per_tok = num_experts_per_tok
+        self.gate = nn.Linear(hidden_size, num_experts, bias=False)
+        self.switch_mlp = _MockSwitchGLU(hidden_size, intermediate_size, num_experts)
+        self.e_score_correction_bias = mx.zeros((num_experts,))
+        self.sharding_group = None
+
+    def __call__(self, x):
+        gates = self.gate(x.astype(mx.float32))
+        scores = mx.sigmoid(gates)
+        orig_scores = scores
+        scores = scores + self.e_score_correction_bias
+        k = self.num_experts_per_tok
+        inds = mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+        scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+        scores = scores / (mx.sum(scores, axis=-1, keepdims=True) + 1e-20)
+        scores = scores.astype(x.dtype)
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None]).sum(axis=-2)
+        return y
+
+
+class _MockMiniMaxDecoderLayer(nn.Module):
+    """MiniMax decoder layer: MoE is at block_sparse_moe, NOT mlp."""
+
+    def __init__(
+        self, hidden_size, intermediate_size, num_experts, num_experts_per_tok, is_moe
+    ):
+        super().__init__()
+        if is_moe:
+            self.block_sparse_moe = _MockMiniMaxSparseMoeBlock(
+                hidden_size, intermediate_size, num_experts, num_experts_per_tok
+            )
+        else:
+            self.mlp = _MockMLP(hidden_size, intermediate_size)
+
+
+class _MockMiniMaxModel(nn.Module):
+    def __init__(
+        self,
+        hidden_size,
+        intermediate_size,
+        num_experts,
+        num_experts_per_tok,
+        num_dense,
+        num_moe,
+    ):
+        super().__init__()
+        self.args = type(
+            "Args",
+            (),
+            {
+                "hidden_size": hidden_size,
+                "intermediate_size": intermediate_size,
+                "num_local_experts": num_experts,
+                "num_experts_per_tok": num_experts_per_tok,
+            },
+        )()
+        layers = []
+        for i in range(num_dense):
+            layers.append(
+                _MockMiniMaxDecoderLayer(
+                    hidden_size,
+                    intermediate_size,
+                    num_experts,
+                    num_experts_per_tok,
+                    is_moe=False,
+                )
+            )
+        for i in range(num_moe):
+            layers.append(
+                _MockMiniMaxDecoderLayer(
+                    hidden_size,
+                    intermediate_size,
+                    num_experts,
+                    num_experts_per_tok,
+                    is_moe=True,
+                )
+            )
+        self.layers = layers
+
+    def __call__(self, x, cache=None):
+        for layer in self.layers:
+            if hasattr(layer, "block_sparse_moe"):
+                x = layer.block_sparse_moe(x)
+            else:
+                x = layer.mlp(x)
+        return x
+
+
+class TestFlashMoeMiniMax:
+    @pytest.fixture()
+    def model_and_store(self, tmp_path):
+        from tests.test_flash_moe_bundler import _make_synthetic_minimax_moe_weights
+
+        hidden, inter, experts = 64, 32, 8
+        num_dense, num_moe = 0, 2
+        num_experts_per_tok = 2
+
+        model_dir = _make_synthetic_minimax_moe_weights(
+            hidden, inter, experts, num_moe, tmp_path
+        )
+        output_dir = tmp_path / "flash_moe"
+
+        from olmlx.engine.flash.moe_bundler import bundle_moe_experts
+
+        bundle_moe_experts(model_dir, output_dir)
+
+        from olmlx.engine.flash.moe_weight_store import FlashMoeWeightStore
+
+        store = FlashMoeWeightStore(
+            output_dir, num_io_threads=4, cache_budget_experts=16
+        )
+
+        model = _MockMiniMaxModel(
+            hidden, inter, experts, num_experts_per_tok, num_dense, num_moe
+        )
+        return model, store, hidden, inter, experts, num_experts_per_tok
+
+    def test_replaces_block_sparse_moe_layers(self, model_and_store):
+        """MoE layers at block_sparse_moe should be replaced with FlashMoE."""
+        model, store, hidden, inter, experts, num_experts_per_tok = model_and_store
+
+        from olmlx.engine.flash.flash_moe_model import FlashMoeModelWrapper
+
+        moe_layer_indices = [0, 1]
+        wrapped = FlashMoeModelWrapper(
+            model, store, moe_layer_indices, hidden, inter, experts, num_experts_per_tok
+        )
+
+        for i in [0, 1]:
+            layer = wrapped.layers[i]
+            # The MoE module should be replaced
+            moe_module = getattr(layer, "block_sparse_moe", None)
+            assert moe_module is not None
+            assert hasattr(moe_module, "_flash_moe")
+
+    def test_preserves_minimax_gate_and_bias(self, model_and_store):
+        """Gate and correction bias should be preserved in the wrapper."""
+        model, store, hidden, inter, experts, num_experts_per_tok = model_and_store
+
+        from olmlx.engine.flash.flash_moe_model import FlashMoeModelWrapper
+
+        moe_layer_indices = [0, 1]
+        wrapped = FlashMoeModelWrapper(
+            model, store, moe_layer_indices, hidden, inter, experts, num_experts_per_tok
+        )
+
+        for i in [0, 1]:
+            moe = wrapped.layers[i].block_sparse_moe
+            assert hasattr(moe, "gate")
+            assert hasattr(moe, "e_score_correction_bias")
+
+    def test_minimax_forward_pass(self, model_and_store):
+        """Forward pass through MiniMax Flash-MoE wrapper should produce correct shape."""
+        model, store, hidden, inter, experts, num_experts_per_tok = model_and_store
+
+        from olmlx.engine.flash.flash_moe_model import FlashMoeModelWrapper
+
+        moe_layer_indices = [0, 1]
+        wrapped = FlashMoeModelWrapper(
+            model, store, moe_layer_indices, hidden, inter, experts, num_experts_per_tok
+        )
+
+        x = mx.random.normal((1, 4, hidden))
+        result = wrapped.layers[0].block_sparse_moe(x)
+        mx.eval(result)
+        assert result.shape == (1, 4, hidden)


### PR DESCRIPTION
## Summary

- Fix Flash-MoE preparation and model wrapping for MiniMax M2.5 (and similar models that use `block_sparse_moe` instead of `mlp` as the MoE module attribute)
- The bundler now detects both `mlp.switch_mlp` and `block_sparse_moe.switch_mlp` weight prefixes in safetensors
- The model wrapper dynamically finds the MoE module on each layer (`layer.mlp` or `layer.block_sparse_moe`)
- Added `_FlashMoEMiniMax` wrapper implementing sigmoid routing with `e_score_correction_bias`

## Test plan

- [x] All 1362 existing tests pass (no regressions)
- [x] New bundler tests: detect prefix, preserve data, quantized, sharded — all for `block_sparse_moe` naming
- [x] New model wrapper tests: layer replacement, gate/bias preservation, forward pass — for MiniMax-style models
- [ ] Manual: `olmlx flash prepare mlx-community/MiniMax-M2.5-4bit` completes successfully
- [ ] Manual: `OLMLX_EXPERIMENTAL_FLASH_MOE=true olmlx serve` loads and serves MiniMax M2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)