### PR TITLE
fix: preserve user edits to models.json across saves

### DIFF
--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -173,7 +173,7 @@ class ModelConfig:
     inference_queue_timeout: float | None = None
     inference_timeout: float | None = None
     #: Unrecognized keys from the JSON entry, preserved for round-trip fidelity.
-    _extra: dict[str, Any] = field(default_factory=dict, repr=False, compare=False)
+    _extra: dict[str, Any] = field(default_factory=dict, repr=False)
 
     @classmethod
     def from_entry(cls, entry: str | dict) -> ModelConfig:
@@ -487,8 +487,8 @@ class ModelRegistry:
                 mc = replace(existing, hf_path=hf_path)
             else:
                 mc = ModelConfig(hf_path=hf_path)
-        if existing is not None and existing == mc and existing._extra == mc._extra:
-            return  # identical, no save needed (_extra excluded from == due to compare=False)
+        if existing is not None and existing == mc:
+            return  # identical, no save needed
         self._mappings[normalized] = mc
         self._raw_unrecognized.pop(normalized, None)
         self._dirty_keys.add(normalized)
@@ -503,6 +503,11 @@ class ModelRegistry:
             self._save_mappings_locked()
 
     def _save_mappings_locked(self):
+        # NOTE: This method reads self._mappings which is mutated outside
+        # _save_lock (in add_mapping/remove). This is safe because the lock
+        # is only contended by sync callers on the same thread. Do NOT make
+        # this method async without also locking the dict mutations.
+        #
         # Snapshot the dirty/removed sets so concurrent add_mapping/remove
         # calls that mutate them outside the lock aren't silently cleared.
         dirty_snapshot = set(self._dirty_keys)
@@ -538,12 +543,10 @@ class ModelRegistry:
                     disk_data[k] = self._mappings[k].to_entry()
 
         # Preserve unrecognized entries (forward/backward compatibility).
-        # Skip in the corruption fallback path — don't re-inject previously
-        # invalid data into the recovered output.
-        if disk_read_ok:
-            for k, v in self._raw_unrecognized.items():
-                if k not in disk_data:
-                    disk_data[k] = v
+        # These may be valid entries written by a newer version.
+        for k, v in self._raw_unrecognized.items():
+            if k not in disk_data:
+                disk_data[k] = v
 
         _atomic_write_json(disk_data, settings.models_config)
         # Only clear the keys we actually flushed — concurrent additions

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -527,7 +527,9 @@ class ModelRegistry:
 
         if not disk_read_ok and self._mappings:
             # File was missing or corrupt — write full in-memory state to
-            # avoid silently dropping live entries.
+            # avoid silently dropping live entries. Removed keys are already
+            # absent from _mappings (remove() pops them), so they won't
+            # reappear. dirty/removed snapshots are not needed here.
             logger.warning(
                 "models.json missing or corrupt; writing full in-memory state"
             )
@@ -538,8 +540,10 @@ class ModelRegistry:
                 disk_data.pop(key, None)
 
             # Overlay only keys that were modified in this process.
-            # Merge any unknown keys from the current disk entry so that
-            # user-added extra keys survive even for server-touched models.
+            # For dirty keys, the in-memory state is authoritative for known
+            # fields (hf_path, experimental, options, etc.) — external edits
+            # to those fields are overwritten. Unknown extra keys from the
+            # disk entry ARE merged so user-added keys survive.
             for k in dirty_snapshot:
                 if k in self._mappings:
                     mc = self._mappings[k]

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -483,9 +483,9 @@ class ModelRegistry:
                 return
             mc = ModelConfig(
                 hf_path=hf_path,
-                _extra=existing._extra if existing is not None else {},
+                _extra=dict(existing._extra) if existing is not None else {},
             )
-        if existing is not None and existing == mc:
+        if existing is not None and existing == mc and existing._extra == mc._extra:
             return  # identical, no save needed
         self._mappings[normalized] = mc
         self._raw_unrecognized.pop(normalized, None)
@@ -504,14 +504,22 @@ class ModelRegistry:
             except (json.JSONDecodeError, OSError):
                 pass  # corrupt or unreadable — proceed with empty base
 
-        # Remove explicitly deleted keys
-        for key in self._removed_keys:
-            disk_data.pop(key, None)
+        if not disk_data and self._mappings:
+            # File was missing or corrupt — write full in-memory state to
+            # avoid silently dropping live entries.
+            logger.warning(
+                "models.json missing or corrupt; writing full in-memory state"
+            )
+            disk_data = {k: v.to_entry() for k, v in self._mappings.items()}
+        else:
+            # Remove explicitly deleted keys
+            for key in self._removed_keys:
+                disk_data.pop(key, None)
 
-        # Overlay only keys that were modified in this process
-        for k in self._dirty_keys:
-            if k in self._mappings:
-                disk_data[k] = self._mappings[k].to_entry()
+            # Overlay only keys that were modified in this process
+            for k in self._dirty_keys:
+                if k in self._mappings:
+                    disk_data[k] = self._mappings[k].to_entry()
 
         # Preserve unrecognized entries (forward/backward compatibility)
         for k, v in self._raw_unrecognized.items():

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -4,6 +4,7 @@ import difflib
 import json
 import os
 import tempfile
+import threading
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
@@ -324,6 +325,7 @@ class ModelRegistry:
         self._raw_unrecognized: dict[str, Any] = {}
         self._dirty_keys: set[str] = set()
         self._removed_keys: set[str] = set()
