### PR TITLE
fix: fall back to mlx-lm when VLM detection fails

### DIFF
--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -933,12 +933,27 @@ class ModelManager:
                     return "vlm"
             except (ImportError, ModuleNotFoundError):
                 pass
-            # Has vision keys but mlx-vlm doesn't recognize it — still try as VLM
+            # Has vision keys but mlx-vlm can't handle it — check mlx-lm
+            try:
+                from mlx_lm.utils import MODEL_REMAPPING as LM_REMAP
+
+                mapped = LM_REMAP.get(model_type, model_type)
+                spec = importlib.util.find_spec(f"mlx_lm.models.{mapped}")
+                if spec is not None:
+                    logger.info(
+                        "Config has vision keys but model_type '%s' not in mlx-vlm; "
+                        "mlx-lm supports it, using text",
+                        model_type,
+                    )
+                    return "text"
+            except (ImportError, ModuleNotFoundError):
+                pass
+            # Neither library explicitly supports it — try both via fallback
             logger.info(
-                "Config has vision keys but model_type '%s' not in mlx-vlm, will try anyway",
+                "Config has vision keys but model_type '%s' not in mlx-vlm or mlx-lm",
                 model_type,
             )
-            return "vlm"
+            return "unknown"
 
         # No vision keys — check mlx-lm
         try:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -226,7 +226,36 @@ class TestDetectModelKind:
             kind = manager._detect_model_kind("test/model")
         assert kind == "unknown"
 
-    def test_vlm_no_spec_found(self, tmp_path, registry, mock_store):
+    def test_vision_keys_unsupported_by_vlm_but_supported_by_lm(
+        self, tmp_path, registry, mock_store
+    ):
+        """Model has vision keys but mlx-vlm doesn't support it; mlx-lm does → text."""
+        config_path = self._make_config(
+            tmp_path,
+            {
+                "model_type": "llama",  # known to mlx-lm
+                "vision_config": {},
+                "image_token_id": 42,
+            },
+        )
+        manager = self._make_manager(registry, mock_store)
+
+        import importlib.util
+
+        real_find_spec = importlib.util.find_spec
+
+        def no_vlm_yes_lm(name, *args, **kwargs):
+            if name.startswith("mlx_vlm.models."):
+                return None
+            return real_find_spec(name, *args, **kwargs)
+
+        with patch("huggingface_hub.hf_hub_download", return_value=config_path):
+            with patch("importlib.util.find_spec", side_effect=no_vlm_yes_lm):
+                kind = manager._detect_model_kind("test/model")
+        assert kind == "text"
+
+    def test_vision_keys_unsupported_by_both(self, tmp_path, registry, mock_store):
+        """Model has vision keys but neither library supports it → unknown."""
         config_path = self._make_config(
             tmp_path,
             {
@@ -248,8 +277,8 @@ class TestDetectModelKind:
         with patch("huggingface_hub.hf_hub_download", return_value=config_path):
             with patch("importlib.util.find_spec", side_effect=none_for_models):
                 kind = manager._detect_model_kind("test/vlm")
-        # Has vision keys but spec not found — still returns vlm
-        assert kind == "vlm"
+        # Neither library supports it — return unknown to try both
+        assert kind == "unknown"
 
     def test_text_model_with_real_imports(self, tmp_path, registry, mock_store):
         """Test _detect_model_kind with a model_type that exists in mlx-lm."""


### PR DESCRIPTION
## Summary
- Models like `gemma-4` have vision config keys (`image_token_id`, `vision_config`) but aren't supported by mlx-vlm yet. `_detect_model_kind()` unconditionally returned `"vlm"`, bypassing the mlx-lm fallback and causing a hard `ValueError`.
- Now checks mlx-lm when mlx-vlm doesn't support the model type, and returns `"unknown"` (tries both) when neither library supports it.
- Fixes loading of `mlx-community/gemma-4-31b-8bit` and similar models once mlx-lm adds support.

## Test plan
- [x] New test: vision keys present, mlx-vlm unsupported, mlx-lm supported → returns `"text"`
- [x] New test: vision keys present, neither library supports → returns `"unknown"`
- [x] Existing detection tests still pass (8/8)
- [x] Full model_manager test suite passes (77/77)

🤖 Generated with [Claude Code](https://claude.com/claude-code)