### PR TITLE
feat: speculative prefetcher for LLM in a Flash

### DIFF
--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -1133,6 +1133,8 @@ def _cmd_flash_dense_prepare(args, model_path):
     print(f"  Training epochs: {args.epochs}")
     print()
 
+    from olmlx.config import experimental
+
     output_dir = prepare_model_for_flash(
         model_path=model_path,
         rank=args.rank,
@@ -1142,6 +1144,7 @@ def _cmd_flash_dense_prepare(args, model_path):
         calibration_dataset=args.calibration_dataset,
         activation_threshold=args.threshold,
         epochs=args.epochs,
+        train_lookahead=experimental.flash_prefetch,
         progress_callback=_flash_progress,
     )
 
@@ -1344,7 +1347,6 @@ def build_parser() -> argparse.ArgumentParser:
         default=4,
         help="Rank multiplier for sensitive layers (default: 4)",
     )
-
     info_p = flash_sub.add_parser(
         "info", help="Show flash preparation info for a model"
     )

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -77,6 +77,11 @@ class ExperimentalSettings(BaseSettings):
     flash_bypass_os_cache: bool = False
     flash_preallocated_buffer: bool = False
     flash_memory_budget_fraction: Annotated[float, Field(gt=0, le=1.0)] | None = None
+    flash_prefetch: bool = False
+    flash_prefetch_confidence_threshold: Annotated[float, Field(gt=0, le=1.0)] = 0.3
+    flash_prefetch_min_neurons: Annotated[int, Field(gt=0)] = 64
+    flash_prefetch_max_neurons: Annotated[int, Field(gt=0)] | None = None
+    flash_prefetch_io_threads: Annotated[int, Field(gt=0)] = 16
     flash_speculative: bool = False
     flash_speculative_draft_model: str | None = None
     flash_speculative_tokens: Annotated[int, Field(gt=0)] = 4

--- a/olmlx/engine/flash/flash_mlp.py
+++ b/olmlx/engine/flash/flash_mlp.py
@@ -12,8 +12,13 @@ from collections import deque
 import mlx.core as mx
 import mlx.nn as nn
 
+from typing import TYPE_CHECKING
+
 from olmlx.engine.flash.predictor import SparsityPredictor
 from olmlx.engine.flash.weight_store import FlashWeightStore
+
+if TYPE_CHECKING:
+    from olmlx.engine.flash.prefetch import Prefetcher
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +139,7 @@ class FlashMLP(nn.Module):
         sparsity_threshold: float = 0.5,
         min_active_neurons: int = 128,
         max_active_neurons: int | None = None,
+        prefetcher: Prefetcher | None = None,
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -145,11 +151,17 @@ class FlashMLP(nn.Module):
         self.sparsity_threshold = sparsity_threshold
         self.min_active_neurons = min_active_neurons
         self.max_active_neurons = max_active_neurons
+        self.prefetcher = prefetcher
 
     def __call__(self, x: mx.array) -> mx.array:
         """Sparse FFN forward pass."""
         orig_shape = x.shape
         flat_x = x.reshape(-1, self.hidden_size)
+
+        # Wait for any pending prefetch for THIS layer (submitted by the
+        # previous layer's call to prefetcher.submit).
+        if self.prefetcher is not None:
+            self.prefetcher.wait(self.layer_idx)
 
         # Predict active neurons
         predicted = self.predictor.predict_active(
@@ -167,7 +179,13 @@ class FlashMLP(nn.Module):
         else:
             combined = predicted_list
 
-        # Load weights from store
+        # Start prefetch for the NEXT layer before blocking on current I/O.
+        # Uses flat_x (pre-MLP hidden state) as an approximate signal for
+        # the next layer's activation pattern.
+        if self.prefetcher is not None:
+            self.prefetcher.submit(self.layer_idx, flat_x)
+
+        # Load weights from store (blocking — but next layer I/O is in flight)
         gate_cols, up_cols, down_rows = self.weight_store.load_neurons(
             self.layer_idx, combined
         )

--- a/olmlx/engine/flash/flash_model.py
+++ b/olmlx/engine/flash/flash_model.py
@@ -14,7 +14,8 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from olmlx.engine.flash.flash_mlp import FlashMLP, WindowManager
-from olmlx.engine.flash.predictor import PredictorBank
+from olmlx.engine.flash.prefetch import Prefetcher
+from olmlx.engine.flash.predictor import LookaheadBank, PredictorBank
 from olmlx.engine.flash.weight_store import FlashWeightStore
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,12 @@ class FlashConfig:
     io_threads: int = 32
     cache_budget_neurons: int = 1024
     memory_budget_fraction: float | None = None
+    # Speculative prefetch settings
+    prefetch: bool = False
+    prefetch_confidence_threshold: float = 0.3
+    prefetch_min_neurons: int = 64
+    prefetch_max_neurons: int | None = None
+    prefetch_io_threads: int = 16
 
 
 class FlashModelWrapper(nn.Module):
@@ -50,6 +57,7 @@ class FlashModelWrapper(nn.Module):
         predictor_bank: PredictorBank,
         weight_store: FlashWeightStore,
         flash_config: FlashConfig,
+        lookahead_bank: LookaheadBank | None = None,
     ):
         super().__init__()
         # Store in __dict__ directly so __getattr__ can find it without
@@ -63,6 +71,28 @@ class FlashModelWrapper(nn.Module):
             memory_budget_fraction=flash_config.memory_budget_fraction,
             intermediate_size=flash_config.intermediate_size,
         )
+
+        # Create speculative prefetcher if enabled
+        self.prefetcher: Prefetcher | None = None
+        if flash_config.prefetch:
+            self.prefetcher = Prefetcher(
+                predictor_bank=predictor_bank,
+                weight_store=weight_store,
+                num_layers=flash_config.num_layers,
+                lookahead_bank=lookahead_bank,
+                confidence_threshold=flash_config.prefetch_confidence_threshold,
+                min_neurons=flash_config.prefetch_min_neurons,
+                max_neurons=flash_config.prefetch_max_neurons,
+                io_threads=flash_config.prefetch_io_threads,
+            )
+            logger.info(
+                "Speculative prefetcher enabled (threshold=%.2f, io_threads=%d, "
+                "lookahead=%s)",
+                flash_config.prefetch_confidence_threshold,
+                flash_config.prefetch_io_threads,
+                "dedicated" if lookahead_bank is not None else "fallback",
+            )
+
         self._replace_mlps(predictor_bank, weight_store, flash_config)
 
     def _replace_mlps(
@@ -88,6 +118,7 @@ class FlashModelWrapper(nn.Module):
                 sparsity_threshold=config.sparsity_threshold,
                 min_active_neurons=config.min_active_neurons,
                 max_active_neurons=config.max_active_neurons,
+                prefetcher=self.prefetcher,
             )
 
             # Free original MLP weights to reclaim RAM

--- a/olmlx/engine/flash/predictor.py
+++ b/olmlx/engine/flash/predictor.py
@@ -175,50 +175,8 @@ class PredictorBank:
         )
 
 
-class LookaheadPredictor(nn.Module):
-    """Cross-layer predictor: given hidden state at layer L, predict active
-    neurons at layer L+1.
-
-    Same low-rank architecture as SparsityPredictor but trained on a
-    cross-layer objective (input_L → target_{L+1}). Biased toward recall
-    since mispredictions only waste cache slots, not correctness.
-    """
-
-    def __init__(self, hidden_size: int, intermediate_size: int, rank: int = 64):
-        super().__init__()
-        self.down = nn.Linear(hidden_size, rank, bias=False)
-        self.up = nn.Linear(rank, intermediate_size, bias=False)
-
-    def __call__(self, x: mx.array) -> mx.array:
-        """Return activation scores for next-layer neurons (0-1 range)."""
-        return mx.sigmoid(self.up(mx.maximum(self.down(x), 0)))
-
-    def predict_active(
-        self,
-        x: mx.array,
-        threshold: float = 0.3,
-        min_neurons: int = 64,
-        max_neurons: int | None = None,
-    ) -> mx.array:
-        """Return sorted indices of predicted-active neurons for next layer."""
-        if x.ndim == 1:
-            x = x.reshape(1, -1)
-        scores = self(x).mean(axis=0)
-        mx.eval(scores)
-
-        n = scores.shape[0]
-        min_neurons = min(min_neurons, n)
-
-        active_mask = scores > threshold
-        num_active = int(mx.sum(active_mask).item())
-
-        k = max(num_active, min_neurons)
-        if max_neurons is not None:
-            k = min(k, max_neurons)
-        k = min(k, n)
-
-        indices = mx.argpartition(scores, kth=n - k)[n - k :]
-        return mx.sort(indices)
+# Same architecture as SparsityPredictor, trained on cross-layer objective.
+LookaheadPredictor = SparsityPredictor
 
 
 class LookaheadBank:
@@ -237,7 +195,7 @@ class LookaheadBank:
     ):
         self.num_layers = num_layers
         self.predictors = [
-            LookaheadPredictor(hidden_size, intermediate_size, rank)
+            SparsityPredictor(hidden_size, intermediate_size, rank)
             for _ in range(num_layers - 1)
         ]
 
@@ -282,7 +240,7 @@ class LookaheadBank:
             rank, hidden_size = down_w.shape
             intermediate_size, _ = up_w.shape
 
-            pred = LookaheadPredictor(hidden_size, intermediate_size, rank)
+            pred = SparsityPredictor(hidden_size, intermediate_size, rank)
             pred.down.weight = down_w
             pred.up.weight = up_w
             bank.predictors.append(pred)

--- a/olmlx/engine/flash/predictor.py
+++ b/olmlx/engine/flash/predictor.py
@@ -224,15 +224,26 @@ class LookaheadBank:
             raise FileNotFoundError(f"No lookahead predictor files found in {path}")
 
         bank = cls.__new__(cls)
-        bank.num_layers = len(files) + 1
         bank.predictors = []
 
+        parsed: dict[int, Path] = {}
         for f in files:
             m = re.search(r"lookahead_(\d+)", f.stem)
             if m is None:
                 raise ValueError(f"Cannot parse pair index from {f.name}")
-            i = int(m.group(1))
+            parsed[int(m.group(1))] = f
 
+        expected = list(range(len(parsed)))
+        if sorted(parsed.keys()) != expected:
+            raise ValueError(
+                f"Non-contiguous lookahead files: found indices {sorted(parsed.keys())}, "
+                f"expected {expected}"
+            )
+
+        bank.num_layers = len(parsed) + 1
+
+        for i in expected:
+            f = parsed[i]
             weights = dict(mx.load(str(f)))
             down_w = weights[f"pair_{i}.down.weight"]
             up_w = weights[f"pair_{i}.up.weight"]

--- a/olmlx/engine/flash/predictor.py
+++ b/olmlx/engine/flash/predictor.py
@@ -173,3 +173,133 @@ class PredictorBank:
         return self.predictors[layer_idx].predict_active(
             hidden_state, threshold, min_neurons, max_neurons
         )
+
+
+class LookaheadPredictor(nn.Module):
+    """Cross-layer predictor: given hidden state at layer L, predict active
+    neurons at layer L+1.
+
+    Same low-rank architecture as SparsityPredictor but trained on a
+    cross-layer objective (input_L → target_{L+1}). Biased toward recall
+    since mispredictions only waste cache slots, not correctness.
+    """
+
+    def __init__(self, hidden_size: int, intermediate_size: int, rank: int = 64):
+        super().__init__()
+        self.down = nn.Linear(hidden_size, rank, bias=False)
+        self.up = nn.Linear(rank, intermediate_size, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """Return activation scores for next-layer neurons (0-1 range)."""
+        return mx.sigmoid(self.up(mx.maximum(self.down(x), 0)))
+
+    def predict_active(
+        self,
+        x: mx.array,
+        threshold: float = 0.3,
+        min_neurons: int = 64,
+        max_neurons: int | None = None,
+    ) -> mx.array:
+        """Return sorted indices of predicted-active neurons for next layer."""
+        if x.ndim == 1:
+            x = x.reshape(1, -1)
+        scores = self(x).mean(axis=0)
+        mx.eval(scores)
+
+        n = scores.shape[0]
+        min_neurons = min(min_neurons, n)
+
+        active_mask = scores > threshold
+        num_active = int(mx.sum(active_mask).item())
+
+        k = max(num_active, min_neurons)
+        if max_neurons is not None:
+            k = min(k, max_neurons)
+        k = min(k, n)
+
+        indices = mx.argpartition(scores, kth=n - k)[n - k :]
+        return mx.sort(indices)
+
+
+class LookaheadBank:
+    """Collection of per-layer-pair lookahead predictors.
+
+    Predictor at index i predicts layer i+1 neurons given layer i hidden state.
+    There are num_layers - 1 predictors (no predictor for the last layer).
+    """
+
+    def __init__(
+        self,
+        num_layers: int,
+        hidden_size: int,
+        intermediate_size: int,
+        rank: int = 64,
+    ):
+        self.num_layers = num_layers
+        self.predictors = [
+            LookaheadPredictor(hidden_size, intermediate_size, rank)
+            for _ in range(num_layers - 1)
+        ]
+
+    def save(self, path: Path) -> None:
+        """Save all lookahead predictor weights to a directory."""
+        path.mkdir(parents=True, exist_ok=True)
+        for i, pred in enumerate(self.predictors):
+            weights = dict(pred.parameters())
+            flat = {}
+            for key, val in weights.items():
+                if isinstance(val, dict):
+                    for subkey, subval in val.items():
+                        flat[f"pair_{i}.{key}.{subkey}"] = subval
+                else:
+                    flat[f"pair_{i}.{key}"] = val
+            mx.savez(str(path / f"lookahead_{i:02d}.npz"), **flat)
+
+    @classmethod
+    def load(cls, path: Path) -> LookaheadBank:
+        """Load lookahead bank from a directory."""
+        files = sorted(
+            path.glob("lookahead_*.npz"),
+            key=lambda f: int(re.search(r"(\d+)", f.name).group(1)),
+        )
+        if not files:
+            raise FileNotFoundError(f"No lookahead predictor files found in {path}")
+
+        bank = cls.__new__(cls)
+        bank.num_layers = len(files) + 1
+        bank.predictors = []
+
+        for f in files:
+            m = re.search(r"lookahead_(\d+)", f.stem)
+            if m is None:
+                raise ValueError(f"Cannot parse pair index from {f.name}")
+            i = int(m.group(1))
+
+            weights = dict(mx.load(str(f)))
+            down_w = weights[f"pair_{i}.down.weight"]
+            up_w = weights[f"pair_{i}.up.weight"]
+
+            rank, hidden_size = down_w.shape
+            intermediate_size, _ = up_w.shape
+
+            pred = LookaheadPredictor(hidden_size, intermediate_size, rank)
+            pred.down.weight = down_w
+            pred.up.weight = up_w
+            bank.predictors.append(pred)
+
+        return bank
+
+    def predict_next_layer(
+        self,
+        layer_idx: int,
+        hidden_state: mx.array,
+        threshold: float = 0.3,
+        min_neurons: int = 64,
+        max_neurons: int | None = None,
+    ) -> mx.array:
+        """Predict active neuron indices for layer_idx + 1."""
+        if layer_idx >= len(self.predictors):
+            return mx.array([], dtype=mx.int32)
+        return self.predictors[layer_idx].predict_active(
+            hidden_state, threshold, min_neurons, max_neurons
+        )

--- a/olmlx/engine/flash/predictor.py
+++ b/olmlx/engine/flash/predictor.py
@@ -223,9 +223,6 @@ class LookaheadBank:
         if not files:
             raise FileNotFoundError(f"No lookahead predictor files found in {path}")
 
-        bank = cls.__new__(cls)
-        bank.predictors = []
-
         parsed: dict[int, Path] = {}
         for f in files:
             m = re.search(r"lookahead_(\d+)", f.stem)
@@ -240,21 +237,33 @@ class LookaheadBank:
                 f"expected {expected}"
             )
 
-        bank.num_layers = len(parsed) + 1
-
+        # Pre-load all weights to infer per-layer dimensions.
+        loaded: list[tuple[mx.array, mx.array]] = []
+        hidden_size = intermediate_size = 0
         for i in expected:
-            f = parsed[i]
-            weights = dict(mx.load(str(f)))
+            weights = dict(mx.load(str(parsed[i])))
             down_w = weights[f"pair_{i}.down.weight"]
             up_w = weights[f"pair_{i}.up.weight"]
-
-            rank, hidden_size = down_w.shape
+            _, hidden_size = down_w.shape
             intermediate_size, _ = up_w.shape
+            loaded.append((down_w, up_w))
 
-            pred = SparsityPredictor(hidden_size, intermediate_size, rank)
-            pred.down.weight = down_w
-            pred.up.weight = up_w
-            bank.predictors.append(pred)
+        # Use first file's rank for the constructor (predictors will be
+        # overwritten anyway — this just sets num_layers correctly).
+        rank = loaded[0][0].shape[0]
+        num_layers = len(parsed) + 1
+        bank = cls(num_layers, hidden_size, intermediate_size, rank)
+
+        # Replace freshly-initialized weights with loaded ones.
+        for i, (down_w, up_w) in enumerate(loaded):
+            r = down_w.shape[0]
+            if r != rank:
+                # Mixed ranks: rebuild predictor with correct dimensions.
+                bank.predictors[i] = SparsityPredictor(
+                    hidden_size, intermediate_size, r
+                )
+            bank.predictors[i].down.weight = down_w
+            bank.predictors[i].up.weight = up_w
 
         return bank
 

--- a/olmlx/engine/flash/prefetch.py
+++ b/olmlx/engine/flash/prefetch.py
@@ -36,6 +36,7 @@ class PrefetchStats:
     submitted: int = 0
     cache_hits: int = 0
     cache_misses: int = 0
+    failures: int = 0
 
     def hit_rate(self) -> float:
         total = self.cache_hits + self.cache_misses
@@ -196,9 +197,11 @@ class Prefetcher:
                 if missing:
                     self._weight_store.prefetch_neurons(layer_idx, missing)
             except Exception:
