### PR TITLE
fix: release Metal GPU memory in MoE bundler shard cache

### DIFF
--- a/olmlx/engine/flash/moe_bundler.py
+++ b/olmlx/engine/flash/moe_bundler.py
@@ -161,7 +161,12 @@ def _load_tensor(model_dir: Path, name: str, index: dict | None) -> np.ndarray:
 
 def _clear_shard_cache():
     """Clear the shard cache to free memory."""
+    if _shard_cache:
+        logger.debug("Clearing shard cache (%d files)", len(_shard_cache))
     _shard_cache.clear()
+    import mlx.core as mx
+
+    mx.clear_cache()
 
 
 def _try_load_tensor(

--- a/olmlx/engine/flash/moe_bundler.py
+++ b/olmlx/engine/flash/moe_bundler.py
@@ -161,11 +161,11 @@ def _load_tensor(model_dir: Path, name: str, index: dict | None) -> np.ndarray:
 
 def _clear_shard_cache():
     """Clear the shard cache to free memory."""
+    import mlx.core as mx
+
     if _shard_cache:
         logger.debug("Clearing shard cache (%d files)", len(_shard_cache))
     _shard_cache.clear()
-    import mlx.core as mx
-
     mx.clear_cache()
 
 

--- a/tests/test_flash_moe_bundler.py
+++ b/tests/test_flash_moe_bundler.py
@@ -431,6 +431,28 @@ class TestBundleMoeExperts:
         assert 0 in layouts
         assert layouts[0].num_experts == experts
 
+    def test_bundle_clears_metal_memory(self, tmp_path):
+        """Bundling should call mx.clear_cache() to release Metal GPU memory."""
+        hidden, inter, experts = 64, 32, 4
+        num_moe, num_dense = 2, 1
+        model_dir = _make_synthetic_moe_weights(
+            hidden, inter, experts, num_moe, num_dense, tmp_path
+        )
+        output_dir = tmp_path / "flash_moe"
+
+        from unittest.mock import patch
+
+        from olmlx.engine.flash.moe_bundler import _shard_cache, bundle_moe_experts
+
+        with patch("mlx.core.clear_cache") as mock_clear:
+            bundle_moe_experts(model_dir, output_dir)
+
+            # mx.clear_cache() should be called at least once per layer + bookkeeping
+            assert mock_clear.call_count >= num_moe
+
+        # Cache must be empty after bundling
+        assert len(_shard_cache) == 0
+
 
 def _make_synthetic_minimax_moe_weights(
     hidden_size: int,


### PR DESCRIPTION
## Summary

Closes #171.

- `_clear_shard_cache()` cleared the Python dict but never called `mx.clear_cache()`, so Metal GPU buffers from `mx.load()` lingered between layers
- The regular bundler (`bundler.py`) already called `mx.clear_cache()` — the MoE bundler now matches
- Added debug logging of cache size before clearing

## Test plan

- [x] New test `test_bundle_clears_metal_memory` verifies `mx.clear_cache()` is called during bundling and `_shard_cache` is empty after completion
- [x] All 22 existing bundler tests pass
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)