### PR TITLE
feat: address open GitHub issues #126, #128, #129, #130

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,23 @@
 
 Ollama-compatible API server using Apple MLX for local inference on Apple Silicon.
 
+## Usage Context
+
+This is a **single-user, localhost-only** inference server. It is not designed for multi-tenant or public-facing deployment. Implications for code review:
+
+- **No authentication/authorization** — the server binds to localhost by default; there are no user accounts or API keys.
+- **No rate limiting** — one user, one machine. The inference lock provides natural backpressure.
+- **No TLS** — traffic stays on the loopback interface.
+- **Error messages may include internal details** (paths, model names) — acceptable for a local tool.
+- **No Cache-Control headers** — no shared proxy or browser caching concerns.
+
 ## Project Structure
 
 ```
 olmlx/
 ├── app.py              # FastAPI app factory, middleware, router registration
 ├── config.py           # Settings (pydantic-settings, OLMLX_ env prefix)
-├── cli.py              # CLI with subcommands (serve, chat, service, models, config)
+├── cli.py              # CLI with subcommands (serve, chat, service, models incl. search, config)
 ├── __main__.py         # Entry point (delegates to cli.py)
 ├── chat/
 │   ├── __init__.py     # Package exports
@@ -21,7 +31,7 @@ olmlx/
 │   ├── distributed_worker.py # Worker entry point for non-rank-0 nodes (launched via SSH)
 │   ├── inference.py    # generate_chat, generate_completion, generate_embeddings
 │   ├── model_manager.py # Model loading/unloading, keep-alive, LRU eviction
-│   ├── registry.py    # Ollama name → HuggingFace repo mapping via models.json
+│   ├── registry.py    # Ollama name → HuggingFace repo mapping via models.json, fuzzy search
 │   ├── template_caps.py # Chat template capability detection (tools, thinking)
 │   ├── tool_parser.py  # Multi-format tool call parsing (Qwen, Mistral, Llama, DeepSeek, bare JSON)
 │   ├── turboquant.py   # TurboQuant_mse: rotation, Lloyd-Max codebooks, bit-packed quantize/dequantize
@@ -51,7 +61,7 @@ olmlx/
 │   ├── pull.py         # Ollama pull schemas
 │   └── status.py       # Ollama status schemas
 └── utils/
-    ├── streaming.py    # async_mlx_stream — sync-to-async streaming bridge
+    ├── streaming.py    # async_mlx_stream, safe_ndjson_stream — streaming bridge + error wrapper
     └── timing.py       # Timer, TimingStats
 ```
 
@@ -64,9 +74,9 @@ olmlx/
 - **Model storage**: Models stored by HF repo path (e.g. `Qwen--Qwen3-8B`). `ModelManager` takes a `ModelStore` dependency for local-first config loading and auto-download.
 - **Active inference protection**: `LoadedModel.active_refs` prevents LRU eviction and expiry of models currently serving requests.
 - **Memory safety**: After loading, checks Metal memory (active + cache) against `OLMLX_MEMORY_LIMIT_FRACTION` of system RAM. Rejects oversized models with `MemoryError` (HTTP 503) to prevent uncatchable Metal OOM crashes.
-- **Stream cleanup**: All streaming routers use `try/finally` with `await result.aclose()` to ensure GPU resources are released on client disconnect.
+- **Stream cleanup**: NDJSON routers (generate, chat, manage) use `safe_ndjson_stream()` from `utils/streaming.py` — a shared async generator that wraps a source with error handling and guaranteed `aclose()`. OpenAI and Anthropic routers have their own cleanup patterns due to SSE framing differences.
 - **Auto-registration**: Direct HF paths (e.g. `Qwen/Qwen3-8B`) are auto-registered in `models.json` on first load or pull.
-- **Prompt caching**: KV cache reuse across requests when prompts share a common prefix. Works with both mlx-lm (text) and mlx-vlm (vision) models. Controlled via `OLMLX_PROMPT_CACHE` setting.
+- **Prompt caching**: KV cache reuse across requests when prompts share a common prefix. Works with both mlx-lm (text) and mlx-vlm (vision) models. Controlled via `OLMLX_PROMPT_CACHE` setting. `PromptCacheStore` async wrappers (`async_get`, `async_set`, `async_evict_all_to_disk`) offload disk I/O to `asyncio.to_thread()` to avoid blocking the event loop. All `_entries` mutations happen on the event loop; an eviction-generation counter prevents re-insertion of stale disk data after bulk eviction.
 - **TurboQuant KV cache quantization** (experimental): Compresses KV cache using TurboQuant_mse (arxiv 2504.19874). Algorithm: random rotation → Lloyd-Max scalar quantization per coordinate → bit-packed storage → inverse rotation on fetch. Supports 2-bit (~7.5x compression) and 4-bit (~3.9x compression). `TurboQuantKVCache` is a drop-in replacement for mlx-lm's `KVCache` — dequantizes on each `update_and_fetch` call (O(n) per step, same as attention). Per-layer rotation matrices via QR decomposition. Codebooks are standard Gaussian Lloyd-Max centroids scaled by 1/√(head_dim). Indices bit-packed: 2 per byte (4-bit) or 4 per byte (2-bit). Head dim detected from `model.args.head_dim` or K projection weight shape. Incompatible with disk cache offload (guarded in `_save_to_disk`). Config: `OLMLX_EXPERIMENTAL_KV_CACHE_QUANT=turboquant:4` (or `:2`), validated at startup.
 - **Model load timeout**: Configurable via `OLMLX_MODEL_LOAD_TIMEOUT` with dedicated `ModelLoadTimeoutError` (HTTP 504).
 - **Terminal chat** (`chat/`): `olmlx chat` runs inference directly in-process via `ModelManager`/`generate_chat()` — no HTTP server needed. Connects to external MCP servers (stdio/SSE) for tool use with a full agent loop (model → tool calls → MCP execution → results fed back → continue). Uses `parse_model_output()` from `engine/tool_parser.py` for thinking/tool extraction. MCP config uses Claude Desktop format (`~/.olmlx/mcp.json`).

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -606,6 +606,23 @@ def cmd_models_list(_args):
         )
 
 
+def cmd_models_search(args):
+    """Search for models by name."""
+    try:
+        store = _create_store()
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    results = store.registry.search(args.query)
+    if not results:
+        print(f"No models matching '{args.query}'.")
+        return
+    print(f"{'NAME':<30} {'HF PATH'}")
+    print("-" * 60)
+    for name, hf_path in results:
+        print(f"{name:<30} {hf_path}")
+
+
 def cmd_models_show(args):
     """Show details for a specific model."""
     try:
@@ -619,7 +636,11 @@ def cmd_models_show(args):
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
     if manifest is None:
-        print(f"Model '{args.model_name}' not found locally.", file=sys.stderr)
+        print(
+            f"Model '{args.model_name}' not found locally.\n"
+            f"Try: olmlx models search {args.model_name}",
+            file=sys.stderr,
+        )
         sys.exit(1)
     print(f"Name:           {manifest.name}")
     print(f"HF Path:        {manifest.hf_path}")
@@ -653,7 +674,10 @@ def cmd_models_pull(args):
     except SystemExit:
         raise
     except Exception as e:
-        print(f"Error: {e}", file=sys.stderr, flush=True)
+        msg = f"Error: {e}"
+        if "not found" in str(e).lower():
+            msg += f"\nTry: olmlx models search {args.model_name}"
+        print(msg, file=sys.stderr, flush=True)
         sys.exit(1)
 
 
@@ -1136,6 +1160,8 @@ def build_parser() -> argparse.ArgumentParser:
     del_p = mdl_sub.add_parser("delete", help="Delete a local model")
     del_p.add_argument("model_name", help="Model name or HF path")
     del_p.add_argument("--yes", "-y", action="store_true", help="Skip confirmation")
+    search_p = mdl_sub.add_parser("search", help="Search for models by name")
+    search_p.add_argument("query", help="Search query")
 
     chat_p = sub.add_parser("chat", help="Interactive chat")
     chat_p.add_argument("model_name", nargs="?", help="Model name or HF path")
@@ -1262,6 +1288,8 @@ def cli_main():
             cmd_models_show(args)
         elif args.models_command == "delete":
             cmd_models_delete(args)
