### PR TITLE
fix: correct KV cache memory estimate for NAS models

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -395,8 +395,17 @@ def _estimate_kv_cache_bytes(model: Any, num_tokens: int) -> int:
     )
     bytes_per_element = 2  # float16/bfloat16
 
-    # Try layer introspection for NAS/variable-attention models
-    inner = getattr(model, "model", None)
+    # Try layer introspection for NAS/variable-attention models.
+    # Track which sub-model owns the args so we introspect the right layers
+    # (for VLMs, args came from model.language_model — introspect that, not
+    # model.model which could be a vision encoder).
+    lang_model_component = getattr(model, "language_model", None)
+    args_owner = (
+        lang_model_component
+        if (lang_model_component is not None and getattr(model, "args", None) is None)
+        else model
+    )
+    inner = getattr(args_owner, "model", None)
     layers = getattr(inner, "layers", None) if inner is not None else None
     if isinstance(layers, (list, tuple)) and len(layers) > 0:
         per_layer_kv_sum = 0

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1506,6 +1506,33 @@ class TestEstimateKvCacheBytes:
         result = _estimate_kv_cache_bytes(model, 1000)
         assert result == int(131_072_000 * _inf_mod.MEMORY_SAFETY_FACTOR)
 
+    def test_vlm_introspects_language_model_layers(self):
+        """VLM layer introspection uses language_model.model.layers, not model.model."""
+        model = MagicMock(spec=[])
+        model.language_model = MagicMock(spec=[])
+        model.language_model.args = self._make_model_args(
+            num_hidden_layers=32,
+            num_attention_heads=32,
+            hidden_size=4096,
+        )
+        # Remove num_key_value_heads from args to force introspection
+        del model.language_model.args.num_key_value_heads
+
+        # language_model.model.layers has the real attention layers
+        layers = []
+        for _ in range(32):
+            layer = MagicMock()
+            layer.self_attn = MagicMock()
+            layer.self_attn.n_kv_heads = 4
+            layers.append(layer)
+        model.language_model.model = MagicMock()
+        model.language_model.model.layers = layers
+
+        # Should use introspected kv_heads=4, not fallback to num_attention_heads=32
+        result = _estimate_kv_cache_bytes(model, 1000)
+        expected_raw = 32 * 2 * 4 * 128 * 1000 * 2
+        assert result == int(expected_raw * _inf_mod.MEMORY_SAFETY_FACTOR)
+
     def test_raises_when_no_args_found(self):
         """Raises AttributeError when model has no discoverable args."""
         model = MagicMock(spec=[])
@@ -1584,7 +1611,9 @@ class TestEstimateKvCacheBytes:
 
         layers = []
         for _ in range(32):
-            layer = MagicMock(spec=[])  # no self_attn attribute
+            layer = MagicMock(spec=["attention"])  # has "attention", not "self_attn"
+            layer.attention = MagicMock()
+            layer.attention.n_kv_heads = 8
             layers.append(layer)
         model.model = MagicMock()
         model.model.layers = layers


### PR DESCRIPTION
## Summary
- **KV cache estimate was ~13x too high for NAS models** (e.g. Nemotron-Super-49B): `_estimate_kv_cache_bytes` fell back to `num_attention_heads` (64) since `num_key_value_heads` is absent from nemotron-nas `ModelArgs`, and counted all 80 layers instead of the 49 with actual attention (31 are no-op). This caused valid prompts to be rejected with a spurious `MemoryError`.
- **Fixed by introspecting `model.model.layers`** to count only layers with real attention (`self_attn is not None`) and read per-layer `n_kv_heads`. Falls back to the original args-based estimate for standard models.
- **Fixed misleading error message**: previously showed prompt token count but the byte estimate included `max_tokens`; now shows the actual total used in the calculation.

## Test plan
- [x] New test: NAS model with 49/80 attention layers and per-layer `n_kv_heads=8` produces correct estimate
- [x] New test: model without introspectable layers falls back to args-based estimate
- [x] All 9 `TestEstimateKvCacheBytes` tests pass
- [x] All 1503 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)