+        self._save_lock = threading.Lock()
         self._aliases: dict[str, str] = {}
         self._aliases_path = settings.models_config.parent / "aliases.json"
 
@@ -481,10 +483,10 @@ class ModelRegistry:
             # No rich config supplied — preserve existing entry if hf_path matches
             if existing is not None and existing.hf_path == hf_path:
                 return
-            mc = ModelConfig(
-                hf_path=hf_path,
-                _extra=dict(existing._extra) if existing is not None else {},
-            )
+            if existing is not None:
+                mc = replace(existing, hf_path=hf_path)
+            else:
+                mc = ModelConfig(hf_path=hf_path)
         if existing is not None and existing == mc and existing._extra == mc._extra:
             return  # identical, no save needed (_extra excluded from == due to compare=False)
         self._mappings[normalized] = mc
@@ -494,6 +496,10 @@ class ModelRegistry:
         self._save_mappings()
 
     def _save_mappings(self):
+        with self._save_lock:
+            self._save_mappings_locked()
+
+    def _save_mappings_locked(self):
         # Re-read disk state as base to preserve external edits (e.g. user
         # editing models.json while the server is running).
         disk_data: dict[str, Any] = {}
@@ -538,7 +544,8 @@ class ModelRegistry:
         normalized = self.normalize_name(name)
         if self._aliases.pop(normalized, None) is not None:
             self._save_aliases()
-        if self._mappings.pop(normalized, None) is not None:
+        raw_removed = self._raw_unrecognized.pop(normalized, None)
+        if self._mappings.pop(normalized, None) is not None or raw_removed is not None:
             self._removed_keys.add(normalized)
             self._dirty_keys.discard(normalized)
             self._save_mappings()

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -146,6 +146,18 @@ def _validate_keep_alive(value: str) -> None:
         )
 
 
+_KNOWN_CONFIG_KEYS: frozenset[str] = frozenset(
+    {
+        "hf_path",
+        "experimental",
+        "options",
+        "keep_alive",
+        "inference_queue_timeout",
+        "inference_timeout",
+    }
+)
+
+
 @dataclass
 class ModelConfig:
     """Per-model configuration resolved from models.json."""
@@ -159,6 +171,8 @@ class ModelConfig:
     keep_alive: str | None = None
     inference_queue_timeout: float | None = None
     inference_timeout: float | None = None
+    #: Unrecognized keys from the JSON entry, preserved for round-trip fidelity.
+    _extra: dict[str, Any] = field(default_factory=dict, repr=False, compare=False)
 
     @classmethod
     def from_entry(cls, entry: str | dict) -> ModelConfig:
@@ -195,6 +209,7 @@ class ModelConfig:
                 if it_raw is not None
                 else None
             )
+            extra = {k: v for k, v in entry.items() if k not in _KNOWN_CONFIG_KEYS}
             return cls(
                 hf_path=hf_path,
                 experimental=experimental,
@@ -202,6 +217,7 @@ class ModelConfig:
                 keep_alive=keep_alive,
                 inference_queue_timeout=inference_queue_timeout,
                 inference_timeout=inference_timeout,
+                _extra=extra,
             )
         raise TypeError(
             f"Model config entry must be str or dict, got {type(entry).__name__}"
@@ -209,16 +225,18 @@ class ModelConfig:
 
     def to_entry(self) -> str | dict:
         """Serialize to models.json format. Plain models become strings."""
-        has_overrides = (
-            self.experimental
-            or self.options
-            or self.keep_alive is not None
-            or self.inference_queue_timeout is not None
-            or self.inference_timeout is not None
-        )
-        if not has_overrides:
+        if (
+            not self.experimental
+            and not self.options
+            and self.keep_alive is None
+            and self.inference_queue_timeout is None
+            and self.inference_timeout is None
+            and not self._extra
+        ):
             return self.hf_path
-        result: dict[str, Any] = {"hf_path": self.hf_path}
+        # Start with extra keys as base, then overlay known keys on top
+        result: dict[str, Any] = dict(self._extra)
+        result["hf_path"] = self.hf_path
         if self.experimental:
             result["experimental"] = self.experimental
         if self.options:
@@ -300,6 +318,8 @@ class ModelRegistry:
     def __init__(self):
         self._mappings: dict[str, ModelConfig] = {}
         self._raw_unrecognized: dict[str, Any] = {}
+        self._dirty_keys: set[str] = set()
+        self._removed_keys: set[str] = set()
         self._aliases: dict[str, str] = {}
         self._aliases_path = settings.models_config.parent / "aliases.json"
 
@@ -318,6 +338,8 @@ class ModelRegistry:
                 raw = {}
             self._mappings = {}
             self._raw_unrecognized = {}
+            self._dirty_keys = set()
+            self._removed_keys = set()
             for k, v in raw.items():
                 try:
                     self._mappings[k] = ModelConfig.from_entry(v)
@@ -456,16 +478,36 @@ class ModelRegistry:
             return  # identical, no save needed
         self._mappings[normalized] = mc
         self._raw_unrecognized.pop(normalized, None)
+        self._dirty_keys.add(normalized)
+        self._removed_keys.discard(normalized)
         self._save_mappings()
 
     def _save_mappings(self):
-        # Preserve unrecognized entries so they survive round-trips through
-        # versions that can't parse them (forward/backward compatibility).
-        serialized = {k: v.to_entry() for k, v in self._mappings.items()}
+        # Re-read disk state as base to preserve external edits (e.g. user
+        # editing models.json while the server is running).
+        disk_data: dict[str, Any] = {}
+        if settings.models_config.exists():
+            try:
+                with open(settings.models_config) as f:
+                    disk_data = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                pass  # corrupt or unreadable — proceed with empty base
+
+        # Remove explicitly deleted keys
+        for key in self._removed_keys:
+            disk_data.pop(key, None)
+
+        # Overlay only keys that were modified in this process
+        for k in self._dirty_keys:
+            if k in self._mappings:
+                disk_data[k] = self._mappings[k].to_entry()
+
+        # Preserve unrecognized entries (forward/backward compatibility)
         for k, v in self._raw_unrecognized.items():
-            if k not in serialized:
-                serialized[k] = v
-        _atomic_write_json(serialized, settings.models_config)
+            if k not in disk_data:
+                disk_data[k] = v
+
+        _atomic_write_json(disk_data, settings.models_config)
 
     def remove(self, name: str):
         """Remove a model alias or mapping."""
@@ -474,6 +516,8 @@ class ModelRegistry:
         if self._aliases.pop(normalized, None) is not None:
             self._save_aliases()
         if self._mappings.pop(normalized, None) is not None:
+            self._removed_keys.add(normalized)
+            self._dirty_keys.discard(normalized)
             self._save_mappings()
 
     def search(self, query: str, max_results: int = 5) -> list[tuple[str, str]]:

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -468,7 +468,12 @@ class ModelRegistry:
                     f"hf_path mismatch: argument {hf_path!r} != "
                     f"model_config.hf_path {model_config.hf_path!r}"
                 )
