### PR TITLE
fix: handle non-trimmable prompt cache (Qwen3-Next)

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1274,31 +1274,45 @@ async def _stream_completion(
                 lm.prompt_cache_store.remove(cache_id)
                 # Trim cache to suffix_start so it aligns with where we resume
                 trim_amount = len(cached.tokens) - suffix_start
+                trimmed = 0
                 if trim_amount > 0:
-                    trim_prompt_cache(working_cache, trim_amount)
+                    trimmed = trim_prompt_cache(working_cache, trim_amount)
 
-                suffix_tokens = prompt_tokens[suffix_start:]
-
-                # Report suffix_start as cache_read — the number of tokens
-                # whose KV entries are actually reused from cache.  On exact
-                # match, suffix_start = prefix_len - 1 because stream_generate
-                # re-processes the token at suffix_start (its KV is not reused).
-                cache_read_tokens = suffix_start
-                cache_creation_tokens = len(suffix_tokens)
-                logger.info(
-                    "Prompt cache hit: %d prefix tokens reused, %d new tokens to process (was %d total)",
-                    prefix_len,
-                    len(suffix_tokens),
-                    len(prompt_tokens),
-                )
-                gen_kwargs["prompt_cache"] = working_cache
-                if lm.is_vlm:
-                    # VLM stream_generate expects a string prompt; pass
-                    # pre-tokenized tokens via input_ids to bypass prepare_inputs.
-                    gen_kwargs["input_ids"] = mx.array([suffix_tokens])
+                if trimmed == 0 and trim_amount > 0:
+                    # Cache layers are non-trimmable (e.g. Qwen3-Next hybrid
+                    # cache with ArraysCache for linear attention layers).
+                    # Fall through to create a fresh cache instead of passing
+                    # a stale, misaligned cache to stream_generate.
+                    logger.warning(
+                        "Prompt cache trim returned 0 (non-trimmable cache layers); "
+                        "discarding stale cache and creating fresh"
+                    )
+                    del working_cache
+                    # Fall through to fresh-cache creation below
                 else:
-                    prompt = suffix_tokens
-            else:
+                    suffix_tokens = prompt_tokens[suffix_start:]
+
+                    # Report suffix_start as cache_read — the number of tokens
+                    # whose KV entries are actually reused from cache.  On exact
+                    # match, suffix_start = prefix_len - 1 because stream_generate
+                    # re-processes the token at suffix_start (its KV is not reused).
+                    cache_read_tokens = suffix_start
+                    cache_creation_tokens = len(suffix_tokens)
+                    logger.info(
+                        "Prompt cache hit: %d prefix tokens reused, %d new tokens to process (was %d total)",
+                        prefix_len,
+                        len(suffix_tokens),
+                        len(prompt_tokens),
+                    )
+                    gen_kwargs["prompt_cache"] = working_cache
+                    if lm.is_vlm:
+                        # VLM stream_generate expects a string prompt; pass
+                        # pre-tokenized tokens via input_ids to bypass prepare_inputs.
+                        gen_kwargs["input_ids"] = mx.array([suffix_tokens])
+                    else:
+                        prompt = suffix_tokens
+
+            if "prompt_cache" not in gen_kwargs:
                 # No usable prefix — free old cache and create fresh
                 lm.prompt_cache_store.remove(cache_id)
                 kv_quant = lm.kv_cache_quant

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1689,14 +1689,29 @@ async def _stream_completion(
             if max_cache_tokens is not None and actual_total > max_cache_tokens:
                 trim_amount = actual_total - max_cache_tokens
                 try:
-                    trim_prompt_cache(prompt_cache, trim_amount)
+                    trimmed = trim_prompt_cache(prompt_cache, trim_amount)
+                    if trimmed != trim_amount:
+                        # Hybrid/non-trimmable cache (e.g. Qwen3-Next).  A
+                        # partial trim would leave the stored cache misaligned
+                        # with stored_tokens metadata; better to invalidate
+                        # now than carry a broken cache forward.  The except
+                        # handler below performs the actual cleanup.
+                        raise RuntimeError(
+                            f"trim_prompt_cache returned {trimmed}, "
+                            f"expected {trim_amount} (non-trimmable layers)"
+                        )
                     if stats.eval_count != len(generated_tokens):
                         # None-ID tokens present: can't map generated_tokens
                         # to KV cache positions. Trim KV cache down to prompt
                         # boundary so depth == len(stored_tokens).
                         extra = max_cache_tokens - len(full_prompt_tokens)
                         if extra > 0:
-                            trim_prompt_cache(prompt_cache, extra)
+                            trimmed_extra = trim_prompt_cache(prompt_cache, extra)
+                            if trimmed_extra != extra:
+                                raise RuntimeError(
+                                    f"trim_prompt_cache returned {trimmed_extra}, "
+                                    f"expected {extra} (non-trimmable layers)"
+                                )
                         stored_tokens = list(full_prompt_tokens)[:max_cache_tokens]
                     else:
                         stored_tokens = stored_tokens[:max_cache_tokens]

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -495,11 +495,22 @@ def _estimate_kv_cache_bytes(
             )
             # Sliding-window attention: cap effective tokens at the window
             # size.  Use `is True` to avoid being fooled by truthy MagicMocks
-            # in tests; production code sets a literal bool.
+            # in tests; production code sets a literal bool.  Prefer a
+            # per-layer window if exposed (defensive — Gemma 4 today shares
+            # a single window across all sliding layers via args, but a
+            # future model could expose heterogeneous windows).
             is_sliding = getattr(self_attn, "is_sliding", None) is True
+            layer_sw: int | None = None
+            for attr in ("sliding_window_size", "sliding_window"):
+                v = getattr(self_attn, attr, None)
+                if isinstance(v, int) and v > 0:
+                    layer_sw = v
+                    break
+            if layer_sw is None and isinstance(sliding_window, int):
+                layer_sw = sliding_window
             effective_tokens = (
-                min(num_tokens, sliding_window)
-                if is_sliding and isinstance(sliding_window, int)
+                min(num_tokens, layer_sw)
+                if is_sliding and layer_sw is not None
                 else num_tokens
             )
             raw_total += (
@@ -1749,19 +1760,29 @@ async def _stream_completion(
             max_cache_tokens = settings.prompt_cache_max_tokens
             if max_cache_tokens is not None and actual_total > max_cache_tokens:
                 trim_amount = actual_total - max_cache_tokens
+                # cache_invalidated drives the post-trim flow.  Set when:
+                # (a) trim returns the wrong amount (non-trimmable hybrid
+                # cache like Qwen3-Next — expected operating condition), or
+                # (b) trim raises an unexpected exception.  In either case
+                # the storage block is skipped and the cache reference is
+                # released.  Using a flag avoids signalling a normal "this
+                # cache type can't be trimmed" outcome via an exception.
+                cache_invalidated = False
                 try:
                     trimmed = trim_prompt_cache(prompt_cache, trim_amount)
                     if trimmed != trim_amount:
-                        # Hybrid/non-trimmable cache (e.g. Qwen3-Next).  A
-                        # partial trim would leave the stored cache misaligned
-                        # with stored_tokens metadata; better to invalidate
-                        # now than carry a broken cache forward.  The except
-                        # handler below performs the actual cleanup.
-                        raise RuntimeError(
-                            f"trim_prompt_cache returned {trimmed}, "
-                            f"expected {trim_amount} (non-trimmable layers)"
+                        # Hybrid/non-trimmable cache: a partial trim would
+                        # leave the stored cache misaligned with stored_tokens
+                        # metadata, so invalidate rather than carry a broken
+                        # cache forward.
+                        logger.warning(
+                            "Cache trim incomplete (asked for %d, got %d); "
+                            "invalidating cache",
+                            trim_amount,
+                            trimmed,
                         )
-                    if stats.eval_count != len(generated_tokens):
+                        cache_invalidated = True
+                    elif stats.eval_count != len(generated_tokens):
                         # None-ID tokens present: can't map generated_tokens
                         # to KV cache positions. Trim KV cache down to prompt
                         # boundary so depth == len(stored_tokens).
@@ -1769,13 +1790,30 @@ async def _stream_completion(
                         if extra > 0:
                             trimmed_extra = trim_prompt_cache(prompt_cache, extra)
                             if trimmed_extra != extra:
-                                raise RuntimeError(
-                                    f"trim_prompt_cache returned {trimmed_extra}, "
-                                    f"expected {extra} (non-trimmable layers)"
+                                logger.warning(
+                                    "Cache trim incomplete (asked for %d, got %d); "
+                                    "invalidating cache",
+                                    extra,
+                                    trimmed_extra,
                                 )
-                        stored_tokens = list(full_prompt_tokens)[:max_cache_tokens]
+                                cache_invalidated = True
+                        if not cache_invalidated:
+                            stored_tokens = list(full_prompt_tokens)[:max_cache_tokens]
                     else:
                         stored_tokens = stored_tokens[:max_cache_tokens]
+                except Exception:
+                    cache_invalidated = True
+                    logger.warning(
+                        "Cache trim raised; invalidating cache",
+                        exc_info=True,
+                    )
+
+                if cache_invalidated:
+                    lm.prompt_cache_store.remove(cache_id)
+                    prompt_cache = None
+                    gc.collect()
+                    mx.clear_cache()
+                else:
                     evicted = await lm.prompt_cache_store.async_set(
                         cache_id,
                         CachedPromptState(tokens=stored_tokens, cache=prompt_cache),
@@ -1792,15 +1830,6 @@ async def _stream_completion(
                         actual_total,
                         len(stored_tokens),
                         max_cache_tokens,
-                    )
-                except Exception:
-                    lm.prompt_cache_store.remove(cache_id)
-                    prompt_cache = None
-                    gc.collect()
-                    mx.clear_cache()
-                    logger.warning(
-                        "Cache trim failed; invalidating cache",
-                        exc_info=True,
                     )
             else:
                 evicted = await lm.prompt_cache_store.async_set(

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -454,7 +454,7 @@ def _estimate_kv_cache_bytes(
             sq_per_entry = head_dim // (8 // quant_bits) + 4
             _tq_ratio = sq_per_entry / fp16_per_entry
 
-    # Try layer introspection for NAS/variable-attention models.
+    # Try layer introspection for NAS/variable-attention/hybrid models.
     # Track which sub-model owns the args so we introspect the right layers
     # (for VLMs, args came from model.language_model — introspect that, not
     # model.model which could be a vision encoder).
@@ -467,25 +467,54 @@ def _estimate_kv_cache_bytes(
     inner = getattr(args_owner, "model", None)
     layers = getattr(inner, "layers", None) if inner is not None else None
     if isinstance(layers, (list, tuple)) and len(layers) > 0:
-        per_layer_kv_sum = 0
+        # Per-layer accounting for hybrid attention (e.g. Gemma 4): some
+        # layers may use sliding-window attention with a different
+        # n_kv_heads/head_dim and a hard cap on cache depth, while others
+        # use full attention with their own dimensions.
+        sliding_window = getattr(args, "sliding_window", None)
+        raw_total = 0
+        found_attn_layer = False
+        introspection_complete = True
         for layer in layers:
             self_attn = getattr(layer, "self_attn", None)
             if self_attn is None:
                 continue  # no-op attention layer — no KV cache
             layer_kv_heads = getattr(self_attn, "n_kv_heads", None)
-            if layer_kv_heads is None:
+            if not isinstance(layer_kv_heads, int):
                 # Standard model — fall back to args
+                introspection_complete = False
                 break
-            per_layer_kv_sum += layer_kv_heads
-        else:
-            # All layers inspected successfully — but only trust the result
-            # if we actually found some attention layers.  per_layer_kv_sum == 0
-            # likely means the attention module uses a different attribute name
-            # (e.g. "attention" instead of "self_attn"); fall through to the
-            # args-based estimate in that case.
-            if per_layer_kv_sum > 0:
-                raw = 2 * per_layer_kv_sum * head_dim * num_tokens * bytes_per_element
-                return int(raw * _tq_ratio * MEMORY_SAFETY_FACTOR)
+            found_attn_layer = True
+            # Per-layer head_dim falls back to the global head_dim if the
+            # attention module doesn't expose its own as an int (most
+            # uniform models).  isinstance check guards against test
+            # MagicMocks auto-creating non-numeric attributes.
+            attn_head_dim = getattr(self_attn, "head_dim", None)
+            layer_head_dim = (
+                attn_head_dim if isinstance(attn_head_dim, int) else head_dim
+            )
+            # Sliding-window attention: cap effective tokens at the window
+            # size.  Use `is True` to avoid being fooled by truthy MagicMocks
+            # in tests; production code sets a literal bool.
+            is_sliding = getattr(self_attn, "is_sliding", None) is True
+            effective_tokens = (
+                min(num_tokens, sliding_window)
+                if is_sliding and isinstance(sliding_window, int)
+                else num_tokens
+            )
+            raw_total += (
+                2
+                * layer_kv_heads
+                * layer_head_dim
+                * effective_tokens
+                * bytes_per_element
+            )
+        # Only trust introspection when every encountered layer reported its
+        # KV heads.  found_attn_layer == False likely means the attention
+        # module uses a different attribute name (e.g. "attention" instead of
+        # "self_attn"); fall through to the args-based estimate in that case.
+        if introspection_complete and found_attn_layer:
+            return int(raw_total * _tq_ratio * MEMORY_SAFETY_FACTOR)
 
     # Fallback: uniform estimate from args
     num_layers = args.num_hidden_layers

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -789,7 +789,9 @@ _CLIENT_TOOL_FORMAT_PATTERNS = (
 )
 
 
-def _add_native_tool_hint(messages: list[dict]) -> list[dict]:
+def _add_native_tool_hint(
+    messages: list[dict], native_template_text: str = ""
+) -> list[dict]:
     """Append a hint to the system message to use native tool call format.
 
     Clients like opencode and Claude Code embed their own tool-format
@@ -810,9 +812,13 @@ def _add_native_tool_hint(messages: list[dict]) -> list[dict]:
     fallback for models *without* native tool support — when the model DOES
     have native support, the template format is authoritative.
 
-    Only applied when the system message actually contains a known
-    conflicting format pattern — leaves untouched system prompts (and
-    user-authored intentional tool guidance) alone.
+    Only applied when the system message contains a conflict pattern that
+    is NOT also present in the model's own chat template.  This prevents
+    false positives for models like Mistral whose template natively contains
+    ``[TOOL_CALLS]``: in that case the client's instructions match the
+    model's native format and the "Disregard" override would suppress
+    legitimate guidance.  Pass ``native_template_text`` from the call site;
+    omit it (or pass empty) to skip the suppression check.
     """
     if not messages or messages[0].get("role") != "system":
         return messages
@@ -823,7 +829,14 @@ def _add_native_tool_hint(messages: list[dict]) -> list[dict]:
         return messages
     if _NATIVE_TOOL_HINT in content:
         return messages
-    if not any(p in content for p in _CLIENT_TOOL_FORMAT_PATTERNS):
+    # A pattern is only a "conflict" if it appears in the system message
+    # AND the model's own template doesn't use it natively.
+    triggered = [
+        p
+        for p in _CLIENT_TOOL_FORMAT_PATTERNS
+        if p in content and p not in native_template_text
+    ]
+    if not triggered:
         return messages
     messages = list(messages)  # shallow copy
     messages[0] = {
@@ -831,6 +844,25 @@ def _add_native_tool_hint(messages: list[dict]) -> list[dict]:
         "content": content + "\n\n" + _NATIVE_TOOL_HINT,
     }
     return messages
+
+
+def _get_chat_template_text(tokenizer: Any) -> str:
+    """Extract the chat template as a single string for substring matching.
+
+    Handles both text tokenizers (chat_template directly) and VLM processors
+    (chat_template on the wrapped tokenizer).  Lists of named templates are
+    flattened into a single space-joined string.
+    """
+    tpl = getattr(tokenizer, "chat_template", None)
+    if tpl is None:
+        sub = getattr(tokenizer, "tokenizer", None)
+        if sub is not None:
+            tpl = getattr(sub, "chat_template", None)
+    if tpl is None:
+        return ""
+    if isinstance(tpl, list):
+        return " ".join(t.get("template", "") for t in tpl if isinstance(t, dict))
+    return tpl if isinstance(tpl, str) else ""
 
 
 def _apply_chat_template(
@@ -2063,10 +2095,13 @@ async def generate_chat(
     # conflict with the model's native tool call format.  With long prompts,
     # models like Gemma 4 follow the client's text instructions instead of
     # generating native tool call tokens.  Appending a short override to the
-    # system message steers the model back to the native format.
+    # system message steers the model back to the native format.  We pass
+    # the model's own chat template so the helper can suppress patterns the
+    # template uses natively (e.g. Mistral's `[TOOL_CALLS]`).
     caps = lm.template_caps or TemplateCaps()
     if tools and caps.supports_tools:
-        messages = _add_native_tool_hint(messages)
+        template_text = _get_chat_template_text(lm.tokenizer)
+        messages = _add_native_tool_hint(messages, template_text)
 
     if lm.is_vlm:
         # VLM models must use the VLM generation path for tokenization.

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -508,6 +508,17 @@ def _estimate_kv_cache_bytes(
                     break
             if layer_sw is None and isinstance(sliding_window, int):
                 layer_sw = sliding_window
+            if is_sliding and layer_sw is None:
+                # A sliding-window layer with no resolvable window size
+                # falls through to a full-prompt estimate (safe overestimate
+                # — won't cause OOM, just a spurious 503 on long prompts).
+                # Log so the condition is diagnosable without a debugger.
+                logger.debug(
+                    "Layer %d reports is_sliding=True but no window size "
+                    "found on self_attn or args; using full token count for "
+                    "KV estimation (safe overestimate)",
+                    getattr(self_attn, "layer_idx", -1),
+                )
             effective_tokens = (
                 min(num_tokens, layer_sw)
                 if is_sliding and layer_sw is not None
@@ -1813,6 +1824,11 @@ async def _stream_completion(
                     prompt_cache = None
                     gc.collect()
                     mx.clear_cache()
+                    # No _safe_sync() needed here (unlike the pre-generation
+                    # trim-fallback path): no fresh cache allocation follows
+                    # immediately — the function is about to return.  The
+                    # next request's pre-generation path will sync before
+                    # its own allocation.
                 else:
                     evicted = await lm.prompt_cache_store.async_set(
                         cache_id,

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -752,6 +752,7 @@ _CLIENT_TOOL_FORMAT_PATTERNS = (
     "<function=",  # Llama 3.x style — used by opencode, Claude Code
     "[TOOL_CALLS]",  # Mistral style
     "<|python_tag|>",  # Llama 3.x JSON style
+    "<tool_call>",  # Qwen style — clients sometimes inject this even for non-Qwen models
 )
 
 
@@ -1309,6 +1310,13 @@ async def _stream_completion(
             # Set before mutation so finally guard can clean up on error
             full_prompt_tokens = prompt_tokens
 
+            # Label for the fresh-cache log line.  Set to "trim-fallback" if
+            # we discard a stale cache because trim_prompt_cache could not
+            # align it (e.g. Qwen3-Next hybrid cache).  Otherwise the log
+            # block below picks "miss" or "init" based on whether `cached`
+            # was populated.
+            fresh_cache_label: str | None = None
+
             # stream_generate requires at least 1 token, so we must back up
             # by one position on exact-match.  If that would mean suffix_start=0
             # (single-token prompt), the cache hit is useless — trimming the
@@ -1351,6 +1359,7 @@ async def _stream_completion(
                     # `cached.cache` aliases `working_cache` and would otherwise
                     # keep the stale KV tensors resident.
                     cached = None
+                    fresh_cache_label = "trim-fallback"
                     # Fall through to fresh-cache creation below
                 else:
                     suffix_tokens = prompt_tokens[suffix_start:]
@@ -1398,9 +1407,11 @@ async def _stream_completion(
                     new_cache = make_prompt_cache(cache_model)
                 gen_kwargs["prompt_cache"] = new_cache
                 cache_creation_tokens = len(prompt_tokens)
+                if fresh_cache_label is None:
+                    fresh_cache_label = "miss" if cached is not None else "init"
                 logger.info(
                     "Prompt cache %s: creating fresh cache for %d tokens",
-                    "miss" if cached is not None else "init",
+                    fresh_cache_label,
                     len(prompt_tokens),
                 )
                 if lm.is_vlm:

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -752,7 +752,11 @@ _CLIENT_TOOL_FORMAT_PATTERNS = (
     "<function=",  # Llama 3.x style — used by opencode, Claude Code
     "[TOOL_CALLS]",  # Mistral style
     "<|python_tag|>",  # Llama 3.x JSON style
-    "<tool_call>",  # Qwen style — clients sometimes inject this even for non-Qwen models
+    # NB: `<tool_call>` is intentionally absent — it's Qwen's *native* tool
+    # call format token, so it would false-positive on Qwen models where the
+    # client's instructions match the native format.  The opencode/Claude
+    # Code case is still caught by `<function=`, which appears alongside
+    # `<tool_call>` in their format examples.
 )
 
 
@@ -1353,11 +1357,13 @@ async def _stream_completion(
                         trim_amount,
                         trimmed,
                     )
+                    # Release the stale cache's GPU memory before allocating
+                    # the fresh one.  Both `working_cache` (a local alias)
+                    # and `cached.cache` (via the CachedPromptState) hold
+                    # references to the same KV tensors — both must be
+                    # broken or the tensors stay resident through the
+                    # remainder of this function.
                     del working_cache
-                    # Release the stale cache reference now so its GPU memory
-                    # can be reclaimed before the fresh cache is allocated.
-                    # `cached.cache` aliases `working_cache` and would otherwise
-                    # keep the stale KV tensors resident.
                     cached = None
                     fresh_cache_label = "trim-fallback"
                     # Fall through to fresh-cache creation below

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -773,6 +773,14 @@ def _add_native_tool_hint(messages: list[dict]) -> list[dict]:
     A short override at the end of the system message steers the model back
     to the native format without modifying the client's original content.
 
+    **Scope: this is intentionally general, not Gemma 4-specific.**
+    Any model with native tool support (Qwen3, Mistral, Llama 3.x, Gemma 4,
+    etc.) can be confused by client-injected non-native format instructions
+    at long prompt lengths.  Gemma 4 is just where the symptom was first
+    observed.  The patterns matched are the formats clients inject as a
+    fallback for models *without* native tool support — when the model DOES
+    have native support, the template format is authoritative.
+
     Only applied when the system message actually contains a known
     conflicting format pattern — leaves untouched system prompts (and
     user-authored intentional tool guidance) alone.
@@ -1362,9 +1370,19 @@ async def _stream_completion(
                     # and `cached.cache` (via the CachedPromptState) hold
                     # references to the same KV tensors — both must be
                     # broken or the tensors stay resident through the
-                    # remainder of this function.
+                    # remainder of this function.  Then force GC + Metal
+                    # buffer reclamation, mirroring the memory-pressure
+                    # eviction path above: CPython's GC is non-deterministic
+                    # and Metal buffers won't be reclaimed in time for the
+                    # fresh cache allocation otherwise — for a 32B+ model
+                    # this could transiently double KV memory and trigger
+                    # the uncatchable Metal OOM the memory guards exist to
+                    # prevent.
                     del working_cache
                     cached = None
+                    gc.collect()
+                    mx.clear_cache()
+                    _safe_sync()
                     fresh_cache_label = "trim-fallback"
                     # Fall through to fresh-cache creation below
                 else:
@@ -1391,7 +1409,11 @@ async def _stream_completion(
                         prompt = suffix_tokens
 
             if "prompt_cache" not in gen_kwargs:
-                # No usable prefix — free old cache and create fresh
+                # Reached on either: (a) no usable prefix in cache miss, or
+                # (b) trim-fallback above.  In the trim-fallback path the
+                # cache was already removed before the trim attempt — this
+                # remove is then a harmless no-op (PromptCacheStore.remove
+                # is idempotent).  Kept for the cache-miss path.
                 lm.prompt_cache_store.remove(cache_id)
                 kv_quant = lm.kv_cache_quant
                 if kv_quant is not None:

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -743,6 +743,17 @@ _NATIVE_TOOL_HINT = (
     "You MUST use only the native tool call format provided by the system."
 )
 
+# Substrings that indicate the system message contains client-injected
+# tool-format instructions targeting a non-native format.  These are formats
+# clients embed as a fallback for models without native tool support, but
+# they conflict with templates that DO have native tool support and confuse
+# the model at long prompt lengths.
+_CLIENT_TOOL_FORMAT_PATTERNS = (
+    "<function=",  # Llama 3.x style — used by opencode, Claude Code
+    "[TOOL_CALLS]",  # Mistral style
+    "<|python_tag|>",  # Llama 3.x JSON style
+)
+
 
 def _add_native_tool_hint(messages: list[dict]) -> list[dict]:
     """Append a hint to the system message to use native tool call format.
@@ -756,15 +767,27 @@ def _add_native_tool_hint(messages: list[dict]) -> list[dict]:
 
     A short override at the end of the system message steers the model back
     to the native format without modifying the client's original content.
+
+    Only applied when the system message actually contains a known
+    conflicting format pattern — leaves untouched system prompts (and
+    user-authored intentional tool guidance) alone.
     """
+    if not messages or messages[0].get("role") != "system":
+        return messages
+    content = messages[0].get("content", "")
+    # Multimodal content (list of parts) is not handled — the conflict pattern
+    # is text-only and the hint targets text-only system messages.
+    if not isinstance(content, str):
+        return messages
+    if _NATIVE_TOOL_HINT in content:
+        return messages
+    if not any(p in content for p in _CLIENT_TOOL_FORMAT_PATTERNS):
+        return messages
     messages = list(messages)  # shallow copy
-    if messages and messages[0].get("role") == "system":
-        content = messages[0].get("content", "")
-        if isinstance(content, str) and _NATIVE_TOOL_HINT not in content:
-            messages[0] = {
-                **messages[0],
-                "content": content + "\n\n" + _NATIVE_TOOL_HINT,
-            }
+    messages[0] = {
+        **messages[0],
+        "content": content + "\n\n" + _NATIVE_TOOL_HINT,
+    }
     return messages
 
 
@@ -1308,16 +1331,26 @@ async def _stream_completion(
                 if trim_amount > 0:
                     trimmed = trim_prompt_cache(working_cache, trim_amount)
 
-                if trimmed == 0 and trim_amount > 0:
-                    # Cache layers are non-trimmable (e.g. Qwen3-Next hybrid
-                    # cache with ArraysCache for linear attention layers).
-                    # Fall through to create a fresh cache instead of passing
-                    # a stale, misaligned cache to stream_generate.
+                if trim_amount > 0 and trimmed != trim_amount:
+                    # Cache layers are non-trimmable or only partially
+                    # trimmable (e.g. Qwen3-Next hybrid cache with ArraysCache
+                    # for linear attention layers — trim_prompt_cache returns
+                    # 0 for any cache where some layer is non-trimmable).  A
+                    # partial trim would leave the KV state misaligned with
+                    # the prompt, so fall through to fresh-cache creation
+                    # rather than passing a stale cache to stream_generate.
                     logger.warning(
-                        "Prompt cache trim returned 0 (non-trimmable cache layers); "
-                        "discarding stale cache and creating fresh"
+                        "Prompt cache trim incomplete (asked for %d, got %d); "
+                        "discarding stale cache and creating fresh",
+                        trim_amount,
+                        trimmed,
                     )
                     del working_cache
+                    # Release the stale cache reference now so its GPU memory
+                    # can be reclaimed before the fresh cache is allocated.
+                    # `cached.cache` aliases `working_cache` and would otherwise
+                    # keep the stale KV tensors resident.
+                    cached = None
                     # Fall through to fresh-cache creation below
                 else:
                     suffix_tokens = prompt_tokens[suffix_start:]

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -738,6 +738,36 @@ def _inject_tools_into_system(messages: list[dict], tools: list[dict]) -> list[d
     return messages
 
 
+_NATIVE_TOOL_HINT = (
+    "Disregard any tool call format instructions above. "
+    "You MUST use only the native tool call format provided by the system."
+)
+
+
+def _add_native_tool_hint(messages: list[dict]) -> list[dict]:
+    """Append a hint to the system message to use native tool call format.
+
+    Clients like opencode and Claude Code embed their own tool-format
+    instructions (e.g. ``<function=Name>``) in the system message.  These
+    conflict with the model's native tool call format (e.g. Gemma 4's
+    ``<|tool_call>call:Name{...}<tool_call|>``).  At long prompt lengths
+    the model follows the client's text instructions instead of using native
+    tokens, producing unparseable output.
+
+    A short override at the end of the system message steers the model back
+    to the native format without modifying the client's original content.
+    """
+    messages = list(messages)  # shallow copy
+    if messages and messages[0].get("role") == "system":
+        content = messages[0].get("content", "")
+        if isinstance(content, str) and _NATIVE_TOOL_HINT not in content:
+            messages[0] = {
+                **messages[0],
+                "content": content + "\n\n" + _NATIVE_TOOL_HINT,
+            }
+    return messages
+
+
 def _apply_chat_template(
     tokenizer: Any,
     messages: list[dict],
@@ -1912,6 +1942,16 @@ async def generate_chat(
     # to the flat format chat templates expect ({name, arguments: {...}}).
     messages = _normalize_tool_calls_in_messages(messages)
 
+    # When native tools are used, clients (e.g. opencode, Claude Code) may
+    # include their own tool-format instructions in the system message that
+    # conflict with the model's native tool call format.  With long prompts,
+    # models like Gemma 4 follow the client's text instructions instead of
+    # generating native tool call tokens.  Appending a short override to the
+    # system message steers the model back to the native format.
+    caps = lm.template_caps or TemplateCaps()
+    if tools and caps.supports_tools:
+        messages = _add_native_tool_hint(messages)
+
     if lm.is_vlm:
         # VLM models must use the VLM generation path for tokenization.
         # Pass tools natively through the template when supported — this
@@ -1919,7 +1959,6 @@ async def generate_chat(
         # which is far more effective than injecting JSON into the system
         # message.  Fall back to system-message injection for models whose
         # template lacks tool support.
-        caps = lm.template_caps or TemplateCaps()
         # Resolve enable_thinking for templates that support it.
         vlm_thinking = enable_thinking if caps.supports_enable_thinking else None
         # Convert role="tool" messages to tool_responses format for models

--- a/olmlx/engine/template_caps.py
+++ b/olmlx/engine/template_caps.py
@@ -59,9 +59,14 @@ def detect_caps(tokenizer: Any) -> TemplateCaps:
 
     has_channel_format = "<|channel|>" in tpl
 
-    # tool_responses is accessed as message.tool_responses — use the dot prefix
-    # to avoid false-matching template comments or string literals.
-    uses_tool_responses = ".tool_responses" in tpl
+    # tool_responses is accessed as message.tool_responses (dot notation) or
+    # message['tool_responses'] (bracket notation, e.g. Gemma 4).  Use dot
+    # prefix and bracket patterns to avoid false-matching comments or literals.
+    uses_tool_responses = (
+        ".tool_responses" in tpl
+        or "['tool_responses']" in tpl
+        or '["tool_responses"]' in tpl
+    )
 
     return TemplateCaps(
         supports_tools=supports_tools,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -191,7 +191,13 @@ def mock_mlx_primitives(monkeypatch):
     # Prompt cache
     mock_make_cache = MagicMock(return_value=[MagicMock()])
     _start("olmlx.engine.inference.make_prompt_cache", mock_make_cache)
-    _start("olmlx.engine.inference.trim_prompt_cache", MagicMock())
+    # Successful trim returns the requested amount; without this, the
+    # `trimmed != trim_amount` guard in _stream_completion would fire the
+    # non-trimmable cache fallback and skip the suffix path.
+    _start(
+        "olmlx.engine.inference.trim_prompt_cache",
+        MagicMock(side_effect=lambda c, n: n),
+    )
     # _find_common_prefix is pure Python — let it run unpatched
 
     # HuggingFace download

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -319,6 +319,35 @@ class TestAddNativeToolHint:
         result = _add_native_tool_hint(messages)
         assert "native tool call format" not in result[0]["content"]
 
+    def test_no_hint_when_pattern_is_in_template(self):
+        """Skip patterns that the model's own chat template uses natively.
+
+        Mistral's template literally contains `[TOOL_CALLS]`, so client
+        instructions referencing that pattern match the native format and
+        should not trigger the override.
+        """
+        from olmlx.engine.inference import _add_native_tool_hint
+
+        messages = [
+            {"role": "system", "content": "Use [TOOL_CALLS] [...]"},
+        ]
+        # Mistral-style template — contains [TOOL_CALLS] natively
+        template_text = "{% if tools %}[TOOL_CALLS] {{ tools }}{% endif %}"
+        result = _add_native_tool_hint(messages, template_text)
+        assert "native tool call format" not in result[0]["content"]
+
+    def test_hint_fires_when_pattern_not_in_template(self):
+        """Pattern in system message but NOT in template → hint fires."""
+        from olmlx.engine.inference import _add_native_tool_hint
+
+        messages = [
+            {"role": "system", "content": "Use <function=Name>...</function>"},
+        ]
+        # Gemma 4-style template — uses <|tool_call> tokens, not <function=
+        template_text = "{% if tools %}<|tool_call>{{ tools }}<tool_call|>{% endif %}"
+        result = _add_native_tool_hint(messages, template_text)
+        assert "native tool call format" in result[0]["content"]
+
     def test_no_hint_when_no_conflict_pattern(self):
         """Plain system prompts without conflicting format instructions are untouched."""
         from olmlx.engine.inference import _add_native_tool_hint

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -270,6 +270,47 @@ class TestInjectToolsIntoSystem:
         assert "direct_tool" in result[0]["content"]
 
 
+class TestAddNativeToolHint:
+    def test_appends_hint_to_system_message(self):
+        from olmlx.engine.inference import _add_native_tool_hint
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hi"},
+        ]
+        result = _add_native_tool_hint(messages)
+        assert "native tool call format" in result[0]["content"]
+        # Original not modified
+        assert "native" not in messages[0]["content"]
+
+    def test_no_system_message_is_noop(self):
+        from olmlx.engine.inference import _add_native_tool_hint
+
+        messages = [{"role": "user", "content": "hi"}]
+        result = _add_native_tool_hint(messages)
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+
+    def test_not_duplicated(self):
+        from olmlx.engine.inference import _add_native_tool_hint
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+        ]
+        result = _add_native_tool_hint(messages)
+        result2 = _add_native_tool_hint(result)
+        assert result2[0]["content"].count("native tool call format") == 1
+
+    def test_non_string_content_is_noop(self):
+        from olmlx.engine.inference import _add_native_tool_hint
+
+        messages = [
+            {"role": "system", "content": [{"type": "text", "text": "hi"}]},
+        ]
+        result = _add_native_tool_hint(messages)
+        assert result[0]["content"] == [{"type": "text", "text": "hi"}]
+
+
 class TestConvertToolMessagesToResponses:
     def test_no_tool_messages_unchanged(self):
         """Messages without role=tool pass through unchanged."""

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -304,15 +304,20 @@ class TestAddNativeToolHint:
         result = _add_native_tool_hint(messages)
         assert "native tool call format" in result[0]["content"]
 
-    def test_appends_hint_when_qwen_tool_call_pattern_present(self):
-        """Qwen-style <tool_call> instructions injected for non-Qwen models."""
+    def test_no_hint_for_qwen_native_tool_call(self):
+        """`<tool_call>` is Qwen's native format — must not trigger the hint.
+
+        For Qwen models, client instructions describing `<tool_call>` match
+        the model's actual native format.  Adding the hint would tell the
+        model to "disregard" instructions that are correct for it.
+        """
         from olmlx.engine.inference import _add_native_tool_hint
 
         messages = [
-            {"role": "system", "content": "Use <tool_call>...</tool_call>"},
+            {"role": "system", "content": "Use <tool_call>{...}</tool_call>"},
         ]
         result = _add_native_tool_hint(messages)
-        assert "native tool call format" in result[0]["content"]
+        assert "native tool call format" not in result[0]["content"]
 
     def test_no_hint_when_no_conflict_pattern(self):
         """Plain system prompts without conflicting format instructions are untouched."""

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2645,6 +2645,43 @@ class TestEstimateKvCacheBytes:
         # formula (60 * 2 * 16 * 256 * 33181 * 2 * 1.3) ≈ 38 GB would not.
         assert result < 16 * 1024**3, f"Expected ~4.3 GB, got {result / 1024**3:.1f} GB"
 
+    def test_per_layer_sliding_window_override(self):
+        """Per-layer self_attn.sliding_window_size takes precedence over args.sliding_window.
+
+        Defensive test: today no shipping model exposes heterogeneous
+        per-layer windows, but the introspection should honour them if a
+        future model does.
+        """
+        args = MagicMock(spec=[])
+        args.num_hidden_layers = 4
+        args.num_attention_heads = 8
+        args.num_key_value_heads = 8
+        args.hidden_size = 1024
+        args.head_dim = 128
+        args.sliding_window = 4096  # global default
+
+        model = MagicMock(spec=[])
+        model.args = args
+
+        layers = []
+        for _ in range(4):
+            layer = MagicMock()
+            attn = MagicMock()
+            attn.n_kv_heads = 8
+            attn.head_dim = 128
+            attn.is_sliding = True
+            # Per-layer window — overrides the global args.sliding_window
+            attn.sliding_window_size = 512
+            layer.self_attn = attn
+            layers.append(layer)
+        model.model = MagicMock()
+        model.model.layers = layers
+
+        # 8000 tokens, but per-layer window is 512 (not 4096)
+        result = _estimate_kv_cache_bytes(model, 8000)
+        expected_raw = 4 * 2 * 8 * 128 * 512 * 2
+        assert result == int(expected_raw * _inf_mod.MEMORY_SAFETY_FACTOR)
+
     def test_sliding_window_cap_short_prompt(self):
         """When num_tokens < sliding_window, sliding layers should NOT be capped down."""
         args = MagicMock(spec=[])

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -271,11 +271,14 @@ class TestInjectToolsIntoSystem:
 
 
 class TestAddNativeToolHint:
-    def test_appends_hint_to_system_message(self):
+    def test_appends_hint_when_function_pattern_present(self):
         from olmlx.engine.inference import _add_native_tool_hint
 
         messages = [
-            {"role": "system", "content": "You are helpful."},
+            {
+                "role": "system",
+                "content": "Use this format: <function=Name>...</function>",
+            },
             {"role": "user", "content": "hi"},
         ]
         result = _add_native_tool_hint(messages)
@@ -283,19 +286,49 @@ class TestAddNativeToolHint:
         # Original not modified
         assert "native" not in messages[0]["content"]
 
+    def test_appends_hint_when_tool_calls_pattern_present(self):
+        from olmlx.engine.inference import _add_native_tool_hint
+
+        messages = [
+            {"role": "system", "content": "Mistral format: [TOOL_CALLS] [...]"},
+        ]
+        result = _add_native_tool_hint(messages)
+        assert "native tool call format" in result[0]["content"]
+
+    def test_appends_hint_when_python_tag_pattern_present(self):
+        from olmlx.engine.inference import _add_native_tool_hint
+
+        messages = [
+            {"role": "system", "content": "Use <|python_tag|>{...}"},
+        ]
+        result = _add_native_tool_hint(messages)
+        assert "native tool call format" in result[0]["content"]
+
+    def test_no_hint_when_no_conflict_pattern(self):
+        """Plain system prompts without conflicting format instructions are untouched."""
+        from olmlx.engine.inference import _add_native_tool_hint
+
+        messages = [
+            {"role": "system", "content": "You are a helpful coding assistant."},
+            {"role": "user", "content": "hi"},
+        ]
+        result = _add_native_tool_hint(messages)
+        assert result[0]["content"] == "You are a helpful coding assistant."
+
     def test_no_system_message_is_noop(self):
         from olmlx.engine.inference import _add_native_tool_hint
 
-        messages = [{"role": "user", "content": "hi"}]
+        messages = [{"role": "user", "content": "<function=foo>bar</function>"}]
         result = _add_native_tool_hint(messages)
         assert len(result) == 1
         assert result[0]["role"] == "user"
+        assert "native tool call format" not in result[0]["content"]
 
     def test_not_duplicated(self):
         from olmlx.engine.inference import _add_native_tool_hint
 
         messages = [
-            {"role": "system", "content": "You are helpful."},
+            {"role": "system", "content": "Use <function=Name>...</function>"},
         ]
         result = _add_native_tool_hint(messages)
         result2 = _add_native_tool_hint(result)
@@ -305,10 +338,13 @@ class TestAddNativeToolHint:
         from olmlx.engine.inference import _add_native_tool_hint
 
         messages = [
-            {"role": "system", "content": [{"type": "text", "text": "hi"}]},
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": "<function=foo>"}],
+            },
         ]
         result = _add_native_tool_hint(messages)
-        assert result[0]["content"] == [{"type": "text", "text": "hi"}]
+        assert result[0]["content"] == [{"type": "text", "text": "<function=foo>"}]
 
 
 class TestConvertToolMessagesToResponses:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2557,6 +2557,95 @@ class TestEstimateKvCacheBytes:
         naive_raw = 61 * 2 * 128 * naive_head_dim * 1000 * 2
         assert result < naive_raw  # MLA should be ~25x smaller
 
+    def test_gemma4_hybrid_attention_with_sliding_window(self):
+        """Gemma 4-style hybrid model: sliding-window + full attention with per-layer head_dim.
+
+        Gemma 4 31b has:
+          - 60 layers total
+          - 50 sliding-window layers (n_kv=16, head_dim=256, capped at 1024 tokens)
+          - 10 full-attention layers (n_kv=4, head_dim=512, uncapped)
+
+        Naive estimation (uniform layers, no window cap) overestimates by ~8x
+        for long prompts and triggers spurious MemoryError 503s.
+        """
+        args = MagicMock(spec=[])
+        args.num_hidden_layers = 60
+        args.num_attention_heads = 32
+        args.num_key_value_heads = 16
+        args.hidden_size = 5376
+        args.head_dim = 256
+        args.global_head_dim = 512
+        args.sliding_window = 1024
+
+        model = MagicMock(spec=[])
+        model.args = args
+
+        layers = []
+        for i in range(60):
+            layer = MagicMock()
+            attn = MagicMock()
+            # Mimic mlx-vlm gemma4: full-attention layers have larger head_dim
+            # but fewer kv_heads.  Layer types alternate (5 sliding, 1 full).
+            if i % 6 == 5:
+                attn.n_kv_heads = 4
+                attn.head_dim = 512
+                attn.is_sliding = False
+            else:
+                attn.n_kv_heads = 16
+                attn.head_dim = 256
+                attn.is_sliding = True
+            layer.self_attn = attn
+            layers.append(layer)
+        model.model = MagicMock()
+        model.model.layers = layers
+
+        num_tokens = 33181
+        # Expected per-layer:
+        #   sliding: 2 * 16 * 256 * min(33181, 1024) * 2 = 16,777,216 bytes
+        #   full:    2 * 4 * 512 * 33181 * 2 = 271,773,696 bytes
+        #   sum: 50 * 16,777,216 + 10 * 271,773,696 = 838,860,800 + 2,717,736,960
+        #      = 3,556,597,760 bytes raw (≈3.31 GB)
+        sliding_per_layer = 2 * 16 * 256 * 1024 * 2
+        full_per_layer = 2 * 4 * 512 * num_tokens * 2
+        expected_raw = 50 * sliding_per_layer + 10 * full_per_layer
+
+        result = _estimate_kv_cache_bytes(model, num_tokens)
+        assert result == int(expected_raw * _inf_mod.MEMORY_SAFETY_FACTOR)
+
+        # Sanity check: result should fit in 16 GB.  The naive uniform-layer
+        # formula (60 * 2 * 16 * 256 * 33181 * 2 * 1.3) ≈ 38 GB would not.
+        assert result < 16 * 1024**3, f"Expected ~4.3 GB, got {result / 1024**3:.1f} GB"
+
+    def test_sliding_window_cap_short_prompt(self):
+        """When num_tokens < sliding_window, sliding layers should NOT be capped down."""
+        args = MagicMock(spec=[])
+        args.num_hidden_layers = 4
+        args.num_attention_heads = 8
+        args.num_key_value_heads = 8
+        args.hidden_size = 1024
+        args.head_dim = 128
+        args.sliding_window = 1024
+
+        model = MagicMock(spec=[])
+        model.args = args
+
+        layers = []
+        for _ in range(4):
+            layer = MagicMock()
+            attn = MagicMock()
+            attn.n_kv_heads = 8
+            attn.head_dim = 128
+            attn.is_sliding = True
+            layer.self_attn = attn
+            layers.append(layer)
+        model.model = MagicMock()
+        model.model.layers = layers
+
+        # 500 < 1024, so sliding layers use full prompt length
+        result = _estimate_kv_cache_bytes(model, 500)
+        expected_raw = 4 * 2 * 8 * 128 * 500 * 2
+        assert result == int(expected_raw * _inf_mod.MEMORY_SAFETY_FACTOR)
+
     def test_turboquant_4bit_reduces_estimate(self):
         """TurboQuant 4-bit KV cache should reduce the memory estimate.
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -304,6 +304,16 @@ class TestAddNativeToolHint:
         result = _add_native_tool_hint(messages)
         assert "native tool call format" in result[0]["content"]
 
+    def test_appends_hint_when_qwen_tool_call_pattern_present(self):
+        """Qwen-style <tool_call> instructions injected for non-Qwen models."""
+        from olmlx.engine.inference import _add_native_tool_hint
+
+        messages = [
+            {"role": "system", "content": "Use <tool_call>...</tool_call>"},
+        ]
+        result = _add_native_tool_hint(messages)
+        assert "native tool call format" in result[0]["content"]
+
     def test_no_hint_when_no_conflict_pattern(self):
         """Plain system prompts without conflicting format instructions are untouched."""
         from olmlx.engine.inference import _add_native_tool_hint

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -345,6 +345,12 @@ class TestNonTrimmableCacheFallback:
         assert prompt_cache_arg is fresh_cache
         assert prompt_cache_arg is not stale_cache
 
+        # Critical: the full prompt must be passed, not the suffix.  A
+        # regression where suffix_tokens is computed alongside the fresh
+        # cache would produce misaligned generation.
+        prompt_arg = call_args[1].get("prompt") or call_args[0][2]
+        assert prompt_arg == [10, 20, 30, 40, 50, 60, 70, 80]
+
 
 class TestCacheMissCreatesFresh:
     @pytest.mark.asyncio
@@ -828,7 +834,10 @@ class TestCacheExactMatchTrimAlignment:
         tokens = _make_stream_tokens("out", prompt_tokens=1)
         mock_stream = _make_mock_stream(tokens)
 
-        mock_trim = MagicMock()
+        # Successful trim returns the requested amount; the check
+        # `trimmed != trim_amount` would otherwise fire the non-trimmable
+        # fallback and skip the suffix path under test.
+        mock_trim = MagicMock(side_effect=lambda c, n: n)
 
         mock_mx = MagicMock()
         with (
@@ -1832,7 +1841,10 @@ class TestMultiCacheBehavior:
         tokens = _make_stream_tokens("Hello", prompt_tokens=5)
         mock_stream = _make_mock_stream(tokens)
 
-        mock_trim = MagicMock()
+        # Successful trim returns the requested amount; the check
+        # `trimmed != trim_amount` would otherwise fire the non-trimmable
+        # fallback and zero-out cache_read_tokens.
+        mock_trim = MagicMock(side_effect=lambda c, n: n)
         mock_mx = MagicMock()
         with (
             patch("olmlx.engine.inference.mx", mock_mx),

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -1037,7 +1037,10 @@ class TestSingleTokenPromptCacheEdgeCase:
         mock_stream = _make_mock_stream(tokens)
 
         mock_make_cache = MagicMock(return_value=[MagicMock()])
-        mock_trim = MagicMock()
+        # Successful trim returns the requested amount; the
+        # `trimmed != trim_amount` guard would otherwise treat the bare
+        # MagicMock return as a non-trimmable failure.
+        mock_trim = MagicMock(side_effect=lambda c, n: n)
 
         mock_mx = MagicMock()
         with (
@@ -1093,7 +1096,10 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
 
         mock_cache_obj = [MagicMock()]
         mock_make_cache = MagicMock(return_value=mock_cache_obj)
-        mock_trim = MagicMock()
+        # Successful trim returns the requested amount; the
+        # `trimmed != trim_amount` guard would otherwise treat the bare
+        # MagicMock return as a non-trimmable failure.
+        mock_trim = MagicMock(side_effect=lambda c, n: n)
 
         mock_mx = MagicMock()
         with (
@@ -1149,7 +1155,10 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
 
         mock_cache_obj = [MagicMock()]
         mock_make_cache = MagicMock(return_value=mock_cache_obj)
-        mock_trim = MagicMock()
+        # Successful trim returns the requested amount; the
+        # `trimmed != trim_amount` guard would otherwise treat the bare
+        # MagicMock return as a non-trimmable failure.
+        mock_trim = MagicMock(side_effect=lambda c, n: n)
 
         mock_mx = MagicMock()
         with (
@@ -1198,7 +1207,10 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
 
         mock_cache_obj = [MagicMock()]
         mock_make_cache = MagicMock(return_value=mock_cache_obj)
-        mock_trim = MagicMock()
+        # Successful trim returns the requested amount; the
+        # `trimmed != trim_amount` guard would otherwise treat the bare
+        # MagicMock return as a non-trimmable failure.
+        mock_trim = MagicMock(side_effect=lambda c, n: n)
 
         # First request: 5 prompt + 2 generated = 7 > limit of 5 → trimmed to 5
         tokens1 = _make_stream_tokens("Hello", " world", prompt_tokens=5)
@@ -1320,7 +1332,10 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
 
         mock_cache_obj = [MagicMock()]
         mock_make_cache = MagicMock(return_value=mock_cache_obj)
-        mock_trim = MagicMock()
+        # Successful trim returns the requested amount; the
+        # `trimmed != trim_amount` guard would otherwise treat the bare
+        # MagicMock return as a non-trimmable failure.
+        mock_trim = MagicMock(side_effect=lambda c, n: n)
 
         mock_mx = MagicMock()
         with (
@@ -1402,7 +1417,10 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
 
         mock_cache_obj = [MagicMock()]
         mock_make_cache = MagicMock(return_value=mock_cache_obj)
-        mock_trim = MagicMock()
+        # Successful trim returns the requested amount; the
+        # `trimmed != trim_amount` guard would otherwise treat the bare
+        # MagicMock return as a non-trimmable failure.
+        mock_trim = MagicMock(side_effect=lambda c, n: n)
 
         mock_mx = MagicMock()
         with (
@@ -1494,6 +1512,68 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
         # Response should complete with a final done chunk
         assert chunks[-1]["done"] is True
         # Cache should be invalidated, not left in corrupted state
+        assert lm.prompt_cache_store.get("") is None
+
+    @pytest.mark.asyncio
+    async def test_cache_invalidated_on_non_trimmable_storage(self, mock_manager):
+        """Storage path: non-trimmable cache (trim returns wrong amount) is invalidated.
+
+        Regression test for the post-generation storage path mirror of the
+        pre-generation non-trimmable fix: for hybrid caches like Qwen3-Next,
+        `trim_prompt_cache` silently returns 0 instead of the requested
+        amount, leaving the stored cache misaligned with `stored_tokens`
+        metadata.  The storage path must invalidate in that case rather
+        than store a broken cache.
+        """
+        from olmlx.engine.inference import generate_chat
+
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.tokenizer.apply_chat_template = MagicMock(return_value="prompt")
+        lm.tokenizer.bos_token = None
+        lm.tokenizer.encode = MagicMock(return_value=[10, 20, 30, 40, 50])
+
+        tokens = _make_stream_tokens("Hello", " world", prompt_tokens=5)
+        mock_stream = _make_mock_stream(tokens)
+
+        mock_cache_obj = [MagicMock()]
+        mock_make_cache = MagicMock(return_value=mock_cache_obj)
+        # Simulates a non-trimmable hybrid cache: returns 0 regardless of
+        # the requested trim_amount.
+        mock_trim = MagicMock(return_value=0)
+
+        mock_mx = MagicMock()
+        with (
+            patch("olmlx.engine.inference.mx", mock_mx),
+            patch(
+                "olmlx.engine.inference.async_mlx_stream",
+                return_value=mock_stream,
+            ),
+            patch(
+                "olmlx.engine.inference.make_prompt_cache",
+                mock_make_cache,
+            ),
+            patch(
+                "olmlx.engine.inference.trim_prompt_cache",
+                mock_trim,
+            ),
+            patch("olmlx.engine.inference.settings") as mock_settings,
+        ):
+            mock_settings.prompt_cache = True
+            mock_settings.prompt_cache_max_tokens = 6
+            mock_settings.default_keep_alive = "5m"
+            chunks = []
+            gen = await generate_chat(
+                mock_manager,
+                "qwen3",
+                [{"role": "user", "content": "hi"}],
+                stream=True,
+            )
+            async for chunk in gen:
+                chunks.append(chunk)
+
+        # Response should complete normally
+        assert chunks[-1]["done"] is True
+        # Cache must NOT be stored — it would be misaligned
         assert lm.prompt_cache_store.get("") is None
 
 

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -347,8 +347,14 @@ class TestNonTrimmableCacheFallback:
 
         # Critical: the full prompt must be passed, not the suffix.  A
         # regression where suffix_tokens is computed alongside the fresh
-        # cache would produce misaligned generation.
-        prompt_arg = call_args[1].get("prompt") or call_args[0][2]
+        # cache would produce misaligned generation.  `prompt` is the third
+        # positional arg to async_mlx_stream — fail loudly if the call
+        # signature changes rather than silently falling back to a wrong
+        # value.
+        assert len(call_args.args) >= 3, (
+            "async_mlx_stream call signature changed; update this test"
+        )
+        prompt_arg = call_args.args[2]
         assert prompt_arg == [10, 20, 30, 40, 50, 60, 70, 80]
 
 

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -263,6 +263,89 @@ class TestCacheReusedOnPrefixMatch:
         )  # same object, removed from store before use
 
 
+class TestNonTrimmableCacheFallback:
+    @pytest.mark.asyncio
+    async def test_non_trimmable_cache_creates_fresh(self, mock_manager):
+        """When trim_prompt_cache returns 0 (e.g. ArraysCache layers), fall back to fresh cache.
+
+        Regression test for Qwen3-Next hybrid cache: ArraysCache.is_trimmable()
+        returns False, causing trim_prompt_cache to silently return 0.  Without
+        the fallback, the stale untrimmed cache is passed to stream_generate
+        with misaligned prompt tokens, producing garbage output.
+        """
+        from olmlx.engine.inference import generate_chat
+        from olmlx.engine.model_manager import CachedPromptState
+
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.tokenizer.apply_chat_template = MagicMock(return_value="formatted prompt v2")
+        lm.tokenizer.bos_token = None
+
+        # Previously cached: 5 prompt tokens + 2 generated tokens
+        stale_cache = [MagicMock()]
+        lm.prompt_cache_store.set(
+            "",
+            CachedPromptState(
+                tokens=[10, 20, 30, 40, 50, 100, 101],
+                cache=stale_cache,
+            ),
+        )
+
+        # New prompt: shares first 5 tokens, adds 3 more
+        lm.tokenizer.encode = MagicMock(return_value=[10, 20, 30, 40, 50, 60, 70, 80])
+
+        tokens = _make_stream_tokens("New", " output", prompt_tokens=3)
+        mock_stream = _make_mock_stream(tokens)
+
+        # trim_prompt_cache returns 0 — simulates non-trimmable cache (ArraysCache)
+        mock_trim = MagicMock(return_value=0)
+
+        fresh_cache = [MagicMock()]
+        mock_make_cache = MagicMock(return_value=fresh_cache)
+
+        mock_mx = MagicMock()
+        with (
+            patch("olmlx.engine.inference.mx", mock_mx),
+            patch(
+                "olmlx.engine.inference.async_mlx_stream",
+                return_value=mock_stream,
+            ) as mock_async_stream,
+            patch(
+                "olmlx.engine.inference.trim_prompt_cache",
+                mock_trim,
+            ),
+            patch(
+                "olmlx.engine.inference.make_prompt_cache",
+                mock_make_cache,
+            ),
+            patch("olmlx.engine.inference.settings") as mock_settings,
+        ):
+            mock_settings.prompt_cache = True
+            mock_settings.prompt_cache_max_tokens = 32768
+            mock_settings.default_keep_alive = "5m"
+            gen = await generate_chat(
+                mock_manager,
+                "qwen3",
+                [{"role": "user", "content": "hi again"}],
+                stream=True,
+            )
+            chunks = []
+            async for chunk in gen:
+                chunks.append(chunk)
+
+        # trim was attempted
+        mock_trim.assert_called_once()
+
+        # Since trim returned 0, should fall back to fresh cache
+        mock_make_cache.assert_called_once_with(lm.model)
+
+        # async_mlx_stream should receive the FULL prompt (not suffix)
+        # and the fresh cache (not the stale one)
+        call_args = mock_async_stream.call_args
+        prompt_cache_arg = call_args[1].get("prompt_cache")
+        assert prompt_cache_arg is fresh_cache
+        assert prompt_cache_arg is not stale_cache
+
+
 class TestCacheMissCreatesFresh:
     @pytest.mark.asyncio
     async def test_no_common_prefix_creates_fresh_cache(self, mock_manager):

--- a/tests/test_template_caps.py
+++ b/tests/test_template_caps.py
@@ -184,3 +184,14 @@ class TestDetectCaps:
     def test_uses_tool_responses_defaults(self):
         caps = TemplateCaps()
         assert caps.uses_tool_responses is False
+
+    def test_uses_tool_responses_bracket_notation(self):
+        """Gemma 4 template uses message['tool_responses'] (bracket notation)."""
+        tok = MagicMock()
+        tok.chat_template = (
+            "{% for msg in messages %}"
+            "{% if msg['tool_responses'] %}{{ msg['tool_responses'] }}{% endif %}"
+            "{% endfor %}"
+        )
+        caps = detect_caps(tok)
+        assert caps.uses_tool_responses is True


### PR DESCRIPTION
## Summary

### Fix 1: Non-trimmable prompt cache fallback (Qwen3-Next)
- Qwen3-Next uses a hybrid cache: `KVCache` for 12 standard attention layers + `ArraysCache` for 36 linear attention layers
- `ArraysCache.is_trimmable()` returns `False`, causing `trim_prompt_cache()` to silently return 0
- The code ignored this return value and passed the **stale, untrimmed cache** to `stream_generate` with misaligned prompt tokens, producing garbage output and premature EOS
- **Fix**: check `trim_prompt_cache`'s return value (`trimmed != trim_amount`); fall back to fresh cache. Apply the same guard to the post-generation storage path. Force `gc.collect()` + `mx.clear_cache()` + `_safe_sync()` after dropping references so the stale cache's GPU memory is reclaimed before the fresh allocation.

### Fix 2: Gemma 4 native tool call format
- Clients like opencode embed tool-format instructions (`<function=Name>`) in the system message that conflict with Gemma 4's native format (`<|tool_call>call:Name{...}<tool_call|>`)
- With long prompts, the model follows the client's text instructions instead of generating native tool call tokens, producing unparseable output
- **Fix**: append a short override to the system message when known conflict patterns (`<function=`, `[TOOL_CALLS]`, `<|python_tag|>`) are detected. Intentionally general — applies to any model with native tool support, not just Gemma 4.

### Fix 3: `uses_tool_responses` detection for Gemma 4
- Gemma 4's template uses bracket notation (`message['tool_responses']`) not dot notation (`message.tool_responses`)
- **Fix**: detect both bracket and dot notation

### Fix 4: KV cache size estimation for hybrid sliding-window attention (Gemma 4 31b)
- `_estimate_kv_cache_bytes` treated every layer as full attention with a single global `head_dim`
- For Gemma 4 31b's hybrid architecture this was doubly wrong: 50 of 60 layers are sliding-window attention (capped at 1024 tokens) but were counted at full prompt length, and the 10 full-attention layers actually use `head_dim=512`, not the global `head_dim=256`
- Net result for 33k tokens: **34.6 GB estimate vs ~4.3 GB actual** — an ~8× overestimate that triggered spurious MemoryError 503s on prompts that would have fit comfortably in available memory
- **Fix**: restructured the per-layer introspection to compute per-layer KV bytes directly. Reads per-layer `head_dim` from `self_attn.head_dim` and detects sliding-window layers via `self_attn.is_sliding`, capping `effective_tokens` at `args.sliding_window`.

## Test plan

- [x] Regression tests for all four fixes
- [x] All 1882 tests pass
- [x] Manual verification on Gemma 4 31b 8bit: 33,181 tokens estimates 4.31 GB (was 34.6 GB), fits in 16.6 GB available
- [ ] Manual: Gemma 4 with opencode — verify tool calls work with long system prompts
- [ ] Manual: Qwen3-Coder-Next in Flash-MoE mode — verify sequential requests produce full output

🤖 Generated with [Claude Code](https://claude.com/claude-code)