+        elif args.models_command == "search":
+            cmd_models_search(args)
         else:
             parser.parse_args(["models", "--help"])
     elif args.command == "flash":

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1589,7 +1589,9 @@ async def generate_chat(
     prompt_tokens = None
     if use_prompt_cache:
         prompt_tokens = _tokenize_for_cache(lm.text_tokenizer, prompt)
-        cached_state = await lm.prompt_cache_store.async_get(cache_id)
+        # Memory-only peek for debug logging; the authoritative lookup happens
+        # inside _stream_completion under the inference lock.
+        cached_state = lm.prompt_cache_store._entries.get(cache_id)
         logger.debug(
             "Prompt cache enabled: %d prompt tokens, existing cache=%s",
             len(prompt_tokens),

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -889,7 +889,7 @@ async def _stream_completion(
             logger.warning(
                 "Memory pressure high, evicting prompt caches to free GPU memory"
             )
-            lm.prompt_cache_store.evict_all_to_disk()
+            await lm.prompt_cache_store.async_evict_all_to_disk()
             gc.collect()
             mx.clear_cache()
             _safe_sync()  # Bug #120: ensure freed buffers are reclaimed
@@ -904,7 +904,7 @@ async def _stream_completion(
             and prompt_tokens is not None
             and make_prompt_cache is not None
         ):
-            cached = lm.prompt_cache_store.get(cache_id)
+            cached = await lm.prompt_cache_store.async_get(cache_id)
             logger.debug(
                 "Cache lookup: cached=%s, new prompt=%d tokens",
                 (
@@ -1047,7 +1047,7 @@ async def _stream_completion(
                     # Use full_prompt_tokens[:suffix_start] to match the trimmed
                     # KV state — working_cache was trimmed to suffix_start tokens.
                     if had_cache and full_prompt_tokens is not None:
-                        lm.prompt_cache_store.set(
+                        await lm.prompt_cache_store.async_set(
                             cache_id,
                             CachedPromptState(
                                 tokens=list(full_prompt_tokens[:suffix_start]),
@@ -1058,7 +1058,7 @@ async def _stream_completion(
                     # can actually reclaim GPU memory.
                     working_cache = None  # noqa: F841
                     working = None
-                    lm.prompt_cache_store.evict_all_to_disk()
+                    await lm.prompt_cache_store.async_evict_all_to_disk()
                     gc.collect()
                     mx.clear_cache()
                     # After evicting the prompt cache, mlx_lm will prefill
@@ -1235,7 +1235,7 @@ async def _stream_completion(
                         stored_tokens = list(full_prompt_tokens)[:max_cache_tokens]
                     else:
                         stored_tokens = stored_tokens[:max_cache_tokens]
-                    evicted = lm.prompt_cache_store.set(
+                    evicted = await lm.prompt_cache_store.async_set(
                         cache_id,
                         CachedPromptState(tokens=stored_tokens, cache=prompt_cache),
                     )
@@ -1262,7 +1262,7 @@ async def _stream_completion(
                         exc_info=True,
                     )
             else:
-                evicted = lm.prompt_cache_store.set(
+                evicted = await lm.prompt_cache_store.async_set(
                     cache_id,
                     CachedPromptState(
                         tokens=stored_tokens,
@@ -1589,7 +1589,7 @@ async def generate_chat(
     prompt_tokens = None
     if use_prompt_cache:
         prompt_tokens = _tokenize_for_cache(lm.text_tokenizer, prompt)
-        cached_state = lm.prompt_cache_store.get(cache_id)
+        cached_state = await lm.prompt_cache_store.async_get(cache_id)
         logger.debug(
             "Prompt cache enabled: %d prompt tokens, existing cache=%s",
             len(prompt_tokens),

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1591,7 +1591,7 @@ async def generate_chat(
         prompt_tokens = _tokenize_for_cache(lm.text_tokenizer, prompt)
         # Memory-only peek for debug logging; the authoritative lookup happens
         # inside _stream_completion under the inference lock.
-        cached_state = lm.prompt_cache_store._entries.get(cache_id)
+        cached_state = lm.prompt_cache_store.peek(cache_id)
         logger.debug(
             "Prompt cache enabled: %d prompt tokens, existing cache=%s",
             len(prompt_tokens),

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -253,13 +253,54 @@ class PromptCacheStore:
         self._evict_all_to_disk_sync()
 
     def _evict_all_to_disk_sync(self) -> None:
-        """Sync implementation of evict_all_to_disk (used by async wrapper)."""
+        """Sync implementation of evict_all_to_disk."""
         if self._disk_enabled:
             for cache_id, state in list(self._entries.items()):
                 self._save_to_disk(cache_id, state)
         self._entries.clear()
 
+    def _save_entries_to_disk(
+        self, entries: list[tuple[str, CachedPromptState]]
+    ) -> None:
+        """Save a snapshot of entries to disk (safe to call from a worker thread)."""
+        for cache_id, state in entries:
+            self._save_to_disk(cache_id, state)
+
+    def _read_from_disk(self, cache_id: str) -> CachedPromptState | None:
+        """Read a cache entry from disk without mutating _entries.
+
+        Returns the restored state, or None.  The caller is responsible for
+        inserting it into _entries on the event loop.
+        """
+        if not self._disk_enabled:
+            return None
+        file_path = self._disk_file_path(cache_id)
+        if not file_path.exists():
+            return None
+        try:
+            cache, metadata = load_prompt_cache(str(file_path), return_metadata=True)
+            tokens = json.loads(metadata.get("tokens", "[]"))
+            state = CachedPromptState(tokens=tokens, cache=cache)
+            file_path.unlink(missing_ok=True)
+            logger.info(
+                "Restored cache '%s' from disk (%d tokens)",
+                cache_id,
+                len(tokens),
+            )
+            return state
+        except Exception:
+            logger.warning(
+                "Failed to load cache '%s' from disk",
+                cache_id,
+                exc_info=True,
+            )
+            file_path.unlink(missing_ok=True)
+            return None
+
     # -- Async wrappers that offload disk I/O to threads ----------------
+    #
+    # All _entries mutations happen on the event loop.  Only pure disk I/O
+    # (read/write safetensors, unlink, stat) is dispatched to a worker thread.
 
     async def async_get(self, cache_id: str) -> CachedPromptState | None:
         """Async version of get(). Memory lookup is sync; disk fallback runs in a thread."""
@@ -267,8 +308,13 @@ class PromptCacheStore:
         if state is not None:
             self._entries.move_to_end(cache_id)
             return state
-        # Memory miss — offload disk load to thread
-        return await asyncio.to_thread(self._load_from_disk, cache_id)
+        # Memory miss — read from disk in a thread, then insert on the event loop
+        loaded = await asyncio.to_thread(self._read_from_disk, cache_id)
+        if loaded is not None:
+            evicted = self.set(cache_id, loaded)
+            if evicted is not None:
+                del evicted
+        return loaded
 
     async def async_set(
         self, cache_id: str, state: CachedPromptState
@@ -280,8 +326,18 @@ class PromptCacheStore:
         return evicted
 
     async def async_evict_all_to_disk(self) -> None:
-        """Async version of evict_all_to_disk(). Offloads disk I/O to a thread."""
-        await asyncio.to_thread(self._evict_all_to_disk_sync)
+        """Async version of evict_all_to_disk(). Offloads disk I/O to a thread.
+
+        Snapshots and clears _entries on the event loop first, then saves
+        the snapshot to disk in a worker thread — no thread touches _entries.
+        """
+        if self._disk_enabled:
+            snapshot = list(self._entries.items())
+        else:
+            snapshot = []
+        self._entries.clear()
+        if snapshot:
+            await asyncio.to_thread(self._save_entries_to_disk, snapshot)
 
     def clear(self) -> None:
         """Remove all cache entries and disk cache files."""

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -330,9 +330,11 @@ class PromptCacheStore:
         # if so, keep the fresher in-memory entry and discard the stale disk load.
         if cache_id in self._entries:
             self._entries.move_to_end(cache_id)
+            # Capture before any await — entries could be cleared during unlink
+            existing = self._entries[cache_id]
             if disk_path is not None:
                 await asyncio.to_thread(disk_path.unlink, True)
-            return self._entries.get(cache_id)
+            return existing
         evicted_id, evicted = self._set_in_memory(cache_id, loaded)
         # Save evicted entry to disk first to avoid a window where
         # evicted_id is in neither memory nor disk.
@@ -357,6 +359,11 @@ class PromptCacheStore:
 
         Snapshots and clears _entries on the event loop first, then saves
         the snapshot to disk in a worker thread — no thread touches _entries.
+
+        Note: there is a brief window between clearing memory and completing
+        the disk writes where entries are in neither location.  Any async_get
+        during this window will return None (cache miss).  This is acceptable
+        for a single-user server where this only runs under memory pressure.
         """
         if self._disk_enabled:
             snapshot = list(self._entries.items())

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -263,6 +263,7 @@ class PromptCacheStore:
             for cache_id, state in list(self._entries.items()):
                 self._save_to_disk(cache_id, state)
         self._entries.clear()
+        self._evict_generation += 1
 
     def _save_entries_to_disk(
         self, entries: list[tuple[str, CachedPromptState]]
@@ -321,10 +322,9 @@ class PromptCacheStore:
         if loaded is None:
             return None
         # If entries were bulk-evicted during the await (memory pressure),
-        # don't re-insert — the eviction was intentional.
+        # don't re-insert — the eviction was intentional.  Leave the disk
+        # file intact so it can be restored later.
         if self._evict_generation != gen_before:
-            if disk_path is not None:
-                await asyncio.to_thread(disk_path.unlink, True)
             return None
         # Another coroutine may have populated this cache_id during the await;
         # if so, keep the fresher in-memory entry and discard the stale disk load.
@@ -334,12 +334,13 @@ class PromptCacheStore:
                 await asyncio.to_thread(disk_path.unlink, True)
             return self._entries.get(cache_id)
         evicted_id, evicted = self._set_in_memory(cache_id, loaded)
-        # Delete disk file only after successful insertion
-        if disk_path is not None:
-            await asyncio.to_thread(disk_path.unlink, True)
-        # Save evicted entry to disk (mirrors async_set behavior)
+        # Save evicted entry to disk first to avoid a window where
+        # evicted_id is in neither memory nor disk.
         if evicted_id is not None and evicted is not None:
             await asyncio.to_thread(self._save_to_disk, evicted_id, evicted)
+        # Delete disk file only after successful insertion and eviction save
+        if disk_path is not None:
+            await asyncio.to_thread(disk_path.unlink, True)
         return loaded
 
     async def async_set(

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -322,9 +322,11 @@ class PromptCacheStore:
         # if so, keep the fresher in-memory entry and discard the stale disk load.
         if cache_id in self._entries:
             self._entries.move_to_end(cache_id)
+            existing = self._entries.get(cache_id)
             if disk_path is not None:
                 await asyncio.to_thread(disk_path.unlink, True)
-            return self._entries[cache_id]
+            # Re-check after await — entries may have been cleared
+            return self._entries.get(cache_id) or existing
         evicted_id, evicted = self._set_in_memory(cache_id, loaded)
         # Delete disk file only after successful insertion
         if disk_path is not None:
@@ -332,8 +334,6 @@ class PromptCacheStore:
         # Save evicted entry to disk (mirrors async_set behavior)
         if evicted_id is not None and evicted is not None:
             await asyncio.to_thread(self._save_to_disk, evicted_id, evicted)
-        elif evicted is not None:
-            del evicted
         return loaded
 
     async def async_set(

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -323,12 +323,12 @@ class PromptCacheStore:
         if cache_id in self._entries:
             self._entries.move_to_end(cache_id)
             if disk_path is not None:
-                disk_path.unlink(missing_ok=True)
+                await asyncio.to_thread(disk_path.unlink, True)
             return self._entries[cache_id]
         evicted_id, evicted = self._set_in_memory(cache_id, loaded)
         # Delete disk file only after successful insertion
         if disk_path is not None:
-            disk_path.unlink(missing_ok=True)
+            await asyncio.to_thread(disk_path.unlink, True)
         # Save evicted entry to disk (mirrors async_set behavior)
         if evicted_id is not None and evicted is not None:
             await asyncio.to_thread(self._save_to_disk, evicted_id, evicted)

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -448,6 +448,8 @@ class ModelManager:
     ) -> LoadedModel:
         """Ensure a model is loaded and return it."""
         normalized = self.registry.normalize_name(name)
+        if normalized != name:
+            logger.info("Normalized model name '%s' -> '%s'", name, normalized)
 
         while True:
             # If a previous load timed out and the background thread is still
@@ -512,10 +514,16 @@ class ModelManager:
 
                 hf_path = self.registry.resolve(name)
                 if hf_path is None:
-                    raise ValueError(
-                        f"Model '{name}' not found. "
-                        f"Add it to {settings.models_config} or use a HuggingFace path like 'mlx-community/Qwen2.5-3B-Instruct-4bit'"
+                    suggestions = self.registry.search(name, max_results=3)
+                    msg = f"Model '{name}' not found."
+                    if suggestions:
+                        names = ", ".join(s[0] for s in suggestions)
+                        msg += f" Did you mean: {names}?"
+                    msg += (
+                        f"\nAdd it to {settings.models_config} or use a HuggingFace path "
+                        f"like 'mlx-community/Qwen2.5-3B-Instruct-4bit'"
                     )
+                    raise ValueError(msg)
 
                 # Auto-register direct HF paths so future requests find them
                 if "/" in name:

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -191,6 +191,10 @@ class PromptCacheStore:
             path.unlink(missing_ok=True)
             logger.info("Disk cache cleanup: removed %s", path)
 
+    def peek(self, cache_id: str) -> CachedPromptState | None:
+        """Read-only check for a cache entry without LRU side effects."""
+        return self._entries.get(cache_id)
+
     def get(self, cache_id: str) -> CachedPromptState | None:
         """Get a cache entry, promoting it to MRU.
 
@@ -308,10 +312,12 @@ class PromptCacheStore:
         if state is not None:
             self._entries.move_to_end(cache_id)
             return state
-        # Memory miss — read from disk in a thread, then insert on the event loop
+        # Memory miss — read from disk in a thread, then insert on the event loop.
+        # Use _set_in_memory (no disk I/O) to avoid blocking the event loop
+        # if insertion evicts another entry.
         loaded = await asyncio.to_thread(self._read_from_disk, cache_id)
         if loaded is not None:
-            evicted = self.set(cache_id, loaded)
+            _evicted_id, evicted = self._set_in_memory(cache_id, loaded)
             if evicted is not None:
                 del evicted
         return loaded

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -237,10 +237,49 @@ class PromptCacheStore:
         Used during memory pressure to free GPU memory while preserving
         cache state on disk for later restoration.
         """
+        self._evict_all_to_disk_sync()
+
+    def _evict_all_to_disk_sync(self) -> None:
+        """Sync implementation of evict_all_to_disk (used by async wrapper)."""
         if self._disk_enabled:
             for cache_id, state in list(self._entries.items()):
                 self._save_to_disk(cache_id, state)
         self._entries.clear()
+
+    # -- Async wrappers that offload disk I/O to threads ----------------
+
+    async def async_get(self, cache_id: str) -> CachedPromptState | None:
+        """Async version of get(). Memory lookup is sync; disk fallback runs in a thread."""
+        state = self._entries.get(cache_id)
+        if state is not None:
+            self._entries.move_to_end(cache_id)
+            return state
+        # Memory miss — offload disk load to thread
+        return await asyncio.to_thread(self._load_from_disk, cache_id)
+
+    async def async_set(
+        self, cache_id: str, state: CachedPromptState
+    ) -> CachedPromptState | None:
+        """Async version of set(). Memory ops are sync; disk save runs in a thread."""
+        # Do the in-memory operations synchronously (fast)
+        if cache_id in self._entries:
+            self._entries.move_to_end(cache_id)
+            old = self._entries[cache_id]
+            self._entries[cache_id] = state
+            return old if old.cache is not state.cache else None
+        evicted: CachedPromptState | None = None
+        evicted_id: str | None = None
+        if len(self._entries) >= self._max_slots:
+            evicted_id, evicted = self._entries.popitem(last=False)
+        self._entries[cache_id] = state
+        # Offload disk save to thread if there was an eviction
+        if evicted is not None and evicted_id is not None:
+            await asyncio.to_thread(self._save_to_disk, evicted_id, evicted)
+        return evicted
+
+    async def async_evict_all_to_disk(self) -> None:
+        """Async version of evict_all_to_disk(). Offloads disk I/O to a thread."""
+        await asyncio.to_thread(self._evict_all_to_disk_sync)
 
     def clear(self) -> None:
         """Remove all cache entries and disk cache files."""

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -203,6 +203,29 @@ class PromptCacheStore:
         # Memory miss — try disk
         return self._load_from_disk(cache_id)
 
+    def _set_in_memory(
+        self, cache_id: str, state: CachedPromptState
+    ) -> tuple[str | None, CachedPromptState | None]:
+        """Update in-memory entries.
+
+        Returns (evicted_id, evicted_or_displaced):
+        - On cache-ID collision: (None, displaced_state_or_None)
+        - On LRU eviction: (evicted_id, evicted_state)
+        - No eviction needed: (None, None)
+        """
+        if cache_id in self._entries:
+            self._entries.move_to_end(cache_id)
+            old = self._entries[cache_id]
+            self._entries[cache_id] = state
+            displaced = old if old.cache is not state.cache else None
+            return None, displaced
+        evicted: CachedPromptState | None = None
+        evicted_id: str | None = None
+        if len(self._entries) >= self._max_slots:
+            evicted_id, evicted = self._entries.popitem(last=False)
+        self._entries[cache_id] = state
+        return evicted_id, evicted
+
     def set(self, cache_id: str, state: CachedPromptState) -> CachedPromptState | None:
         """Set a cache entry, evicting LRU if at capacity.
 
@@ -210,18 +233,8 @@ class PromptCacheStore:
         cleanup (different .cache object), or None when no cleanup is needed.
         Evicted entries are saved to disk if disk offload is enabled.
         """
-        if cache_id in self._entries:
-            self._entries.move_to_end(cache_id)
-            old = self._entries[cache_id]
-            self._entries[cache_id] = state
-            return old if old.cache is not state.cache else None
-        evicted: CachedPromptState | None = None
-        evicted_id: str | None = None
-        if len(self._entries) >= self._max_slots:
-            evicted_id, evicted = self._entries.popitem(last=False)
-        self._entries[cache_id] = state
-        # Save evicted entry to disk
-        if evicted is not None and evicted_id is not None:
+        evicted_id, evicted = self._set_in_memory(cache_id, state)
+        if evicted_id is not None and evicted is not None:
             self._save_to_disk(evicted_id, evicted)
         return evicted
 
@@ -261,19 +274,8 @@ class PromptCacheStore:
         self, cache_id: str, state: CachedPromptState
     ) -> CachedPromptState | None:
         """Async version of set(). Memory ops are sync; disk save runs in a thread."""
-        # Do the in-memory operations synchronously (fast)
-        if cache_id in self._entries:
-            self._entries.move_to_end(cache_id)
-            old = self._entries[cache_id]
-            self._entries[cache_id] = state
-            return old if old.cache is not state.cache else None
-        evicted: CachedPromptState | None = None
-        evicted_id: str | None = None
-        if len(self._entries) >= self._max_slots:
-            evicted_id, evicted = self._entries.popitem(last=False)
-        self._entries[cache_id] = state
-        # Offload disk save to thread if there was an eviction
-        if evicted is not None and evicted_id is not None:
+        evicted_id, evicted = self._set_in_memory(cache_id, state)
+        if evicted_id is not None and evicted is not None:
             await asyncio.to_thread(self._save_to_disk, evicted_id, evicted)
         return evicted
 

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -270,28 +270,30 @@ class PromptCacheStore:
         for cache_id, state in entries:
             self._save_to_disk(cache_id, state)
 
-    def _read_from_disk(self, cache_id: str) -> CachedPromptState | None:
+    def _read_from_disk(
+        self, cache_id: str
+    ) -> tuple[CachedPromptState | None, Path | None]:
         """Read a cache entry from disk without mutating _entries.
 
-        Returns the restored state, or None.  The caller is responsible for
-        inserting it into _entries on the event loop.
+        Returns (state, file_path) so the caller can delete the file after
+        a successful insertion into _entries.  Returns (None, None) on miss
+        or failure.
         """
         if not self._disk_enabled:
-            return None
+            return None, None
         file_path = self._disk_file_path(cache_id)
         if not file_path.exists():
-            return None
+            return None, None
         try:
             cache, metadata = load_prompt_cache(str(file_path), return_metadata=True)
             tokens = json.loads(metadata.get("tokens", "[]"))
             state = CachedPromptState(tokens=tokens, cache=cache)
-            file_path.unlink(missing_ok=True)
             logger.info(
                 "Restored cache '%s' from disk (%d tokens)",
                 cache_id,
                 len(tokens),
             )
-            return state
+            return state, file_path
         except Exception:
             logger.warning(
                 "Failed to load cache '%s' from disk",
@@ -299,7 +301,7 @@ class PromptCacheStore:
                 exc_info=True,
             )
             file_path.unlink(missing_ok=True)
-            return None
+            return None, None
 
     # -- Async wrappers that offload disk I/O to threads ----------------
     #
@@ -313,13 +315,25 @@ class PromptCacheStore:
             self._entries.move_to_end(cache_id)
             return state
         # Memory miss — read from disk in a thread, then insert on the event loop.
-        # Use _set_in_memory (no disk I/O) to avoid blocking the event loop
-        # if insertion evicts another entry.
-        loaded = await asyncio.to_thread(self._read_from_disk, cache_id)
-        if loaded is not None:
-            _evicted_id, evicted = self._set_in_memory(cache_id, loaded)
-            if evicted is not None:
-                del evicted
+        loaded, disk_path = await asyncio.to_thread(self._read_from_disk, cache_id)
+        if loaded is None:
+            return None
+        # Another coroutine may have populated this cache_id during the await;
+        # if so, keep the fresher in-memory entry and discard the stale disk load.
+        if cache_id in self._entries:
+            self._entries.move_to_end(cache_id)
+            if disk_path is not None:
+                disk_path.unlink(missing_ok=True)
+            return self._entries[cache_id]
+        evicted_id, evicted = self._set_in_memory(cache_id, loaded)
+        # Delete disk file only after successful insertion
+        if disk_path is not None:
+            disk_path.unlink(missing_ok=True)
+        # Save evicted entry to disk (mirrors async_set behavior)
+        if evicted_id is not None and evicted is not None:
+            await asyncio.to_thread(self._save_to_disk, evicted_id, evicted)
+        elif evicted is not None:
+            del evicted
         return loaded
 
     async def async_set(

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -87,6 +87,7 @@ class PromptCacheStore:
         self._disk_path = disk_path
         self._model_name = model_name.replace("/", "--")
         self._disk_max_bytes = disk_max_bytes
+        self._evict_generation = 0  # bumped by async_evict_all_to_disk
 
     @property
     def _disk_enabled(self) -> bool:
@@ -315,18 +316,23 @@ class PromptCacheStore:
             self._entries.move_to_end(cache_id)
             return state
         # Memory miss — read from disk in a thread, then insert on the event loop.
+        gen_before = self._evict_generation
         loaded, disk_path = await asyncio.to_thread(self._read_from_disk, cache_id)
         if loaded is None:
+            return None
+        # If entries were bulk-evicted during the await (memory pressure),
+        # don't re-insert — the eviction was intentional.
+        if self._evict_generation != gen_before:
+            if disk_path is not None:
+                await asyncio.to_thread(disk_path.unlink, True)
             return None
         # Another coroutine may have populated this cache_id during the await;
         # if so, keep the fresher in-memory entry and discard the stale disk load.
         if cache_id in self._entries:
             self._entries.move_to_end(cache_id)
-            existing = self._entries.get(cache_id)
             if disk_path is not None:
                 await asyncio.to_thread(disk_path.unlink, True)
-            # Re-check after await — entries may have been cleared
-            return self._entries.get(cache_id) or existing
+            return self._entries.get(cache_id)
         evicted_id, evicted = self._set_in_memory(cache_id, loaded)
         # Delete disk file only after successful insertion
         if disk_path is not None:
@@ -356,6 +362,7 @@ class PromptCacheStore:
         else:
             snapshot = []
         self._entries.clear()
+        self._evict_generation += 1
         if snapshot:
             await asyncio.to_thread(self._save_entries_to_disk, snapshot)
 

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -150,5 +150,26 @@ class ModelRegistry:
         if self._mappings.pop(normalized, None) is not None:
             self._save_mappings()
 
+    def search(self, query: str, max_results: int = 5) -> list[tuple[str, str]]:
+        """Fuzzy search models by name. Returns [(name, hf_path), ...]."""
+        import difflib
+
+        all_models = self.list_models()
+        all_names = list(all_models.keys())
+        # Also search base names without tags
+        base_map = {n.split(":")[0]: n for n in all_names}
+        candidates = all_names + list(base_map.keys())
+        matches = difflib.get_close_matches(
+            query, candidates, n=max_results * 2, cutoff=0.4
+        )
+        seen: set[str] = set()
+        results: list[tuple[str, str]] = []
+        for m in matches:
+            full = base_map.get(m, m)
+            if full not in seen and full in all_models:
+                seen.add(full)
+                results.append((full, all_models[full]))
+        return results[:max_results]
+
     def _save_aliases(self):
         _atomic_write_json(self._aliases, self._aliases_path)

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -1,3 +1,4 @@
+import difflib
 import json
 import os
 import tempfile
@@ -154,8 +155,6 @@ class ModelRegistry:
         """Fuzzy search models by name. Returns [(name, hf_path), ...]."""
         if not query or len(query) > 200:
             return []
-        import difflib
-
         all_models = self.list_models()
         all_names = list(all_models.keys())
         # Map each base name (without tag) to all full names that share it

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -156,19 +156,24 @@ class ModelRegistry:
 
         all_models = self.list_models()
         all_names = list(all_models.keys())
-        # Also search base names without tags
-        base_map = {n.split(":")[0]: n for n in all_names}
-        candidates = all_names + list(base_map.keys())
+        # Map each base name (without tag) to all full names that share it
+        base_to_full: dict[str, list[str]] = {}
+        for n in all_names:
+            base_to_full.setdefault(n.split(":")[0], []).append(n)
+        # Deduplicated candidate list: full names + base names
+        candidates = list(dict.fromkeys(all_names + list(base_to_full.keys())))
         matches = difflib.get_close_matches(
             query, candidates, n=max_results * 2, cutoff=0.4
         )
         seen: set[str] = set()
         results: list[tuple[str, str]] = []
         for m in matches:
-            full = base_map.get(m, m)
-            if full not in seen and full in all_models:
-                seen.add(full)
-                results.append((full, all_models[full]))
+            # Expand base name matches to all full names
+            full_names = base_to_full.get(m, [m])
+            for full in full_names:
+                if full not in seen and full in all_models:
+                    seen.add(full)
+                    results.append((full, all_models[full]))
         return results[:max_results]
 
     def _save_aliases(self):

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -152,6 +152,8 @@ class ModelRegistry:
 
     def search(self, query: str, max_results: int = 5) -> list[tuple[str, str]]:
         """Fuzzy search models by name. Returns [(name, hf_path), ...]."""
+        if not query or len(query) > 200:
+            return []
         import difflib
 
         all_models = self.list_models()

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -163,7 +163,7 @@ class ModelRegistry:
         # Deduplicated candidate list: full names + base names
         candidates = list(dict.fromkeys(all_names + list(base_to_full.keys())))
         matches = difflib.get_close_matches(
-            query, candidates, n=max_results * 2, cutoff=0.4
+            query, candidates, n=max(max_results * 4, 20), cutoff=0.4
         )
         seen: set[str] = set()
         results: list[tuple[str, str]] = []

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -7,6 +7,7 @@ from fastapi.responses import StreamingResponse
 
 from olmlx.engine.inference import generate_chat
 from olmlx.schemas.chat import ChatRequest, Message
+from olmlx.utils.streaming import safe_ndjson_stream
 
 logger = logging.getLogger(__name__)
 
@@ -35,61 +36,55 @@ async def chat(req: ChatRequest, request: Request):
             cache_id=cache_id,
         )
 
-        async def stream_response():
-            try:
-                full_text = ""
-                async for chunk in result:
-                    if chunk.get("cache_info"):
-                        continue
-                    now = datetime.now(timezone.utc).isoformat()
-                    if chunk.get("done"):
-                        stats = chunk.get("stats")
-                        final = {
-                            "model": req.model,
-                            "created_at": now,
-                            "message": Message(
-                                role="assistant", content=""
-                            ).model_dump(),
-                            "done": True,
-                            "done_reason": "stop",
-                        }
-                        if stats:
-                            final.update(stats.to_dict())
-                        yield json.dumps(final) + "\n"
-                    else:
-                        text = chunk.get("text", "")
-                        full_text += text
-                        yield (
-                            json.dumps(
-                                {
-                                    "model": req.model,
-                                    "created_at": now,
-                                    "message": Message(
-                                        role="assistant", content=text
-                                    ).model_dump(),
-                                    "done": False,
-                                }
-                            )
-                            + "\n"
-                        )
-            except Exception as exc:
-                logger.error("Error during chat streaming: %s", exc, exc_info=True)
-                yield (
-                    json.dumps(
-                        {
-                            "model": req.model,
-                            "created_at": datetime.now(timezone.utc).isoformat(),
-                            "error": "An internal server error occurred during streaming.",
-                            "done": True,
-                            "done_reason": "error",
-                        }
-                    )
-                    + "\n"
+        def format_chunk(chunk):
+            if chunk.get("cache_info"):
+                return None
+            now = datetime.now(timezone.utc).isoformat()
+            if chunk.get("done"):
+                stats = chunk.get("stats")
+                final = {
+                    "model": req.model,
+                    "created_at": now,
+                    "message": Message(role="assistant", content="").model_dump(),
+                    "done": True,
+                    "done_reason": "stop",
+                }
+                if stats:
+                    final.update(stats.to_dict())
+                return json.dumps(final) + "\n"
+            text = chunk.get("text", "")
+            return (
+                json.dumps(
+                    {
+                        "model": req.model,
+                        "created_at": now,
+                        "message": Message(role="assistant", content=text).model_dump(),
+                        "done": False,
+                    }
                 )
-            finally:
-                await result.aclose()
+                + "\n"
+            )
 
-        return StreamingResponse(stream_response(), media_type="application/x-ndjson")
+        def format_error(exc):
+            return (
+                json.dumps(
+                    {
+                        "model": req.model,
+                        "created_at": datetime.now(timezone.utc).isoformat(),
+                        "error": "An internal server error occurred during streaming.",
+                        "done": True,
+                        "done_reason": "error",
+                    }
+                )
+                + "\n"
+            )
+
+        return StreamingResponse(
+            safe_ndjson_stream(
+                result, format_chunk, format_error, logger, "chat streaming"
+            ),
+            media_type="application/x-ndjson",
+        )
     else:
         result = await generate_chat(
             manager,

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -81,7 +81,11 @@ async def chat(req: ChatRequest, request: Request):
 
         return StreamingResponse(
             safe_ndjson_stream(
-                result, format_chunk, format_error, logger, "chat streaming"
+                result,
+                format_chunk,
+                format_error,
+                log=logger,
+                log_prefix="chat streaming",
             ),
             media_type="application/x-ndjson",
         )

--- a/olmlx/routers/generate.py
+++ b/olmlx/routers/generate.py
@@ -79,7 +79,11 @@ async def generate(req: GenerateRequest, request: Request):
 
         return StreamingResponse(
             safe_ndjson_stream(
-                result, format_chunk, format_error, logger, "generate streaming"
+                result,
+                format_chunk,
+                format_error,
+                log=logger,
+                log_prefix="generate streaming",
             ),
             media_type="application/x-ndjson",
         )

--- a/olmlx/routers/generate.py
+++ b/olmlx/routers/generate.py
@@ -7,6 +7,7 @@ from fastapi.responses import StreamingResponse
 
 from olmlx.engine.inference import generate_completion
 from olmlx.schemas.generate import GenerateRequest
+from olmlx.utils.streaming import safe_ndjson_stream
 
 logger = logging.getLogger(__name__)
 
@@ -36,52 +37,52 @@ async def generate(req: GenerateRequest, request: Request):
             images=req.images,
         )
 
-        async def stream_response():
-            try:
-                async for chunk in result:
-                    now = datetime.now(timezone.utc).isoformat()
-                    if chunk.get("done"):
-                        stats = chunk.get("stats")
-                        final = {
-                            "model": req.model,
-                            "created_at": now,
-                            "response": "",
-                            "done": True,
-                            "done_reason": "stop",
-                        }
-                        if stats:
-                            final.update(stats.to_dict())
-                        yield json.dumps(final) + "\n"
-                    else:
-                        yield (
-                            json.dumps(
-                                {
-                                    "model": req.model,
-                                    "created_at": now,
-                                    "response": chunk.get("text", ""),
-                                    "done": False,
-                                }
-                            )
-                            + "\n"
-                        )
-            except Exception as exc:
-                logger.error("Error during generate streaming: %s", exc, exc_info=True)
-                yield (
-                    json.dumps(
-                        {
-                            "model": req.model,
-                            "created_at": datetime.now(timezone.utc).isoformat(),
-                            "error": "An internal server error occurred during streaming.",
-                            "done": True,
-                            "done_reason": "error",
-                        }
-                    )
-                    + "\n"
+        def format_chunk(chunk):
+            now = datetime.now(timezone.utc).isoformat()
+            if chunk.get("done"):
+                stats = chunk.get("stats")
+                final = {
+                    "model": req.model,
+                    "created_at": now,
+                    "response": "",
+                    "done": True,
+                    "done_reason": "stop",
+                }
+                if stats:
+                    final.update(stats.to_dict())
+                return json.dumps(final) + "\n"
+            return (
+                json.dumps(
+                    {
+                        "model": req.model,
+                        "created_at": now,
+                        "response": chunk.get("text", ""),
+                        "done": False,
+                    }
                 )
-            finally:
-                await result.aclose()
+                + "\n"
+            )
 
-        return StreamingResponse(stream_response(), media_type="application/x-ndjson")
+        def format_error(exc):
+            return (
+                json.dumps(
+                    {
+                        "model": req.model,
+                        "created_at": datetime.now(timezone.utc).isoformat(),
+                        "error": "An internal server error occurred during streaming.",
+                        "done": True,
+                        "done_reason": "error",
+                    }
+                )
+                + "\n"
+            )
+
+        return StreamingResponse(
+            safe_ndjson_stream(
+                result, format_chunk, format_error, logger, "generate streaming"
+            ),
+            media_type="application/x-ndjson",
+        )
     else:
         result = await generate_completion(
             manager,

--- a/olmlx/routers/manage.py
+++ b/olmlx/routers/manage.py
@@ -13,6 +13,7 @@ from olmlx.schemas.manage import (
     WarmupRequest,
 )
 from olmlx.schemas.pull import PullRequest
+from olmlx.utils.streaming import safe_ndjson_stream
 
 logger = logging.getLogger(__name__)
 
@@ -24,18 +25,18 @@ async def pull_model(req: PullRequest, request: Request):
     store = request.app.state.model_store
 
     if req.stream:
-
-        async def stream_progress():
-            pull_iter = store.pull(req.model).__aiter__()
-            try:
-                async for event in pull_iter:
-                    yield json.dumps(event) + "\n"
-            except Exception as e:
-                yield json.dumps({"status": "error", "error": str(e)}) + "\n"
-            finally:
-                await pull_iter.aclose()
-
-        return StreamingResponse(stream_progress(), media_type="application/x-ndjson")
+        return StreamingResponse(
+            safe_ndjson_stream(
+                store.pull(req.model),
+                format_chunk=lambda e: json.dumps(e) + "\n",
+                format_error=lambda e: (
+                    json.dumps({"status": "error", "error": str(e)}) + "\n"
+                ),
+                log=logger,
+                log_prefix="pull streaming",
+            ),
+            media_type="application/x-ndjson",
+        )
     else:
         events = []
         try:

--- a/olmlx/routers/manage.py
+++ b/olmlx/routers/manage.py
@@ -26,11 +26,14 @@ async def pull_model(req: PullRequest, request: Request):
     if req.stream:
 
         async def stream_progress():
+            pull_iter = store.pull(req.model).__aiter__()
             try:
-                async for event in store.pull(req.model):
+                async for event in pull_iter:
                     yield json.dumps(event) + "\n"
             except Exception as e:
                 yield json.dumps({"status": "error", "error": str(e)}) + "\n"
+            finally:
+                await pull_iter.aclose()
 
         return StreamingResponse(stream_progress(), media_type="application/x-ndjson")
     else:

--- a/olmlx/utils/streaming.py
+++ b/olmlx/utils/streaming.py
@@ -25,6 +25,9 @@ async def safe_ndjson_stream(
     """
     try:
         async for item in source:
+            # Note: format_chunk exceptions are also caught below.  This is
+            # intentional — once streaming has started the HTTP status is 200,
+            # so the best we can do is emit an error payload and log it.
             formatted = format_chunk(item)
             if formatted is not None:
                 yield formatted

--- a/olmlx/utils/streaming.py
+++ b/olmlx/utils/streaming.py
@@ -42,6 +42,8 @@ async def safe_ndjson_stream(
                 exc_info=True,
             )
     finally:
+        # When called via aclose() (client disconnect), GeneratorExit is
+        # swallowed after this cleanup completes — the intended behaviour.
         await source.aclose()
 
 

--- a/olmlx/utils/streaming.py
+++ b/olmlx/utils/streaming.py
@@ -10,6 +10,30 @@ from typing import Any, Callable
 logger = logging.getLogger(__name__)
 
 
+async def safe_ndjson_stream(
+    source, format_chunk, format_error, logger, log_prefix="streaming"
+):
+    """Wrap an async source with error handling and guaranteed cleanup.
+
+    Args:
+        source: Async iterator to consume (must support aclose()).
+        format_chunk: Callable(item) -> str for each yielded item.
+        format_error: Callable(Exception) -> str for error formatting.
+        logger: Logger instance.
+        log_prefix: Prefix for error log messages.
+    """
+    try:
+        async for item in source:
+            formatted = format_chunk(item)
+            if formatted is not None:
+                yield formatted
+    except Exception as exc:
+        logger.error("Error during %s: %s", log_prefix, exc, exc_info=True)
+        yield format_error(exc)
+    finally:
+        await source.aclose()
+
+
 @dataclass
 class StreamToken:
     text: str

--- a/olmlx/utils/streaming.py
+++ b/olmlx/utils/streaming.py
@@ -33,7 +33,14 @@ async def safe_ndjson_stream(
                 yield formatted
     except Exception as exc:
         log.error("Error during %s: %s", log_prefix, exc, exc_info=True)
-        yield format_error(exc)
+        try:
+            yield format_error(exc)
+        except Exception:
+            log.error(
+                "format_error raised during %s error handling",
+                log_prefix,
+                exc_info=True,
+            )
     finally:
         await source.aclose()
 

--- a/olmlx/utils/streaming.py
+++ b/olmlx/utils/streaming.py
@@ -11,15 +11,16 @@ logger = logging.getLogger(__name__)
 
 
 async def safe_ndjson_stream(
-    source, format_chunk, format_error, logger, log_prefix="streaming"
+    source, format_chunk, format_error, log, log_prefix="streaming"
 ):
     """Wrap an async source with error handling and guaranteed cleanup.
 
     Args:
         source: Async iterator to consume (must support aclose()).
         format_chunk: Callable(item) -> str for each yielded item.
+            Return None to skip an item.
         format_error: Callable(Exception) -> str for error formatting.
-        logger: Logger instance.
+        log: Logger instance for error reporting.
         log_prefix: Prefix for error log messages.
     """
     try:
@@ -28,7 +29,7 @@ async def safe_ndjson_stream(
             if formatted is not None:
                 yield formatted
     except Exception as exc:
-        logger.error("Error during %s: %s", log_prefix, exc, exc_info=True)
+        log.error("Error during %s: %s", log_prefix, exc, exc_info=True)
         yield format_error(exc)
     finally:
         await source.aclose()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Shared fixtures for olmlx tests."""
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -10,6 +10,30 @@ from olmlx.engine.model_manager import LoadedModel, ModelManager
 from olmlx.engine.registry import ModelRegistry
 from olmlx.engine.template_caps import TemplateCaps
 from olmlx.models.store import ModelStore
+
+
+def make_error_stream(chunks, error_msg="GPU error"):
+    """Create an async iterator that yields chunks then raises RuntimeError.
+
+    Each instance has a trackable ``aclose`` mock.
+    """
+
+    class ErrorStream:
+        def __init__(self):
+            self._idx = 0
+            self.aclose = AsyncMock()
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._idx < len(chunks):
+                chunk = chunks[self._idx]
+                self._idx += 1
+                return chunk
+            raise RuntimeError(error_msg)
+
+    return ErrorStream()
 
 
 @pytest.fixture

--- a/tests/integration/test_edge_cases.py
+++ b/tests/integration/test_edge_cases.py
@@ -1,0 +1,141 @@
+"""Tests for edge cases: zero-token generation and empty message lists."""
+
+from tests.integration.conftest import set_stream_responses
+
+
+# ---------------------------------------------------------------------------
+# Zero-token generation edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestZeroTokenGeneration:
+    """Verify well-formed responses when generation produces zero tokens."""
+
+    async def test_generate_zero_max_tokens(self, integration_ctx):
+        """POST /api/generate with num_predict: 0 returns well-formed response."""
+        set_stream_responses([""])
+        resp = await integration_ctx.client.post(
+            "/api/generate",
+            json={
+                "model": "qwen3",
+                "prompt": "Hello",
+                "stream": False,
+                "options": {"num_predict": 0},
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["done"] is True
+        assert "response" in data
+        # No division-by-zero — TPS fields should be present or absent, not NaN
+        for key in ("prompt_eval_duration", "eval_duration"):
+            if key in data and data[key] is not None:
+                assert isinstance(data[key], (int, float))
+
+    async def test_chat_zero_max_tokens(self, integration_ctx):
+        """POST /api/chat with num_predict: 0 returns well-formed response."""
+        set_stream_responses([""])
+        resp = await integration_ctx.client.post(
+            "/api/chat",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "stream": False,
+                "options": {"num_predict": 0},
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["done"] is True
+        assert "message" in data
+        assert data["message"]["role"] == "assistant"
+
+    async def test_openai_zero_max_tokens_rejected(self, integration_ctx):
+        """POST /v1/chat/completions with max_tokens: 0 is rejected (ge=1)."""
+        # OpenAI schema requires max_tokens >= 1, so 0 should be a validation error
+        resp = await integration_ctx.client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 0,
+            },
+        )
+        assert resp.status_code == 422
+
+    async def test_openai_zero_max_completion_tokens_rejected(self, integration_ctx):
+        """POST /v1/chat/completions with max_completion_tokens: 0 is rejected."""
+        resp = await integration_ctx.client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_completion_tokens": 0,
+            },
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Empty message list edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyMessages:
+    """Verify behavior when message list is empty."""
+
+    async def test_chat_empty_messages(self, integration_ctx):
+        """POST /api/chat with messages: [] returns an error or valid response."""
+        set_stream_responses([""])
+        resp = await integration_ctx.client.post(
+            "/api/chat",
+            json={
+                "model": "qwen3",
+                "messages": [],
+                "stream": False,
+            },
+        )
+        # Empty messages may be accepted (model generates from empty prompt)
+        # or rejected. Either way, no crash.
+        assert resp.status_code in (200, 400, 422)
+        # If 200, verify well-formed
+        if resp.status_code == 200:
+            data = resp.json()
+            assert data["done"] is True
+            assert "message" in data
+
+    async def test_openai_empty_messages(self, integration_ctx):
+        """POST /v1/chat/completions with messages: [] returns an error or valid response."""
+        set_stream_responses([""])
+        resp = await integration_ctx.client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "qwen3",
+                "messages": [],
+                "stream": False,
+            },
+        )
+        # Pydantic may accept empty list or reject it
+        assert resp.status_code in (200, 400, 422)
+        if resp.status_code == 200:
+            data = resp.json()
+            assert "choices" in data
+
+    async def test_anthropic_empty_messages(self, integration_ctx):
+        """POST /v1/messages with messages: [] returns an error or valid response."""
+        set_stream_responses([""])
+        resp = await integration_ctx.client.post(
+            "/v1/messages",
+            json={
+                "model": "qwen3",
+                "max_tokens": 100,
+                "messages": [],
+                "stream": False,
+            },
+        )
+        # Anthropic API requires at least one message, but our schema may not
+        # enforce it. Either way, no crash.
+        assert resp.status_code in (200, 400, 422)
+        if resp.status_code == 200:
+            data = resp.json()
+            assert "content" in data

--- a/tests/integration/test_streaming_disconnect.py
+++ b/tests/integration/test_streaming_disconnect.py
@@ -1,0 +1,186 @@
+"""Tests for streaming disconnect / aclose cleanup.
+
+Verify that GPU resources are properly cleaned up when clients disconnect
+mid-stream.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+
+from tests.integration.conftest import set_stream_responses
+
+
+class TestStreamingDisconnect:
+    """Test that early client disconnect triggers stream cleanup."""
+
+    async def test_generate_stream_early_disconnect(self, integration_ctx):
+        """Start streaming /api/generate, consume 1 chunk, close. Verify cleanup."""
+        set_stream_responses(["Hello", " world", " foo", " bar", " baz"])
+
+        resp = await integration_ctx.client.post(
+            "/api/generate",
+            json={
+                "model": "qwen3",
+                "prompt": "Hi",
+                "stream": True,
+            },
+        )
+        # The full response is returned by httpx (it buffers).
+        # Verify that the response completed and produced valid NDJSON.
+        assert resp.status_code == 200
+        lines = [line for line in resp.text.strip().split("\n") if line.strip()]
+        assert len(lines) >= 1
+        # Last line should be done=True (stream completed normally)
+        last = json.loads(lines[-1])
+        assert last["done"] is True
+
+    async def test_chat_stream_early_disconnect(self, integration_ctx):
+        """Start streaming /api/chat, verify stream completes with cleanup."""
+        set_stream_responses(["Hello", " world", " foo"])
+
+        resp = await integration_ctx.client.post(
+            "/api/chat",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "stream": True,
+            },
+        )
+        assert resp.status_code == 200
+        lines = [line for line in resp.text.strip().split("\n") if line.strip()]
+        assert len(lines) >= 1
+        last = json.loads(lines[-1])
+        assert last["done"] is True
+
+    async def test_openai_stream_early_disconnect(self, integration_ctx):
+        """Start streaming /v1/chat/completions, verify stream completes."""
+        set_stream_responses(["Hello", " world", " foo"])
+
+        resp = await integration_ctx.client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "stream": True,
+            },
+        )
+        assert resp.status_code == 200
+        # OpenAI SSE format: data: {...}\n\n  and data: [DONE]\n\n
+        assert "data: [DONE]" in resp.text
+
+    async def test_generate_stream_aclose_called_on_error(self, integration_ctx):
+        """Verify result.aclose() is called even when stream generator raises."""
+        # Patch generate_completion to return a mock async generator that errors
+        mock_result = AsyncMock()
+        mock_result.aclose = AsyncMock()
+
+        async def _error_gen():
+            yield {"text": "Hello"}
+            raise RuntimeError("GPU exploded")
+
+        mock_result.__aiter__ = _error_gen().__aiter__
+        mock_result.__anext__ = _error_gen().__anext__
+
+        # Create a proper async iterator mock
+        error_chunks = [{"text": "Hello"}]
+
+        class ErrorStream:
+            def __init__(self):
+                self._idx = 0
+                self.aclose = AsyncMock()
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self._idx < len(error_chunks):
+                    self._idx += 1
+                    return error_chunks[0]
+                raise RuntimeError("GPU exploded")
+
+        error_stream = ErrorStream()
+
+        with patch(
+            "olmlx.routers.generate.generate_completion",
+            return_value=error_stream,
+        ):
+            resp = await integration_ctx.client.post(
+                "/api/generate",
+                json={
+                    "model": "qwen3",
+                    "prompt": "Hi",
+                    "stream": True,
+                },
+            )
+            assert resp.status_code == 200
+            # aclose should have been called in the finally block
+            error_stream.aclose.assert_awaited_once()
+
+    async def test_chat_stream_aclose_called_on_error(self, integration_ctx):
+        """Verify result.aclose() is called for /api/chat even on error."""
+
+        class ErrorStream:
+            def __init__(self):
+                self._yielded = False
+                self.aclose = AsyncMock()
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not self._yielded:
+                    self._yielded = True
+                    return {"text": "Hello"}
+                raise RuntimeError("GPU exploded")
+
+        error_stream = ErrorStream()
+
+        with patch(
+            "olmlx.routers.chat.generate_chat",
+            return_value=error_stream,
+        ):
+            resp = await integration_ctx.client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "stream": True,
+                },
+            )
+            assert resp.status_code == 200
+            error_stream.aclose.assert_awaited_once()
+
+    async def test_openai_stream_aclose_called_on_error(self, integration_ctx):
+        """Verify result.aclose() is called for /v1/chat/completions even on error."""
+
+        class ErrorStream:
+            def __init__(self):
+                self._yielded = False
+                self.aclose = AsyncMock()
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not self._yielded:
+                    self._yielded = True
+                    return {"text": "Hello"}
+                raise RuntimeError("GPU exploded")
+
+        error_stream = ErrorStream()
+
+        with patch(
+            "olmlx.routers.openai.generate_chat",
+            return_value=error_stream,
+        ):
+            resp = await integration_ctx.client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "stream": True,
+                },
+            )
+            assert resp.status_code == 200
+            error_stream.aclose.assert_awaited_once()

--- a/tests/integration/test_streaming_disconnect.py
+++ b/tests/integration/test_streaming_disconnect.py
@@ -12,10 +12,10 @@ from tests.integration.conftest import set_stream_responses
 
 
 class TestStreamingDisconnect:
-    """Test that early client disconnect triggers stream cleanup."""
+    """Test streaming completion and cleanup."""
 
-    async def test_generate_stream_early_disconnect(self, integration_ctx):
-        """Start streaming /api/generate, consume 1 chunk, close. Verify cleanup."""
+    async def test_generate_stream_completes_normally(self, integration_ctx):
+        """Streaming /api/generate completes with valid NDJSON and done=True."""
         set_stream_responses(["Hello", " world", " foo", " bar", " baz"])
 
         resp = await integration_ctx.client.post(
@@ -35,8 +35,8 @@ class TestStreamingDisconnect:
         last = json.loads(lines[-1])
         assert last["done"] is True
 
-    async def test_chat_stream_early_disconnect(self, integration_ctx):
-        """Start streaming /api/chat, verify stream completes with cleanup."""
+    async def test_chat_stream_completes_normally(self, integration_ctx):
+        """Streaming /api/chat completes with valid NDJSON and done=True."""
         set_stream_responses(["Hello", " world", " foo"])
 
         resp = await integration_ctx.client.post(
@@ -53,8 +53,8 @@ class TestStreamingDisconnect:
         last = json.loads(lines[-1])
         assert last["done"] is True
 
-    async def test_openai_stream_early_disconnect(self, integration_ctx):
-        """Start streaming /v1/chat/completions, verify stream completes."""
+    async def test_openai_stream_completes_normally(self, integration_ctx):
+        """Streaming /v1/chat/completions completes with SSE [DONE] sentinel."""
         set_stream_responses(["Hello", " world", " foo"])
 
         resp = await integration_ctx.client.post(

--- a/tests/integration/test_streaming_disconnect.py
+++ b/tests/integration/test_streaming_disconnect.py
@@ -5,9 +5,9 @@ mid-stream.
 """
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
-
+from tests.conftest import make_error_stream
 from tests.integration.conftest import set_stream_responses
 
 
@@ -71,35 +71,7 @@ class TestStreamingDisconnect:
 
     async def test_generate_stream_aclose_called_on_error(self, integration_ctx):
         """Verify result.aclose() is called even when stream generator raises."""
-        # Patch generate_completion to return a mock async generator that errors
-        mock_result = AsyncMock()
-        mock_result.aclose = AsyncMock()
-
-        async def _error_gen():
-            yield {"text": "Hello"}
-            raise RuntimeError("GPU exploded")
-
-        mock_result.__aiter__ = _error_gen().__aiter__
-        mock_result.__anext__ = _error_gen().__anext__
-
-        # Create a proper async iterator mock
-        error_chunks = [{"text": "Hello"}]
-
-        class ErrorStream:
-            def __init__(self):
-                self._idx = 0
-                self.aclose = AsyncMock()
-
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                if self._idx < len(error_chunks):
-                    self._idx += 1
-                    return error_chunks[0]
-                raise RuntimeError("GPU exploded")
-
-        error_stream = ErrorStream()
+        error_stream = make_error_stream([{"text": "Hello"}], error_msg="GPU exploded")
 
         with patch(
             "olmlx.routers.generate.generate_completion",
@@ -119,22 +91,7 @@ class TestStreamingDisconnect:
 
     async def test_chat_stream_aclose_called_on_error(self, integration_ctx):
         """Verify result.aclose() is called for /api/chat even on error."""
-
-        class ErrorStream:
-            def __init__(self):
-                self._yielded = False
-                self.aclose = AsyncMock()
-
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                if not self._yielded:
-                    self._yielded = True
-                    return {"text": "Hello"}
-                raise RuntimeError("GPU exploded")
-
-        error_stream = ErrorStream()
+        error_stream = make_error_stream([{"text": "Hello"}], error_msg="GPU exploded")
 
         with patch(
             "olmlx.routers.chat.generate_chat",
@@ -153,22 +110,7 @@ class TestStreamingDisconnect:
 
     async def test_openai_stream_aclose_called_on_error(self, integration_ctx):
         """Verify result.aclose() is called for /v1/chat/completions even on error."""
-
-        class ErrorStream:
-            def __init__(self):
-                self._yielded = False
-                self.aclose = AsyncMock()
-
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                if not self._yielded:
-                    self._yielded = True
-                    return {"text": "Hello"}
-                raise RuntimeError("GPU exploded")
-
-        error_stream = ErrorStream()
+        error_stream = make_error_stream([{"text": "Hello"}], error_msg="GPU exploded")
 
         with patch(
             "olmlx.routers.openai.generate_chat",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ from olmlx.cli import (
     cmd_models_delete,
     cmd_models_list,
     cmd_models_pull,
+    cmd_models_search,
     cmd_models_show,
     cmd_service_install,
     cmd_service_status,
@@ -732,3 +733,73 @@ class TestBuildParserModels:
         args = parser.parse_args(["config", "show"])
         assert args.command == "config"
         assert args.config_command == "show"
+
+    def test_models_search(self):
+        parser = build_parser()
+        args = parser.parse_args(["models", "search", "qwen"])
+        assert args.command == "models"
+        assert args.models_command == "search"
+        assert args.query == "qwen"
+
+
+class TestModelsSearchCmd:
+    def test_cmd_models_search_found(self, capsys, mock_store, _patch_store):
+        """Search with matches should print model names and HF paths."""
+        # mock_store.registry must have a search method
+        mock_store.registry = MagicMock()
+        mock_store.registry.search.return_value = [
+            ("qwen3:latest", "Qwen/Qwen3-8B-MLX"),
+        ]
+        args = MagicMock(query="qwen3")
+        cmd_models_search(args)
+        out = capsys.readouterr().out
+        assert "qwen3:latest" in out
+        assert "Qwen/Qwen3-8B-MLX" in out
+
+    def test_cmd_models_search_not_found(self, capsys, mock_store, _patch_store):
+        """Search with no matches should show 'No models matching' message."""
+        mock_store.registry = MagicMock()
+        mock_store.registry.search.return_value = []
+        args = MagicMock(query="zzzzzzz")
+        cmd_models_search(args)
+        out = capsys.readouterr().out
+        assert "No models matching" in out
+
+
+class TestCliMainModelsSearch:
+    def test_models_search_calls_handler(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["olmlx", "models", "search", "qwen"])
+        mock_fn = MagicMock()
+        monkeypatch.setattr("olmlx.cli.cmd_models_search", mock_fn)
+        cli_main()
+        mock_fn.assert_called_once()
+
+
+class TestModelsShowSuggestion:
+    def test_show_not_found_suggests_search(self, capsys, mock_store, _patch_store):
+        """When model not found, stderr should suggest running search."""
+        mock_store.show.return_value = None
+        args = MagicMock(model_name="qwem3")
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_models_show(args)
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "olmlx models search" in err
+
+
+class TestModelsPullSuggestion:
+    def test_pull_not_found_suggests_search(self, capsys, mock_store, _patch_store):
+        """When pull fails with 'not found', stderr should suggest running search."""
+
+        async def fake_pull(name):
+            if False:
+                yield {}
+            raise ValueError(f"Model '{name}' not found in config")
+
+        mock_store.pull = fake_pull
+        args = MagicMock(model_name="nonexistent")
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_models_pull(args)
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "olmlx models search" in err

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1510,3 +1510,105 @@ class TestSSHCommandConstruction:
         cli_module._cleanup_workers()
         for key in ("MLX_RANK", "MLX_HOSTFILE"):
             os.environ.pop(key, None)
+
+
+class TestSidebandProtocolExtended:
+    """Extended tests for the length-prefixed JSON sideband protocol."""
+
+    def test_sideband_protocol_send_recv_roundtrip(self):
+        """Create a real socket pair, send via _send_message, receive via _recv_message."""
+        from olmlx.engine.distributed import _recv_message, _send_message
+
+        server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server_sock.bind(("127.0.0.1", 0))
+        port = server_sock.getsockname()[1]
+        server_sock.listen(1)
+
+        client_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        client_sock.connect(("127.0.0.1", port))
+        conn, _ = server_sock.accept()
+
+        try:
+            original = {
+                "prompt_tokens": [1, 2, 3, 4, 5],
+                "prompt_text": "Hello world test",
+                "max_tokens": 256,
+                "gen_kwargs": {"temp": 0.7, "top_p": 0.9},
+                "action": "generate",
+            }
+            _send_message(client_sock, original)
+            received = _recv_message(conn)
+            assert received == original
+            assert received["prompt_tokens"] == [1, 2, 3, 4, 5]
+            assert received["gen_kwargs"]["temp"] == 0.7
+        finally:
+            client_sock.close()
+            conn.close()
+            server_sock.close()
+
+    def test_sideband_protocol_large_message(self):
+        """Send a large JSON payload and verify integrity."""
+        from olmlx.engine.distributed import _recv_message, _send_message
+
+        server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server_sock.bind(("127.0.0.1", 0))
+        port = server_sock.getsockname()[1]
+        server_sock.listen(1)
+
+        client_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        client_sock.connect(("127.0.0.1", port))
+        conn, _ = server_sock.accept()
+
+        try:
+            # Large message with many stop sequences and long prompt
+            large_msg = {
+                "prompt_tokens": list(range(10000)),
+                "prompt_text": "x" * 100000,
+                "max_tokens": 4096,
+                "gen_kwargs": {
+                    "temp": 0.7,
+                    "stop": [f"stop_{i}" for i in range(100)],
+                    "nested": {"deep": {"data": list(range(500))}},
+                },
+                "action": "generate",
+            }
+            _send_message(client_sock, large_msg)
+            received = _recv_message(conn)
+            assert received == large_msg
+            assert len(received["prompt_tokens"]) == 10000
+            assert len(received["prompt_text"]) == 100000
+            assert len(received["gen_kwargs"]["stop"]) == 100
+        finally:
+            client_sock.close()
+            conn.close()
+            server_sock.close()
+
+    def test_sideband_recv_partial_read(self):
+        """Verify _recv_message returns None when connection drops mid-message."""
+        import struct
+
+        from olmlx.engine.distributed import _recv_message
+
+        server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server_sock.bind(("127.0.0.1", 0))
+        port = server_sock.getsockname()[1]
+        server_sock.listen(1)
+
+        client_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        client_sock.connect(("127.0.0.1", port))
+        conn, _ = server_sock.accept()
+
+        try:
+            # Send length header claiming 1000 bytes, but only send 10 bytes
+            header = struct.pack("!I", 1000)
+            client_sock.sendall(header + b"partial da")
+            # Close the sender — recv should detect incomplete message
+            client_sock.close()
+            result = _recv_message(conn)
+            assert result is None
+        finally:
+            conn.close()
+            server_sock.close()

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1536,6 +1536,9 @@ class TestKvCachePreflightCheck:
         lm.prompt_cache_store = MagicMock()
         lm.prompt_cache_store.get.return_value = None
         lm.prompt_cache_store.evict_all_to_disk = MagicMock()
+        lm.prompt_cache_store.async_get = AsyncMock(return_value=None)
+        lm.prompt_cache_store.async_set = AsyncMock(return_value=None)
+        lm.prompt_cache_store.async_evict_all_to_disk = AsyncMock()
         lm.active_refs = 0
         return lm
 

--- a/tests/test_kv_disk_cache.py
+++ b/tests/test_kv_disk_cache.py
@@ -405,7 +405,7 @@ class TestAsyncDiskCache:
 
     @pytest.mark.asyncio
     async def test_async_get_disk_fallback_uses_thread(self, tmp_path):
-        """On memory miss with disk hit, asyncio.to_thread IS called with _load_from_disk."""
+        """On memory miss with disk hit, asyncio.to_thread IS called with _read_from_disk."""
         store = PromptCacheStore(
             max_slots=2,
             disk_path=tmp_path,
@@ -416,21 +416,18 @@ class TestAsyncDiskCache:
         disk_file.parent.mkdir(parents=True, exist_ok=True)
         disk_file.touch()
 
+        loaded_state = CachedPromptState(tokens=[10, 20], cache=["restored_kv"])
         with patch(
-            "olmlx.engine.model_manager.load_prompt_cache",
-            return_value=(["restored_kv"], {"tokens": "[10, 20]"}),
-        ):
-            with patch(
-                "asyncio.to_thread",
-                new_callable=AsyncMock,
-                return_value=CachedPromptState(tokens=[10, 20], cache=["restored_kv"]),
-            ) as mock_thread:
-                result = await store.async_get("a")
-                mock_thread.assert_called_once()
-                # Verify _load_from_disk was the function passed to to_thread
-                assert mock_thread.call_args[0][0] == store._load_from_disk
-                assert mock_thread.call_args[0][1] == "a"
-                assert result is not None
+            "asyncio.to_thread",
+            new_callable=AsyncMock,
+            return_value=loaded_state,
+        ) as mock_thread:
+            result = await store.async_get("a")
+            mock_thread.assert_called_once()
+            # Verify _read_from_disk was the function passed to to_thread
+            assert mock_thread.call_args[0][0] == store._read_from_disk
+            assert mock_thread.call_args[0][1] == "a"
+            assert result is not None
 
     @pytest.mark.asyncio
     async def test_async_set_eviction_saves_in_thread(self, tmp_path):
@@ -462,7 +459,7 @@ class TestAsyncDiskCache:
 
     @pytest.mark.asyncio
     async def test_async_evict_all_uses_thread(self, tmp_path):
-        """Verify evict_all_to_disk is offloaded to a thread."""
+        """Verify evict_all_to_disk snapshots on event loop, saves in a thread."""
         store = PromptCacheStore(
             max_slots=4,
             disk_path=tmp_path,
@@ -474,8 +471,10 @@ class TestAsyncDiskCache:
         with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
             await store.async_evict_all_to_disk()
             mock_thread.assert_called_once()
-            # The function passed should be _evict_all_to_disk_sync or similar
-            assert mock_thread.call_args[0][0] == store._evict_all_to_disk_sync
+            # _save_entries_to_disk is called with the snapshot
+            assert mock_thread.call_args[0][0] == store._save_entries_to_disk
+            # _entries should already be cleared (snapshot-then-clear on event loop)
+            assert len(store) == 0
 
     def test_sync_methods_unchanged(self, tmp_path):
         """Regression: sync get()/set() still work exactly as before."""

--- a/tests/test_kv_disk_cache.py
+++ b/tests/test_kv_disk_cache.py
@@ -423,11 +423,11 @@ class TestAsyncDiskCache:
             return_value=(loaded_state, disk_file),
         ) as mock_thread:
             result = await store.async_get("a")
-            mock_thread.assert_called_once()
-            # Verify _read_from_disk was the function passed to to_thread
-            assert mock_thread.call_args[0][0] == store._read_from_disk
-            assert mock_thread.call_args[0][1] == "a"
             assert result is not None
+            # First call: _read_from_disk; second call: unlink
+            assert mock_thread.call_count >= 1
+            assert mock_thread.call_args_list[0][0][0] == store._read_from_disk
+            assert mock_thread.call_args_list[0][0][1] == "a"
 
     @pytest.mark.asyncio
     async def test_async_set_eviction_saves_in_thread(self, tmp_path):

--- a/tests/test_kv_disk_cache.py
+++ b/tests/test_kv_disk_cache.py
@@ -3,7 +3,9 @@
 import os
 import time
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from olmlx.engine.model_manager import CachedPromptState, PromptCacheStore
 
@@ -384,3 +386,119 @@ class TestConfigSettings:
         assert s.prompt_cache_disk is True
         assert s.prompt_cache_disk_max_gb == 5.0
         assert s.prompt_cache_disk_path == Path("/tmp/kv")
+
+
+class TestAsyncDiskCache:
+    """Test async wrappers that offload disk I/O to threads."""
+
+    @pytest.mark.asyncio
+    async def test_async_get_memory_hit_no_thread(self):
+        """When cache is in memory, asyncio.to_thread is NOT called."""
+        store = PromptCacheStore(max_slots=2)
+        store.set("a", _make_state(1))
+
+        with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+            result = await store.async_get("a")
+            assert result is not None
+            assert result.tokens == [1]
+            mock_thread.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_get_disk_fallback_uses_thread(self, tmp_path):
+        """On memory miss with disk hit, asyncio.to_thread IS called with _load_from_disk."""
+        store = PromptCacheStore(
+            max_slots=2,
+            disk_path=tmp_path,
+            model_name="test-model",
+        )
+
+        disk_file = store._disk_file_path("a")
+        disk_file.parent.mkdir(parents=True, exist_ok=True)
+        disk_file.touch()
+
+        with patch(
+            "olmlx.engine.model_manager.load_prompt_cache",
+            return_value=(["restored_kv"], {"tokens": "[10, 20]"}),
+        ):
+            with patch(
+                "asyncio.to_thread",
+                new_callable=AsyncMock,
+                return_value=CachedPromptState(tokens=[10, 20], cache=["restored_kv"]),
+            ) as mock_thread:
+                result = await store.async_get("a")
+                mock_thread.assert_called_once()
+                # Verify _load_from_disk was the function passed to to_thread
+                assert mock_thread.call_args[0][0] == store._load_from_disk
+                assert mock_thread.call_args[0][1] == "a"
+                assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_async_set_eviction_saves_in_thread(self, tmp_path):
+        """Fill cache to capacity, async_set a new entry, verify _save_to_disk runs via asyncio.to_thread."""
+        store = PromptCacheStore(
+            max_slots=1,
+            disk_path=tmp_path,
+            model_name="test-model",
+        )
+        state_a = _make_state(1)
+        store.set("a", state_a)
+
+        with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+            await store.async_set("b", _make_state(2))
+            mock_thread.assert_called_once()
+            # Verify _save_to_disk was called with the evicted entry
+            assert mock_thread.call_args[0][0] == store._save_to_disk
+            assert mock_thread.call_args[0][1] == "a"
+            assert mock_thread.call_args[0][2] is state_a
+
+    @pytest.mark.asyncio
+    async def test_async_set_no_eviction_no_thread(self):
+        """When cache has room, no thread needed."""
+        store = PromptCacheStore(max_slots=4)
+
+        with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+            await store.async_set("a", _make_state(1))
+            mock_thread.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_evict_all_uses_thread(self, tmp_path):
+        """Verify evict_all_to_disk is offloaded to a thread."""
+        store = PromptCacheStore(
+            max_slots=4,
+            disk_path=tmp_path,
+            model_name="test-model",
+        )
+        store.set("a", _make_state(1))
+        store.set("b", _make_state(2))
+
+        with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+            await store.async_evict_all_to_disk()
+            mock_thread.assert_called_once()
+            # The function passed should be _evict_all_to_disk_sync or similar
+            assert mock_thread.call_args[0][0] == store._evict_all_to_disk_sync
+
+    def test_sync_methods_unchanged(self, tmp_path):
+        """Regression: sync get()/set() still work exactly as before."""
+        store = PromptCacheStore(
+            max_slots=2,
+            disk_path=tmp_path,
+            model_name="test-model",
+        )
+        state_a = _make_state(1)
+        state_b = _make_state(2)
+
+        # set works
+        result = store.set("a", state_a)
+        assert result is None  # no eviction
+        assert len(store) == 1
+
+        # get works
+        got = store.get("a")
+        assert got is state_a
+
+        # eviction via set works
+        store.set("b", state_b)
+        assert len(store) == 2
+
+        # get returns None for missing
+        assert store.get("missing") is None

--- a/tests/test_kv_disk_cache.py
+++ b/tests/test_kv_disk_cache.py
@@ -420,7 +420,7 @@ class TestAsyncDiskCache:
         with patch(
             "asyncio.to_thread",
             new_callable=AsyncMock,
-            return_value=loaded_state,
+            return_value=(loaded_state, disk_file),
         ) as mock_thread:
             result = await store.async_get("a")
             mock_thread.assert_called_once()

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1498,3 +1498,14 @@ class TestMemoryCheck:
         assert mock_gc.call_count == 2
         assert mock_clear.call_count == 2
         assert "qwen3:latest" not in manager._loaded
+
+
+class TestEnsureLoadedNotFoundSuggestions:
+    @pytest.mark.asyncio
+    async def test_ensure_loaded_not_found_suggests_similar(self, registry, mock_store):
+        """When model not found, error should include 'Did you mean' with suggestions."""
+        manager = ModelManager(registry, mock_store)
+        with pytest.raises(ValueError, match="Did you mean") as exc_info:
+            await manager.ensure_loaded("qwem3")  # typo for qwen3
+        # Should mention the similar model
+        assert "qwen3:latest" in str(exc_info.value)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -228,6 +228,45 @@ class TestModelRegistry:
         assert "qwen3:latest" in models
 
 
+class TestModelRegistrySearch:
+    def test_search_exact_match(self, registry):
+        """Searching 'qwen3' should return the qwen3 entry."""
+        results = registry.search("qwen3")
+        assert len(results) >= 1
+        names = [r[0] for r in results]
+        assert "qwen3:latest" in names
+
+    def test_search_close_match(self, registry):
+        """Searching 'qwem3' (typo) should still return qwen3."""
+        results = registry.search("qwem3")
+        assert len(results) >= 1
+        names = [r[0] for r in results]
+        assert "qwen3:latest" in names
+
+    def test_search_no_match(self, registry):
+        """Searching 'zzzzzzz' should return empty list."""
+        results = registry.search("zzzzzzz")
+        assert results == []
+
+    def test_search_max_results(self, tmp_path, monkeypatch):
+        """With many models, search respects the max_results limit."""
+        config = {f"model{i}:latest": f"org/model{i}" for i in range(20)}
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+        results = reg.search("model", max_results=3)
+        assert len(results) <= 3
+
+    def test_search_base_name_without_tag(self, registry):
+        """Searching 'llama3' should match 'llama3:8b'."""
+        results = registry.search("llama3")
+        assert len(results) >= 1
+        names = [r[0] for r in results]
+        assert "llama3:8b" in names
+
+
 class TestAtomicWriteJson:
     def test_atomic_write_json_creates_valid_file(self, tmp_path):
         target = tmp_path / "data.json"

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -1979,3 +1979,108 @@ class TestStreamCloseOnce:
         assert tracker.close_count == 1, (
             f"Expected result.aclose() called once, got {tracker.close_count}"
         )
+
+
+class TestAnthropicStreamingCleanup:
+    """Tests for streaming error handling and cleanup in the Anthropic router."""
+
+    @staticmethod
+    def _parse_sse_events(text: str) -> list[dict]:
+        """Parse SSE text into a list of {event, data} dicts."""
+        events = []
+        current_event = None
+        current_data = []
+        for line in text.split("\n"):
+            if line.startswith("event: "):
+                current_event = line[7:]
+            elif line.startswith("data: "):
+                current_data.append(line[6:])
+            elif line == "" and (current_event or current_data):
+                data_str = "\n".join(current_data)
+                try:
+                    data = json.loads(data_str)
+                except json.JSONDecodeError:
+                    data = data_str
+                events.append({"event": current_event, "data": data})
+                current_event = None
+                current_data = []
+        return events
+
+    async def test_streaming_error_emits_error_event(self, app_client):
+        """When the model stream raises mid-stream, an SSE error event is emitted."""
+
+        class ErrorStream:
+            def __init__(self):
+                self._yielded = False
+                self.aclose = AsyncMock()
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not self._yielded:
+                    self._yielded = True
+                    return {"text": "partial"}
+                raise RuntimeError("GPU error mid-stream")
+
+        error_stream = ErrorStream()
+
+        with patch(
+            "olmlx.routers.anthropic.generate_chat",
+            return_value=error_stream,
+        ):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "max_tokens": 100,
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                },
+            )
+
+        assert resp.status_code == 200
+        events = self._parse_sse_events(resp.text)
+        # Should contain an error event
+        error_events = [e for e in events if e.get("event") == "error"]
+        assert len(error_events) >= 1
+        error_data = error_events[0]["data"]
+        assert error_data["type"] == "error"
+        assert error_data["error"]["type"] == "api_error"
+
+    async def test_streaming_cleanup_on_error(self, app_client):
+        """Verify result.aclose() is called even when the inner generator raises."""
+
+        class ErrorStream:
+            def __init__(self):
+                self._yielded = False
+                self.aclose = AsyncMock()
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not self._yielded:
+                    self._yielded = True
+                    return {"text": "partial"}
+                raise RuntimeError("GPU error mid-stream")
+
+        error_stream = ErrorStream()
+
+        with patch(
+            "olmlx.routers.anthropic.generate_chat",
+            return_value=error_stream,
+        ):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "max_tokens": 100,
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                },
+            )
+
+        assert resp.status_code == 200
+        # The finally block in stream_sse should call result.aclose()
+        error_stream.aclose.assert_awaited_once()

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -1984,46 +1984,14 @@ class TestStreamCloseOnce:
 class TestAnthropicStreamingCleanup:
     """Tests for streaming error handling and cleanup in the Anthropic router."""
 
-    @staticmethod
-    def _parse_sse_events(text: str) -> list[dict]:
-        """Parse SSE text into a list of {event, data} dicts."""
-        events = []
-        current_event = None
-        current_data = []
-        for line in text.split("\n"):
-            if line.startswith("event: "):
-                current_event = line[7:]
-            elif line.startswith("data: "):
-                current_data.append(line[6:])
-            elif line == "" and (current_event or current_data):
-                data_str = "\n".join(current_data)
-                try:
-                    data = json.loads(data_str)
-                except json.JSONDecodeError:
-                    data = data_str
-                events.append({"event": current_event, "data": data})
-                current_event = None
-                current_data = []
-        return events
-
     async def test_streaming_error_emits_error_event(self, app_client):
         """When the model stream raises mid-stream, an SSE error event is emitted."""
+        from tests.conftest import make_error_stream
+        from tests.integration.conftest import parse_sse_events
 
-        class ErrorStream:
-            def __init__(self):
-                self._yielded = False
-                self.aclose = AsyncMock()
-
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                if not self._yielded:
-                    self._yielded = True
-                    return {"text": "partial"}
-                raise RuntimeError("GPU error mid-stream")
-
-        error_stream = ErrorStream()
+        error_stream = make_error_stream(
+            [{"text": "partial"}], error_msg="GPU error mid-stream"
+        )
 
         with patch(
             "olmlx.routers.anthropic.generate_chat",
@@ -2040,7 +2008,7 @@ class TestAnthropicStreamingCleanup:
             )
 
         assert resp.status_code == 200
-        events = self._parse_sse_events(resp.text)
+        events = parse_sse_events(resp.text)
         # Should contain an error event
         error_events = [e for e in events if e.get("event") == "error"]
         assert len(error_events) >= 1
@@ -2050,22 +2018,11 @@ class TestAnthropicStreamingCleanup:
 
     async def test_streaming_cleanup_on_error(self, app_client):
         """Verify result.aclose() is called even when the inner generator raises."""
+        from tests.conftest import make_error_stream
 
-        class ErrorStream:
-            def __init__(self):
-                self._yielded = False
-                self.aclose = AsyncMock()
-
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                if not self._yielded:
-                    self._yielded = True
-                    return {"text": "partial"}
-                raise RuntimeError("GPU error mid-stream")
-
-        error_stream = ErrorStream()
+        error_stream = make_error_stream(
+            [{"text": "partial"}], error_msg="GPU error mid-stream"
+        )
 
         with patch(
             "olmlx.routers.anthropic.generate_chat",

--- a/tests/test_routers_manage.py
+++ b/tests/test_routers_manage.py
@@ -249,3 +249,54 @@ class TestManageRouter:
                 },
             )
         assert resp.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_pull_streaming_calls_aclose_on_iterator(self, app_client):
+        """Verify the pull iterator's aclose() is explicitly called via finally block."""
+        from unittest.mock import patch
+
+        original_aclose_called = False
+
+        async def mock_pull(name):
+            nonlocal original_aclose_called
+            try:
+                yield {"status": "pulling manifest"}
+                yield {"status": "success"}
+            finally:
+                original_aclose_called = True
+
+        # We wrap mock_pull to track aclose calls on the actual iterator
+        aclose_explicitly_called = False
+
+        class TrackingAsyncGen:
+            def __init__(self, gen):
+                self._gen = gen
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                return await self._gen.__anext__()
+
+            async def aclose(self):
+                nonlocal aclose_explicitly_called
+                aclose_explicitly_called = True
+                await self._gen.aclose()
+
+        def tracked_pull(name):
+            return TrackingAsyncGen(mock_pull(name))
+
+        with patch.object(
+            app_client._transport.app.state.model_store,
+            "pull",
+            side_effect=tracked_pull,
+        ):
+            resp = await app_client.post(
+                "/api/pull",
+                json={
+                    "model": "qwen3",
+                    "stream": True,
+                },
+            )
+        assert resp.status_code == 200
+        assert aclose_explicitly_called is True

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -499,7 +499,7 @@ class TestSafeNdjsonStream:
             src,
             format_chunk=lambda x: f"[{x}]",
             format_error=lambda e: f"ERR:{e}",
-            logger=logging.getLogger("test"),
+            log=logging.getLogger("test"),
         ):
             chunks.append(chunk)
 
@@ -527,7 +527,7 @@ class TestSafeNdjsonStream:
             src,
             format_chunk=lambda x: f"[{x}]",
             format_error=lambda e: f"ERR:{e}",
-            logger=logging.getLogger("test"),
+            log=logging.getLogger("test"),
         ):
             chunks.append(chunk)
 
@@ -555,7 +555,7 @@ class TestSafeNdjsonStream:
             src,
             format_chunk=lambda x: f"[{x}]",
             format_error=lambda e: f"ERR:{e}",
-            logger=logging.getLogger("test"),
+            log=logging.getLogger("test"),
         )
         # Consume one item then break
         async for chunk in stream:
@@ -586,7 +586,7 @@ class TestSafeNdjsonStream:
             src,
             format_chunk=lambda x: f"[{x}]",
             format_error=lambda e: f"ERR:{e}",
-            logger=logging.getLogger("test"),
+            log=logging.getLogger("test"),
         ):
             chunks.append(chunk)
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -472,3 +472,123 @@ class TestPrefillCancelCallback:
 
         call_kwargs = mock_mlx_vlm.stream_generate.call_args
         assert "prompt_progress_callback" not in call_kwargs.kwargs
+
+
+class TestSafeNdjsonStream:
+    """Tests for the safe_ndjson_stream helper."""
+
+    @pytest.mark.asyncio
+    async def test_normal_completion(self):
+        """Source yields 3 items, all formatted and yielded, source closed."""
+        from olmlx.utils.streaming import safe_ndjson_stream
+
+        closed = False
+
+        async def source():
+            nonlocal closed
+            try:
+                yield "a"
+                yield "b"
+                yield "c"
+            finally:
+                closed = True
+
+        src = source()
+        chunks = []
+        async for chunk in safe_ndjson_stream(
+            src,
+            format_chunk=lambda x: f"[{x}]",
+            format_error=lambda e: f"ERR:{e}",
+            logger=logging.getLogger("test"),
+        ):
+            chunks.append(chunk)
+
+        assert chunks == ["[a]", "[b]", "[c]"]
+        assert closed is True
+
+    @pytest.mark.asyncio
+    async def test_error_formats_and_closes(self):
+        """Source raises mid-stream, error is formatted and yielded, source closed."""
+        from olmlx.utils.streaming import safe_ndjson_stream
+
+        closed = False
+
+        async def source():
+            nonlocal closed
+            try:
+                yield "ok"
+                raise RuntimeError("boom")
+            finally:
+                closed = True
+
+        src = source()
+        chunks = []
+        async for chunk in safe_ndjson_stream(
+            src,
+            format_chunk=lambda x: f"[{x}]",
+            format_error=lambda e: f"ERR:{e}",
+            logger=logging.getLogger("test"),
+        ):
+            chunks.append(chunk)
+
+        assert chunks == ["[ok]", "ERR:boom"]
+        assert closed is True
+
+    @pytest.mark.asyncio
+    async def test_generator_exit_closes_source(self):
+        """Consumer breaks early (GeneratorExit), source still closed."""
+        from olmlx.utils.streaming import safe_ndjson_stream
+
+        closed = False
+
+        async def source():
+            nonlocal closed
+            try:
+                yield "a"
+                yield "b"
+                yield "c"
+            finally:
+                closed = True
+
+        src = source()
+        stream = safe_ndjson_stream(
+            src,
+            format_chunk=lambda x: f"[{x}]",
+            format_error=lambda e: f"ERR:{e}",
+            logger=logging.getLogger("test"),
+        )
+        # Consume one item then break
+        async for chunk in stream:
+            break
+
+        # Explicitly close the wrapper to trigger cleanup
+        await stream.aclose()
+        assert closed is True
+
+    @pytest.mark.asyncio
+    async def test_empty_source(self):
+        """Source yields nothing, still closes properly."""
+        from olmlx.utils.streaming import safe_ndjson_stream
+
+        closed = False
+
+        async def source():
+            nonlocal closed
+            try:
+                return
+                yield  # make it a generator
+            finally:
+                closed = True
+
+        src = source()
+        chunks = []
+        async for chunk in safe_ndjson_stream(
+            src,
+            format_chunk=lambda x: f"[{x}]",
+            format_error=lambda e: f"ERR:{e}",
+            logger=logging.getLogger("test"),
+        ):
+            chunks.append(chunk)
+
+        assert chunks == []
+        assert closed is True


### PR DESCRIPTION
## Summary

- **perf: offload blocking disk I/O to threads (#126)** — `PromptCacheStore` async wrappers (`async_get`, `async_set`, `async_evict_all_to_disk`) that offload safetensors read/write to `asyncio.to_thread()`, unblocking the event loop during disk cache operations
- **feat: model discovery and better error messages (#129)** — `ModelRegistry.search()` with `difflib` fuzzy matching, "Did you mean: ..." in model-not-found errors, `olmlx models search <query>` CLI command, normalization logging, search suggestions in CLI error output
- **refactor: extract streaming error helper, fix manage.py cleanup bug (#128)** — `safe_ndjson_stream()` async generator in `utils/streaming.py` replacing duplicated try/except/finally in generate, chat, and manage routers; fixes missing `aclose()` in `/api/pull` streaming endpoint
- **test: cover critical path gaps (#130)** — 40 new tests: zero-token generation, empty messages, streaming disconnect/aclose cleanup, Anthropic SSE error events, distributed sideband protocol roundtrip
- **Code review cleanup** — fixed thread safety race (pre-lock `async_get` in `generate_chat` could mutate `OrderedDict` from worker thread), extracted `_set_in_memory()` to deduplicate `set()`/`async_set()`, consolidated 5 copies of `ErrorStream` test helper into shared factory

## Test plan

- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run pytest` — 1448 tests pass (1 pre-existing `mx.logsumexp` mock failure deselected)
- [ ] CI confirms all checks green
- [ ] Smoke test: `uv run olmlx models search qwen` returns matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)