### PR TITLE
fix: preserve non-KVCache entries in TurboQuant for hybrid models

### DIFF
--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import mlx.core as mx
 
-from mlx_lm.models.cache import _BaseCache, create_attention_mask
+from mlx_lm.models.cache import KVCache, _BaseCache, create_attention_mask
 
 from olmlx.engine.turboquant import (
     TurboQuantRotation,
@@ -177,8 +177,13 @@ def _detect_head_dim(model: Any) -> int:
         ) from e
 
 
-def make_turboquant_cache(model: Any, bits: int) -> list[TurboQuantKVCache]:
-    """Create a list of TurboQuantKVCache objects, one per model layer."""
+def make_turboquant_cache(model: Any, bits: int) -> list:
+    """Create a cache list with TurboQuantKVCache for attention layers.
+
+    For hybrid models (e.g. Nemotron-H with SSM + attention layers), only
+    attention-layer caches (KVCache) are replaced with TurboQuantKVCache.
+    Non-attention caches (e.g. ArraysCache for SSM/Mamba layers) are preserved.
+    """
     num_layers = len(model.layers)
     head_dim = _detect_head_dim(model)
 
@@ -189,16 +194,31 @@ def make_turboquant_cache(model: Any, bits: int) -> list[TurboQuantKVCache]:
             f"got head_dim={head_dim}"
         )
 
+    # Get default cache layout from model if available (hybrid models
+    # return different cache types per layer, e.g. ArraysCache for SSM)
+    try:
+        default_caches = model.make_cache()
+        if not isinstance(default_caches, list) or len(default_caches) != num_layers:
+            default_caches = [None] * num_layers
+    except AttributeError:
+        default_caches = [None] * num_layers
+
     caches = []
-    for i in range(num_layers):
-        rot_k = TurboQuantRotation(head_dim=head_dim, seed=i * 2)
-        rot_v = TurboQuantRotation(head_dim=head_dim, seed=i * 2 + 1)
-        caches.append(
-            TurboQuantKVCache(bits=bits, rotation_key=rot_k, rotation_value=rot_v)
-        )
+    tq_count = 0
+    for i, default in enumerate(default_caches):
+        if default is None or isinstance(default, KVCache):
+            rot_k = TurboQuantRotation(head_dim=head_dim, seed=i * 2)
+            rot_v = TurboQuantRotation(head_dim=head_dim, seed=i * 2 + 1)
+            caches.append(
+                TurboQuantKVCache(bits=bits, rotation_key=rot_k, rotation_value=rot_v)
+            )
+            tq_count += 1
+        else:
+            caches.append(default)
 
     logger.info(
-        "Created TurboQuant KV cache: %d layers, %d-bit, head_dim=%d",
+        "Created TurboQuant KV cache: %d/%d layers quantized, %d-bit, head_dim=%d",
+        tq_count,
         num_layers,
         bits,
         head_dim,

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -196,11 +196,11 @@ def make_turboquant_cache(model: Any, bits: int) -> list:
 
     # Get default cache layout from model if available (hybrid models
     # return different cache types per layer, e.g. ArraysCache for SSM)
-    try:
+    if hasattr(model, "make_cache"):
         default_caches = model.make_cache()
         if not isinstance(default_caches, list) or len(default_caches) != num_layers:
             default_caches = [None] * num_layers
-    except AttributeError:
+    else:
         default_caches = [None] * num_layers
 
     caches = []

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -461,6 +461,53 @@ class TestMakeTurboQuantCache:
         cache = make_turboquant_cache(model, bits=4)
         assert cache[0].rotation_key.matrix.shape == (128, 128)
 
+    def test_hybrid_model_preserves_non_kv_caches(self):
+        """Hybrid models (e.g. Nemotron-H) have SSM layers needing ArraysCache."""
+        from unittest.mock import MagicMock
+
+        from mlx_lm.models.cache import ArraysCache, KVCache
+
+        from olmlx.engine.turboquant_cache import (
+            TurboQuantKVCache,
+            make_turboquant_cache,
+        )
+
+        model = MagicMock()
+        model.layers = [MagicMock() for _ in range(4)]
+        model.args.head_dim = 64
+        # Simulate Nemotron-H: SSM, attention, SSM, attention
+        model.make_cache.return_value = [
+            ArraysCache(size=2),
+            KVCache(),
+            ArraysCache(size=2),
+            KVCache(),
+        ]
+
+        cache = make_turboquant_cache(model, bits=4)
+        assert len(cache) == 4
+        assert isinstance(cache[0], ArraysCache)
+        assert isinstance(cache[1], TurboQuantKVCache)
+        assert isinstance(cache[2], ArraysCache)
+        assert isinstance(cache[3], TurboQuantKVCache)
+
+    def test_model_without_make_cache_all_turboquant(self):
+        """Models without make_cache() get TurboQuantKVCache for all layers."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.turboquant_cache import (
+            TurboQuantKVCache,
+            make_turboquant_cache,
+        )
+
+        model = MagicMock(spec=[])  # no make_cache attribute
+        model.layers = [MagicMock() for _ in range(3)]
+        model.args = MagicMock()
+        model.args.head_dim = 64
+
+        cache = make_turboquant_cache(model, bits=4)
+        assert len(cache) == 3
+        assert all(isinstance(c, TurboQuantKVCache) for c in cache)
+
 
 # ---------------------------------------------------------------------------
 # Config tests


### PR DESCRIPTION
## Summary

- Fixes #134 — TurboQuant KV cache crashes on hybrid models (Nemotron-H, MiniMax) with `create_attention_mask() missing 2 required positional arguments`
- `make_turboquant_cache` now calls `model.make_cache()` to get the default cache layout, then only replaces `KVCache` entries with `TurboQuantKVCache` — non-attention caches (e.g. `ArraysCache` for SSM/Mamba layers) are preserved
- Falls back to all-TurboQuantKVCache for models without `make_cache()`

## Test plan

- [x] New test: hybrid model with mixed `ArraysCache`/`KVCache` preserves non-KVCache entries
- [x] New test: model without `make_cache()` falls back to all-TurboQuantKVCache
- [x] All 1420 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)