-            mc = model_config
+            if existing is not None and existing._extra and not model_config._extra:
+                from dataclasses import replace
+
+                mc = replace(model_config, _extra=existing._extra)
+            else:
+                mc = model_config
         else:
             # No rich config supplied — preserve existing entry if hf_path matches
             if existing is not None and existing.hf_path == hf_path:
@@ -511,6 +516,8 @@ class ModelRegistry:
                 disk_data[k] = v
 
         _atomic_write_json(disk_data, settings.models_config)
+        self._dirty_keys.clear()
+        self._removed_keys.clear()
 
     def remove(self, name: str):
         """Remove a model alias or mapping."""

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -555,7 +555,7 @@ class ModelRegistry:
                             if ek not in _KNOWN_CONFIG_KEYS
                         }
                         if disk_extras:
-                            merged = {**disk_extras, **mc._extra}
+                            merged = {**mc._extra, **disk_extras}
                             mc = replace(mc, _extra=merged)
                     disk_data[k] = mc.to_entry()
 

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -499,10 +499,11 @@ class ModelRegistry:
             self._save_mappings_locked()
 
     def _save_mappings_locked(self):
-        # Safety: all callers run on the asyncio event loop (single-threaded),
-        # so _mappings/_dirty_keys/_removed_keys mutations in add_mapping/remove
-        # never race with reads here. The lock only serializes disk writes.
-        # Do NOT make this async without also locking the dict mutations.
+        # The lock is defensive — it serializes disk I/O but does not cover
+        # dict mutations in add_mapping/remove. This is safe today because
+        # all callers run on the single-threaded asyncio event loop. If
+        # multi-threaded access is ever needed, the lock must be expanded
+        # to cover all _mappings/_dirty_keys/_removed_keys mutations.
         #
         # Snapshot the dirty/removed sets so concurrent add_mapping/remove
         # calls that mutate them outside the lock aren't silently cleared.
@@ -536,10 +537,23 @@ class ModelRegistry:
             for key in removed_snapshot:
                 disk_data.pop(key, None)
 
-            # Overlay only keys that were modified in this process
+            # Overlay only keys that were modified in this process.
+            # Merge any unknown keys from the current disk entry so that
+            # user-added extra keys survive even for server-touched models.
             for k in dirty_snapshot:
                 if k in self._mappings:
-                    disk_data[k] = self._mappings[k].to_entry()
+                    mc = self._mappings[k]
+                    disk_entry = disk_data.get(k)
+                    if isinstance(disk_entry, dict):
+                        disk_extras = {
+                            ek: ev
+                            for ek, ev in disk_entry.items()
+                            if ek not in _KNOWN_CONFIG_KEYS
+                        }
+                        if disk_extras:
+                            merged = {**disk_extras, **mc._extra}
+                            mc = replace(mc, _extra=merged)
+                    disk_data[k] = mc.to_entry()
 
         # Preserve unrecognized entries (forward/backward compatibility).
         # These may be valid entries written by a newer version.

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -234,9 +234,8 @@ class ModelConfig:
             and not self._extra
         ):
             return self.hf_path
-        # Start with extra keys as base, then overlay known keys on top
-        result: dict[str, Any] = dict(self._extra)
-        result["hf_path"] = self.hf_path
+        # Put hf_path first for readability, then known keys, then extra
+        result: dict[str, Any] = {"hf_path": self.hf_path}
         if self.experimental:
             result["experimental"] = self.experimental
         if self.options:
@@ -247,6 +246,7 @@ class ModelConfig:
             result["inference_queue_timeout"] = self.inference_queue_timeout
         if self.inference_timeout is not None:
             result["inference_timeout"] = self.inference_timeout
