### PR TITLE
feat: add request correlation IDs for log tracing

### DIFF
--- a/olmlx/__init__.py
+++ b/olmlx/__init__.py
@@ -1,5 +1,1 @@
 __version__ = "0.1.0"
-
-__all__ = ["request_id_var"]
-
-from olmlx.app import request_id_var as request_id_var

--- a/olmlx/__init__.py
+++ b/olmlx/__init__.py
@@ -1,1 +1,5 @@
 __version__ = "0.1.0"
+
+__all__ = ["request_id_var"]
+
+from olmlx.app import request_id_var as request_id_var

--- a/olmlx/app.py
+++ b/olmlx/app.py
@@ -1,6 +1,8 @@
 import logging
 import traceback
+import uuid
 from contextlib import asynccontextmanager
+from contextvars import ContextVar
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -25,6 +27,8 @@ from olmlx.routers import (
 )
 
 logger = logging.getLogger("olmlx")
+
+request_id_var: ContextVar[str] = ContextVar("request_id", default="")
 
 
 @asynccontextmanager
@@ -131,6 +135,19 @@ class ForceJSONMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Generate and attach request IDs for log tracing."""
+
+    async def dispatch(self, request: Request, call_next):
+        request_id = str(uuid.uuid4())
+        request.state.request_id = request_id
+        request_id_var.set(request_id)
+
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
+        return response
+
+
 def _make_error_response(
     path: str,
     status_code: int,
@@ -160,6 +177,7 @@ def create_app() -> FastAPI:
     )
 
     app.add_middleware(ForceJSONMiddleware)
+    app.add_middleware(RequestIDMiddleware)
 
     @app.exception_handler(ValueError)
     async def value_error_handler(request: Request, exc: ValueError):

--- a/olmlx/app.py
+++ b/olmlx/app.py
@@ -2,7 +2,6 @@ import logging
 import traceback
 import uuid
 from contextlib import asynccontextmanager
-from contextvars import ContextVar
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -10,6 +9,7 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from olmlx.config import settings
+from olmlx.context import request_id_var
 from olmlx.engine.inference import ServerBusyError
 from olmlx.engine.model_manager import ModelLoadTimeoutError, ModelManager
 from olmlx.engine.registry import ModelRegistry
@@ -27,8 +27,6 @@ from olmlx.routers import (
 )
 
 logger = logging.getLogger("olmlx")
-
-request_id_var: ContextVar[str] = ContextVar("request_id", default="")
 
 
 @asynccontextmanager
@@ -136,16 +134,26 @@ class ForceJSONMiddleware(BaseHTTPMiddleware):
 
 
 class RequestIDMiddleware(BaseHTTPMiddleware):
-    """Generate and attach request IDs for log tracing."""
+    """Generate and attach request IDs for log tracing.
+
+    The ContextVar is reset in the finally block before the response body is fully
+    consumed. This relies on Starlette's BaseHTTPMiddleware running the inner app
+    as a sub-task that copies the current context, so request_id_var is available
+    for log messages during streaming inference.
+    """
 
     async def dispatch(self, request: Request, call_next):
         request_id = str(uuid.uuid4())
         request.state.request_id = request_id
-        request_id_var.set(request_id)
-
-        response = await call_next(request)
-        response.headers["X-Request-ID"] = request_id
-        return response
+        token = request_id_var.set(request_id)
+        response = None
+        try:
+            response = await call_next(request)
+            return response
+        finally:
+            if response is not None:
+                response.headers["X-Request-ID"] = request_id
+            request_id_var.reset(token)
 
 
 def _make_error_response(
@@ -174,6 +182,7 @@ def create_app() -> FastAPI:
         allow_origins=settings.cors_origins,
         allow_methods=["*"],
         allow_headers=["*"],
+        expose_headers=["X-Request-ID"],
     )
 
     app.add_middleware(ForceJSONMiddleware)

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -749,15 +749,7 @@ def cmd_models_delete(args):
 
 def _configure_logging():
     """Configure logging from settings."""
-
-    class RequestIDFormatter(logging.Formatter):
-        def format(self, record):
-            from olmlx.app import request_id_var
-
-            request_id = request_id_var.get()
-            if request_id:
-                record.msg = f"[{request_id[:8]}] {record.msg}"
-            return super().format(record)
+    from olmlx.context import RequestIDFormatter
 
     handler = logging.StreamHandler()
     handler.setFormatter(
@@ -768,7 +760,9 @@ def _configure_logging():
     )
     root = logging.getLogger()
     root.setLevel(getattr(logging, settings.log_level))
-    root.handlers = [handler]
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+    root.addHandler(handler)
 
 
 def cmd_chat(args):

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -749,10 +749,26 @@ def cmd_models_delete(args):
 
 def _configure_logging():
     """Configure logging from settings."""
-    logging.basicConfig(
-        level=getattr(logging, settings.log_level),
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+
+    class RequestIDFormatter(logging.Formatter):
+        def format(self, record):
+            from olmlx.app import request_id_var
+
+            request_id = request_id_var.get()
+            if request_id:
+                record.msg = f"[{request_id[:8]}] {record.msg}"
+            return super().format(record)
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        RequestIDFormatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
     )
+    root = logging.getLogger()
+    root.setLevel(getattr(logging, settings.log_level))
+    root.handlers = [handler]
 
 
 def cmd_chat(args):

--- a/olmlx/context.py
+++ b/olmlx/context.py
@@ -1,0 +1,17 @@
+import copy
+import logging
+from contextvars import ContextVar
+
+request_id_var: ContextVar[str] = ContextVar("request_id", default="")
+
+
+class RequestIDFormatter(logging.Formatter):
+    """Formatter that prefixes log messages with request ID from ContextVar."""
+
+    def format(self, record):
+        request_id = request_id_var.get()
+        if request_id:
+            record = copy.copy(record)
+            record.msg = f"[{request_id[:8]}] {record.getMessage()}"
+            record.args = ()
+        return super().format(record)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -83,6 +83,8 @@ class TestCreateApp:
         origins = cors_mw[0].kwargs["allow_origins"]
         assert "http://localhost:3000" in origins
         assert "*" not in origins
+        expose_headers = cors_mw[0].kwargs["expose_headers"]
+        assert "X-Request-ID" in expose_headers
 
 
 class TestLifespan:
@@ -428,3 +430,64 @@ class TestRequestIDMiddleware:
         assert resp.status_code == 400
         assert "x-request-id" in resp.headers
         assert len(resp.headers["x-request-id"]) == 36
+
+    @pytest.mark.asyncio
+    async def test_request_id_header_present_on_simple_route(self, app_client):
+        """Verify X-Request-ID header is present on all responses."""
+        resp = await app_client.get("/api/version")
+        assert resp.status_code == 200
+        assert "x-request-id" in resp.headers
+
+
+class TestRequestIDFormatter:
+    def test_formatter_adds_prefix_when_request_id_set(self):
+        import logging
+
+        from olmlx.context import RequestIDFormatter, request_id_var
+
+        formatter = RequestIDFormatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Processing request",
+            args=(),
+            exc_info=None,
+        )
+
+        token = request_id_var.set("abc12345-1234-1234-1234-123456789abc")
+        try:
+            result = formatter.format(record)
+            assert "[abc12345] " in result
+            assert "Processing request" in result
+        finally:
+            request_id_var.reset(token)
+
+    def test_formatter_no_prefix_when_request_id_not_set(self):
+        import logging
+
+        from olmlx.context import RequestIDFormatter
+
+        formatter = RequestIDFormatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Processing request",
+            args=(),
+            exc_info=None,
+        )
+
+        result = formatter.format(record)
+        assert "Processing request" in result
+        assert "[abc12345]" not in result

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -397,3 +397,34 @@ class TestErrorHandlers:
         resp = await app_client.get("/")
         assert resp.status_code == 200
         assert "running" in resp.text.lower()
+
+
+class TestRequestIDMiddleware:
+    @pytest.mark.asyncio
+    async def test_request_id_header_present(self, app_client):
+        resp = await app_client.get("/")
+        assert resp.status_code == 200
+        assert "x-request-id" in resp.headers
+        assert len(resp.headers["x-request-id"]) == 36  # UUID format
+
+    @pytest.mark.asyncio
+    async def test_request_id_different_per_request(self, app_client):
+        resp1 = await app_client.get("/")
+        resp2 = await app_client.get("/")
+        assert resp1.headers["x-request-id"] != resp2.headers["x-request-id"]
+
+    @pytest.mark.asyncio
+    async def test_request_id_on_error_response(self, app_client):
+        from unittest.mock import AsyncMock
+
+        with patch(
+            "olmlx.routers.generate.generate_completion", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.side_effect = ValueError("test error")
+            resp = await app_client.post(
+                "/api/generate",
+                json={"model": "qwen3", "prompt": "hi", "stream": False},
+            )
+        assert resp.status_code == 400
+        assert "x-request-id" in resp.headers
+        assert len(resp.headers["x-request-id"]) == 36


### PR DESCRIPTION
## Summary

Add request correlation IDs for log tracing (#186):

- Add `RequestIDMiddleware` that generates a UUID per request
- Add `X-Request-ID` response header on all responses including errors
- Add `RequestIDFormatter` that prefixes log messages with request ID
- Add `ContextVar` for async context propagation across the request lifecycle

### Example log output

```
2026-04-12 10:30:00 [INFO] olmlx: [a1b2c3d4] Processing chat request
2026-04-12 10:30:01 [INFO] olmlx: [a1b2c3d4] Generated 128 tokens
```

## Test plan

- [x] 3 new tests for RequestIDMiddleware (header present, unique per request, on error responses)
- [x] All 26 app tests pass
- [x] ruff check + format clean

Closes #186