-                logger.debug(
+                logger.warning(
                     "Prefetch I/O failed for layer %d", layer_idx, exc_info=True
                 )
+                with self._lock:
+                    self.stats.failures += 1
             finally:
                 state.done.set()
 

--- a/olmlx/engine/flash/prefetch.py
+++ b/olmlx/engine/flash/prefetch.py
@@ -86,6 +86,14 @@ class Prefetcher:
     def num_layers(self) -> int:
         return self._num_layers
 
+    @property
+    def hidden_size(self) -> int | None:
+        """Input dimension the sparsity predictors expect, or None if unknown."""
+        predictors = self._predictor_bank.predictors
+        if predictors and hasattr(predictors[0], "down"):
+            return predictors[0].down.weight.shape[1]
+        return None
+
     # ------------------------------------------------------------------
     # Cross-layer prefetch (Path A)
     # ------------------------------------------------------------------
@@ -173,6 +181,8 @@ class Prefetcher:
 
         state = _LayerPrefetchState()
         with self._lock:
+            if layer_idx in self._pending:
+                return  # already in flight — don't overwrite
             self._pending[layer_idx] = state
             self.stats.submitted += 1
 
@@ -192,4 +202,4 @@ class Prefetcher:
 
     def close(self) -> None:
         """Shut down the prefetch thread pool."""
-        self._executor.shutdown(wait=False)
+        self._executor.shutdown(wait=True)

--- a/olmlx/engine/flash/prefetch.py
+++ b/olmlx/engine/flash/prefetch.py
@@ -195,7 +195,9 @@ class Prefetcher:
                     self.stats.cache_hits += len(cached)
                     self.stats.cache_misses += len(missing)
                 if missing:
-                    self._weight_store.prefetch_neurons(layer_idx, missing)
+                    self._weight_store.prefetch_neurons(
+                        layer_idx, missing, executor=self._executor
+                    )
             except Exception:
                 logger.warning(
                     "Prefetch I/O failed for layer %d", layer_idx, exc_info=True
@@ -205,7 +207,14 @@ class Prefetcher:
             finally:
                 state.done.set()
 
-        self._executor.submit(_do_prefetch)
+        try:
+            self._executor.submit(_do_prefetch)
+        except Exception:
+            state.done.set()
+            with self._lock:
+                self._pending.pop(layer_idx, None)
+                self.stats.submitted -= 1
+            logger.warning("Failed to submit prefetch for layer %d", layer_idx)
 
     def close(self) -> None:
         """Shut down the prefetch thread pool."""

--- a/olmlx/engine/flash/prefetch.py
+++ b/olmlx/engine/flash/prefetch.py
@@ -1,0 +1,215 @@
+"""Speculative prefetcher for LLM in a Flash.
+
+Predicts which neurons will be needed for upcoming layers or tokens and
+starts background SSD I/O before the forward pass reaches those layers.
+
+Two prefetch paths:
+
+- **Cross-layer** (always-on): while layer L computes, predict and prefetch
+  neurons for layer L+1. Uses the current layer's pre-MLP hidden state as
+  an approximate signal for the next layer's activation pattern.
+
+- **Draft-informed** (speculative decoding only): after the draft model
+  generates candidate tokens, predict neurons for all layers of the target
+  verification pass and submit bulk I/O before the target forward pass starts.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
+
+import mlx.core as mx
+
+from olmlx.engine.flash.predictor import LookaheadBank, PredictorBank
+from olmlx.engine.flash.weight_store import FlashWeightStore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PrefetchStats:
+    """Counters for monitoring prefetch effectiveness."""
+
+    submitted: int = 0
+    cache_hits: int = 0
+    cache_misses: int = 0
+
+    def hit_rate(self) -> float:
+        total = self.cache_hits + self.cache_misses
+        return self.cache_hits / total if total > 0 else 0.0
+
+
+@dataclass
+class _LayerPrefetchState:
+    """In-flight prefetch state for a single layer."""
+
+    futures: list[Future] = field(default_factory=list)
+    done: threading.Event = field(default_factory=threading.Event)
+
+
+class Prefetcher:
+    """Orchestrates background neuron prefetching from SSD.
+
+    Thread-safe: ``submit`` is called from the main forward-pass thread;
+    the actual I/O runs on a dedicated thread pool.
+    """
+
+    def __init__(
+        self,
+        predictor_bank: PredictorBank,
+        weight_store: FlashWeightStore,
+        num_layers: int,
+        *,
+        lookahead_bank: LookaheadBank | None = None,
+        confidence_threshold: float = 0.3,
+        min_neurons: int = 64,
+        max_neurons: int | None = None,
+        io_threads: int = 16,
+    ):
+        self._predictor_bank = predictor_bank
+        self._lookahead_bank = lookahead_bank
+        self._weight_store = weight_store
+        self._num_layers = num_layers
+        self._threshold = confidence_threshold
+        self._min_neurons = min_neurons
+        self._max_neurons = max_neurons
+        self._executor = ThreadPoolExecutor(max_workers=io_threads)
+
+        self._lock = threading.Lock()
+        self._pending: dict[int, _LayerPrefetchState] = {}
+        self.stats = PrefetchStats()
+
+    # ------------------------------------------------------------------
+    # Cross-layer prefetch (Path A)
+    # ------------------------------------------------------------------
+
+    def submit(self, layer_idx: int, hidden_state: mx.array) -> None:
+        """Predict neurons for ``layer_idx + 1`` and start background I/O.
+
+        Called from ``FlashMLP.__call__`` *before* the blocking
+        ``load_neurons`` for the current layer, so the next layer's I/O
+        overlaps with this layer's I/O + compute.
+
+        When a ``LookaheadBank`` is available, uses the dedicated cross-layer
+        predictor (trained on input_L → target_{L+1}). Otherwise, falls back
+        to the sparsity predictor for layer L+1 applied to layer L's hidden
+        state (an approximation).
+
+        Args:
+            layer_idx: Current layer being computed.
+            hidden_state: Pre-MLP hidden state at this layer, shape
+                ``(tokens, hidden_size)`` or ``(batch, tokens, hidden_size)``.
+        """
+        next_layer = layer_idx + 1
+        if next_layer >= self._num_layers:
+            return
+
+        if self._lookahead_bank is not None:
+            indices = self._predict_lookahead(layer_idx, hidden_state)
+        else:
+            indices = self._predict(next_layer, hidden_state)
+        self._submit_io(next_layer, indices)
+
+    def wait(self, layer_idx: int) -> None:
+        """Block until any pending prefetch for *layer_idx* completes."""
+        with self._lock:
+            state = self._pending.pop(layer_idx, None)
+        if state is None:
+            return
+        state.done.wait()
+
+    # ------------------------------------------------------------------
+    # Bulk prefetch (Path B — draft-informed)
+    # ------------------------------------------------------------------
+
+    def submit_bulk(
+        self,
+        layer_hidden_states: dict[int, mx.array],
+    ) -> None:
+        """Predict and prefetch neurons for multiple layers at once.
+
+        Used by speculative decoding after draft generation: the caller
+        provides approximate hidden states per layer (e.g. from the draft
+        model), and we submit I/O for every layer before the target
+        forward pass begins.
+
+        Args:
+            layer_hidden_states: Mapping of ``layer_idx`` to hidden state
+                tensors (any shape with last dim = hidden_size).
+        """
+        for layer_idx, hidden in layer_hidden_states.items():
+            if layer_idx >= self._num_layers:
+                continue
+            indices = self._predict(layer_idx, hidden)
+            self._submit_io(layer_idx, indices)
+
+    def cancel(self) -> None:
+        """Cancel all in-flight prefetch I/O (e.g. on draft rejection).
+
+        Already-completed reads remain in the cache (harmless).
+        In-flight futures are allowed to finish but their results are
+        discarded by clearing the pending map.
+        """
+        with self._lock:
+            self._pending.clear()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _predict(self, layer_idx: int, hidden_state: mx.array) -> list[int]:
+        """Run the sparsity predictor for a layer with prefetch settings."""
+        flat = hidden_state.reshape(-1, hidden_state.shape[-1])
+        indices = self._predictor_bank.predict_layer(
+            layer_idx,
+            flat,
+            threshold=self._threshold,
+            min_neurons=self._min_neurons,
+            max_neurons=self._max_neurons,
+        )
+        return indices.tolist()
+
+    def _predict_lookahead(self, layer_idx: int, hidden_state: mx.array) -> list[int]:
+        """Run the dedicated cross-layer lookahead predictor."""
+        assert self._lookahead_bank is not None
+        flat = hidden_state.reshape(-1, hidden_state.shape[-1])
+        indices = self._lookahead_bank.predict_next_layer(
+            layer_idx,
+            flat,
+            threshold=self._threshold,
+            min_neurons=self._min_neurons,
+            max_neurons=self._max_neurons,
+        )
+        return indices.tolist()
+
+    def _submit_io(self, layer_idx: int, neuron_indices: list[int]) -> None:
+        """Submit background prefetch I/O for a layer."""
+        if not neuron_indices:
+            return
+
+        state = _LayerPrefetchState()
+        with self._lock:
+            # Cancel any prior pending prefetch for this layer
+            self._pending[layer_idx] = state
+            self.stats.submitted += 1
+
+        def _do_prefetch():
+            try:
+                self._weight_store.prefetch_neurons(
+                    layer_idx, neuron_indices, executor=self._executor
+                )
+            except Exception:
+                logger.debug(
+                    "Prefetch I/O failed for layer %d", layer_idx, exc_info=True
+                )
+            finally:
+                state.done.set()
+
+        self._executor.submit(_do_prefetch)
+
+    def close(self) -> None:
+        """Shut down the prefetch thread pool."""
+        self._executor.shutdown(wait=False)

--- a/olmlx/engine/flash/prefetch.py
+++ b/olmlx/engine/flash/prefetch.py
@@ -188,9 +188,14 @@ class Prefetcher:
 
         def _do_prefetch():
             try:
-                # Use the weight store's own I/O pool (not the prefetcher's
-                # orchestration pool) to avoid contention.
-                self._weight_store.prefetch_neurons(layer_idx, neuron_indices)
+                cached, missing = self._weight_store.get_cached_indices(
+                    layer_idx, neuron_indices
+                )
+                with self._lock:
+                    self.stats.cache_hits += len(cached)
+                    self.stats.cache_misses += len(missing)
+                if missing:
+                    self._weight_store.prefetch_neurons(layer_idx, missing)
             except Exception:
                 logger.debug(
                     "Prefetch I/O failed for layer %d", layer_idx, exc_info=True

--- a/olmlx/engine/flash/prefetch.py
+++ b/olmlx/engine/flash/prefetch.py
@@ -82,6 +82,10 @@ class Prefetcher:
         self._pending: dict[int, _LayerPrefetchState] = {}
         self.stats = PrefetchStats()
 
+    @property
+    def num_layers(self) -> int:
+        return self._num_layers
+
     # ------------------------------------------------------------------
     # Cross-layer prefetch (Path A)
     # ------------------------------------------------------------------
@@ -89,19 +93,9 @@ class Prefetcher:
     def submit(self, layer_idx: int, hidden_state: mx.array) -> None:
         """Predict neurons for ``layer_idx + 1`` and start background I/O.
 
-        Called from ``FlashMLP.__call__`` *before* the blocking
-        ``load_neurons`` for the current layer, so the next layer's I/O
-        overlaps with this layer's I/O + compute.
-
-        When a ``LookaheadBank`` is available, uses the dedicated cross-layer
-        predictor (trained on input_L → target_{L+1}). Otherwise, falls back
-        to the sparsity predictor for layer L+1 applied to layer L's hidden
-        state (an approximation).
-
-        Args:
-            layer_idx: Current layer being computed.
-            hidden_state: Pre-MLP hidden state at this layer, shape
-                ``(tokens, hidden_size)`` or ``(batch, tokens, hidden_size)``.
+        Uses a ``LookaheadBank`` (cross-layer predictor) when available,
+        otherwise falls back to the sparsity predictor for layer L+1
+        applied to layer L's hidden state.
         """
         next_layer = layer_idx + 1
         if next_layer >= self._num_layers:
@@ -129,17 +123,7 @@ class Prefetcher:
         self,
         layer_hidden_states: dict[int, mx.array],
     ) -> None:
-        """Predict and prefetch neurons for multiple layers at once.
-
-        Used by speculative decoding after draft generation: the caller
-        provides approximate hidden states per layer (e.g. from the draft
-        model), and we submit I/O for every layer before the target
-        forward pass begins.
-
-        Args:
-            layer_hidden_states: Mapping of ``layer_idx`` to hidden state
-                tensors (any shape with last dim = hidden_size).
-        """
+        """Predict and prefetch neurons for multiple layers at once."""
         for layer_idx, hidden in layer_hidden_states.items():
             if layer_idx >= self._num_layers:
                 continue
@@ -161,7 +145,6 @@ class Prefetcher:
     # ------------------------------------------------------------------
 
     def _predict(self, layer_idx: int, hidden_state: mx.array) -> list[int]:
-        """Run the sparsity predictor for a layer with prefetch settings."""
         flat = hidden_state.reshape(-1, hidden_state.shape[-1])
         indices = self._predictor_bank.predict_layer(
             layer_idx,
@@ -173,7 +156,6 @@ class Prefetcher:
         return indices.tolist()
 
     def _predict_lookahead(self, layer_idx: int, hidden_state: mx.array) -> list[int]:
-        """Run the dedicated cross-layer lookahead predictor."""
         assert self._lookahead_bank is not None
         flat = hidden_state.reshape(-1, hidden_state.shape[-1])
         indices = self._lookahead_bank.predict_next_layer(
@@ -186,21 +168,19 @@ class Prefetcher:
         return indices.tolist()
 
     def _submit_io(self, layer_idx: int, neuron_indices: list[int]) -> None:
-        """Submit background prefetch I/O for a layer."""
         if not neuron_indices:
             return
 
         state = _LayerPrefetchState()
         with self._lock:
-            # Cancel any prior pending prefetch for this layer
             self._pending[layer_idx] = state
             self.stats.submitted += 1
 
         def _do_prefetch():
             try:
-                self._weight_store.prefetch_neurons(
-                    layer_idx, neuron_indices, executor=self._executor
-                )
+                # Use the weight store's own I/O pool (not the prefetcher's
+                # orchestration pool) to avoid contention.
+                self._weight_store.prefetch_neurons(layer_idx, neuron_indices)
             except Exception:
                 logger.debug(
                     "Prefetch I/O failed for layer %d", layer_idx, exc_info=True

--- a/olmlx/engine/flash/prefetch.py
+++ b/olmlx/engine/flash/prefetch.py
@@ -195,9 +195,7 @@ class Prefetcher:
                     self.stats.cache_hits += len(cached)
                     self.stats.cache_misses += len(missing)
                 if missing:
-                    self._weight_store.prefetch_neurons(
-                        layer_idx, missing, executor=self._executor
-                    )
+                    self._weight_store.prefetch_neurons(layer_idx, missing)
             except Exception:
                 logger.warning(
                     "Prefetch I/O failed for layer %d", layer_idx, exc_info=True

--- a/olmlx/engine/flash/prefetch.py
+++ b/olmlx/engine/flash/prefetch.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 
 import mlx.core as mx
@@ -46,7 +46,6 @@ class PrefetchStats:
 class _LayerPrefetchState:
     """In-flight prefetch state for a single layer."""
 
-    futures: list[Future] = field(default_factory=list)
     done: threading.Event = field(default_factory=threading.Event)
 
 

--- a/olmlx/engine/flash/prepare.py
+++ b/olmlx/engine/flash/prepare.py
@@ -547,6 +547,16 @@ def _train_lookahead_predictors(
             continue
 
         n = min(len(inputs_list), len(targets_list))
+        if n < max(len(inputs_list), len(targets_list)):
+            logger.warning(
+                "Recording count mismatch for lookahead %d→%d: %d inputs, %d targets; "
+                "using %d samples",
+                layer_idx,
+                next_layer,
+                len(inputs_list),
+                len(targets_list),
+                n,
+            )
         inputs = mx.stack(inputs_list[:n])
         targets = mx.stack(targets_list[:n])
 

--- a/olmlx/engine/flash/prepare.py
+++ b/olmlx/engine/flash/prepare.py
@@ -404,6 +404,46 @@ def _stream_record_activations(
     return recordings, hidden_size, intermediate_size, num_layers
 
 
+def _train_single_predictor(
+    pred: nn.Module,
+    inputs: mx.array,
+    targets: mx.array,
+    epochs: int,
+    lr: float,
+    pos_weight_multiplier: float = 1.0,
+) -> None:
+    """Train a single predictor with balanced BCE loss.
+
+    Args:
+        pos_weight_multiplier: Extra scaling on pos_weight for recall bias
+            (e.g. 2.0 for lookahead predictors).
+    """
+    from mlx.optimizers import Adam
+
+    optimizer = Adam(learning_rate=lr)
+
+    eps_w = 1e-7
+    num_pos = float(mx.sum(targets).item()) + eps_w
+    num_neg = float(mx.sum(1 - targets).item()) + eps_w
+    pos_w = min(num_neg / num_pos, 1000.0) * pos_weight_multiplier
+    neg_w = 1.0
+
+    def loss_fn(model, x, y):
+        scores = model(x)
+        eps = 1e-7
+        return -mx.mean(
+            pos_w * y * mx.log(scores + eps)
+            + neg_w * (1 - y) * mx.log(1 - scores + eps)
+        )
+
+    loss_and_grad = nn.value_and_grad(pred, loss_fn)
+
+    for epoch in range(epochs):
+        loss, grads = loss_and_grad(pred, inputs, targets)
+        optimizer.update(pred, grads)
+        mx.eval(pred.parameters(), optimizer.state)
+
+
 def _train_predictors(
     recordings: dict[int, tuple[list[mx.array], list[mx.array]]],
     hidden_size: int,
@@ -416,8 +456,6 @@ def _train_predictors(
     progress_callback: Callable[[str, float], None] | None = None,
 ) -> PredictorBank:
     """Train per-layer sparsity predictors from recorded activations."""
-    from mlx.optimizers import Adam
-
     num_layers = len(recordings)
     bank = PredictorBank(num_layers, hidden_size, intermediate_size, rank, ranks=ranks)
 
@@ -431,47 +469,24 @@ def _train_predictors(
             step += epochs
             continue
 
-        # Stack into training tensors
-        inputs = mx.stack(inputs_list)  # (N, hidden_size)
-        targets = mx.stack(targets_list)  # (N, intermediate_size)
+        inputs = mx.stack(inputs_list)
+        targets = mx.stack(targets_list)
 
-        pred = bank.predictors[layer_idx]
-        optimizer = Adam(learning_rate=lr)
+        _train_single_predictor(
+            bank.predictors[layer_idx],
+            inputs,
+            targets,
+            epochs=epochs,
+            lr=lr,
+            pos_weight_multiplier=1.0 if balanced_loss else 0.0,
+        )
+        step += epochs
 
-        # Compute inverse-frequency class weights for balanced loss.
-        # pos_weight = num_neg / num_pos makes total positive and negative
-        # loss contributions equal regardless of class imbalance.
-        if balanced_loss:
-            eps_w = 1e-7
-            num_pos = float(mx.sum(targets).item()) + eps_w
-            num_neg = float(mx.sum(1 - targets).item()) + eps_w
-            pos_w = min(num_neg / num_pos, 1000.0)
-            neg_w = 1.0
-        else:
-            pos_w = 1.0
-            neg_w = 1.0
-
-        def loss_fn(model, x, y):
-            scores = model(x)
-            eps = 1e-7
-            return -mx.mean(
-                pos_w * y * mx.log(scores + eps)
-                + neg_w * (1 - y) * mx.log(1 - scores + eps)
+        if progress_callback:
+            progress_callback(
+                f"Trained layer {layer_idx}",
+                step / total_steps,
             )
-
-        loss_and_grad = nn.value_and_grad(pred, loss_fn)
-
-        for epoch in range(epochs):
-            loss, grads = loss_and_grad(pred, inputs, targets)
-            optimizer.update(pred, grads)
-            mx.eval(pred.parameters(), optimizer.state)
-            step += 1
-
-            if progress_callback:
-                progress_callback(
-                    f"Training layer {layer_idx} (epoch {epoch + 1}/{epochs})",
-                    step / total_steps,
-                )
 
     return bank
 
@@ -485,16 +500,10 @@ def _train_lookahead_predictors(
     lr: float = 1e-3,
     progress_callback: Callable[[str, float], None] | None = None,
 ) -> LookaheadBank | None:
-    """Train cross-layer lookahead predictors from recorded activations.
-
-    For each layer pair (L, L+1), trains a predictor that takes layer L's
-    input hidden state and predicts layer L+1's activation pattern. This
-    enables speculative prefetching of next-layer neurons.
+    """Train cross-layer lookahead predictors (input_L → target_{L+1}).
 
     Returns None if insufficient recordings for cross-layer pairs.
     """
-    from mlx.optimizers import Adam
-
     num_layers = len(recordings)
     if num_layers < 2:
         logger.warning("Need at least 2 layers for lookahead predictors")
@@ -506,9 +515,7 @@ def _train_lookahead_predictors(
     step = 0
 
     for layer_idx in range(num_layers - 1):
-        # Input: layer L's hidden states (pre-MLP)
         inputs_list = recordings[layer_idx][0]
-        # Target: layer L+1's activation pattern
         next_layer = layer_idx + 1
         targets_list = recordings[next_layer][1] if next_layer in recordings else []
 
@@ -521,45 +528,27 @@ def _train_lookahead_predictors(
             step += epochs
             continue
 
-        # Align lengths (recordings may differ between layers)
         n = min(len(inputs_list), len(targets_list))
         inputs = mx.stack(inputs_list[:n])
         targets = mx.stack(targets_list[:n])
 
-        pred = bank.predictors[layer_idx]
-        optimizer = Adam(learning_rate=lr)
+        # 2x recall boost: false negatives cost latency, false positives
+        # only waste a cache slot.
+        _train_single_predictor(
+            bank.predictors[layer_idx],
+            inputs,
+            targets,
+            epochs=epochs,
+            lr=lr,
+            pos_weight_multiplier=2.0,
+        )
+        step += epochs
 
-        # Heavily bias toward recall: false negatives (missing a needed neuron)
-        # cost latency, while false positives (extra prefetched neuron) only
-        # waste a cache slot.
-        eps_w = 1e-7
-        num_pos = float(mx.sum(targets).item()) + eps_w
-        num_neg = float(mx.sum(1 - targets).item()) + eps_w
-        pos_w = min(num_neg / num_pos, 1000.0) * 2.0  # 2x recall boost
-        neg_w = 1.0
-
-        def loss_fn(model, x, y):
-            scores = model(x)
-            eps = 1e-7
-            return -mx.mean(
-                pos_w * y * mx.log(scores + eps)
-                + neg_w * (1 - y) * mx.log(1 - scores + eps)
+        if progress_callback:
+            progress_callback(
+                f"Trained lookahead {layer_idx}→{next_layer}",
+                step / total_steps,
             )
-
-        loss_and_grad = nn.value_and_grad(pred, loss_fn)
-
-        for epoch in range(epochs):
-            loss, grads = loss_and_grad(pred, inputs, targets)
-            optimizer.update(pred, grads)
-            mx.eval(pred.parameters(), optimizer.state)
-            step += 1
-
-            if progress_callback:
-                progress_callback(
-                    f"Training lookahead {layer_idx}→{next_layer} "
-                    f"(epoch {epoch + 1}/{epochs})",
-                    step / total_steps,
-                )
 
     return bank
 

--- a/olmlx/engine/flash/prepare.py
+++ b/olmlx/engine/flash/prepare.py
@@ -22,7 +22,11 @@ import mlx.nn as nn
 from mlx.utils import tree_map
 
 from olmlx.engine.flash.bundler import bundle_ffn_weights
-from olmlx.engine.flash.predictor import PredictorBank, compute_layer_ranks
+from olmlx.engine.flash.predictor import (
+    LookaheadBank,
+    PredictorBank,
+    compute_layer_ranks,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -472,6 +476,94 @@ def _train_predictors(
     return bank
 
 
+def _train_lookahead_predictors(
+    recordings: dict[int, tuple[list[mx.array], list[mx.array]]],
+    hidden_size: int,
+    intermediate_size: int,
+    rank: int = 64,
+    epochs: int = 5,
+    lr: float = 1e-3,
+    progress_callback: Callable[[str, float], None] | None = None,
+) -> LookaheadBank | None:
+    """Train cross-layer lookahead predictors from recorded activations.
+
+    For each layer pair (L, L+1), trains a predictor that takes layer L's
+    input hidden state and predicts layer L+1's activation pattern. This
+    enables speculative prefetching of next-layer neurons.
+
+    Returns None if insufficient recordings for cross-layer pairs.
+    """
+    from mlx.optimizers import Adam
+
+    num_layers = len(recordings)
+    if num_layers < 2:
+        logger.warning("Need at least 2 layers for lookahead predictors")
+        return None
+
+    bank = LookaheadBank(num_layers, hidden_size, intermediate_size, rank)
+
+    total_steps = (num_layers - 1) * epochs
+    step = 0
+
+    for layer_idx in range(num_layers - 1):
+        # Input: layer L's hidden states (pre-MLP)
+        inputs_list = recordings[layer_idx][0]
+        # Target: layer L+1's activation pattern
+        next_layer = layer_idx + 1
+        targets_list = recordings[next_layer][1] if next_layer in recordings else []
+
+        if not inputs_list or not targets_list:
+            logger.warning(
+                "No cross-layer pair for layers %d→%d, skipping",
+                layer_idx,
+                next_layer,
+            )
+            step += epochs
+            continue
+
+        # Align lengths (recordings may differ between layers)
+        n = min(len(inputs_list), len(targets_list))
+        inputs = mx.stack(inputs_list[:n])
+        targets = mx.stack(targets_list[:n])
+
+        pred = bank.predictors[layer_idx]
+        optimizer = Adam(learning_rate=lr)
+
+        # Heavily bias toward recall: false negatives (missing a needed neuron)
+        # cost latency, while false positives (extra prefetched neuron) only
+        # waste a cache slot.
+        eps_w = 1e-7
+        num_pos = float(mx.sum(targets).item()) + eps_w
+        num_neg = float(mx.sum(1 - targets).item()) + eps_w
+        pos_w = min(num_neg / num_pos, 1000.0) * 2.0  # 2x recall boost
+        neg_w = 1.0
+
+        def loss_fn(model, x, y):
+            scores = model(x)
+            eps = 1e-7
+            return -mx.mean(
+                pos_w * y * mx.log(scores + eps)
+                + neg_w * (1 - y) * mx.log(1 - scores + eps)
+            )
+
+        loss_and_grad = nn.value_and_grad(pred, loss_fn)
+
+        for epoch in range(epochs):
+            loss, grads = loss_and_grad(pred, inputs, targets)
+            optimizer.update(pred, grads)
+            mx.eval(pred.parameters(), optimizer.state)
+            step += 1
+
+            if progress_callback:
+                progress_callback(
+                    f"Training lookahead {layer_idx}→{next_layer} "
+                    f"(epoch {epoch + 1}/{epochs})",
+                    step / total_steps,
+                )
+
+    return bank
+
+
 def prepare_model_for_flash(
     model_path: str,
     output_dir: Path | None = None,
@@ -482,6 +574,8 @@ def prepare_model_for_flash(
     calibration_dataset: str | None = None,
     activation_threshold: float = 0.01,
     epochs: int = 5,
+    lookahead_rank: int = 64,
+    train_lookahead: bool = True,
     progress_callback: Callable[[str, float], None] | None = None,
 ) -> Path:
     """Full preparation pipeline for flash inference.
@@ -548,13 +642,32 @@ def prepare_model_for_flash(
         ranks=layer_ranks,
         epochs=epochs,
         progress_callback=lambda desc, frac: (
-            progress_callback(desc, 0.4 + frac * 0.2) if progress_callback else None
+            progress_callback(desc, 0.4 + frac * 0.15) if progress_callback else None
         ),
     )
 
+    # Step 3b: Train lookahead predictors (cross-layer)
+    lookahead_bank = None
+    if train_lookahead and num_layers >= 2:
+        if progress_callback:
+            progress_callback("Training lookahead predictors", 0.55)
+
+        lookahead_bank = _train_lookahead_predictors(
+            recordings,
+            hidden_size,
+            intermediate_size,
+            rank=lookahead_rank,
+            epochs=epochs,
+            progress_callback=lambda desc, frac: (
+                progress_callback(desc, 0.55 + frac * 0.1)
+                if progress_callback
+                else None
+            ),
+        )
+
     # Step 4: Bundle FFN weights
     if progress_callback:
-        progress_callback("Bundling weights", 0.6)
+        progress_callback("Bundling weights", 0.65)
 
     model_dir = Path(model_path)
     bundle_ffn_weights(model_dir, output_dir)
@@ -565,6 +678,9 @@ def prepare_model_for_flash(
 
     predictor_bank.save(output_dir / "predictors")
 
+    if lookahead_bank is not None:
+        lookahead_bank.save(output_dir / "lookahead_predictors")
+
     # Step 6: Write config
     flash_config = {
         "hidden_size": hidden_size,
@@ -574,6 +690,8 @@ def prepare_model_for_flash(
         "predictor_ranks": layer_ranks,
         "sensitive_layers": sensitive_layers,
         "sensitive_rank_multiplier": sensitive_rank_multiplier,
+        "lookahead_rank": lookahead_rank,
+        "has_lookahead_predictors": lookahead_bank is not None,
         "num_calibration_samples": num_samples,
         "calibration_dataset": calibration_dataset or "c4",
         "activation_threshold": activation_threshold,

--- a/olmlx/engine/flash/prepare.py
+++ b/olmlx/engine/flash/prepare.py
@@ -595,7 +595,7 @@ def prepare_model_for_flash(
     activation_threshold: float = 0.01,
     epochs: int = 5,
     lookahead_rank: int = 64,
-    train_lookahead: bool = True,
+    train_lookahead: bool = False,
     progress_callback: Callable[[str, float], None] | None = None,
 ) -> Path:
     """Full preparation pipeline for flash inference.

--- a/olmlx/engine/flash/prepare.py
+++ b/olmlx/engine/flash/prepare.py
@@ -410,22 +410,26 @@ def _train_single_predictor(
     targets: mx.array,
     epochs: int,
     lr: float,
-    pos_weight_multiplier: float = 1.0,
+    pos_weight_multiplier: float | None = 1.0,
 ) -> None:
     """Train a single predictor with balanced BCE loss.
 
     Args:
         pos_weight_multiplier: Extra scaling on pos_weight for recall bias
-            (e.g. 2.0 for lookahead predictors).
+            (e.g. 2.0 for lookahead predictors). ``None`` disables class
+            balancing entirely (pos_w = neg_w = 1.0).
     """
     from mlx.optimizers import Adam
 
     optimizer = Adam(learning_rate=lr)
 
-    eps_w = 1e-7
-    num_pos = float(mx.sum(targets).item()) + eps_w
-    num_neg = float(mx.sum(1 - targets).item()) + eps_w
-    pos_w = min(num_neg / num_pos, 1000.0) * pos_weight_multiplier
+    if pos_weight_multiplier is not None:
+        eps_w = 1e-7
+        num_pos = float(mx.sum(targets).item()) + eps_w
+        num_neg = float(mx.sum(1 - targets).item()) + eps_w
+        pos_w = min(num_neg / num_pos, 1000.0) * pos_weight_multiplier
+    else:
+        pos_w = 1.0
     neg_w = 1.0
 
     def loss_fn(model, x, y):
@@ -478,7 +482,7 @@ def _train_predictors(
             targets,
             epochs=epochs,
             lr=lr,
-            pos_weight_multiplier=1.0 if balanced_loss else 0.0,
+            pos_weight_multiplier=1.0 if balanced_loss else None,
         )
         step += epochs
 

--- a/olmlx/engine/flash/prepare.py
+++ b/olmlx/engine/flash/prepare.py
@@ -411,6 +411,7 @@ def _train_single_predictor(
     epochs: int,
     lr: float,
     pos_weight_multiplier: float | None = 1.0,
+    epoch_callback: Callable[[int], None] | None = None,
 ) -> None:
     """Train a single predictor with balanced BCE loss.
 
@@ -418,6 +419,7 @@ def _train_single_predictor(
         pos_weight_multiplier: Extra scaling on pos_weight for recall bias
             (e.g. 2.0 for lookahead predictors). ``None`` disables class
             balancing entirely (pos_w = neg_w = 1.0).
+        epoch_callback: Called after each epoch with the epoch index (0-based).
     """
     from mlx.optimizers import Adam
 
@@ -446,6 +448,8 @@ def _train_single_predictor(
         loss, grads = loss_and_grad(pred, inputs, targets)
         optimizer.update(pred, grads)
         mx.eval(pred.parameters(), optimizer.state)
+        if epoch_callback is not None:
+            epoch_callback(epoch)
 
 
 def _train_predictors(
@@ -471,10 +475,21 @@ def _train_predictors(
         if not inputs_list:
             logger.warning("No recordings for layer %d, skipping", layer_idx)
             step += epochs
+            if progress_callback:
+                progress_callback(f"Skipped layer {layer_idx}", step / total_steps)
             continue
 
         inputs = mx.stack(inputs_list)
         targets = mx.stack(targets_list)
+
+        def _on_epoch(epoch: int, _li=layer_idx) -> None:
+            nonlocal step
+            step += 1
+            if progress_callback:
+                progress_callback(
+                    f"Training layer {_li} epoch {epoch + 1}/{epochs}",
+                    step / total_steps,
+                )
 
         _train_single_predictor(
             bank.predictors[layer_idx],
@@ -483,14 +498,8 @@ def _train_predictors(
             epochs=epochs,
             lr=lr,
             pos_weight_multiplier=1.0 if balanced_loss else None,
+            epoch_callback=_on_epoch,
         )
-        step += epochs
-
-        if progress_callback:
-            progress_callback(
-                f"Trained layer {layer_idx}",
-                step / total_steps,
-            )
 
     return bank
 
@@ -530,11 +539,25 @@ def _train_lookahead_predictors(
                 next_layer,
             )
             step += epochs
+            if progress_callback:
+                progress_callback(
+                    f"Skipped lookahead {layer_idx}→{next_layer}",
+                    step / total_steps,
+                )
             continue
 
         n = min(len(inputs_list), len(targets_list))
         inputs = mx.stack(inputs_list[:n])
         targets = mx.stack(targets_list[:n])
+
+        def _on_epoch(epoch: int, _li=layer_idx, _nl=next_layer) -> None:
+            nonlocal step
+            step += 1
+            if progress_callback:
+                progress_callback(
+                    f"Training lookahead {_li}→{_nl} epoch {epoch + 1}/{epochs}",
+                    step / total_steps,
+                )
 
         # 2x recall boost: false negatives cost latency, false positives
         # only waste a cache slot.
@@ -545,14 +568,8 @@ def _train_lookahead_predictors(
             epochs=epochs,
             lr=lr,
             pos_weight_multiplier=2.0,
+            epoch_callback=_on_epoch,
         )
-        step += epochs
-
-        if progress_callback:
-            progress_callback(
-                f"Trained lookahead {layer_idx}→{next_layer}",
-                step / total_steps,
-            )
 
     return bank
 

--- a/olmlx/engine/flash/speculative.py
+++ b/olmlx/engine/flash/speculative.py
@@ -260,14 +260,16 @@ class SpeculativeFlashDecoder:
             )
             return
 
-        # Mean across draft positions as a single representative signal
-        stacked = mx.concatenate(
-            [h.reshape(1, -1) for h in draft_hidden_states], axis=0
-        )
-        representative = stacked.mean(axis=0, keepdims=True)
-        mx.eval(representative)
+        # Map draft positions to target layers by depth ratio so early layers
+        # get signals from early draft steps and deep layers from late steps.
+        num_layers = self._prefetcher.num_layers
+        num_draft = len(draft_hidden_states)
+        layer_states: dict[int, mx.array] = {}
+        for i in range(num_layers):
+            draft_idx = round(i * (num_draft - 1) / max(num_layers - 1, 1))
+            layer_states[i] = draft_hidden_states[draft_idx].reshape(1, -1)
+        mx.eval(*layer_states.values())
 
-        layer_states = {i: representative for i in range(self._prefetcher.num_layers)}
         self._prefetcher.submit_bulk(layer_states)
 
     # ------------------------------------------------------------------

--- a/olmlx/engine/flash/speculative.py
+++ b/olmlx/engine/flash/speculative.py
@@ -64,9 +64,6 @@ class SpeculativeFlashDecoder:
         self._last_target_logit: mx.array | None = None
         self._pending_token: int | None = None
 
-        # Hidden state capture for draft-informed prefetch
-        self._draft_hidden_states: list[mx.array] | None = None
-
     def _update_acceptance_rate(self, num_accepted: int) -> None:
         """Update the rolling acceptance rate via EMA."""
         num_accepted_draft = (
@@ -140,12 +137,13 @@ class SpeculativeFlashDecoder:
 
         # 1. Draft: feed pending token, then generate lambda candidates
         #    Draft cache advances from offset to offset + lambda.
-        draft_tokens = self._draft_generate_cached(pending_token, self._lambda)
+        draft_tokens, draft_logits = self._draft_generate_cached(
+            pending_token, self._lambda
+        )
 
-        # 1.5. Draft-informed prefetch: use captured draft hidden states to
-        #      predict and prefetch target neurons before the target forward pass.
-        if self._prefetcher is not None and self._draft_hidden_states:
-            self._submit_draft_prefetch()
+        # 1.5. Draft-informed prefetch: submit bulk I/O before target forward pass.
+        if self._prefetcher is not None and draft_logits:
+            self._submit_draft_prefetch(draft_logits)
 
         # 2. Target: feed [pending, D1, ..., D_lambda] in one pass.
         #    Target cache advances from offset to offset + lambda + 1.
@@ -199,28 +197,19 @@ class SpeculativeFlashDecoder:
         self._update_acceptance_rate(num_accepted)
         return accepted, self._lambda
 
-    def _draft_generate_cached(self, pending_token: int, n: int) -> list[int]:
+    def _draft_generate_cached(
+        self, pending_token: int, n: int
+    ) -> tuple[list[int], list[mx.array]]:
         """Generate n candidate tokens using the persistent draft cache.
 
-        Feeds ``pending_token`` first (the last accepted token not yet in cache),
-        then generates n tokens autoregressively. Draft cache advances by n.
-
-        When a prefetcher is attached, captures the last hidden state from each
-        draft step (before the LM head) for use in draft-informed prefetching.
-
-        Args:
-            pending_token: Token to feed before generating.
-            n: Number of tokens to generate.
-
         Returns:
-            List of n generated token IDs.
+            (tokens, captured_logits) — captured_logits is non-empty only
+            when a prefetcher is attached, for draft-informed prefetching.
         """
         assert self._draft_cache is not None
 
         capture = self._prefetcher is not None
-        if capture:
-            self._draft_hidden_states = []
-
+        captured: list[mx.array] = []
         next_token = pending_token
         tokens: list[int] = []
 
@@ -231,53 +220,28 @@ class SpeculativeFlashDecoder:
             mx.eval(next_logits)
 
             if capture:
-                # Capture the last hidden state for prefetching.
-                # The logits are (1, 1, vocab); we want (1, hidden).
-                # Use the draft model's last hidden state if available,
-                # otherwise fall back to the logits centroid as a proxy.
-                self._draft_hidden_states.append(next_logits)
+                captured.append(next_logits)
 
             next_token = int(mx.argmax(next_logits, axis=-1).item())
             tokens.append(next_token)
 
-        return tokens
+        return tokens, captured
 
-    def _submit_draft_prefetch(self) -> None:
-        """Submit bulk prefetch using draft hidden states.
+    def _submit_draft_prefetch(self, draft_logits: list[mx.array]) -> None:
+        """Submit bulk prefetch using captured draft logits as proxy signals.
 
-        The draft model's output logits are used as approximate signals for
-        the target model's neuron activation patterns. While imperfect (logit
-        space != hidden space), the sparsity predictor trained on hidden states
-        still provides useful cache warming — any hit is pure latency savings.
-
-        For each captured draft step, we predict neurons for all target layers
-        and submit parallel I/O.
+        Logit space != hidden space, but the sparsity predictor still provides
+        useful cache warming — any hit is pure latency savings.
         """
         assert self._prefetcher is not None
-        assert self._draft_hidden_states is not None
 
-        if not self._draft_hidden_states:
-            return
-
-        # Stack all draft hidden states: (num_draft, hidden_or_vocab)
-        # Use the mean across draft positions as a single representative signal
-        stacked = mx.concatenate(
-            [h.reshape(1, -1) for h in self._draft_hidden_states], axis=0
-        )
-        representative = stacked.mean(axis=0, keepdims=True)  # (1, dim)
+        # Mean across draft positions as a single representative signal
+        stacked = mx.concatenate([h.reshape(1, -1) for h in draft_logits], axis=0)
+        representative = stacked.mean(axis=0, keepdims=True)
         mx.eval(representative)
 
-        # Submit prefetch for all layers using this representative signal.
-        # The predictor's Linear layers will handle dimension mismatches
-        # gracefully if vocab_size != hidden_size by only using the
-        # cross-layer prefetch path (which uses actual hidden states).
-        # Here we use bulk prefetch for all layers we can.
-        layer_states = {}
-        for layer_idx in range(self._prefetcher._num_layers):
-            layer_states[layer_idx] = representative
-
+        layer_states = {i: representative for i in range(self._prefetcher.num_layers)}
         self._prefetcher.submit_bulk(layer_states)
-        self._draft_hidden_states = None
 
     # ------------------------------------------------------------------
     # Stateless API (backward compatibility)

--- a/olmlx/engine/flash/speculative.py
+++ b/olmlx/engine/flash/speculative.py
@@ -137,13 +137,13 @@ class SpeculativeFlashDecoder:
 
         # 1. Draft: feed pending token, then generate lambda candidates
         #    Draft cache advances from offset to offset + lambda.
-        draft_tokens, draft_logits = self._draft_generate_cached(
+        draft_tokens, draft_hidden = self._draft_generate_cached(
             pending_token, self._lambda
         )
 
         # 1.5. Draft-informed prefetch: submit bulk I/O before target forward pass.
-        if self._prefetcher is not None and draft_logits:
-            self._submit_draft_prefetch(draft_logits)
+        if self._prefetcher is not None and draft_hidden:
+            self._submit_draft_prefetch(draft_hidden)
 
         # 2. Target: feed [pending, D1, ..., D_lambda] in one pass.
         #    Target cache advances from offset to offset + lambda + 1.
@@ -203,46 +203,67 @@ class SpeculativeFlashDecoder:
         """Generate n candidate tokens using the persistent draft cache.
 
         Returns:
-            (tokens, captured_logits) — captured_logits is non-empty only
-            when a prefetcher is attached, for draft-informed prefetching.
+            (tokens, captured_hidden_states) — captured is non-empty only
+            when a prefetcher is attached AND the draft model exposes an
+            inner .model attribute for hidden state extraction.
         """
         assert self._draft_cache is not None
 
-        capture = self._prefetcher is not None
+        # Determine if we can capture hidden states (pre-lm_head) for prefetch.
+        # mlx-lm models expose .model (transformer) and .lm_head (projection).
+        inner_model = getattr(self._draft, "model", None)
+        lm_head = getattr(self._draft, "lm_head", None)
+        can_capture = (
+            self._prefetcher is not None
+            and inner_model is not None
+            and lm_head is not None
+        )
+
         captured: list[mx.array] = []
         next_token = pending_token
         tokens: list[int] = []
 
         for _ in range(n):
             inp = mx.array([[next_token]])
-            logits = self._draft(inp, cache=self._draft_cache)
-            next_logits = logits[:, -1, :]
-            mx.eval(next_logits)
-
-            if capture:
-                captured.append(next_logits)
+            if can_capture:
+                hidden = inner_model(inp, cache=self._draft_cache)
+                logits = lm_head(hidden)
+                next_logits = logits[:, -1, :]
+                mx.eval(next_logits)
+                captured.append(hidden[:, -1, :])
+            else:
+                logits = self._draft(inp, cache=self._draft_cache)
+                next_logits = logits[:, -1, :]
+                mx.eval(next_logits)
 
             next_token = int(mx.argmax(next_logits, axis=-1).item())
             tokens.append(next_token)
 
         return tokens, captured
 
-    def _submit_draft_prefetch(self, draft_logits: list[mx.array]) -> None:
-        """Submit bulk prefetch using captured draft logits as proxy signals.
+    def _submit_draft_prefetch(self, draft_hidden_states: list[mx.array]) -> None:
+        """Submit bulk prefetch using captured draft hidden states.
 
-        Only effective when vocab_size == hidden_size (rare). When dimensions
-        mismatch, skip silently — the cross-layer prefetch (Path A) still
-        provides coverage during the target forward pass.
+        When the draft model's hidden_size differs from the target model's
+        (as reported by the prefetcher), skip silently — the cross-layer
+        prefetch (Path A) still provides coverage during the target forward pass.
         """
         assert self._prefetcher is not None
 
-        vocab_size = draft_logits[0].shape[-1]
+        hidden_dim = draft_hidden_states[0].shape[-1]
         expected = self._prefetcher.hidden_size
-        if expected is not None and vocab_size != expected:
+        if expected is not None and hidden_dim != expected:
+            logger.debug(
+                "Draft hidden_size %d != target hidden_size %d; skipping Path B",
+                hidden_dim,
+                expected,
+            )
             return
 
         # Mean across draft positions as a single representative signal
-        stacked = mx.concatenate([h.reshape(1, -1) for h in draft_logits], axis=0)
+        stacked = mx.concatenate(
+            [h.reshape(1, -1) for h in draft_hidden_states], axis=0
+        )
         representative = stacked.mean(axis=0, keepdims=True)
         mx.eval(representative)
 

--- a/olmlx/engine/flash/speculative.py
+++ b/olmlx/engine/flash/speculative.py
@@ -230,10 +230,16 @@ class SpeculativeFlashDecoder:
     def _submit_draft_prefetch(self, draft_logits: list[mx.array]) -> None:
         """Submit bulk prefetch using captured draft logits as proxy signals.
 
-        Logit space != hidden space, but the sparsity predictor still provides
-        useful cache warming — any hit is pure latency savings.
+        Only effective when vocab_size == hidden_size (rare). When dimensions
+        mismatch, skip silently — the cross-layer prefetch (Path A) still
+        provides coverage during the target forward pass.
         """
         assert self._prefetcher is not None
+
+        vocab_size = draft_logits[0].shape[-1]
+        expected = self._prefetcher.hidden_size
+        if expected is not None and vocab_size != expected:
+            return
 
         # Mean across draft positions as a single representative signal
         stacked = mx.concatenate([h.reshape(1, -1) for h in draft_logits], axis=0)

--- a/olmlx/engine/flash/speculative.py
+++ b/olmlx/engine/flash/speculative.py
@@ -262,13 +262,21 @@ class SpeculativeFlashDecoder:
 
         # Map draft positions to target layers by depth ratio so early layers
         # get signals from early draft steps and deep layers from late steps.
+        # Deduplicate: with 32 layers and 4 draft steps, ~8 layers share each
+        # draft_idx — reuse the same tensor to avoid redundant predictor calls.
         num_layers = self._prefetcher.num_layers
         num_draft = len(draft_hidden_states)
-        layer_states: dict[int, mx.array] = {}
+        draft_to_layers: dict[int, list[int]] = {}
         for i in range(num_layers):
             draft_idx = round(i * (num_draft - 1) / max(num_layers - 1, 1))
-            layer_states[i] = draft_hidden_states[draft_idx].reshape(1, -1)
-        mx.eval(*layer_states.values())
+            draft_to_layers.setdefault(draft_idx, []).append(i)
+
+        layer_states: dict[int, mx.array] = {}
+        for draft_idx, layers in draft_to_layers.items():
+            hidden = draft_hidden_states[draft_idx].reshape(1, -1)
+            for layer_idx in layers:
+                layer_states[layer_idx] = hidden
+        mx.eval(*{id(v): v for v in layer_states.values()}.values())
 
         self._prefetcher.submit_bulk(layer_states)
 

--- a/olmlx/engine/flash/speculative.py
+++ b/olmlx/engine/flash/speculative.py
@@ -8,14 +8,22 @@ where alpha is the rolling acceptance rate.
 
 from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING
+
 import mlx.core as mx
 import mlx.nn as nn
+
+if TYPE_CHECKING:
+    from olmlx.engine.flash.prefetch import Prefetcher
 
 try:
     from mlx_lm.models.cache import make_prompt_cache, trim_prompt_cache
 except ImportError:
     make_prompt_cache = None  # type: ignore[assignment]
     trim_prompt_cache = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
 
 
 class SpeculativeFlashDecoder:
@@ -40,12 +48,14 @@ class SpeculativeFlashDecoder:
         target_model: nn.Module,
         num_speculative_tokens: int = 4,
         acceptance_rate_ema: float = 0.9,
+        prefetcher: Prefetcher | None = None,
     ):
         self._draft = draft_model
         self._target = target_model
         self._lambda = num_speculative_tokens
         self._alpha = 0.5  # initial acceptance rate estimate
         self._alpha_ema = acceptance_rate_ema
+        self._prefetcher = prefetcher
 
         # Persistent KV cache state (populated by prefill/step)
         self._target_cache: list | None = None
@@ -53,6 +63,9 @@ class SpeculativeFlashDecoder:
         self._cache_seq_len: int = 0
         self._last_target_logit: mx.array | None = None
         self._pending_token: int | None = None
+
+        # Hidden state capture for draft-informed prefetch
+        self._draft_hidden_states: list[mx.array] | None = None
 
     def _update_acceptance_rate(self, num_accepted: int) -> None:
         """Update the rolling acceptance rate via EMA."""
@@ -129,6 +142,11 @@ class SpeculativeFlashDecoder:
         #    Draft cache advances from offset to offset + lambda.
         draft_tokens = self._draft_generate_cached(pending_token, self._lambda)
 
+        # 1.5. Draft-informed prefetch: use captured draft hidden states to
+        #      predict and prefetch target neurons before the target forward pass.
+        if self._prefetcher is not None and self._draft_hidden_states:
+            self._submit_draft_prefetch()
+
         # 2. Target: feed [pending, D1, ..., D_lambda] in one pass.
         #    Target cache advances from offset to offset + lambda + 1.
         all_tokens = mx.array([[pending_token] + draft_tokens])
@@ -145,6 +163,10 @@ class SpeculativeFlashDecoder:
         # 3. Verify draft tokens against target logits
         accepted = self._verify(draft_tokens, verification_logits)
         num_accepted = len(accepted)
+
+        # Cancel speculative prefetch for rejected tokens (harmless if already done)
+        if self._prefetcher is not None and num_accepted < self._lambda:
+            self._prefetcher.cancel()
 
         # 4. Trim caches to the position after the last accepted token.
         #    Desired offset after step: cache_seq_len + num_accepted
@@ -183,6 +205,9 @@ class SpeculativeFlashDecoder:
         Feeds ``pending_token`` first (the last accepted token not yet in cache),
         then generates n tokens autoregressively. Draft cache advances by n.
 
+        When a prefetcher is attached, captures the last hidden state from each
+        draft step (before the LM head) for use in draft-informed prefetching.
+
         Args:
             pending_token: Token to feed before generating.
             n: Number of tokens to generate.
@@ -192,6 +217,10 @@ class SpeculativeFlashDecoder:
         """
         assert self._draft_cache is not None
 
+        capture = self._prefetcher is not None
+        if capture:
+            self._draft_hidden_states = []
+
         next_token = pending_token
         tokens: list[int] = []
 
@@ -200,10 +229,55 @@ class SpeculativeFlashDecoder:
             logits = self._draft(inp, cache=self._draft_cache)
             next_logits = logits[:, -1, :]
             mx.eval(next_logits)
+
+            if capture:
+                # Capture the last hidden state for prefetching.
+                # The logits are (1, 1, vocab); we want (1, hidden).
+                # Use the draft model's last hidden state if available,
+                # otherwise fall back to the logits centroid as a proxy.
+                self._draft_hidden_states.append(next_logits)
+
             next_token = int(mx.argmax(next_logits, axis=-1).item())
             tokens.append(next_token)
 
         return tokens
+
+    def _submit_draft_prefetch(self) -> None:
+        """Submit bulk prefetch using draft hidden states.
+
+        The draft model's output logits are used as approximate signals for
+        the target model's neuron activation patterns. While imperfect (logit
+        space != hidden space), the sparsity predictor trained on hidden states
+        still provides useful cache warming — any hit is pure latency savings.
+
+        For each captured draft step, we predict neurons for all target layers
+        and submit parallel I/O.
+        """
+        assert self._prefetcher is not None
+        assert self._draft_hidden_states is not None
+
+        if not self._draft_hidden_states:
+            return
+
+        # Stack all draft hidden states: (num_draft, hidden_or_vocab)
+        # Use the mean across draft positions as a single representative signal
+        stacked = mx.concatenate(
+            [h.reshape(1, -1) for h in self._draft_hidden_states], axis=0
+        )
+        representative = stacked.mean(axis=0, keepdims=True)  # (1, dim)
+        mx.eval(representative)
+
+        # Submit prefetch for all layers using this representative signal.
+        # The predictor's Linear layers will handle dimension mismatches
+        # gracefully if vocab_size != hidden_size by only using the
+        # cross-layer prefetch path (which uses actual hidden states).
+        # Here we use bulk prefetch for all layers we can.
+        layer_states = {}
+        for layer_idx in range(self._prefetcher._num_layers):
+            layer_states[layer_idx] = representative
+
+        self._prefetcher.submit_bulk(layer_states)
+        self._draft_hidden_states = None
 
     # ------------------------------------------------------------------
     # Stateless API (backward compatibility)

--- a/olmlx/engine/flash/weight_store.py
+++ b/olmlx/engine/flash/weight_store.py
@@ -87,6 +87,18 @@ class NeuronCache:
                     result[idx] = layer_cache[idx]
             return result
 
+    def get_cached_indices(
+        self, layer_idx: int, neuron_indices: list[int]
+    ) -> tuple[list[int], list[int]]:
+        """Return (cached_indices, missing_indices)."""
+        with self._lock:
+            layer_cache = self._cache.get(layer_idx)
+            if layer_cache is None:
+                return [], list(neuron_indices)
+            cached = [idx for idx in neuron_indices if idx in layer_cache]
+            missing = [idx for idx in neuron_indices if idx not in layer_cache]
+            return cached, missing
+
 
 class PreallocatedNeuronBuffer:
     """Pre-allocated DRAM buffer for neuron weights (Paper Section 3.3).
@@ -417,6 +429,47 @@ class FlashWeightStore:
             mx.stack(up_cols, axis=1),
             mx.stack(down_rows, axis=0),
         )
+
+    def prefetch_neurons(
+        self,
+        layer_idx: int,
+        neuron_indices: list[int],
+        executor: ThreadPoolExecutor | None = None,
+    ) -> None:
+        """Load neurons into cache without returning matrices.
+
+        Used by the speculative prefetcher to warm the cache in the background.
+        An external *executor* can be passed to avoid contention with the main
+        I/O thread pool; if ``None``, the store's own pool is used.
+        """
+        pool = executor or self._executor
+
+        if self._use_preallocated:
+            buf = self._buffers[layer_idx]
+            with buf.lock:
+                _, missing = buf.get_cached_indices(neuron_indices)
+            if not missing:
+                return
+            futures = {
+                idx: pool.submit(self._read_neuron_raw, layer_idx, idx)
+                for idx in missing
+            }
+            with buf.lock:
+                for idx, future in futures.items():
+                    gate, up, down = future.result()
+                    buf.insert(idx, gate, up, down)
+        else:
+            assert self._cache is not None
+            _, missing = self._cache.get_cached_indices(layer_idx, neuron_indices)
+            if not missing:
+                return
+            futures = {
+                idx: pool.submit(self._read_neuron, layer_idx, idx)
+                for idx in missing
+            }
+            for idx, future in futures.items():
+                data = future.result()
+                self._cache.put(layer_idx, idx, data)
 
     def close(self) -> None:
         """Release file descriptors and shut down the I/O thread pool."""

--- a/olmlx/engine/flash/weight_store.py
+++ b/olmlx/engine/flash/weight_store.py
@@ -481,11 +481,10 @@ class FlashWeightStore:
             if not missing:
                 return
             futures = {
-                idx: pool.submit(self._read_neuron, layer_idx, idx) for idx in missing
+                pool.submit(self._read_neuron, layer_idx, idx): idx for idx in missing
             }
-            for idx, future in futures.items():
-                data = future.result()
-                self._cache.put(layer_idx, idx, data)
+            for fut in as_completed(futures):
+                self._cache.put(layer_idx, futures[fut], fut.result())
 
     def close(self) -> None:
         """Release file descriptors and shut down the I/O thread pool."""

--- a/olmlx/engine/flash/weight_store.py
+++ b/olmlx/engine/flash/weight_store.py
@@ -8,7 +8,7 @@ import os
 import sys
 import threading
 from collections import OrderedDict
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 import mlx.core as mx
@@ -466,10 +466,12 @@ class FlashWeightStore:
             if not missing:
                 return
             futures = {
-                idx: pool.submit(self._read_neuron_raw, layer_idx, idx)
+                pool.submit(self._read_neuron_raw, layer_idx, idx): idx
                 for idx in missing
             }
-            results = {idx: fut.result() for idx, fut in futures.items()}
+            results = {}
+            for fut in as_completed(futures):
+                results[futures[fut]] = fut.result()
             with buf.lock:
                 for idx, (gate, up, down) in results.items():
                     buf.insert(idx, gate, up, down)

--- a/olmlx/engine/flash/weight_store.py
+++ b/olmlx/engine/flash/weight_store.py
@@ -430,6 +430,21 @@ class FlashWeightStore:
             mx.stack(down_rows, axis=0),
         )
 
+    def get_cached_indices(
+        self, layer_idx: int, neuron_indices: list[int]
+    ) -> tuple[list[int], list[int]]:
+        """Check which neurons are already cached without loading.
+
+        Returns:
+            (cached, missing) — two lists of neuron indices.
+        """
+        if self._use_preallocated:
+            buf = self._buffers[layer_idx]
+            with buf.lock:
+                return buf.get_cached_indices(neuron_indices)
+        assert self._cache is not None
+        return self._cache.get_cached_indices(layer_idx, neuron_indices)
+
     def prefetch_neurons(
         self,
         layer_idx: int,
@@ -464,8 +479,7 @@ class FlashWeightStore:
             if not missing:
                 return
             futures = {
-                idx: pool.submit(self._read_neuron, layer_idx, idx)
-                for idx in missing
+                idx: pool.submit(self._read_neuron, layer_idx, idx) for idx in missing
             }
             for idx, future in futures.items():
                 data = future.result()

--- a/olmlx/engine/flash/weight_store.py
+++ b/olmlx/engine/flash/weight_store.py
@@ -469,9 +469,9 @@ class FlashWeightStore:
                 idx: pool.submit(self._read_neuron_raw, layer_idx, idx)
                 for idx in missing
             }
+            results = {idx: fut.result() for idx, fut in futures.items()}
             with buf.lock:
-                for idx, future in futures.items():
-                    gate, up, down = future.result()
+                for idx, (gate, up, down) in results.items():
                     buf.insert(idx, gate, up, down)
         else:
             assert self._cache is not None

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -867,11 +867,12 @@ class ModelManager:
                 f"Model '{normalized}' has {lm.active_refs} active request(s)"
             )
         lm = self._loaded.pop(normalized)
-        if lm.weight_store is not None:
-            lm.weight_store.close()
-        # Close prefetcher thread pool if present
+        # Close prefetcher *before* weight store: prefetcher tasks submit into
+        # the weight store's pool, so weight store must outlive the prefetcher.
         if hasattr(lm.model, "prefetcher") and lm.model.prefetcher is not None:
             lm.model.prefetcher.close()
+        if lm.weight_store is not None:
+            lm.weight_store.close()
         # Release draft model Metal memory promptly
         lm.speculative_decoder = None
         return True

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -1004,7 +1004,7 @@ class ModelManager:
         """
         from olmlx.config import experimental
         from olmlx.engine.flash.flash_model import FlashConfig, FlashModelWrapper
-        from olmlx.engine.flash.predictor import PredictorBank
+        from olmlx.engine.flash.predictor import LookaheadBank, PredictorBank
         from olmlx.engine.flash.weight_store import FlashWeightStore
 
         import mlx_lm
@@ -1033,6 +1033,11 @@ class ModelManager:
             io_threads=experimental.flash_io_threads,
             cache_budget_neurons=experimental.flash_cache_budget_neurons,
             memory_budget_fraction=experimental.flash_memory_budget_fraction,
+            prefetch=experimental.flash_prefetch,
+            prefetch_confidence_threshold=experimental.flash_prefetch_confidence_threshold,
+            prefetch_min_neurons=experimental.flash_prefetch_min_neurons,
+            prefetch_max_neurons=experimental.flash_prefetch_max_neurons,
+            prefetch_io_threads=experimental.flash_prefetch_io_threads,
         )
 
         weight_store = FlashWeightStore(
@@ -1043,8 +1048,23 @@ class ModelManager:
             use_preallocated_buffer=experimental.flash_preallocated_buffer,
         )
 
+        # Load lookahead predictors if available (for speculative prefetching)
+        lookahead_bank = None
+        lookahead_path = flash_dir / "lookahead_predictors"
+        if experimental.flash_prefetch and lookahead_path.exists():
+            try:
+                lookahead_bank = LookaheadBank.load(lookahead_path)
+                logger.info("Loaded lookahead predictor bank from %s", lookahead_path)
+            except Exception:
+                logger.warning(
+                    "Failed to load lookahead predictors, falling back to sparsity predictor",
+                    exc_info=True,
+                )
+
         # Wrap model — this replaces FFN layers and frees original weights
-        wrapped = FlashModelWrapper(model, predictor_bank, weight_store, flash_config)
+        wrapped = FlashModelWrapper(
+            model, predictor_bank, weight_store, flash_config, lookahead_bank
+        )
 
         if experimental.flash_speculative:
             from olmlx.engine.flash.speculative import SpeculativeFlashDecoder
@@ -1083,6 +1103,7 @@ class ModelManager:
                 draft_model=draft_model,
                 target_model=wrapped,
                 num_speculative_tokens=experimental.flash_speculative_tokens,
+                prefetcher=wrapped.prefetcher,
             )
             return wrapped, tokenizer, False, caps, decoder
 

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -869,6 +869,9 @@ class ModelManager:
         lm = self._loaded.pop(normalized)
         if lm.weight_store is not None:
             lm.weight_store.close()
+        # Close prefetcher thread pool if present
+        if hasattr(lm.model, "prefetcher") and lm.model.prefetcher is not None:
+            lm.model.prefetcher.close()
         # Release draft model Metal memory promptly
         lm.speculative_decoder = None
         return True

--- a/tests/test_flash_prefetch.py
+++ b/tests/test_flash_prefetch.py
@@ -1,0 +1,728 @@
+"""Tests for speculative prefetching (cross-layer, draft-informed, lookahead)."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+import pytest
+
+from olmlx.engine.flash.flash_mlp import FlashMLP, WindowManager
+from olmlx.engine.flash.prefetch import Prefetcher, PrefetchStats
+from olmlx.engine.flash.predictor import (
+    LookaheadBank,
+    LookaheadPredictor,
+    PredictorBank,
+    SparsityPredictor,
+)
+from olmlx.engine.flash.weight_store import FlashWeightStore, NeuronCache
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_bundled_model(tmp_path, hidden=16, inter=8, num_layers=2):
+    """Create synthetic safetensors and bundle them for flash inference."""
+    from safetensors.numpy import save_file
+
+    from olmlx.engine.flash.bundler import bundle_ffn_weights
+
+    tensors = {}
+    for layer in range(num_layers):
+        prefix = f"model.layers.{layer}.mlp"
+        tensors[f"{prefix}.gate_proj.weight"] = np.random.randn(inter, hidden).astype(
+            np.float16
+        )
+        tensors[f"{prefix}.up_proj.weight"] = np.random.randn(inter, hidden).astype(
+            np.float16
+        )
+        tensors[f"{prefix}.down_proj.weight"] = np.random.randn(hidden, inter).astype(
+            np.float16
+        )
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    save_file(tensors, str(model_dir / "model.safetensors"))
+
+    flash_dir = tmp_path / "flash"
+    bundle_ffn_weights(model_dir, flash_dir)
+    return flash_dir, model_dir, tensors
+
+
+# ---------------------------------------------------------------------------
+# NeuronCache.get_cached_indices tests
+# ---------------------------------------------------------------------------
+
+
+class TestNeuronCacheGetCachedIndices:
+    def test_empty_cache(self):
+        cache = NeuronCache(max_neurons_per_layer=64)
+        cached, missing = cache.get_cached_indices(0, [0, 1, 2])
+        assert cached == []
+        assert missing == [0, 1, 2]
+
+    def test_all_cached(self):
+        cache = NeuronCache(max_neurons_per_layer=64)
+        for i in range(3):
+            cache.put(0, i, (mx.zeros(4), mx.zeros(4), mx.zeros(4)))
+        cached, missing = cache.get_cached_indices(0, [0, 1, 2])
+        assert cached == [0, 1, 2]
+        assert missing == []
+
+    def test_partial_cache(self):
+        cache = NeuronCache(max_neurons_per_layer=64)
+        cache.put(0, 0, (mx.zeros(4), mx.zeros(4), mx.zeros(4)))
+        cache.put(0, 2, (mx.zeros(4), mx.zeros(4), mx.zeros(4)))
+        cached, missing = cache.get_cached_indices(0, [0, 1, 2])
+        assert cached == [0, 2]
+        assert missing == [1]
+
+    def test_wrong_layer(self):
+        cache = NeuronCache(max_neurons_per_layer=64)
+        cache.put(0, 0, (mx.zeros(4), mx.zeros(4), mx.zeros(4)))
+        cached, missing = cache.get_cached_indices(1, [0])
+        assert cached == []
+        assert missing == [0]
+
+
+# ---------------------------------------------------------------------------
+# FlashWeightStore.prefetch_neurons tests
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetchNeurons:
+    @pytest.fixture()
+    def store_setup(self, tmp_path):
+        hidden, inter, num_layers = 16, 8, 2
+        flash_dir, _, _ = _make_bundled_model(tmp_path, hidden, inter, num_layers)
+        store = FlashWeightStore(flash_dir, num_io_threads=4, cache_budget_neurons=64)
+        return store, hidden, inter
+
+    def test_prefetch_warms_cache(self, store_setup):
+        """After prefetch, load_neurons should find everything cached."""
+        store, hidden, inter = store_setup
+        neuron_indices = list(range(inter))
+
+        # Prefetch neurons
+        store.prefetch_neurons(0, neuron_indices)
+
+        # Verify they're now cached by checking load_neurons is instant
+        gate, up, down = store.load_neurons(0, neuron_indices)
+        mx.eval(gate, up, down)
+        assert gate.shape == (hidden, inter)
+        assert up.shape == (hidden, inter)
+        assert down.shape == (inter, hidden)
+
+    def test_prefetch_idempotent(self, store_setup):
+        """Prefetching the same neurons twice should not error."""
+        store, _, inter = store_setup
+        neuron_indices = list(range(inter))
+        store.prefetch_neurons(0, neuron_indices)
+        store.prefetch_neurons(0, neuron_indices)  # should be a no-op
+
+    def test_prefetch_empty_list(self, store_setup):
+        """Prefetching empty list should be a no-op."""
+        store, _, _ = store_setup
+        store.prefetch_neurons(0, [])  # should not error
+
+    def test_prefetch_preallocated_buffer(self, tmp_path):
+        """prefetch_neurons should work with preallocated buffer path."""
+        hidden, inter, num_layers = 16, 8, 2
+        flash_dir, _, _ = _make_bundled_model(tmp_path, hidden, inter, num_layers)
+        store = FlashWeightStore(
+            flash_dir,
+            num_io_threads=4,
+            cache_budget_neurons=64,
+            use_preallocated_buffer=True,
+        )
+        neuron_indices = list(range(inter))
+        store.prefetch_neurons(0, neuron_indices)
+
+        # Verify they're cached
+        gate, up, down = store.load_neurons(0, neuron_indices)
+        mx.eval(gate, up, down)
+        assert gate.shape == (hidden, inter)
+
+
+# ---------------------------------------------------------------------------
+# Prefetcher tests (Phase 1 — cross-layer)
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetcher:
+    @pytest.fixture()
+    def prefetch_setup(self, tmp_path):
+        hidden, inter, num_layers = 16, 8, 2
+        flash_dir, _, _ = _make_bundled_model(tmp_path, hidden, inter, num_layers)
+        store = FlashWeightStore(flash_dir, num_io_threads=4, cache_budget_neurons=64)
+        bank = PredictorBank(num_layers, hidden, inter, rank=4)
+        prefetcher = Prefetcher(
+            predictor_bank=bank,
+            weight_store=store,
+            num_layers=num_layers,
+            confidence_threshold=0.3,
+            min_neurons=2,
+            io_threads=4,
+        )
+        return prefetcher, store, bank, hidden, inter, num_layers
+
+    def test_submit_and_wait(self, prefetch_setup):
+        """submit() for layer 0 should prefetch layer 1 neurons."""
+        prefetcher, store, _, hidden, _, _ = prefetch_setup
+        x = mx.random.normal((1, hidden)).astype(mx.float16)
+
+        prefetcher.submit(0, x)
+        prefetcher.wait(1)
+
+        # Stats should show submission
+        assert prefetcher.stats.submitted >= 1
+
+    def test_submit_last_layer_noop(self, prefetch_setup):
+        """submit() for the last layer should be a no-op."""
+        prefetcher, _, _, hidden, _, num_layers = prefetch_setup
+        x = mx.random.normal((1, hidden)).astype(mx.float16)
+
+        initial_submitted = prefetcher.stats.submitted
+        prefetcher.submit(num_layers - 1, x)
+        assert prefetcher.stats.submitted == initial_submitted
+
+    def test_wait_without_submit(self, prefetch_setup):
+        """wait() with no pending prefetch should return immediately."""
+        prefetcher, _, _, _, _, _ = prefetch_setup
+        prefetcher.wait(0)  # should not hang
+
+    def test_cancel_clears_pending(self, prefetch_setup):
+        """cancel() should clear all pending prefetches."""
+        prefetcher, _, _, hidden, _, _ = prefetch_setup
+        x = mx.random.normal((1, hidden)).astype(mx.float16)
+
+        prefetcher.submit(0, x)
+        prefetcher.cancel()
+        # wait should not find anything
+        prefetcher.wait(1)
+
+    def test_submit_bulk(self, prefetch_setup):
+        """submit_bulk should prefetch neurons for multiple layers."""
+        prefetcher, _, _, hidden, _, num_layers = prefetch_setup
+        x = mx.random.normal((1, hidden)).astype(mx.float16)
+
+        layer_states = {i: x for i in range(num_layers)}
+        prefetcher.submit_bulk(layer_states)
+
+        # Wait for all layers
+        for i in range(num_layers):
+            prefetcher.wait(i)
+
+        assert prefetcher.stats.submitted >= 1
+
+    def test_close(self, prefetch_setup):
+        """close() should shut down executor without error."""
+        prefetcher, _, _, _, _, _ = prefetch_setup
+        prefetcher.close()
+
+
+# ---------------------------------------------------------------------------
+# FlashMLP + Prefetcher integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestFlashMLPWithPrefetcher:
+    @pytest.fixture()
+    def mlp_setup(self, tmp_path):
+        hidden, inter, num_layers = 16, 8, 2
+        flash_dir, _, _ = _make_bundled_model(tmp_path, hidden, inter, num_layers)
+        store = FlashWeightStore(flash_dir, num_io_threads=4, cache_budget_neurons=64)
+        bank = PredictorBank(num_layers, hidden, inter, rank=4)
+        wm = WindowManager(num_layers=num_layers, window_size=3)
+        prefetcher = Prefetcher(
+            predictor_bank=bank,
+            weight_store=store,
+            num_layers=num_layers,
+            confidence_threshold=0.3,
+            min_neurons=2,
+            io_threads=4,
+        )
+
+        mlps = []
+        for i in range(num_layers):
+            mlp = FlashMLP(
+                layer_idx=i,
+                hidden_size=hidden,
+                intermediate_size=inter,
+                predictor=bank.predictors[i],
+                weight_store=store,
+                window_manager=wm,
+                sparsity_threshold=0.5,
+                min_active_neurons=inter,
+                prefetcher=prefetcher,
+            )
+            mlps.append(mlp)
+        return mlps, prefetcher, hidden
+
+    def test_forward_with_prefetcher(self, mlp_setup):
+        """FlashMLP should produce valid output when prefetcher is attached."""
+        mlps, prefetcher, hidden = mlp_setup
+        x = mx.random.normal((1, 1, hidden)).astype(mx.float16)
+
+        # Run layer 0 — should trigger prefetch for layer 1
+        out0 = mlps[0](x)
+        mx.eval(out0)
+        assert out0.shape == (1, 1, hidden)
+
+        # Run layer 1 — should benefit from prefetch
+        out1 = mlps[1](out0)
+        mx.eval(out1)
+        assert out1.shape == (1, 1, hidden)
+
+        # Prefetcher should have submitted at least 1 prefetch
+        assert prefetcher.stats.submitted >= 1
+
+    def test_forward_without_prefetcher(self, tmp_path):
+        """FlashMLP should work normally when prefetcher is None."""
+        hidden, inter, num_layers = 16, 8, 1
+        flash_dir, _, _ = _make_bundled_model(tmp_path, hidden, inter, num_layers)
+        store = FlashWeightStore(flash_dir, num_io_threads=2, cache_budget_neurons=64)
+        pred = SparsityPredictor(hidden, inter, rank=4)
+        wm = WindowManager(num_layers=1, window_size=3)
+
+        mlp = FlashMLP(
+            layer_idx=0,
+            hidden_size=hidden,
+            intermediate_size=inter,
+            predictor=pred,
+            weight_store=store,
+            window_manager=wm,
+            sparsity_threshold=0.5,
+            min_active_neurons=inter,
+            prefetcher=None,
+        )
+
+        x = mx.random.normal((1, 1, hidden)).astype(mx.float16)
+        out = mlp(x)
+        mx.eval(out)
+        assert out.shape == (1, 1, hidden)
+
+
+# ---------------------------------------------------------------------------
+# LookaheadPredictor tests (Phase 3)
+# ---------------------------------------------------------------------------
+
+
+class TestLookaheadPredictor:
+    def test_output_shape(self):
+        hidden, inter = 16, 8
+        pred = LookaheadPredictor(hidden, inter, rank=4)
+        x = mx.random.normal((2, hidden))
+        scores = pred(x)
+        mx.eval(scores)
+        assert scores.shape == (2, inter)
+        # Scores should be in [0, 1] (sigmoid)
+        assert float(mx.min(scores).item()) >= 0
+        assert float(mx.max(scores).item()) <= 1
+
+    def test_predict_active_returns_sorted_indices(self):
+        hidden, inter = 16, 8
+        pred = LookaheadPredictor(hidden, inter, rank=4)
+        x = mx.random.normal((2, hidden))
+        indices = pred.predict_active(x, threshold=0.3, min_neurons=2)
+        mx.eval(indices)
+        assert indices.ndim == 1
+        assert len(indices) >= 2
+        # Verify sorted
+        idx_list = indices.tolist()
+        assert idx_list == sorted(idx_list)
+
+    def test_predict_active_min_neurons(self):
+        hidden, inter = 16, 8
+        pred = LookaheadPredictor(hidden, inter, rank=4)
+        x = mx.random.normal((1, hidden))
+        indices = pred.predict_active(x, threshold=0.99, min_neurons=4)
+        mx.eval(indices)
+        assert len(indices) >= 4
+
+    def test_predict_active_max_neurons(self):
+        hidden, inter = 16, 8
+        pred = LookaheadPredictor(hidden, inter, rank=4)
+        x = mx.random.normal((1, hidden))
+        indices = pred.predict_active(x, threshold=0.01, min_neurons=1, max_neurons=3)
+        mx.eval(indices)
+        assert len(indices) <= 3
+
+
+class TestLookaheadBank:
+    def test_save_load_roundtrip(self, tmp_path):
+        hidden, inter, num_layers = 16, 8, 3
+        bank = LookaheadBank(num_layers, hidden, inter, rank=4)
+
+        # Set known weights
+        for i, pred in enumerate(bank.predictors):
+            pred.down.weight = mx.ones_like(pred.down.weight) * (i + 1)
+            pred.up.weight = mx.ones_like(pred.up.weight) * (i + 1) * 0.1
+
+        save_dir = tmp_path / "lookahead"
+        bank.save(save_dir)
+
+        loaded = LookaheadBank.load(save_dir)
+        assert loaded.num_layers == num_layers
+        assert len(loaded.predictors) == num_layers - 1
+
+        for i in range(num_layers - 1):
+            mx.eval(loaded.predictors[i].parameters())
+            assert mx.allclose(
+                loaded.predictors[i].down.weight,
+                bank.predictors[i].down.weight,
+                atol=1e-5,
+            )
+
+    def test_predict_next_layer(self):
+        hidden, inter, num_layers = 16, 8, 3
+        bank = LookaheadBank(num_layers, hidden, inter, rank=4)
+        x = mx.random.normal((1, hidden))
+
+        indices = bank.predict_next_layer(0, x, threshold=0.3, min_neurons=2)
+        mx.eval(indices)
+        assert len(indices) >= 2
+
+    def test_predict_last_layer_returns_empty(self):
+        hidden, inter, num_layers = 16, 8, 3
+        bank = LookaheadBank(num_layers, hidden, inter, rank=4)
+        x = mx.random.normal((1, hidden))
+
+        # Layer 2 is the last (index num_layers-1), its predictor index = 2
+        # which is >= len(predictors) = 2
+        indices = bank.predict_next_layer(num_layers - 1, x, min_neurons=1)
+        mx.eval(indices)
+        assert len(indices) == 0
+
+    def test_load_nonexistent_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            LookaheadBank.load(tmp_path / "nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# Prefetcher with LookaheadBank tests (Phase 3)
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetcherWithLookahead:
+    @pytest.fixture()
+    def prefetch_la_setup(self, tmp_path):
+        hidden, inter, num_layers = 16, 8, 3
+        flash_dir, _, _ = _make_bundled_model(tmp_path, hidden, inter, num_layers)
+        store = FlashWeightStore(flash_dir, num_io_threads=4, cache_budget_neurons=64)
+        sparsity_bank = PredictorBank(num_layers, hidden, inter, rank=4)
+        lookahead_bank = LookaheadBank(num_layers, hidden, inter, rank=4)
+        prefetcher = Prefetcher(
+            predictor_bank=sparsity_bank,
+            weight_store=store,
+            num_layers=num_layers,
+            lookahead_bank=lookahead_bank,
+            confidence_threshold=0.3,
+            min_neurons=2,
+            io_threads=4,
+        )
+        return prefetcher, store, hidden, num_layers
+
+    def test_submit_uses_lookahead(self, prefetch_la_setup):
+        """When lookahead_bank is set, submit should use it for cross-layer."""
+        prefetcher, _, hidden, _ = prefetch_la_setup
+        x = mx.random.normal((1, hidden)).astype(mx.float16)
+
+        prefetcher.submit(0, x)
+        prefetcher.wait(1)
+        assert prefetcher.stats.submitted >= 1
+
+    def test_submit_bulk_uses_sparsity(self, prefetch_la_setup):
+        """submit_bulk always uses the sparsity predictor (not lookahead)."""
+        prefetcher, _, hidden, num_layers = prefetch_la_setup
+        x = mx.random.normal((1, hidden)).astype(mx.float16)
+
+        layer_states = {i: x for i in range(num_layers)}
+        prefetcher.submit_bulk(layer_states)
+
+        for i in range(num_layers):
+            prefetcher.wait(i)
+        assert prefetcher.stats.submitted >= 1
+
+
+# ---------------------------------------------------------------------------
+# Lookahead predictor training tests (Phase 3 — prepare.py)
+# ---------------------------------------------------------------------------
+
+
+class TestTrainLookaheadPredictors:
+    def test_train_basic(self):
+        from olmlx.engine.flash.prepare import _train_lookahead_predictors
+
+        hidden, inter = 16, 8
+        num_layers = 3
+        num_samples = 10
+
+        # Create fake recordings: (inputs, targets) per layer
+        recordings = {}
+        for layer_idx in range(num_layers):
+            inputs = [mx.random.normal((hidden,)) for _ in range(num_samples)]
+            targets = [
+                (mx.random.uniform(shape=(inter,)) > 0.5).astype(mx.float32)
+                for _ in range(num_samples)
+            ]
+            recordings[layer_idx] = (inputs, targets)
+
+        bank = _train_lookahead_predictors(
+            recordings,
+            hidden,
+            inter,
+            rank=4,
+            epochs=2,
+        )
+
+        assert bank is not None
+        assert len(bank.predictors) == num_layers - 1
+
+    def test_train_single_layer_returns_none(self):
+        from olmlx.engine.flash.prepare import _train_lookahead_predictors
+
+        recordings = {
+            0: (
+                [mx.random.normal((16,))],
+                [(mx.random.uniform(shape=(8,)) > 0.5).astype(mx.float32)],
+            )
+        }
+        bank = _train_lookahead_predictors(recordings, 16, 8, rank=4, epochs=1)
+        assert bank is None
+
+    def test_train_with_progress(self):
+        from olmlx.engine.flash.prepare import _train_lookahead_predictors
+
+        hidden, inter, num_layers = 16, 8, 2
+        recordings = {}
+        for i in range(num_layers):
+            recordings[i] = (
+                [mx.random.normal((hidden,)) for _ in range(5)],
+                [
+                    (mx.random.uniform(shape=(inter,)) > 0.5).astype(mx.float32)
+                    for _ in range(5)
+                ],
+            )
+
+        progress_calls = []
+
+        def callback(desc, frac):
+            progress_calls.append((desc, frac))
+
+        bank = _train_lookahead_predictors(
+            recordings, hidden, inter, rank=4, epochs=2, progress_callback=callback
+        )
+        assert bank is not None
+        assert len(progress_calls) > 0
+
+
+# ---------------------------------------------------------------------------
+# FlashModelWrapper + Prefetcher integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestFlashModelWrapperPrefetch:
+    def test_wrapper_creates_prefetcher(self, tmp_path):
+        from olmlx.engine.flash.flash_model import FlashConfig, FlashModelWrapper
+
+        dim, num_layers, inter = 16, 2, 8
+        flash_dir, _, _ = _make_bundled_model(tmp_path, dim, inter, num_layers)
+        store = FlashWeightStore(flash_dir, num_io_threads=2, cache_budget_neurons=64)
+
+        from types import SimpleNamespace
+
+        pred_bank = SimpleNamespace(
+            predictors=[
+                SparsityPredictor(dim, inter, rank=4) for _ in range(num_layers)
+            ]
+        )
+        config = FlashConfig(
+            hidden_size=dim,
+            intermediate_size=inter,
+            num_layers=num_layers,
+            prefetch=True,
+            prefetch_confidence_threshold=0.3,
+            prefetch_min_neurons=2,
+            prefetch_io_threads=4,
+        )
+
+        class _FakeModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = [
+                    SimpleNamespace(mlp=nn.Linear(dim, dim)) for _ in range(num_layers)
+                ]
+
+            def __call__(self, x, cache=None, **kwargs):
+                return x
+
+        model = _FakeModel()
+        wrapper = FlashModelWrapper(model, pred_bank, store, config)
+        assert wrapper.prefetcher is not None
+
+        # Each FlashMLP should have the prefetcher set
+        for layer in model.layers:
+            assert isinstance(layer.mlp, FlashMLP)
+            assert layer.mlp.prefetcher is wrapper.prefetcher
+
+    def test_wrapper_no_prefetcher_by_default(self, tmp_path):
+        from olmlx.engine.flash.flash_model import FlashConfig, FlashModelWrapper
+
+        dim, num_layers, inter = 16, 2, 8
+        flash_dir, _, _ = _make_bundled_model(tmp_path, dim, inter, num_layers)
+        store = FlashWeightStore(flash_dir, num_io_threads=2, cache_budget_neurons=64)
+
+        from types import SimpleNamespace
+
+        pred_bank = SimpleNamespace(
+            predictors=[
+                SparsityPredictor(dim, inter, rank=4) for _ in range(num_layers)
+            ]
+        )
+        config = FlashConfig(
+            hidden_size=dim,
+            intermediate_size=inter,
+            num_layers=num_layers,
+            prefetch=False,
+        )
+
+        class _FakeModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = [
+                    SimpleNamespace(mlp=nn.Linear(dim, dim)) for _ in range(num_layers)
+                ]
+
+            def __call__(self, x, cache=None, **kwargs):
+                return x
+
+        model = _FakeModel()
+        wrapper = FlashModelWrapper(model, pred_bank, store, config)
+        assert wrapper.prefetcher is None
+
+    def test_wrapper_with_lookahead_bank(self, tmp_path):
+        from olmlx.engine.flash.flash_model import FlashConfig, FlashModelWrapper
+
+        dim, num_layers, inter = 16, 2, 8
+        flash_dir, _, _ = _make_bundled_model(tmp_path, dim, inter, num_layers)
+        store = FlashWeightStore(flash_dir, num_io_threads=2, cache_budget_neurons=64)
+
+        from types import SimpleNamespace
+
+        pred_bank = SimpleNamespace(
+            predictors=[
+                SparsityPredictor(dim, inter, rank=4) for _ in range(num_layers)
+            ]
+        )
+        la_bank = LookaheadBank(num_layers, dim, inter, rank=4)
+        config = FlashConfig(
+            hidden_size=dim,
+            intermediate_size=inter,
+            num_layers=num_layers,
+            prefetch=True,
+            prefetch_min_neurons=2,
+            prefetch_io_threads=4,
+        )
+
+        class _FakeModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = [
+                    SimpleNamespace(mlp=nn.Linear(dim, dim)) for _ in range(num_layers)
+                ]
+
+            def __call__(self, x, cache=None, **kwargs):
+                return x
+
+        model = _FakeModel()
+        wrapper = FlashModelWrapper(model, pred_bank, store, config, la_bank)
+        assert wrapper.prefetcher is not None
+        assert wrapper.prefetcher._lookahead_bank is la_bank
+
+
+# ---------------------------------------------------------------------------
+# SpeculativeFlashDecoder + Prefetcher (Phase 2) tests
+# ---------------------------------------------------------------------------
+
+
+class TestSpeculativeDecoderPrefetch:
+    def test_decoder_accepts_prefetcher(self):
+        from olmlx.engine.flash.speculative import SpeculativeFlashDecoder
+
+        class _FakeModel(nn.Module):
+            def __init__(self, vocab=32):
+                super().__init__()
+                self.lm_head = nn.Linear(16, vocab, bias=False)
+
+            def __call__(self, x, cache=None, **kwargs):
+                return mx.random.normal((x.shape[0], x.shape[1], 32))
+
+        draft = _FakeModel()
+        target = _FakeModel()
+
+        # Should accept prefetcher kwarg without error
+        decoder = SpeculativeFlashDecoder(
+            draft_model=draft,
+            target_model=target,
+            num_speculative_tokens=2,
+            prefetcher=None,
+        )
+        assert decoder._prefetcher is None
+
+    def test_decoder_draft_captures_hidden_states(self):
+        """When prefetcher is attached, draft generation should capture states."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.flash.speculative import SpeculativeFlashDecoder
+
+        class _FakeModel(nn.Module):
+            def __init__(self, vocab=32):
+                super().__init__()
+                self.lm_head = nn.Linear(16, vocab, bias=False)
+
+            def __call__(self, x, cache=None, **kwargs):
+                return mx.random.normal((x.shape[0], x.shape[1], vocab))
+
+        vocab = 32
+        draft = _FakeModel(vocab)
+        target = _FakeModel(vocab)
+        prefetcher = MagicMock()
+        prefetcher._num_layers = 2
+
+        decoder = SpeculativeFlashDecoder(
+            draft_model=draft,
+            target_model=target,
+            num_speculative_tokens=2,
+            prefetcher=prefetcher,
+        )
+
+        # Simulate cached mode
+        decoder._draft_cache = []
+        decoder._target_cache = []
+        tokens = decoder._draft_generate_cached(0, 2)
+
+        assert len(tokens) == 2
+        assert decoder._draft_hidden_states is not None
+        assert len(decoder._draft_hidden_states) == 2
+
+
+# ---------------------------------------------------------------------------
+# PrefetchStats tests
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetchStats:
+    def test_hit_rate_zero(self):
+        stats = PrefetchStats()
+        assert stats.hit_rate() == 0.0
+
+    def test_hit_rate_all_hits(self):
+        stats = PrefetchStats(cache_hits=10, cache_misses=0)
+        assert stats.hit_rate() == 1.0
+
+    def test_hit_rate_mixed(self):
+        stats = PrefetchStats(cache_hits=3, cache_misses=7)
+        assert abs(stats.hit_rate() - 0.3) < 1e-6

--- a/tests/test_flash_prefetch.py
+++ b/tests/test_flash_prefetch.py
@@ -277,6 +277,28 @@ class TestPrefetcher:
         assert prefetcher.stats.failures >= 1
         store.prefetch_neurons = original
 
+    def test_submit_after_close_does_not_hang(self, prefetch_setup):
+        """If executor.submit() fails, wait() must not hang."""
+        prefetcher, _, _, hidden, _, _ = prefetch_setup
+        prefetcher.close()  # shut down executor so submit() will fail
+
+        x = mx.random.normal((1, hidden)).astype(mx.float16)
+        prefetcher.submit(0, x)
+
+        # wait() must return promptly, not block forever
+        import threading
+
+        completed = threading.Event()
+
+        def _wait():
+            prefetcher.wait(1)
+            completed.set()
+
+        t = threading.Thread(target=_wait)
+        t.start()
+        t.join(timeout=2.0)
+        assert completed.is_set(), "wait() hung after executor.submit() failure"
+
     def test_close(self, prefetch_setup):
         """close() should shut down executor without error."""
         prefetcher, _, _, _, _, _ = prefetch_setup
@@ -436,6 +458,20 @@ class TestLookaheadBank:
                 atol=1e-5,
             )
 
+    def test_load_preserves_all_init_attributes(self, tmp_path):
+        """LookaheadBank.load() must set all attributes that __init__ sets."""
+        hidden, inter, num_layers = 16, 8, 3
+        bank = LookaheadBank(num_layers, hidden, inter, rank=4)
+        save_dir = tmp_path / "lookahead_attrs"
+        bank.save(save_dir)
+
+        loaded = LookaheadBank.load(save_dir)
+
+        # All attributes from __init__ must exist on the loaded bank
+        init_bank = LookaheadBank(num_layers, hidden, inter, rank=4)
+        for attr in vars(init_bank):
+            assert hasattr(loaded, attr), f"Loaded bank missing attribute: {attr}"
+
     def test_predict_next_layer(self):
         hidden, inter, num_layers = 16, 8, 3
         bank = LookaheadBank(num_layers, hidden, inter, rank=4)
@@ -577,6 +613,35 @@ class TestTrainLookaheadPredictors:
         )
         assert bank is not None
         assert len(progress_calls) > 0
+
+    def test_train_warns_on_recording_count_mismatch(self, caplog):
+        """Should warn when input/target recording counts differ across layers."""
+        from olmlx.engine.flash.prepare import _train_lookahead_predictors
+
+        hidden, inter = 16, 8
+        recordings = {
+            0: (
+                [mx.random.normal((hidden,)) for _ in range(10)],
+                [
+                    (mx.random.uniform(shape=(inter,)) > 0.5).astype(mx.float32)
+                    for _ in range(10)
+                ],
+            ),
+            1: (
+                [mx.random.normal((hidden,)) for _ in range(5)],
+                [
+                    (mx.random.uniform(shape=(inter,)) > 0.5).astype(mx.float32)
+                    for _ in range(3)  # fewer targets than inputs in layer 0
+                ],
+            ),
+        }
+
+        with caplog.at_level("WARNING", logger="olmlx.engine.flash.prepare"):
+            bank = _train_lookahead_predictors(
+                recordings, hidden, inter, rank=4, epochs=1
+            )
+        assert bank is not None
+        assert any("Recording count mismatch" in r.message for r in caplog.records)
 
     def test_train_predictors_progress_per_epoch(self):
         """_train_predictors should report progress per epoch, not per layer."""

--- a/tests/test_flash_prefetch.py
+++ b/tests/test_flash_prefetch.py
@@ -217,6 +217,22 @@ class TestPrefetcher:
 
         assert prefetcher.stats.submitted >= 1
 
+    def test_io_failure_increments_counter(self, prefetch_setup):
+        """Prefetch I/O failure should increment stats.failures."""
+        prefetcher, store, _, hidden, _, _ = prefetch_setup
+        # Monkey-patch weight_store to raise on prefetch
+        original = store.prefetch_neurons
+        store.prefetch_neurons = lambda *a, **kw: (_ for _ in ()).throw(
+            IOError("disk read failed")
+        )
+
+        x = mx.random.normal((1, hidden)).astype(mx.float16)
+        prefetcher.submit(0, x)
+        prefetcher.wait(1)
+
+        assert prefetcher.stats.failures >= 1
+        store.prefetch_neurons = original
+
     def test_close(self, prefetch_setup):
         """close() should shut down executor without error."""
         prefetcher, _, _, _, _, _ = prefetch_setup
@@ -672,23 +688,31 @@ class TestSpeculativeDecoderPrefetch:
         )
         assert decoder._prefetcher is None
 
-    def test_decoder_draft_captures_logits_with_prefetcher(self):
-        """When prefetcher is attached, draft generation should capture logits."""
+    def test_decoder_draft_captures_hidden_states_with_prefetcher(self):
+        """When prefetcher is attached, draft generation should capture hidden states."""
         from unittest.mock import MagicMock
 
         from olmlx.engine.flash.speculative import SpeculativeFlashDecoder
 
+        hidden = 16
+        vocab = 32
+
+        class _FakeInnerModel(nn.Module):
+            def __call__(self, x, cache=None, **kwargs):
+                return mx.random.normal((x.shape[0], x.shape[1], hidden))
+
         class _FakeModel(nn.Module):
-            def __init__(self, vocab=32):
+            def __init__(self):
                 super().__init__()
-                self.lm_head = nn.Linear(16, vocab, bias=False)
+                self.model = _FakeInnerModel()
+                self.lm_head = nn.Linear(hidden, vocab, bias=False)
 
             def __call__(self, x, cache=None, **kwargs):
-                return mx.random.normal((x.shape[0], x.shape[1], vocab))
+                h = self.model(x, cache=cache)
+                return self.lm_head(h)
 
-        vocab = 32
-        draft = _FakeModel(vocab)
-        target = _FakeModel(vocab)
+        draft = _FakeModel()
+        target = _FakeModel()
         prefetcher = MagicMock()
         prefetcher.num_layers = 2
 
@@ -702,16 +726,51 @@ class TestSpeculativeDecoderPrefetch:
         # Simulate cached mode
         decoder._draft_cache = []
         decoder._target_cache = []
-        tokens, captured_logits = decoder._draft_generate_cached(0, 2)
+        tokens, captured_hidden = decoder._draft_generate_cached(0, 2)
 
         assert len(tokens) == 2
-        assert len(captured_logits) == 2
-        # Each captured logit should be a (1, vocab) array
-        for logit in captured_logits:
-            assert logit.shape[-1] == vocab
+        assert len(captured_hidden) == 2
+        # Each captured tensor should be (1, hidden_size), not (1, vocab_size)
+        for h in captured_hidden:
+            assert h.shape[-1] == hidden
+
+    def test_decoder_draft_fallback_no_inner_model(self):
+        """Draft model without .model attribute: no capture, tokens still generated."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.flash.speculative import SpeculativeFlashDecoder
+
+        vocab = 32
+
+        class _FlatModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lm_head = nn.Linear(16, vocab, bias=False)
+
+            def __call__(self, x, cache=None, **kwargs):
+                return mx.random.normal((x.shape[0], x.shape[1], vocab))
+
+        draft = _FlatModel()
+        target = _FlatModel()
+        prefetcher = MagicMock()
+        prefetcher.num_layers = 2
+
+        decoder = SpeculativeFlashDecoder(
+            draft_model=draft,
+            target_model=target,
+            num_speculative_tokens=2,
+            prefetcher=prefetcher,
+        )
+
+        decoder._draft_cache = []
+        decoder._target_cache = []
+        tokens, captured_hidden = decoder._draft_generate_cached(0, 2)
+
+        assert len(tokens) == 2
+        assert len(captured_hidden) == 0  # gracefully skipped
 
     def test_decoder_draft_no_capture_without_prefetcher(self):
-        """Without prefetcher, draft generation should return empty logits list."""
+        """Without prefetcher, draft generation should return empty list."""
         from olmlx.engine.flash.speculative import SpeculativeFlashDecoder
 
         vocab = 32
@@ -736,10 +795,67 @@ class TestSpeculativeDecoderPrefetch:
 
         decoder._draft_cache = []
         decoder._target_cache = []
-        tokens, captured_logits = decoder._draft_generate_cached(0, 2)
+        tokens, captured = decoder._draft_generate_cached(0, 2)
 
         assert len(tokens) == 2
-        assert len(captured_logits) == 0
+        assert len(captured) == 0
+
+    def test_submit_draft_prefetch_dimension_mismatch(self):
+        """When draft hidden_size != target hidden_size, submit_bulk is not called."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.flash.speculative import SpeculativeFlashDecoder
+
+        class _FakeModel(nn.Module):
+            def __call__(self, x, cache=None, **kwargs):
+                return mx.random.normal((x.shape[0], x.shape[1], 32))
+
+        draft = _FakeModel()
+        target = _FakeModel()
+        prefetcher = MagicMock()
+        prefetcher.num_layers = 2
+        prefetcher.hidden_size = 64  # different from draft hidden dim of 16
+
+        decoder = SpeculativeFlashDecoder(
+            draft_model=draft,
+            target_model=target,
+            num_speculative_tokens=2,
+            prefetcher=prefetcher,
+        )
+
+        # Call with hidden states of dim 16 (mismatches prefetcher's expected 64)
+        draft_hidden = [mx.random.normal((1, 16)) for _ in range(2)]
+        decoder._submit_draft_prefetch(draft_hidden)
+
+        prefetcher.submit_bulk.assert_not_called()
+
+    def test_submit_draft_prefetch_calls_submit_bulk(self):
+        """When dimensions match, submit_bulk should be called."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.flash.speculative import SpeculativeFlashDecoder
+
+        class _FakeModel(nn.Module):
+            def __call__(self, x, cache=None, **kwargs):
+                return mx.random.normal((x.shape[0], x.shape[1], 32))
+
+        draft = _FakeModel()
+        target = _FakeModel()
+        prefetcher = MagicMock()
+        prefetcher.num_layers = 2
+        prefetcher.hidden_size = 16  # matches draft hidden dim
+
+        decoder = SpeculativeFlashDecoder(
+            draft_model=draft,
+            target_model=target,
+            num_speculative_tokens=2,
+            prefetcher=prefetcher,
+        )
+
+        draft_hidden = [mx.random.normal((1, 16)) for _ in range(2)]
+        decoder._submit_draft_prefetch(draft_hidden)
+
+        prefetcher.submit_bulk.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -759,3 +875,7 @@ class TestPrefetchStats:
     def test_hit_rate_mixed(self):
         stats = PrefetchStats(cache_hits=3, cache_misses=7)
         assert abs(stats.hit_rate() - 0.3) < 1e-6
+
+    def test_failures_default_zero(self):
+        stats = PrefetchStats()
+        assert stats.failures == 0

--- a/tests/test_flash_prefetch.py
+++ b/tests/test_flash_prefetch.py
@@ -672,8 +672,8 @@ class TestSpeculativeDecoderPrefetch:
         )
         assert decoder._prefetcher is None
 
-    def test_decoder_draft_captures_hidden_states(self):
-        """When prefetcher is attached, draft generation should capture states."""
+    def test_decoder_draft_captures_logits_with_prefetcher(self):
+        """When prefetcher is attached, draft generation should capture logits."""
         from unittest.mock import MagicMock
 
         from olmlx.engine.flash.speculative import SpeculativeFlashDecoder
@@ -690,7 +690,7 @@ class TestSpeculativeDecoderPrefetch:
         draft = _FakeModel(vocab)
         target = _FakeModel(vocab)
         prefetcher = MagicMock()
-        prefetcher._num_layers = 2
+        prefetcher.num_layers = 2
 
         decoder = SpeculativeFlashDecoder(
             draft_model=draft,
@@ -702,11 +702,44 @@ class TestSpeculativeDecoderPrefetch:
         # Simulate cached mode
         decoder._draft_cache = []
         decoder._target_cache = []
-        tokens = decoder._draft_generate_cached(0, 2)
+        tokens, captured_logits = decoder._draft_generate_cached(0, 2)
 
         assert len(tokens) == 2
-        assert decoder._draft_hidden_states is not None
-        assert len(decoder._draft_hidden_states) == 2
+        assert len(captured_logits) == 2
+        # Each captured logit should be a (1, vocab) array
+        for logit in captured_logits:
+            assert logit.shape[-1] == vocab
+
+    def test_decoder_draft_no_capture_without_prefetcher(self):
+        """Without prefetcher, draft generation should return empty logits list."""
+        from olmlx.engine.flash.speculative import SpeculativeFlashDecoder
+
+        vocab = 32
+
+        class _FakeModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lm_head = nn.Linear(16, vocab, bias=False)
+
+            def __call__(self, x, cache=None, **kwargs):
+                return mx.random.normal((x.shape[0], x.shape[1], vocab))
+
+        draft = _FakeModel()
+        target = _FakeModel()
+
+        decoder = SpeculativeFlashDecoder(
+            draft_model=draft,
+            target_model=target,
+            num_speculative_tokens=2,
+            prefetcher=None,
+        )
+
+        decoder._draft_cache = []
+        decoder._target_cache = []
+        tokens, captured_logits = decoder._draft_generate_cached(0, 2)
+
+        assert len(tokens) == 2
+        assert len(captured_logits) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_flash_prefetch.py
+++ b/tests/test_flash_prefetch.py
@@ -145,6 +145,50 @@ class TestPrefetchNeurons:
         mx.eval(gate, up, down)
         assert gate.shape == (hidden, inter)
 
+    def test_prefetch_preallocated_does_not_hold_lock_during_io(self, tmp_path):
+        """buf.lock must not be held while waiting on I/O futures."""
+        import threading
+        import time
+
+        hidden, inter, num_layers = 16, 8, 2
+        flash_dir, _, _ = _make_bundled_model(tmp_path, hidden, inter, num_layers)
+        store = FlashWeightStore(
+            flash_dir,
+            num_io_threads=4,
+            cache_budget_neurons=64,
+            use_preallocated_buffer=True,
+        )
+
+        buf = store._buffers[0]
+        lock_held_during_io = threading.Event()
+
+        original_read = store._read_neuron_raw
+
+        def slow_read(layer_idx, neuron_idx):
+            time.sleep(0.05)  # simulate slow I/O
+            return original_read(layer_idx, neuron_idx)
+
+        store._read_neuron_raw = slow_read
+
+        # Start prefetch in background, then try to acquire lock during I/O
+        t = threading.Thread(
+            target=store.prefetch_neurons, args=(0, list(range(inter)))
+        )
+        t.start()
+        time.sleep(0.02)  # let I/O start
+
+        # If lock is free during I/O, we can acquire it immediately
+        if not buf.lock.acquire(timeout=0.2):
+            lock_held_during_io.set()
+        else:
+            buf.lock.release()
+
+        t.join(timeout=5.0)
+
+        assert not lock_held_during_io.is_set(), (
+            "buf.lock was held while I/O futures were in progress"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Prefetcher tests (Phase 1 — cross-layer)
@@ -534,6 +578,40 @@ class TestTrainLookaheadPredictors:
         assert bank is not None
         assert len(progress_calls) > 0
 
+    def test_train_predictors_progress_per_epoch(self):
+        """_train_predictors should report progress per epoch, not per layer."""
+        from olmlx.engine.flash.prepare import _train_predictors
+
+        hidden, inter, num_layers = 16, 8, 3
+        recordings = {}
+        for i in range(num_layers):
+            recordings[i] = (
+                [mx.random.normal((hidden,)) for _ in range(5)],
+                [
+                    (mx.random.uniform(shape=(inter,)) > 0.5).astype(mx.float32)
+                    for _ in range(5)
+                ],
+            )
+
+        progress_calls = []
+
+        def callback(desc, frac):
+            progress_calls.append((desc, frac))
+
+        epochs = 3
+        _train_predictors(
+            recordings,
+            hidden,
+            inter,
+            rank=4,
+            epochs=epochs,
+            progress_callback=callback,
+        )
+
+        # Should have num_layers * epochs callbacks (one per epoch),
+        # not just num_layers callbacks (one per layer)
+        assert len(progress_calls) == num_layers * epochs
+
 
 # ---------------------------------------------------------------------------
 # FlashModelWrapper + Prefetcher integration tests
@@ -856,6 +934,46 @@ class TestSpeculativeDecoderPrefetch:
         decoder._submit_draft_prefetch(draft_hidden)
 
         prefetcher.submit_bulk.assert_called_once()
+
+    def test_submit_draft_prefetch_depth_mapping(self):
+        """Draft positions should map to target layers by depth ratio."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.flash.speculative import SpeculativeFlashDecoder
+
+        class _FakeModel(nn.Module):
+            def __call__(self, x, cache=None, **kwargs):
+                return mx.random.normal((x.shape[0], x.shape[1], 32))
+
+        draft = _FakeModel()
+        target = _FakeModel()
+        prefetcher = MagicMock()
+        prefetcher.num_layers = 6
+        prefetcher.hidden_size = 8
+
+        decoder = SpeculativeFlashDecoder(
+            draft_model=draft,
+            target_model=target,
+            num_speculative_tokens=3,
+            prefetcher=prefetcher,
+        )
+
+        # 3 draft positions, each with a distinct hidden state
+        h0 = mx.ones((1, 8)) * 1.0
+        h1 = mx.ones((1, 8)) * 2.0
+        h2 = mx.ones((1, 8)) * 3.0
+        decoder._submit_draft_prefetch([h0, h1, h2])
+
+        prefetcher.submit_bulk.assert_called_once()
+        layer_states = prefetcher.submit_bulk.call_args[0][0]
+
+        # Different layers should get different signals (not all the same mean)
+        # Early layers should get signal from early draft positions,
+        # late layers from late draft positions
+        assert len(layer_states) == 6
+        val_layer0 = layer_states[0].tolist()[0][0]
+        val_layer5 = layer_states[5].tolist()[0][0]
+        assert val_layer0 != val_layer5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Cross-layer prefetch (Path A)**: While layer L computes, predict and prefetch neurons for layer L+1 via background SSD I/O. Uses a `LookaheadBank` (dedicated cross-layer predictor) when available, otherwise falls back to the sparsity predictor with layer L's hidden state as proxy.
- **Draft-informed prefetch (Path B)**: After the draft model generates speculative candidates, capture logits and bulk-prefetch neurons for all layers before the target verification pass starts. Cancelled on draft rejection.
- **Lookahead predictors (Phase 3)**: Optional per-layer-pair predictors trained on `(input_L → target_{L+1})` with recall-biased loss (2x positive weight). Trained during `prepare_model_for_flash` and serialized alongside sparsity predictors.

### New/modified files

| File | Change |
|------|--------|
| `olmlx/engine/flash/prefetch.py` | **New** — `Prefetcher` orchestrator with `submit`/`wait`/`submit_bulk`/`cancel`, dedicated thread pool |
| `olmlx/engine/flash/predictor.py` | `LookaheadBank` collection + `LookaheadPredictor` type alias |
| `olmlx/engine/flash/flash_mlp.py` | `FlashMLP` wires `wait(L)` before load, `submit(L+1)` before blocking I/O |
| `olmlx/engine/flash/flash_model.py` | `FlashConfig` gains prefetch fields; `FlashModelWrapper` creates `Prefetcher` |
| `olmlx/engine/flash/speculative.py` | `SpeculativeFlashDecoder` captures draft logits for bulk prefetch |
| `olmlx/engine/flash/prepare.py` | `_train_lookahead_predictors` + shared `_train_single_predictor` |
| `olmlx/engine/flash/weight_store.py` | `prefetch_neurons()` + `NeuronCache.get_cached_indices()` |
| `olmlx/config.py` | `flash_prefetch*` experimental settings |
| `olmlx/engine/model_manager.py` | Wires prefetch config and lookahead bank into flash model loading |
| `tests/test_flash_prefetch.py` | **New** — 25+ tests covering all prefetch paths |

### Design notes

- Graceful degradation: prefetch is off by default (`OLMLX_EXPERIMENTAL_FLASH_PREFETCH`). Lookahead bank is optional — falls back to same-layer predictor.
- Thread pool separation: prefetcher orchestration pool is distinct from weight store I/O pool to avoid contention.
- No mutable instance state coupling: draft logits are returned from `_draft_generate_cached` rather than stored on the decoder.

## Test plan

- [x] `tests/test_flash_prefetch.py` — unit tests for all components
- [ ] Manual: enable prefetch on a flash model, verify inference produces correct output
- [ ] Manual: verify prefetch stats show cache warming (submitted > 0)
- [ ] Manual: test with speculative decoding + prefetch enabled

https://claude.ai/code/session_01DH8svMPNoB5mmHDZvrTTYx