+        result.update(self._extra)
         return result
 
 
@@ -473,7 +473,10 @@ class ModelRegistry:
             # No rich config supplied — preserve existing entry if hf_path matches
             if existing is not None and existing.hf_path == hf_path:
                 return
-            mc = ModelConfig(hf_path=hf_path)
+            mc = ModelConfig(
+                hf_path=hf_path,
+                _extra=existing._extra if existing is not None else {},
+            )
         if existing is not None and existing == mc:
             return  # identical, no save needed
         self._mappings[normalized] = mc

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -486,7 +486,7 @@ class ModelRegistry:
                 _extra=dict(existing._extra) if existing is not None else {},
             )
         if existing is not None and existing == mc and existing._extra == mc._extra:
-            return  # identical, no save needed
+            return  # identical, no save needed (_extra excluded from == due to compare=False)
         self._mappings[normalized] = mc
         self._raw_unrecognized.pop(normalized, None)
         self._dirty_keys.add(normalized)
@@ -497,14 +497,16 @@ class ModelRegistry:
         # Re-read disk state as base to preserve external edits (e.g. user
         # editing models.json while the server is running).
         disk_data: dict[str, Any] = {}
+        disk_read_ok = False
         if settings.models_config.exists():
             try:
                 with open(settings.models_config) as f:
                     disk_data = json.load(f)
+                disk_read_ok = True
             except (json.JSONDecodeError, OSError):
-                pass  # corrupt or unreadable — proceed with empty base
+                pass  # corrupt or unreadable
 
-        if not disk_data and self._mappings:
+        if not disk_read_ok and self._mappings:
             # File was missing or corrupt — write full in-memory state to
             # avoid silently dropping live entries.
             logger.warning(

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -505,8 +505,8 @@ class ModelRegistry:
         # multi-threaded access is ever needed, the lock must be expanded
         # to cover all _mappings/_dirty_keys/_removed_keys mutations.
         #
-        # Snapshot the dirty/removed sets so concurrent add_mapping/remove
-        # calls that mutate them outside the lock aren't silently cleared.
+        # Snapshot dirty/removed sets so only keys visible at flush-start are
+        # cleared afterward; additions arriving after the snapshot survive.
         dirty_snapshot = set(self._dirty_keys)
         removed_snapshot = set(self._removed_keys)
 

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -5,6 +5,7 @@ import json
 import os
 import tempfile
 import threading
+import dataclasses
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
@@ -147,16 +148,7 @@ def _validate_keep_alive(value: str) -> None:
         )
 
 
-_KNOWN_CONFIG_KEYS: frozenset[str] = frozenset(
-    {
-        "hf_path",
-        "experimental",
-        "options",
-        "keep_alive",
-        "inference_queue_timeout",
-        "inference_timeout",
-    }
-)
+_KNOWN_CONFIG_KEYS: frozenset[str]  # set after ModelConfig is defined
 
 
 @dataclass
@@ -253,6 +245,13 @@ class ModelConfig:
             {k: v for k, v in self._extra.items() if k not in _KNOWN_CONFIG_KEYS}
         )
         return result
+
+
+# Derived from ModelConfig fields so it stays in sync automatically.
+# Used to separate known config keys from _extra in from_entry()/to_entry().
+_KNOWN_CONFIG_KEYS = frozenset(
+    f.name for f in dataclasses.fields(ModelConfig) if f.name != "_extra"
+)
 
 
 def _atomic_write_json(data: dict, path: Path) -> None:
@@ -496,17 +495,14 @@ class ModelRegistry:
         self._save_mappings()
 
     def _save_mappings(self):
-        # threading.Lock is appropriate here: callers (add_mapping, remove)
-        # are sync methods invoked under ModelManager's asyncio lock, so
-        # the event loop is already yielded before we get here.
         with self._save_lock:
             self._save_mappings_locked()
 
     def _save_mappings_locked(self):
-        # NOTE: This method reads self._mappings which is mutated outside
-        # _save_lock (in add_mapping/remove). This is safe because the lock
-        # is only contended by sync callers on the same thread. Do NOT make
-        # this method async without also locking the dict mutations.
+        # Safety: all callers run on the asyncio event loop (single-threaded),
+        # so _mappings/_dirty_keys/_removed_keys mutations in add_mapping/remove
+        # never race with reads here. The lock only serializes disk writes.
+        # Do NOT make this async without also locking the dict mutations.
         #
         # Snapshot the dirty/removed sets so concurrent add_mapping/remove
         # calls that mutate them outside the lock aren't silently cleared.
@@ -520,10 +516,13 @@ class ModelRegistry:
         if settings.models_config.exists():
             try:
                 with open(settings.models_config) as f:
-                    disk_data = json.load(f)
+                    loaded = json.load(f)
+                if not isinstance(loaded, dict):
+                    raise ValueError(f"Expected dict, got {type(loaded).__name__}")
+                disk_data = loaded
                 disk_read_ok = True
-            except (json.JSONDecodeError, OSError):
-                pass  # corrupt or unreadable
+            except (json.JSONDecodeError, ValueError, OSError):
+                pass  # corrupt, wrong type, or unreadable
 
         if not disk_read_ok and self._mappings:
             # File was missing or corrupt — write full in-memory state to

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -496,10 +496,18 @@ class ModelRegistry:
         self._save_mappings()
 
     def _save_mappings(self):
