### PR TITLE
fix: implicit thinking strip bug, O(n²) string concat (#177, #184)

### DIFF
--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -183,7 +183,9 @@ class ChatSession:
 
         # Implicit thinking: model injects <think> into the template prompt,
         # so generated text starts with thinking content (no <think> prefix).
-        assume_implicit_thinking = self.config.thinking and template_has_thinking
+        # Buffer content before </think> regardless of the thinking display
+        # flag — when disabled, we still need to strip thinking from output.
+        assume_implicit_thinking = template_has_thinking
 
         for turn in range(self.config.max_turns):
             accumulated = ""
@@ -263,19 +265,18 @@ class ChatSession:
                         else:
                             think_content = accumulated[cs:]
                             visible = ""
+                        # When thinking is disabled, suppress thinking events
+                        # but keep the visible text (already stripped above).
+                        if not self.config.thinking:
+                            think_content = ""
                     elif implicit_strip:
-                        # Model produced thinking despite being disabled;
-                        # strip everything before </think> from visible.
+                        # Model produced </think> despite thinking being disabled
+                        # and no explicit <think> tag — strip everything before it.
                         think_content = ""
                         visible = accumulated[close_pos + len(_THINK_CLOSE) :]
                     else:
                         think_content = ""
                         visible = accumulated
-
-                    # When thinking is disabled, suppress thinking events
-                    # but still strip thinking content from visible output.
-                    if not self.config.thinking:
-                        think_content = ""
 
                     # Emit thinking delta
                     if len(think_content) > think_emitted:

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -305,6 +305,12 @@ class ChatSession:
                         repetition_stopped = True
                         break
 
+            # If thinking is disabled and the model skipped the thinking block
+            # entirely (no </think> found), flush buffered content as visible.
+            if implicit_mode and close_pos == -1 and not self.config.thinking:
+                if len(accumulated) > visible_emitted:
+                    yield {"type": "token", "text": accumulated[visible_emitted:]}
+
             # Close any open thinking block (unclosed <think> or implicit)
             if in_thinking:
                 yield {"type": "thinking_end"}

--- a/olmlx/engine/flash/weight_store.py
+++ b/olmlx/engine/flash/weight_store.py
@@ -298,17 +298,17 @@ class FlashWeightStore:
     @staticmethod
     def _full_pread(fd: int, size: int, offset: int) -> bytes:
         """Read exactly *size* bytes via pread, retrying on short reads."""
-        buf = b""
+        buf = bytearray()
         pos = offset
         remaining = size
         while remaining > 0:
             chunk = os.pread(fd, remaining, pos)
             if not chunk:
                 raise OSError(f"Unexpected EOF: wanted {size} bytes at offset {offset}")
-            buf += chunk
+            buf.extend(chunk)
             pos += len(chunk)
             remaining -= len(chunk)
-        return buf
+        return bytes(buf)
 
     def _read_neuron_raw(
         self, layer_idx: int, neuron_idx: int

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -308,7 +308,7 @@ def _emit_content_block(
 
 async def _stream_buffered_with_tools(result, declared_tools=None):
     """Buffer full output, parse tools, yield SSE strings. Yields a final dict with metadata."""
-    full_text = ""
+    text_chunks: list[str] = []
     raw_text = ""
     output_tokens = 0
 
@@ -326,7 +326,9 @@ async def _stream_buffered_with_tools(result, declared_tools=None):
             # For gpt-oss channel format, raw_text is in the done chunk
             raw_text = chunk.get("raw_text", "")
             break
-        full_text += chunk.get("text", "")
+        text_chunks.append(chunk.get("text", ""))
+
+    full_text = "".join(text_chunks)
 
     if raw_text:
         logger.info(

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -160,6 +160,32 @@ class TestImplicitThinkingStreaming:
         assert "</think>" not in token_text
 
     @pytest.mark.asyncio
+    async def test_implicit_strip_multi_chunk(self):
+        """When thinking=False, implicit thinking across chunks is stripped correctly."""
+        session = _make_session(thinking=False, template_has_thinking=True)
+
+        async def fake_stream(*args, **kwargs):
+            # Thinking content arrives in multiple chunks before </think>
+            yield {"text": "First thought. ", "done": False}
+            yield {"text": "Second thought.", "done": False}
+            yield {"text": "</think>", "done": False}
+            yield {"text": "The visible answer.", "done": False}
+            yield {"text": "", "done": True, "stats": MagicMock()}
+
+        with patch("olmlx.chat.session.generate_chat", return_value=fake_stream()):
+            events = []
+            async for event in session.send_message("Q"):
+                events.append(event)
+
+        types = [e["type"] for e in events]
+        # No thinking events should be emitted
+        assert "thinking_start" not in types
+        assert "thinking_token" not in types
+        # Only visible text after </think>
+        token_text = "".join(e["text"] for e in events if e["type"] == "token")
+        assert token_text == "The visible answer."
+
+    @pytest.mark.asyncio
     async def test_no_thinking_output_not_duplicated(self):
         """If model skips thinking (no tags), content shown once, not duplicated."""
         session = _make_session(thinking=True, template_has_thinking=True)

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -186,6 +186,27 @@ class TestImplicitThinkingStreaming:
         assert token_text == "The visible answer."
 
     @pytest.mark.asyncio
+    async def test_thinking_disabled_model_skips_thinking(self):
+        """When thinking=False and model outputs no thinking tags, text must be visible."""
+        session = _make_session(thinking=False, template_has_thinking=True)
+
+        async def fake_stream(*args, **kwargs):
+            # Model skips thinking entirely — no <think> or </think>
+            yield {"text": "Direct answer.", "done": False}
+            yield {"text": "", "done": True, "stats": MagicMock()}
+
+        with patch("olmlx.chat.session.generate_chat", return_value=fake_stream()):
+            events = []
+            async for event in session.send_message("Q"):
+                events.append(event)
+
+        types = [e["type"] for e in events]
+        assert "thinking_start" not in types
+        assert "thinking_token" not in types
+        token_text = "".join(e["text"] for e in events if e["type"] == "token")
+        assert token_text == "Direct answer."
+
+    @pytest.mark.asyncio
     async def test_no_thinking_output_not_duplicated(self):
         """If model skips thinking (no tags), content shown once, not duplicated."""
         session = _make_session(thinking=True, template_has_thinking=True)

--- a/tests/test_flash_weight_store.py
+++ b/tests/test_flash_weight_store.py
@@ -405,3 +405,51 @@ class TestFlashWeightStore:
         expected = mx.array(gate_w[indices].T)
         assert mx.allclose(gate_cols, expected, atol=1e-6)
         store.close()
+
+
+class TestFullPread:
+    """Tests for FlashWeightStore._full_pread handling short reads."""
+
+    def test_single_complete_read(self, tmp_path):
+        """Normal case: pread returns all bytes in one call."""
+        data = b"hello world, this is test data!"
+        p = tmp_path / "test.bin"
+        p.write_bytes(data)
+
+        import os
+
+        fd = os.open(str(p), os.O_RDONLY)
+        try:
+            result = FlashWeightStore._full_pread(fd, len(data), 0)
+            assert result == data
+        finally:
+            os.close(fd)
+
+    def test_short_reads_reassembled(self, tmp_path):
+        """When pread returns partial data, _full_pread retries and assembles."""
+        data = b"abcdefghijklmnopqrstuvwxyz"
+        p = tmp_path / "test.bin"
+        p.write_bytes(data)
+
+        import os
+        from unittest.mock import patch
+
+        fd = os.open(str(p), os.O_RDONLY)
+        try:
+            # Simulate short reads by returning small chunks
+            real_pread = os.pread
+            call_count = [0]
+
+            def short_pread(fd, size, offset):
+                call_count[0] += 1
+                # Return at most 5 bytes per call
+                return real_pread(fd, min(size, 5), offset)
+
+            with patch("os.pread", side_effect=short_pread):
+                result = FlashWeightStore._full_pread(fd, len(data), 0)
+
+            assert result == data
+            # Should have needed multiple calls
+            assert call_count[0] > 1
+        finally:
+            os.close(fd)

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -2106,3 +2106,39 @@ class TestResolveToolNames:
         assert uses[0]["name"] == "Bash"
         assert uses[1]["name"] == "Read"
         assert uses[2]["name"] == "Glob"
+
+
+class TestStreamBufferedWithTools:
+    """Tests for _stream_buffered_with_tools text accumulation."""
+
+    @pytest.mark.asyncio
+    async def test_many_chunks_accumulated_correctly(self):
+        """500+ chunks should be accumulated into correct full_text."""
+        from olmlx.routers.anthropic import _stream_buffered_with_tools
+
+        words = [f"word{i} " for i in range(500)]
+
+        async def fake_result():
+            for word in words:
+                yield {"text": word}
+            yield {"done": True, "stats": MagicMock(eval_count=500)}
+
+        events = []
+        async for event in _stream_buffered_with_tools(fake_result()):
+            events.append(event)
+
+        # Find the text content block events and reconstruct
+        text_deltas = []
+        for event in events:
+            if isinstance(event, str) and '"text_delta"' in event:
+                # Parse SSE event to extract text
+                for line in event.split("\n"):
+                    if line.startswith("data: "):
+                        data = json.loads(line[6:])
+                        if data.get("type") == "content_block_delta":
+                            text_deltas.append(data["delta"]["text"])
+
+        full_text = "".join(text_deltas)
+        expected = "".join(words)
+        # parse_model_output may strip trailing whitespace; check content is preserved
+        assert full_text == expected or full_text == expected.strip()


### PR DESCRIPTION
## Summary
- **#177**: Fix multi-chunk implicit thinking leak when `thinking=False` — content before `</think>` was emitted as visible text because buffering only activated when `thinking=True`. Now buffers whenever `template_has_thinking=True`, and moved `think_content` suppression into the `has_thinking` branch for clarity.
- **#184**: Replace O(n²) string concatenation with list+join in `_stream_buffered_with_tools` (anthropic router) and `bytearray` in `FlashWeightStore._full_pread`. `session.py` and `speculative_stream.py` left unchanged (CPython refcount optimization and BPE boundary issues respectively).

Closes #177, closes #184

## Test plan
- [x] New test: `test_implicit_strip_multi_chunk` — multi-chunk thinking content correctly stripped when `thinking=False`
- [x] New test: `test_many_chunks_accumulated_correctly` — 500 chunks accumulated correctly in anthropic buffered stream
- [x] New tests: `TestFullPread` — single read and short-read reassembly with `bytearray`
- [x] All existing thinking tests pass (implicit, explicit, disabled)
- [x] All 1807 tests pass
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)