+        # threading.Lock is appropriate here: callers (add_mapping, remove)
+        # are sync methods invoked under ModelManager's asyncio lock, so
+        # the event loop is already yielded before we get here.
         with self._save_lock:
             self._save_mappings_locked()
 
     def _save_mappings_locked(self):
+        # Snapshot the dirty/removed sets so concurrent add_mapping/remove
+        # calls that mutate them outside the lock aren't silently cleared.
+        dirty_snapshot = set(self._dirty_keys)
+        removed_snapshot = set(self._removed_keys)
+
         # Re-read disk state as base to preserve external edits (e.g. user
         # editing models.json while the server is running).
         disk_data: dict[str, Any] = {}
@@ -521,22 +529,27 @@ class ModelRegistry:
             disk_data = {k: v.to_entry() for k, v in self._mappings.items()}
         else:
             # Remove explicitly deleted keys
-            for key in self._removed_keys:
+            for key in removed_snapshot:
                 disk_data.pop(key, None)
 
             # Overlay only keys that were modified in this process
-            for k in self._dirty_keys:
+            for k in dirty_snapshot:
                 if k in self._mappings:
                     disk_data[k] = self._mappings[k].to_entry()
 
-        # Preserve unrecognized entries (forward/backward compatibility)
-        for k, v in self._raw_unrecognized.items():
-            if k not in disk_data:
-                disk_data[k] = v
+        # Preserve unrecognized entries (forward/backward compatibility).
+        # Skip in the corruption fallback path — don't re-inject previously
+        # invalid data into the recovered output.
+        if disk_read_ok:
+            for k, v in self._raw_unrecognized.items():
+                if k not in disk_data:
+                    disk_data[k] = v
 
         _atomic_write_json(disk_data, settings.models_config)
-        self._dirty_keys.clear()
-        self._removed_keys.clear()
+        # Only clear the keys we actually flushed — concurrent additions
+        # that arrived after the snapshot are preserved for the next save.
+        self._dirty_keys -= dirty_snapshot
+        self._removed_keys -= removed_snapshot
 
     def remove(self, name: str):
         """Remove a model alias or mapping."""

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -148,7 +148,7 @@ def _validate_keep_alive(value: str) -> None:
         )
 
 
-_KNOWN_CONFIG_KEYS: frozenset[str]  # set after ModelConfig is defined
+_KNOWN_CONFIG_KEYS: frozenset[str] = frozenset()  # set after ModelConfig is defined
 
 
 @dataclass
@@ -514,7 +514,8 @@ class ModelRegistry:
         # editing models.json while the server is running).
         disk_data: dict[str, Any] = {}
         disk_read_ok = False
-        if settings.models_config.exists():
+        file_exists = settings.models_config.exists()
+        if file_exists:
             try:
                 with open(settings.models_config) as f:
                     loaded = json.load(f)
@@ -530,9 +531,8 @@ class ModelRegistry:
             # avoid silently dropping live entries. Removed keys are already
             # absent from _mappings (remove() pops them), so they won't
             # reappear. dirty/removed snapshots are not needed here.
-            logger.warning(
-                "models.json missing or corrupt; writing full in-memory state"
-            )
+            if file_exists:
+                logger.warning("models.json corrupt; writing full in-memory state")
             disk_data = {k: v.to_entry() for k, v in self._mappings.items()}
         else:
             # Remove explicitly deleted keys
@@ -560,10 +560,13 @@ class ModelRegistry:
                     disk_data[k] = mc.to_entry()
 
         # Preserve unrecognized entries (forward/backward compatibility).
-        # These may be valid entries written by a newer version.
-        for k, v in self._raw_unrecognized.items():
-            if k not in disk_data:
-                disk_data[k] = v
+        # These may be valid entries written by a newer version. Only inject
+        # when the disk file was unreadable (recovery) — if the file was read
+        # successfully and an entry is absent, the user intentionally removed it.
+        if not disk_read_ok:
+            for k, v in self._raw_unrecognized.items():
+                if k not in disk_data:
+                    disk_data[k] = v
 
         _atomic_write_json(disk_data, settings.models_config)
         # Only clear the keys we actually flushed — concurrent additions

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -4,7 +4,7 @@ import difflib
 import json
 import os
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -246,7 +246,11 @@ class ModelConfig:
             result["inference_queue_timeout"] = self.inference_queue_timeout
         if self.inference_timeout is not None:
             result["inference_timeout"] = self.inference_timeout
-        result.update(self._extra)
+        # Filter known keys defensively — from_entry() already excludes them,
+        # but _extra can be set directly via ModelConfig construction.
+        result.update(
+            {k: v for k, v in self._extra.items() if k not in _KNOWN_CONFIG_KEYS}
+        )
         return result
 
 
@@ -468,10 +472,9 @@ class ModelRegistry:
                     f"hf_path mismatch: argument {hf_path!r} != "
                     f"model_config.hf_path {model_config.hf_path!r}"
                 )
-            if existing is not None and existing._extra and not model_config._extra:
-                from dataclasses import replace
-
-                mc = replace(model_config, _extra=existing._extra)
+            if existing is not None and existing._extra:
+                merged = {**existing._extra, **model_config._extra}
+                mc = replace(model_config, _extra=merged)
             else:
                 mc = model_config
         else:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1001,6 +1001,27 @@ class TestExtraKeysPreserved:
         assert entry["num_ctx"] == 8192
         assert entry["system_prompt"] == "You are helpful"
 
+    def test_extra_keys_preserved_when_hf_path_changes(self, tmp_path, monkeypatch):
+        """Extra keys must survive when add_mapping re-points to a new hf_path."""
+        config = {
+            "mymodel:latest": {
+                "hf_path": "org/my-model-4bit",
+                "num_ctx": 8192,
+            }
+        }
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+        # Re-point to a different quantization (no model_config supplied)
+        reg.add_mapping("mymodel", "org/my-model-8bit")
+        saved = json.loads(config_path.read_text())
+        entry = saved["mymodel:latest"]
+        assert isinstance(entry, dict)
+        assert entry["hf_path"] == "org/my-model-8bit"
+        assert entry["num_ctx"] == 8192
+
     def test_extra_keys_prevent_string_compaction(self, tmp_path, monkeypatch):
         """A dict entry with hf_path + extra keys must not compact to a string."""
         config = {
@@ -1108,6 +1129,10 @@ class TestDiskMergeOnSave:
 
         saved = json.loads(config_path.read_text())
         assert saved["modelB:latest"] == "org/model-b"
+        # modelA was loaded but never dirtied, so it's lost when the file
+        # disappears — this is expected since the disk is the source of truth
+        # for non-dirty entries.
+        assert "modelA:latest" not in saved
 
     def test_save_with_corrupt_file(self, tmp_path, monkeypatch):
         """If models.json is corrupted while running, dirty keys still get saved."""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1138,7 +1138,7 @@ class TestDiskMergeOnSave:
         assert saved["modelB:latest"] == "org/model-b"
 
     def test_save_with_missing_file(self, tmp_path, monkeypatch):
-        """If models.json is deleted while running, dirty keys still get saved."""
+        """If models.json is deleted while running, full in-memory state is restored."""
         config = {"modelA:latest": "org/model-a"}
         config_path = tmp_path / "models.json"
         config_path.write_text(json.dumps(config))
@@ -1149,18 +1149,17 @@ class TestDiskMergeOnSave:
         # Delete the file
         config_path.unlink()
 
-        # Add a new mapping — should recreate the file
+        # Add a new mapping — should recreate the file with all entries
         reg.add_mapping("modelB", "org/model-b")
 
         saved = json.loads(config_path.read_text())
         assert saved["modelB:latest"] == "org/model-b"
-        # modelA was loaded but never dirtied, so it's lost when the file
-        # disappears — this is expected since the disk is the source of truth
-        # for non-dirty entries.
-        assert "modelA:latest" not in saved
+        # When the file is missing, all in-memory entries are written to
+        # prevent silent data loss.
+        assert saved["modelA:latest"] == "org/model-a"
 
     def test_save_with_corrupt_file(self, tmp_path, monkeypatch):
-        """If models.json is corrupted while running, dirty keys still get saved."""
+        """If models.json is corrupted while running, full in-memory state is restored."""
         config = {"modelA:latest": "org/model-a"}
         config_path = tmp_path / "models.json"
         config_path.write_text(json.dumps(config))
@@ -1171,8 +1170,9 @@ class TestDiskMergeOnSave:
         # Corrupt the file
         config_path.write_text("{broken json!!!")
 
-        # Add a new mapping
+        # Add a new mapping — should restore all entries
         reg.add_mapping("modelB", "org/model-b")
 
         saved = json.loads(config_path.read_text())
         assert saved["modelB:latest"] == "org/model-b"
+        assert saved["modelA:latest"] == "org/model-a"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1123,6 +1123,39 @@ class TestDiskMergeOnSave:
         # User's externally-added extra key must survive
         assert entry["num_ctx"] == 8192
 
+    def test_save_preserves_externally_modified_extra_keys(self, tmp_path, monkeypatch):
+        """External edits to existing extra keys must be picked up from disk."""
+        config = {
+            "mymodel:latest": {
+                "hf_path": "org/my-model",
+                "num_ctx": 4096,
+            }
+        }
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+
+        # User externally changes num_ctx
+        disk = {
+            "mymodel:latest": {
+                "hf_path": "org/my-model",
+                "num_ctx": 8192,
+            }
+        }
+        config_path.write_text(json.dumps(disk))
+
+        # Server touches the same model
+        mc = ModelConfig(hf_path="org/my-model", keep_alive="5m")
+        reg.add_mapping("mymodel", "org/my-model", model_config=mc)
+
+        saved = json.loads(config_path.read_text())
+        entry = saved["mymodel:latest"]
+        assert entry["keep_alive"] == "5m"
+        # Disk value (8192) must win over load-time snapshot (4096)
+        assert entry["num_ctx"] == 8192
+
     def test_save_preserves_disk_config_modifications(self, tmp_path, monkeypatch):
         """Config edits made on disk while server runs must not be overwritten."""
         config = {"mymodel:latest": "org/my-model"}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1022,7 +1022,9 @@ class TestExtraKeysPreserved:
         assert entry["hf_path"] == "org/my-model-8bit"
         assert entry["num_ctx"] == 8192
 
-    def test_extra_keys_preserved_when_model_config_provided(self, tmp_path, monkeypatch):
+    def test_extra_keys_preserved_when_model_config_provided(
+        self, tmp_path, monkeypatch
+    ):
         """_extra keys must survive when add_mapping is called with explicit model_config."""
         config = {
             "mymodel:latest": {

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -927,23 +927,21 @@ class TestRegistryModelConfig:
         assert mc.keep_alive == "30m"
 
     def test_unrecognized_entries_survive_save(self, tmp_path, monkeypatch):
-        """Entries that fail parsing should be preserved on save."""
+        """Entries that fail parsing should be preserved on disk through saves."""
         config = {
             "good:latest": "Qwen/Qwen3-8B-MLX",
             "future-format:latest": {"hf_path": "org/model", "new_field": "value"},
+            "broken:latest": {"weird": True},  # no hf_path — fails from_entry
         }
         config_path = tmp_path / "models.json"
         config_path.write_text(json.dumps(config))
         monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
         reg = ModelRegistry()
         reg.load()
-        # "future-format" should be in _raw_unrecognized (it has unknown fields
-        # but from_entry only validates experimental/options/keep_alive, so
-        # extra keys are ignored). Force an unrecognized entry for testing:
-        reg._raw_unrecognized["broken:latest"] = {"weird": True}
+        assert "broken:latest" in reg._raw_unrecognized
         # Trigger a save
         reg.add_mapping("new-model", "org/new-model")
-        # Reload and verify unrecognized entry survived
+        # The broken entry is on disk, so re-reading preserves it
         saved = json.loads(config_path.read_text())
         assert "broken:latest" in saved
         assert saved["broken:latest"] == {"weird": True}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1095,6 +1095,36 @@ class TestDiskMergeOnSave:
         assert saved["modelC:latest"] == "org/model-c"
         assert saved["modelD:latest"] == "org/model-d"
 
+    def test_save_merges_disk_extras_for_dirty_keys(self, tmp_path, monkeypatch):
+        """Extra keys added on disk for a server-touched model must survive."""
+        config = {"mymodel:latest": {"hf_path": "org/my-model"}}
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+
+        # User externally adds extra keys to the same model
+        disk = {
+            "mymodel:latest": {
+                "hf_path": "org/my-model",
+                "num_ctx": 8192,
+            }
+        }
+        config_path.write_text(json.dumps(disk))
+
+        # Server touches the same model (e.g. auto-registration with keep_alive)
+        mc = ModelConfig(hf_path="org/my-model", keep_alive="10m")
+        reg.add_mapping("mymodel", "org/my-model", model_config=mc)
+
+        saved = json.loads(config_path.read_text())
+        entry = saved["mymodel:latest"]
+        assert isinstance(entry, dict)
+        assert entry["hf_path"] == "org/my-model"
+        assert entry["keep_alive"] == "10m"
+        # User's externally-added extra key must survive
+        assert entry["num_ctx"] == 8192
+
     def test_save_preserves_disk_config_modifications(self, tmp_path, monkeypatch):
         """Config edits made on disk while server runs must not be overwritten."""
         config = {"mymodel:latest": "org/my-model"}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1176,3 +1176,26 @@ class TestDiskMergeOnSave:
         saved = json.loads(config_path.read_text())
         assert saved["modelB:latest"] == "org/model-b"
         assert saved["modelA:latest"] == "org/model-a"
+
+    def test_save_with_externally_emptied_file(self, tmp_path, monkeypatch):
+        """An intentionally emptied {} file should not restore in-memory entries."""
+        config = {"modelA:latest": "org/model-a", "modelB:latest": "org/model-b"}
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg._aliases_path = tmp_path / "aliases.json"
+        reg.load()
+
+        # User externally clears the file
+        config_path.write_text("{}")
+
+        # Add a new model
+        reg.add_mapping("modelC", "org/model-c")
+
+        saved = json.loads(config_path.read_text())
+        # Only the new model should be present — the user intentionally
+        # emptied the file, so old entries must not be restored.
+        assert saved["modelC:latest"] == "org/model-c"
+        assert "modelA:latest" not in saved
+        assert "modelB:latest" not in saved

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1022,6 +1022,29 @@ class TestExtraKeysPreserved:
         assert entry["hf_path"] == "org/my-model-8bit"
         assert entry["num_ctx"] == 8192
 
+    def test_extra_keys_preserved_when_model_config_provided(self, tmp_path, monkeypatch):
+        """_extra keys must survive when add_mapping is called with explicit model_config."""
+        config = {
+            "mymodel:latest": {
+                "hf_path": "org/my-model",
+                "num_ctx": 8192,
+            }
+        }
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+
+        mc = ModelConfig(hf_path="org/my-model", keep_alive="30m")
+        reg.add_mapping("mymodel", "org/my-model", model_config=mc)
+
+        saved = json.loads(config_path.read_text())
+        entry = saved["mymodel:latest"]
+        assert isinstance(entry, dict)
+        assert entry["num_ctx"] == 8192
+        assert entry["keep_alive"] == "30m"
+
     def test_extra_keys_prevent_string_compaction(self, tmp_path, monkeypatch):
         """A dict entry with hf_path + extra keys must not compact to a string."""
         config = {

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -972,3 +972,157 @@ class TestCorruptedJsonFiles:
         reg = ModelRegistry()
         reg.load()
         assert reg._aliases == {}
+
+
+class TestExtraKeysPreserved:
+    """Unknown JSON keys in model config dicts must survive round-trips."""
+
+    def test_extra_keys_preserved_on_round_trip(self, tmp_path, monkeypatch):
+        """Extra keys like num_ctx should survive load → save → reload."""
+        config = {
+            "mymodel:latest": {
+                "hf_path": "org/my-model",
+                "num_ctx": 8192,
+                "system_prompt": "You are helpful",
+            }
+        }
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+        # Trigger save by adding a new mapping
+        reg.add_mapping("other-model", "org/other-model")
+        # Reload and verify extra keys survived
+        saved = json.loads(config_path.read_text())
+        entry = saved["mymodel:latest"]
+        assert isinstance(entry, dict)
+        assert entry["hf_path"] == "org/my-model"
+        assert entry["num_ctx"] == 8192
+        assert entry["system_prompt"] == "You are helpful"
+
+    def test_extra_keys_prevent_string_compaction(self, tmp_path, monkeypatch):
+        """A dict entry with hf_path + extra keys must not compact to a string."""
+        config = {
+            "mymodel:latest": {
+                "hf_path": "org/my-model",
+                "custom_flag": True,
+            }
+        }
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+        reg.add_mapping("trigger", "org/trigger-model")
+        saved = json.loads(config_path.read_text())
+        # Must remain a dict, not be compacted to "org/my-model"
+        assert isinstance(saved["mymodel:latest"], dict)
+        assert saved["mymodel:latest"]["custom_flag"] is True
+
+
+class TestDiskMergeOnSave:
+    """_save_mappings() must re-read disk and merge, not blindly overwrite."""
+
+    def test_save_preserves_entries_added_to_disk_externally(
+        self, tmp_path, monkeypatch
+    ):
+        """Entries added to models.json while server is running must survive."""
+        config = {"modelA:latest": "org/model-a", "modelB:latest": "org/model-b"}
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+
+        # Simulate user editing the file externally
+        disk = json.loads(config_path.read_text())
+        disk["modelC:latest"] = "org/model-c"
+        config_path.write_text(json.dumps(disk))
+
+        # Trigger save by adding a new mapping
+        reg.add_mapping("modelD", "org/model-d")
+
+        saved = json.loads(config_path.read_text())
+        assert saved["modelA:latest"] == "org/model-a"
+        assert saved["modelB:latest"] == "org/model-b"
+        assert saved["modelC:latest"] == "org/model-c"
+        assert saved["modelD:latest"] == "org/model-d"
+
+    def test_save_preserves_disk_config_modifications(self, tmp_path, monkeypatch):
+        """Config edits made on disk while server runs must not be overwritten."""
+        config = {"mymodel:latest": "org/my-model"}
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+
+        # User edits the file to add rich config
+        disk = {
+            "mymodel:latest": {
+                "hf_path": "org/my-model",
+                "options": {"temperature": 0.5},
+            }
+        }
+        config_path.write_text(json.dumps(disk))
+
+        # Trigger save (mymodel was not modified in-memory)
+        reg.add_mapping("other", "org/other-model")
+
+        saved = json.loads(config_path.read_text())
+        # Disk edit should be preserved since we didn't touch mymodel in-memory
+        assert isinstance(saved["mymodel:latest"], dict)
+        assert saved["mymodel:latest"]["options"] == {"temperature": 0.5}
+
+    def test_remove_deletes_from_disk(self, tmp_path, monkeypatch):
+        """remove() should delete entries even if they were re-added to disk."""
+        config = {"modelA:latest": "org/model-a", "modelB:latest": "org/model-b"}
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg._aliases_path = tmp_path / "aliases.json"
+        reg.load()
+
+        reg.remove("modelA")
+
+        saved = json.loads(config_path.read_text())
+        assert "modelA:latest" not in saved
+        assert saved["modelB:latest"] == "org/model-b"
+
+    def test_save_with_missing_file(self, tmp_path, monkeypatch):
+        """If models.json is deleted while running, dirty keys still get saved."""
+        config = {"modelA:latest": "org/model-a"}
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+
+        # Delete the file
+        config_path.unlink()
+
+        # Add a new mapping — should recreate the file
+        reg.add_mapping("modelB", "org/model-b")
+
+        saved = json.loads(config_path.read_text())
+        assert saved["modelB:latest"] == "org/model-b"
+
+    def test_save_with_corrupt_file(self, tmp_path, monkeypatch):
+        """If models.json is corrupted while running, dirty keys still get saved."""
+        config = {"modelA:latest": "org/model-a"}
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+
+        # Corrupt the file
+        config_path.write_text("{broken json!!!")
+
+        # Add a new mapping
+        reg.add_mapping("modelB", "org/model-b")
+
+        saved = json.loads(config_path.read_text())
+        assert saved["modelB:latest"] == "org/model-b"


### PR DESCRIPTION
## Summary

- **Bug 1 — Stale overwrites:** `_save_mappings()` wrote the in-memory state blindly, discarding any manual edits made to `~/.olmlx/models.json` while the server was running. Fix: re-read disk state before saving, track dirty keys (`_dirty_keys`) and removals (`_removed_keys`), and merge only modified entries on top of the current file.
- **Bug 2 — Unknown keys dropped:** `ModelConfig.from_entry()` silently discarded unrecognized JSON keys during the round-trip. Fix: preserve them in a `_extra` field and include them in `to_entry()` output.

## Test plan

- [x] 7 new tests covering both bugs (extra keys round-trip, disk merge, remove, missing/corrupt file)
- [x] All 1822 existing tests pass — zero regressions
- [x] ruff check + format clean
- [ ] Manual: start server, edit models.json externally, load a new model, verify external edits survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)