### PR TITLE
feat: speculative decoding + dflash block-diffusion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ olmlx/
 │   ├── inference.py    # generate_chat, generate_completion, generate_embeddings
 │   ├── model_manager.py # Model loading/unloading, keep-alive, LRU eviction
 │   ├── registry.py    # Ollama name → HuggingFace repo mapping via models.json, fuzzy search
+│   ├── speculative.py  # SpeculativeDecoder: model-agnostic draft→target verification
+│   ├── speculative_stream.py # Streaming adapter for speculative decoding
 │   ├── template_caps.py # Chat template capability detection (tools, thinking)
 │   ├── tool_parser.py  # Multi-format tool call parsing (Qwen, Mistral, Llama, DeepSeek, bare JSON)
 │   ├── spectralquant.py # SpectralQuant: eigenvector rotation, non-uniform quantization, QJL sketcher
@@ -39,6 +41,10 @@ olmlx/
 │   ├── spectralquant_calibrate.py # Eigenspectral calibration: collect KV vectors, eigendecompose, fit codebooks
 │   ├── turboquant.py   # TurboQuant_mse: rotation, Lloyd-Max codebooks, bit-packed quantize/dequantize
 │   ├── turboquant_cache.py # TurboQuantKVCache: drop-in KVCache replacement with TurboQuant compression
+│   ├── dflash/
+│   │   ├── adapters.py      # TargetAdapter ABC + Qwen3Adapter for hidden state extraction
+│   │   ├── decoder.py       # DFlashDecoder: block-diffusion speculative decoding
+│   │   └── draft_model.py   # DFlashDraftModel: cross-attention draft architecture
 │   └── flash/
 │       ├── bundler.py       # Bundle FFN weights into per-layer .flashweights files
 │       ├── flash_mlp.py     # FlashMLP: sparse FFN that loads active neurons from SSD; WindowManager
@@ -46,14 +52,14 @@ olmlx/
 │       ├── predictor.py     # SparsityPredictor, PredictorBank, LookaheadBank (cross-layer)
 │       ├── prefetch.py      # Prefetcher: background neuron prefetch with thread pool + stats
 │       ├── prepare.py       # prepare_model_for_flash pipeline, predictor training
-│       ├── speculative.py   # SpeculativeFlashDecoder: draft→target verification with prefetch
+│       ├── speculative.py   # SpeculativeFlashDecoder: extends SpeculativeDecoder with prefetch
 │       ├── weight_store.py  # FlashWeightStore: SSD I/O, NeuronCache, preallocated buffers
 │       ├── flash_moe.py     # Flash-MoE sparse expert loading
 │       ├── flash_moe_model.py # Flash-MoE model wrapper
 │       ├── moe_bundler.py   # Bundle MoE expert weights
 │       ├── moe_prepare.py   # MoE preparation pipeline
 │       ├── moe_weight_store.py # MoE weight store
-│       └── speculative_stream.py # Streaming integration for speculative decoding
+│       └── speculative_stream.py # Re-exports from engine/speculative_stream.py
 ├── models/
 │   ├── manifest.py     # Model manifest/metadata
 │   └── store.py        # Local model storage
@@ -107,6 +113,8 @@ olmlx/
   - Worker and coordinator must load the same model (all_sum requires matching tensor shapes).
   - **Flash + distributed**: When both Flash and distributed are enabled (tensor strategy), `FlashModelWrapper.shard()` shards only attention projections, leaving FlashMLP layers unsharded. Each rank independently loads active neurons from its local SSD. This is correct because `o_proj` (sharded-to-all) replicates its output via `all_sum`, so every rank feeds identical input to FlashMLP. Pre-sharding is skipped (MLP weights live on SSD). Flash env vars are forwarded to workers. Flash-MoE + distributed remains blocked (expert weights cannot be sharded).
   - Config: `OLMLX_EXPERIMENTAL_DISTRIBUTED=true`, hostfile at `~/.olmlx/hostfile.json` with `{"hosts": ["ip1", "ip2"], "model": "hf-path"}`.
+- **Speculative decoding** (experimental): Two-tier architecture. Base `SpeculativeDecoder` (`engine/speculative.py`) is model-agnostic: draft model generates λ candidates autoregressively, target verifies all in one pass. Uses greedy argmax verification, persistent KV caches, and cache trimming on rejection. `SpeculativeFlashDecoder` (`engine/flash/speculative.py`) extends the base with Flash-specific prefetcher integration (Path B: draft hidden state capture for bulk neuron prediction) and adaptive neuron window sizing. Both share the same streaming adapter (`engine/speculative_stream.py`). Config: `OLMLX_EXPERIMENTAL_SPECULATIVE=true`, `OLMLX_EXPERIMENTAL_SPECULATIVE_DRAFT_MODEL=<hf-path>`, `OLMLX_EXPERIMENTAL_SPECULATIVE_TOKENS=4`.
+- **DFlash block-diffusion decoding** (experimental): Alternative speculative strategy where the draft model is conditioned on hidden states from specific target layers, using cross-attention (DFlashAttention) over concatenated target + current states. Model-specific `TargetAdapter` handles hidden state extraction and KV cache rollback. Implements the same `prefill`/`step`/`reset` interface as `SpeculativeDecoder` for seamless streaming integration. Config: `OLMLX_EXPERIMENTAL_DFLASH=true`, `OLMLX_EXPERIMENTAL_DFLASH_DRAFT_MODEL=<hf-path>`, `OLMLX_EXPERIMENTAL_DFLASH_BLOCK_SIZE=4`. Requires a pre-trained dflash draft model with `config.json` containing `target_layer_ids`.
 - **Speculative prefetch** (experimental): Predicts and pre-loads neuron weights from SSD before they're needed, hiding I/O latency during Flash inference. Three paths:
   - **Path A — Cross-layer**: While layer L computes, predicts layer L+1's active neurons using L's pre-MLP hidden state and starts background SSD reads. Optional `LookaheadBank` provides dedicated cross-layer predictors (trained with `OLMLX_EXPERIMENTAL_FLASH_PREFETCH=true` during preparation); falls back to reusing layer L+1's sparsity predictor.
   - **Path B — Draft-informed**: During speculative decoding, captures the draft model's hidden states (pre-lm_head, via `draft.model()` + `draft.lm_head()`) and submits bulk prefetch for all target layers before verification. Maps draft positions to target layers by depth ratio so early/deep layers get appropriate signals. Deduplicates predictor calls when multiple layers share the same draft position.

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -92,6 +92,11 @@ class ExperimentalSettings(BaseSettings):
     speculative_draft_model: str | None = None
     speculative_tokens: Annotated[int, Field(gt=0)] = 4
 
+    # DFlash block-diffusion speculative decoding
+    dflash: bool = False
+    dflash_draft_model: str | None = None
+    dflash_block_size: Annotated[int, Field(gt=0)] = 4
+
     # TurboQuant KV cache quantization (e.g. "turboquant:4", "turboquant:2")
     kv_cache_quant: str | None = None
 
@@ -114,11 +119,6 @@ class ExperimentalSettings(BaseSettings):
                 f"and bits is one of {_VALID_BITS}."
             )
         return v
-
-    # DFlash block-diffusion speculative decoding
-    dflash: bool = False
-    dflash_draft_model: str | None = None
-    dflash_block_size: Annotated[int, Field(gt=0)] = 4
 
     # Flash MoE (SSD-based expert offloading for MoE models)
     flash_moe: bool = False

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -87,6 +87,11 @@ class ExperimentalSettings(BaseSettings):
     flash_speculative_draft_model: str | None = None
     flash_speculative_tokens: Annotated[int, Field(gt=0)] = 4
 
+    # Standalone speculative decoding (works with any model, not just Flash)
+    speculative: bool = False
+    speculative_draft_model: str | None = None
+    speculative_tokens: Annotated[int, Field(gt=0)] = 4
+
     # TurboQuant KV cache quantization (e.g. "turboquant:4", "turboquant:2")
     kv_cache_quant: str | None = None
 
@@ -109,6 +114,11 @@ class ExperimentalSettings(BaseSettings):
                 f"and bits is one of {_VALID_BITS}."
             )
         return v
+
+    # DFlash block-diffusion speculative decoding
+    dflash: bool = False
+    dflash_draft_model: str | None = None
+    dflash_block_size: Annotated[int, Field(gt=0)] = 4
 
     # Flash MoE (SSD-based expert offloading for MoE models)
     flash_moe: bool = False

--- a/olmlx/engine/dflash/__init__.py
+++ b/olmlx/engine/dflash/__init__.py
@@ -1,0 +1,1 @@
+"""DFlash block-diffusion speculative decoding."""

--- a/olmlx/engine/dflash/adapters.py
+++ b/olmlx/engine/dflash/adapters.py
@@ -62,6 +62,10 @@ class Qwen3Adapter(TargetAdapter):
         lm_head = getattr(model, "lm_head", None)
 
         embed = getattr(inner, "embed_tokens", None) or getattr(inner, "embed", None)
+        if embed is None:
+            raise RuntimeError(
+                "DFlash target model has no embed_tokens or embed attribute"
+            )
         h = embed(tokens)
 
         captured: dict[int, mx.array] = {}

--- a/olmlx/engine/dflash/adapters.py
+++ b/olmlx/engine/dflash/adapters.py
@@ -47,7 +47,15 @@ class TargetAdapter(ABC):
 
 
 class Qwen3Adapter(TargetAdapter):
-    """Adapter for Qwen3 models (standard multi-head attention)."""
+    """Adapter for Qwen3 models (standard multi-head attention).
+
+    Note: forward_with_hidden iterates layers directly (bypassing the
+    model's __call__) to capture intermediate hidden states. This means
+    any mask construction done in the model's forward method is skipped.
+    For KV-cached inference this is correct because mlx-lm attention
+    layers derive causal masking from the cache offset, not from an
+    explicit mask argument.
+    """
 
     def forward_with_hidden(
         self,

--- a/olmlx/engine/dflash/adapters.py
+++ b/olmlx/engine/dflash/adapters.py
@@ -75,18 +75,19 @@ class Qwen3Adapter(TargetAdapter):
         if norm is not None:
             h = norm(h)
 
-        logits = lm_head(h) if lm_head is not None else h
+        if lm_head is None:
+            raise RuntimeError(
+                "DFlash target model has no lm_head attribute; "
+                "cannot compute verification logits"
+            )
+        logits = lm_head(h)
         return logits, captured, cache
 
     def trim_cache(self, cache: list, num_tokens: int) -> None:
         """Trim last num_tokens from cache using mlx-lm's trim_prompt_cache."""
-        try:
-            from mlx_lm.models.cache import trim_prompt_cache
+        from mlx_lm.models.cache import trim_prompt_cache
 
-            trim_prompt_cache(cache, num_tokens)
-        except ImportError:
-            for layer_cache in cache:
-                layer_cache.offset = max(0, layer_cache.offset - num_tokens)
+        trim_prompt_cache(cache, num_tokens)
 
 
 # Registry

--- a/olmlx/engine/dflash/adapters.py
+++ b/olmlx/engine/dflash/adapters.py
@@ -1,0 +1,109 @@
+"""Model-specific adapters for dflash speculative decoding.
+
+Each adapter knows how to:
+- Extract intermediate hidden states from the target model
+- Snapshot and restore KV caches for rollback
+- Trim caches after rejected tokens
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+
+class TargetAdapter(ABC):
+    """Abstract interface for model-specific target integration."""
+
+    @abstractmethod
+    def forward_with_hidden(
+        self,
+        model: Any,
+        tokens: mx.array,
+        cache: Any,
+        target_layer_ids: list[int],
+    ) -> tuple[mx.array, dict[int, mx.array], Any]:
+        """Forward pass that also captures intermediate hidden states.
+
+        Args:
+            model: The target model (or its inner transformer).
+            tokens: (1, seq_len) input token IDs.
+            cache: KV cache (or None for first call).
+            target_layer_ids: Which layer indices to capture.
+
+        Returns:
+            (logits, hidden_states, cache) where hidden_states maps
+            layer_idx -> (1, seq_len, hidden_size).
+        """
+
+    @abstractmethod
+    def trim_cache(self, cache: list, num_tokens: int) -> None:
+        """Remove the last num_tokens from each layer's cache."""
+
+
+class Qwen3Adapter(TargetAdapter):
+    """Adapter for Qwen3 models (standard multi-head attention)."""
+
+    def forward_with_hidden(
+        self,
+        model: Any,
+        tokens: mx.array,
+        cache: Any,
+        target_layer_ids: list[int],
+    ) -> tuple[mx.array, dict[int, mx.array], Any]:
+        inner = getattr(model, "model", model)
+        layers = inner.layers
+        norm = getattr(inner, "norm", None)
+        lm_head = getattr(model, "lm_head", None)
+
+        embed = getattr(inner, "embed_tokens", None) or getattr(inner, "embed", None)
+        h = embed(tokens)
+
+        captured: dict[int, mx.array] = {}
+        target_set = set(target_layer_ids)
+
+        for i, layer in enumerate(layers):
+            h = layer(h, cache=cache[i] if cache is not None else None)
+            if i in target_set:
+                captured[i] = h
+
+        if norm is not None:
+            h = norm(h)
+
+        logits = lm_head(h) if lm_head is not None else h
+        return logits, captured, cache
+
+    def trim_cache(self, cache: list, num_tokens: int) -> None:
+        """Trim last num_tokens from cache using mlx-lm's trim_prompt_cache."""
+        try:
+            from mlx_lm.models.cache import trim_prompt_cache
+
+            trim_prompt_cache(cache, num_tokens)
+        except ImportError:
+            for layer_cache in cache:
+                layer_cache.offset = max(0, layer_cache.offset - num_tokens)
+
+
+# Registry
+ADAPTERS: dict[str, type[TargetAdapter]] = {
+    "qwen3": Qwen3Adapter,
+    "qwen2": Qwen3Adapter,  # same attention structure
+}
+
+
+def get_adapter(model_type: str) -> TargetAdapter:
+    """Look up and instantiate an adapter by model type.
+
+    Raises KeyError if no adapter is registered for the given type.
+    """
+    if model_type not in ADAPTERS:
+        raise KeyError(
+            f"No dflash adapter for model_type={model_type!r}. "
+            f"Available: {list(ADAPTERS.keys())}"
+        )
+    return ADAPTERS[model_type]()

--- a/olmlx/engine/dflash/adapters.py
+++ b/olmlx/engine/dflash/adapters.py
@@ -49,12 +49,9 @@ class TargetAdapter(ABC):
 class Qwen3Adapter(TargetAdapter):
     """Adapter for Qwen3 models (standard multi-head attention).
 
-    Note: forward_with_hidden iterates layers directly (bypassing the
-    model's __call__) to capture intermediate hidden states. This means
-    any mask construction done in the model's forward method is skipped.
-    For KV-cached inference this is correct because mlx-lm attention
-    layers derive causal masking from the cache offset, not from an
-    explicit mask argument.
+    Iterates layers directly (bypassing model.__call__) to capture
+    intermediate hidden states. Constructs a causal mask for multi-token
+    inputs (prefill, verification) so KV cache entries are correct.
     """
 
     def forward_with_hidden(
@@ -76,11 +73,23 @@ class Qwen3Adapter(TargetAdapter):
             )
         h = embed(tokens)
 
+        # Build causal mask for multi-token inputs (prefill, verification).
+        # Single-token decode steps (seq_len=1) don't need a mask.
+        seq_len = tokens.shape[1]
+        offset = cache[0].offset if cache is not None else 0
+        if seq_len > 1:
+            mask = mx.triu(
+                mx.full((seq_len, seq_len + offset), -1e9, dtype=h.dtype),
+                k=1 + offset,
+            )
+        else:
+            mask = None
+
         captured: dict[int, mx.array] = {}
         target_set = set(target_layer_ids)
 
         for i, layer in enumerate(layers):
-            h = layer(h, cache=cache[i] if cache is not None else None)
+            h = layer(h, mask=mask, cache=cache[i] if cache is not None else None)
             if i in target_set:
                 captured[i] = h
 

--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -1,0 +1,175 @@
+"""DFlash block-diffusion speculative decoder.
+
+Uses hidden states from specific target layers to condition a draft model,
+which proposes candidate tokens. The target then verifies all candidates
+in one forward pass. Compatible with the SpeculativeDecoder interface
+(prefill/step/reset) for seamless integration with the streaming pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from olmlx.engine.dflash.adapters import TargetAdapter
+from olmlx.engine.dflash.draft_model import DFlashDraftModel, DraftConfig
+from olmlx.engine.speculative import verify_draft_greedy
+
+try:
+    from mlx_lm.models.cache import make_prompt_cache, trim_prompt_cache
+except ImportError:
+    make_prompt_cache = None  # type: ignore[assignment]
+    trim_prompt_cache = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+class DFlashDecoder:
+    """Block-diffusion speculative decoder.
+
+    Implements the same prefill/step/reset interface as SpeculativeDecoder
+    so it can be used interchangeably with the streaming pipeline.
+
+    Uses trim_prompt_cache for cache rollback (like SpeculativeDecoder)
+    instead of snapshot/restore, avoiding redundant target forward passes
+    and KV cache re-allocation on partial rejection.
+    """
+
+    def __init__(
+        self,
+        target_model: nn.Module,
+        draft_model: DFlashDraftModel,
+        adapter: TargetAdapter,
+        draft_config: DraftConfig,
+        block_size: int = 4,
+    ):
+        if trim_prompt_cache is None:
+            raise RuntimeError(
+                "trim_prompt_cache is unavailable (mlx-lm import missing); "
+                "dflash decoding requires it for correct cache trimming"
+            )
+
+        self._target = target_model
+        self._draft = draft_model
+        self._adapter = adapter
+        self._config = draft_config
+        self._block_size = block_size
+
+        # State
+        self._cache: list | None = None
+        self._cache_seq_len: int = 0
+        self._last_hidden_states: dict[int, mx.array] = {}
+        self._last_target_logit: mx.array | None = None
+        self._pending_token: int | None = None
+
+    def reset(self) -> None:
+        self._cache = None
+        self._cache_seq_len = 0
+        self._last_hidden_states = {}
+        self._last_target_logit = None
+        self._pending_token = None
+
+    def prefill(self, prompt: mx.array) -> int:
+        """Process prompt through target, extract hidden states, return first token.
+
+        Args:
+            prompt: (1, seq_len) input token IDs.
+
+        Returns:
+            First generated token from target's greedy argmax.
+        """
+        self.reset()
+
+        if make_prompt_cache is None:
+            raise RuntimeError("mlx_lm.models.cache not available")
+
+        self._cache = make_prompt_cache(self._target)
+
+        logits, hidden_states, _ = self._adapter.forward_with_hidden(
+            self._target,
+            prompt,
+            cache=self._cache,
+            target_layer_ids=self._config.target_layer_ids,
+        )
+
+        self._last_target_logit = logits[0, -1, :]
+        mx.eval(self._last_target_logit)
+
+        self._last_hidden_states = hidden_states
+        self._cache_seq_len = prompt.shape[1]
+
+        first_token = int(mx.argmax(self._last_target_logit).item())
+        self._pending_token = first_token
+        return first_token
+
+    def step(self) -> tuple[list[int], int]:
+        """One block-diffusion speculative decoding step.
+
+        Returns:
+            (accepted_tokens, block_size).
+        """
+        assert self._cache is not None, "Call prefill() before step()"
+        assert self._pending_token is not None
+
+        pending = self._pending_token
+
+        # 1. Draft: propose block_size candidate tokens
+        draft_tokens = self._draft_block(pending)
+
+        # 2. Target: verify [pending, D1, ..., D_block_size] in one pass
+        all_tokens = mx.array([[pending] + draft_tokens])
+        logits, hidden_states, _ = self._adapter.forward_with_hidden(
+            self._target,
+            all_tokens,
+            cache=self._cache,
+            target_layer_ids=self._config.target_layer_ids,
+        )
+
+        verification_logits = logits[0]  # (block_size+1, vocab)
+        mx.eval(verification_logits)
+
+        # 3. Verify: greedy comparison
+        accepted = verify_draft_greedy(draft_tokens, verification_logits)
+        num_accepted = len(accepted)
+
+        # 4. Trim cache to remove rejected tokens (like SpeculativeDecoder)
+        trim_amount = self._block_size + 1 - num_accepted
+        if trim_amount > 0:
+            self._adapter.trim_cache(self._cache, trim_amount)
+
+        # 5. Slice hidden states to accepted prefix for next draft
+        sliced_hidden = {}
+        for layer_id, h in hidden_states.items():
+            sliced_hidden[layer_id] = h[:, :num_accepted, :]
+        self._last_hidden_states = sliced_hidden
+
+        # 6. Update state
+        self._last_target_logit = verification_logits[num_accepted - 1]
+        mx.eval(self._last_target_logit)
+        self._cache_seq_len += num_accepted
+        self._pending_token = int(mx.argmax(self._last_target_logit).item())
+
+        return accepted, self._block_size
+
+    def _draft_block(self, pending_token: int) -> list[int]:
+        """Use the draft model to propose a block of candidate tokens."""
+        inp = mx.array([[pending_token]])
+
+        # Extract last-position hidden states and pre-compute context once
+        last_hidden = {}
+        for layer_id, h in self._last_hidden_states.items():
+            last_hidden[layer_id] = h[:, -1:, :]
+        context = self._draft._build_context(last_hidden)
+
+        tokens: list[int] = []
+        for _ in range(self._block_size):
+            logits = self._draft.forward_with_context(inp, context)
+            next_logits = logits[:, -1, :]
+            mx.eval(next_logits)
+            next_token = int(mx.argmax(next_logits, axis=-1).item())
+            tokens.append(next_token)
+            inp = mx.array([[next_token]])
+
+        return tokens

--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -124,7 +124,6 @@ class DFlashDecoder:
         )
 
         verification_logits = logits[0]  # (block_size+1, vocab)
-        mx.eval(verification_logits)
 
         # 3. Verify: greedy comparison
         accepted = verify_draft_greedy(draft_tokens, verification_logits)

--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -45,10 +45,10 @@ class DFlashDecoder:
         draft_config: DraftConfig,
         block_size: int = 4,
     ):
-        if trim_prompt_cache is None:
+        if trim_prompt_cache is None or make_prompt_cache is None:
             raise RuntimeError(
-                "trim_prompt_cache is unavailable (mlx-lm import missing); "
-                "dflash decoding requires it for correct cache trimming"
+                "mlx_lm.models.cache (make_prompt_cache, trim_prompt_cache) "
+                "is unavailable; dflash decoding requires it"
             )
 
         self._target = target_model
@@ -154,7 +154,15 @@ class DFlashDecoder:
         return accepted, self._block_size
 
     def _draft_block(self, pending_token: int) -> list[int]:
-        """Use the draft model to propose a block of candidate tokens."""
+        """Use the draft model to propose a block of candidate tokens.
+
+        Unlike SpeculativeDecoder (which accumulates KV state across draft
+        steps), each draft token here is conditioned only on the target's
+        hidden states — not on previous draft tokens. This is by design:
+        the block-diffusion approach generates tokens independently given
+        the target context, trading inter-token coherence for parallelism
+        potential.
+        """
         inp = mx.array([[pending_token]])
 
         # Extract last-position hidden states and pre-compute context once

--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -81,10 +81,6 @@ class DFlashDecoder:
             First generated token from target's greedy argmax.
         """
         self.reset()
-
-        if make_prompt_cache is None:
-            raise RuntimeError("mlx_lm.models.cache not available")
-
         self._cache = make_prompt_cache(self._target)
 
         logits, hidden_states, _ = self._adapter.forward_with_hidden(
@@ -134,6 +130,8 @@ class DFlashDecoder:
         accepted = verify_draft_greedy(draft_tokens, verification_logits)
         num_accepted = len(accepted)
 
+        assert num_accepted >= 1, "verify_draft_greedy must return at least 1 token"
+
         # 4. Trim cache to remove rejected tokens (like SpeculativeDecoder)
         trim_amount = self._block_size + 1 - num_accepted
         if trim_amount > 0:
@@ -169,7 +167,7 @@ class DFlashDecoder:
         last_hidden = {}
         for layer_id, h in self._last_hidden_states.items():
             last_hidden[layer_id] = h[:, -1:, :]
-        context = self._draft._build_context(last_hidden)
+        context = self._draft.build_context(last_hidden)
 
         tokens: list[int] = []
         for _ in range(self._block_size):

--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -156,12 +156,12 @@ class DFlashDecoder:
     def _draft_block(self, pending_token: int) -> list[int]:
         """Use the draft model to propose a block of candidate tokens.
 
-        Unlike SpeculativeDecoder (which accumulates KV state across draft
-        steps), each draft token here is conditioned only on the target's
-        hidden states — not on previous draft tokens. This is by design:
-        the block-diffusion approach generates tokens independently given
-        the target context, trading inter-token coherence for parallelism
-        potential.
+        Each token is fed as input to the next step (autoregressive), but
+        unlike SpeculativeDecoder there is no KV cache accumulating across
+        draft steps — the draft model's self-attention sees only [context,
+        current_token] each time, not the full history of draft tokens.
+        This is by design: the block-diffusion approach relies on the
+        target's hidden states as the primary conditioning signal.
         """
         inp = mx.array([[pending_token]])
 

--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -141,7 +141,7 @@ class DFlashDraftModel(nn.Module):
         Returns:
             (B, L, vocab_size) logits.
         """
-        context = self._build_context(target_hidden_states)
+        context = self.build_context(target_hidden_states)
         return self.forward_with_context(input_ids, context)
 
     def forward_with_context(
@@ -158,7 +158,7 @@ class DFlashDraftModel(nn.Module):
         h = self.norm(h)
         return self.lm_head(h)
 
-    def _build_context(
+    def build_context(
         self, target_hidden_states: dict[int, mx.array]
     ) -> mx.array | None:
         """Combine target hidden states into a context tensor."""

--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -163,7 +163,10 @@ class DFlashDraftModel(nn.Module):
         if not target_hidden_states:
             return None
 
-        # Average hidden states from all target layers
+        # Simple mean pooling across target layers. This collapses
+        # layer-specific signals but keeps the draft model architecture
+        # simple. Pre-trained draft models are trained against this
+        # aggregation; per-layer projections can be added if needed.
         states = list(target_hidden_states.values())
         combined = states[0]
         for s in states[1:]:

--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -68,7 +68,9 @@ class DFlashAttention(nn.Module):
             .transpose(0, 2, 1, 3)
         )
 
-        # Scaled dot-product attention
+        # No causal mask: at inference, _draft_block passes single tokens
+        # (L=1), so masking is a no-op. The architecture is non-causal by
+        # design — queries attend bidirectionally to [context, x].
         scores = (q @ k.transpose(0, 1, 3, 2)) * self.scale
         weights = mx.softmax(scores, axis=-1)
         out = (weights @ v).transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -1,0 +1,176 @@
+"""DFlash draft model architecture.
+
+The draft model takes hidden states from specific target layers as input
+and produces logits for candidate tokens. Uses a cross-attention-like
+mechanism where queries attend to concatenated target + current hidden states.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+@dataclass
+class DraftConfig:
+    """Configuration for the dflash draft model."""
+
+    hidden_size: int
+    num_attention_heads: int
+    num_layers: int
+    target_layer_ids: list[int]
+    vocab_size: int
+    target_hidden_size: int | None = None  # defaults to hidden_size if None
+    head_dim: int | None = None  # defaults to hidden_size // num_attention_heads
+
+    def __post_init__(self):
+        if self.target_hidden_size is None:
+            self.target_hidden_size = self.hidden_size
+        if self.head_dim is None:
+            self.head_dim = self.hidden_size // self.num_attention_heads
+
+
+class DFlashAttention(nn.Module):
+    """Cross-attention: queries attend to concatenation of target + current states."""
+
+    def __init__(self, hidden_size: int, num_heads: int, head_dim: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.scale = head_dim**-0.5
+
+        self.q_proj = nn.Linear(hidden_size, num_heads * head_dim, bias=False)
+        self.k_proj = nn.Linear(hidden_size, num_heads * head_dim, bias=False)
+        self.v_proj = nn.Linear(hidden_size, num_heads * head_dim, bias=False)
+        self.o_proj = nn.Linear(num_heads * head_dim, hidden_size, bias=False)
+
+    def __call__(self, x: mx.array, context: mx.array | None = None) -> mx.array:
+        B, L, _ = x.shape
+
+        q = (
+            self.q_proj(x)
+            .reshape(B, L, self.num_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+
+        # Keys/values from concatenated [context, x] if context provided
+        kv_input = mx.concatenate([context, x], axis=1) if context is not None else x
+        k = (
+            self.k_proj(kv_input)
+            .reshape(B, -1, self.num_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        v = (
+            self.v_proj(kv_input)
+            .reshape(B, -1, self.num_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+
+        # Scaled dot-product attention
+        scores = (q @ k.transpose(0, 1, 3, 2)) * self.scale
+        weights = mx.softmax(scores, axis=-1)
+        out = (weights @ v).transpose(0, 2, 1, 3).reshape(B, L, -1)
+
+        return self.o_proj(out)
+
+
+class DFlashDecoderLayer(nn.Module):
+    """Single draft decoder layer: attention + MLP with residual connections."""
+
+    def __init__(self, hidden_size: int, num_heads: int, head_dim: int):
+        super().__init__()
+        self.attention = DFlashAttention(hidden_size, num_heads, head_dim)
+        self.mlp = nn.Sequential(
+            nn.Linear(hidden_size, hidden_size * 4, bias=False),
+            nn.GELU(),
+            nn.Linear(hidden_size * 4, hidden_size, bias=False),
+        )
+        self.input_layernorm = nn.RMSNorm(hidden_size)
+        self.post_attention_layernorm = nn.RMSNorm(hidden_size)
+
+    def __call__(self, x: mx.array, context: mx.array | None = None) -> mx.array:
+        h = x + self.attention(self.input_layernorm(x), context=context)
+        return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class DFlashDraftModel(nn.Module):
+    """Draft model for dflash speculative decoding.
+
+    Takes current token embeddings and target hidden states as input,
+    produces logits for candidate tokens.
+    """
+
+    def __init__(self, config: DraftConfig):
+        super().__init__()
+        self.config = config
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+
+        # Project target hidden states to draft hidden_size if they differ
+        if config.target_hidden_size != config.hidden_size:
+            self.target_proj = nn.Linear(
+                config.target_hidden_size, config.hidden_size, bias=False
+            )
+        else:
+            self.target_proj = None
+
+        self.layers = [
+            DFlashDecoderLayer(
+                config.hidden_size, config.num_attention_heads, config.head_dim
+            )
+            for _ in range(config.num_layers)
+        ]
+        self.norm = nn.RMSNorm(config.hidden_size)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        target_hidden_states: dict[int, mx.array],
+    ) -> mx.array:
+        """Forward pass.
+
+        Args:
+            input_ids: (B, L) token IDs.
+            target_hidden_states: {layer_idx: (B, L, target_hidden_size)}
+
+        Returns:
+            (B, L, vocab_size) logits.
+        """
+        context = self._build_context(target_hidden_states)
+        return self.forward_with_context(input_ids, context)
+
+    def forward_with_context(
+        self,
+        input_ids: mx.array,
+        context: mx.array | None,
+    ) -> mx.array:
+        """Forward pass with pre-computed context (avoids recomputing per token)."""
+        h = self.embed_tokens(input_ids)
+
+        for layer in self.layers:
+            h = layer(h, context=context)
+
+        h = self.norm(h)
+        return self.lm_head(h)
+
+    def _build_context(
+        self, target_hidden_states: dict[int, mx.array]
+    ) -> mx.array | None:
+        """Combine target hidden states into a context tensor."""
+        if not target_hidden_states:
+            return None
+
+        # Average hidden states from all target layers
+        states = list(target_hidden_states.values())
+        combined = states[0]
+        for s in states[1:]:
+            combined = combined + s
+        combined = combined / len(states)
+
+        if self.target_proj is not None:
+            combined = self.target_proj(combined)
+
+        return combined

--- a/olmlx/engine/flash/speculative.py
+++ b/olmlx/engine/flash/speculative.py
@@ -1,9 +1,8 @@
 """Speculative decoding with flash inference (Paper §5.2).
 
-Uses a small draft model for fast candidate generation, then verifies
-candidates with the big (flash) model in a single forward pass.
-Key optimization: neuron retention window is sized to alpha*(lambda+1)
-where alpha is the rolling acceptance rate.
+Extends the base SpeculativeDecoder with Flash-specific optimizations:
+neuron prefetching (cross-layer and draft-informed) and adaptive
+neuron retention window sizing based on acceptance rate.
 """
 
 from __future__ import annotations
@@ -14,32 +13,22 @@ from typing import TYPE_CHECKING
 import mlx.core as mx
 import mlx.nn as nn
 
+from olmlx.engine.speculative import SpeculativeDecoder
+
 if TYPE_CHECKING:
     from olmlx.engine.flash.prefetch import Prefetcher
-
-try:
-    from mlx_lm.models.cache import make_prompt_cache, trim_prompt_cache
-except ImportError:
-    make_prompt_cache = None  # type: ignore[assignment]
-    trim_prompt_cache = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
 
-class SpeculativeFlashDecoder:
+class SpeculativeFlashDecoder(SpeculativeDecoder):
     """Speculative decoding for flash inference.
 
-    The draft model generates lambda candidate tokens autoregressively.
-    The target model verifies all candidates in one forward pass.
-    Accepted tokens are returned; on rejection, the target's preferred
-    token replaces the first rejected position.
-
-    Supports two modes:
-    - Stateless: ``generate_step(prompt)`` — no cross-step caching (backward compat)
-    - Cached: ``prefill(prompt)`` then ``step()`` — persistent KV caches for O(λ) verification
-
-    Not thread-safe: one decoder instance must serve one request at a time.
-    The inference pipeline serializes requests via ``_inference_lock``.
+    Extends the base decoder with:
+    - Draft hidden state capture for prefetch (Path B)
+    - Prefetch submission after draft generation
+    - Prefetch cancellation on rejection
+    - Adaptive neuron retention window based on acceptance rate
     """
 
     def __init__(
@@ -50,172 +39,20 @@ class SpeculativeFlashDecoder:
         acceptance_rate_ema: float = 0.9,
         prefetcher: Prefetcher | None = None,
     ):
-        if trim_prompt_cache is None:
-            raise RuntimeError(
-                "trim_prompt_cache is unavailable (mlx-lm import missing); "
-                "speculative decoding requires it for correct cache trimming"
-            )
-        self._draft = draft_model
-        self._target = target_model
-        self._lambda = num_speculative_tokens
-        self._alpha = 0.5  # initial acceptance rate estimate
-        self._alpha_ema = acceptance_rate_ema
+        super().__init__(
+            draft_model=draft_model,
+            target_model=target_model,
+            num_speculative_tokens=num_speculative_tokens,
+            acceptance_rate_ema=acceptance_rate_ema,
+        )
         self._prefetcher = prefetcher
-
-        # Persistent KV cache state (populated by prefill/step)
-        self._target_cache: list | None = None
-        self._draft_cache: list | None = None
-        self._cache_seq_len: int = 0
-        self._last_target_logit: mx.array | None = None
-        self._pending_token: int | None = None
-
-    def _update_acceptance_rate(self, num_accepted: int) -> None:
-        """Update the rolling acceptance rate via EMA."""
-        num_accepted_draft = (
-            min(num_accepted - 1, self._lambda) if num_accepted > 0 else 0
-        )
-        acceptance = num_accepted_draft / max(self._lambda, 1)
-        self._alpha = self._alpha_ema * self._alpha + (1 - self._alpha_ema) * acceptance
-
-    # ------------------------------------------------------------------
-    # Cached API: prefill() + step()
-    # ------------------------------------------------------------------
-
-    def reset(self) -> None:
-        self._target_cache = None
-        self._draft_cache = None
-        self._cache_seq_len = 0
-        self._last_target_logit = None
-        self._pending_token = None
-
-    def prefill(self, prompt: mx.array) -> int:
-        """Process the prompt through both models, populating KV caches.
-
-        Args:
-            prompt: (1, seq_len) input token IDs.
-
-        Returns:
-            The first generated token (from target model's greedy argmax).
-        """
-        self.reset()
-
-        if make_prompt_cache is None or trim_prompt_cache is None:
-            raise RuntimeError(
-                "mlx_lm.models.cache not available; cannot use cached speculative decoding"
-            )
-
-        self._target_cache = make_prompt_cache(self._target)
-        self._draft_cache = make_prompt_cache(self._draft)
-
-        target_out = self._target(prompt, cache=self._target_cache)
-        self._last_target_logit = target_out[0, -1, :]
-        mx.eval(self._last_target_logit)
-
-        # Populate draft cache (logits discarded — only cache state needed).
-        # mx.eval forces cache materialization before step() reads from it.
-        draft_logits = self._draft(prompt, cache=self._draft_cache)
-        mx.eval(draft_logits)
-
-        self._cache_seq_len = prompt.shape[1]
-
-        first_token = int(mx.argmax(self._last_target_logit).item())
-        self._pending_token = first_token
-        return first_token
-
-    def step(self) -> tuple[list[int], int]:
-        """One speculative decoding step using persistent KV caches.
-
-        Must call ``prefill()`` first to populate caches.
-
-        State invariant: at entry, both caches are at offset ``_cache_seq_len``.
-        ``_last_target_logit`` predicts the token at position ``_cache_seq_len``
-        (the "pending" token that has been yielded but not yet fed to either cache).
-
-        Returns:
-            (accepted_tokens, num_draft_generated).
-        """
-        assert self._target_cache is not None, "Call prefill() before step()"
-        assert self._draft_cache is not None, "Call prefill() before step()"
-        assert self._pending_token is not None, "Call prefill() before step()"
-
-        pending_token = self._pending_token
-
-        # 1. Draft: feed pending token, then generate lambda candidates
-        #    Draft cache advances from offset to offset + lambda.
-        draft_tokens, draft_hidden = self._draft_generate_cached(
-            pending_token, self._lambda
-        )
-
-        # 1.5. Draft-informed prefetch: submit bulk I/O before target forward pass.
-        if self._prefetcher is not None and draft_hidden:
-            self._submit_draft_prefetch(draft_hidden)
-
-        # 2. Target: feed [pending, D1, ..., D_lambda] in one pass.
-        #    Target cache advances from offset to offset + lambda + 1.
-        all_tokens = mx.array([[pending_token] + draft_tokens])
-        target_out = self._target(all_tokens, cache=self._target_cache)
-        mx.eval(target_out)
-
-        # target_out shape: (1, lambda+1, vocab)
-        # target_out[0, k] is the logit after processing the token at input position k,
-        # predicting what goes at the NEXT position.
-        # target_out[0, 0] processed pending → predicts position offset+1 → verifies D1
-        # target_out[0, lambda] processed D_lambda → bonus token
-        verification_logits = target_out[0]  # (lambda+1, vocab)
-
-        # 3. Verify draft tokens against target logits
-        accepted = self._verify(draft_tokens, verification_logits)
-        num_accepted = len(accepted)
-
-        # Cancel speculative prefetch for rejected tokens (harmless if already done)
-        if self._prefetcher is not None and num_accepted < self._lambda:
-            self._prefetcher.cancel()
-
-        # 4. Trim caches to the position after the last accepted token.
-        #    Desired offset after step: cache_seq_len + num_accepted
-        #    Target was at: cache_seq_len + lambda + 1
-        #    Draft was at:  cache_seq_len + lambda
-        trim_target = max(self._lambda + 1 - num_accepted, 0)
-        trim_draft = max(self._lambda - num_accepted, 0)
-
-        if trim_target > 0 and trim_prompt_cache is not None:
-            trim_prompt_cache(self._target_cache, trim_target)
-        if trim_draft > 0 and trim_prompt_cache is not None:
-            trim_prompt_cache(self._draft_cache, trim_draft)
-
-        # On full acceptance (num_accepted == lambda + 1), the draft cache is at
-        # offset + lambda while the target is at offset + lambda + 1.  Feed the
-        # last draft token through the draft to align both caches at the same offset.
-        if num_accepted > self._lambda:
-            last_draft = mx.array([[draft_tokens[-1]]])
-            align_logits = self._draft(last_draft, cache=self._draft_cache)
-            mx.eval(align_logits)
-
-        # 5. Update state
-        self._cache_seq_len += num_accepted
-        # _verify() always returns at least 1 token (the target's correction).
-        assert num_accepted >= 1, "step(): _verify() must return at least 1 token"
-        self._last_target_logit = verification_logits[num_accepted - 1]
-        mx.eval(self._last_target_logit)
-        self._pending_token = int(mx.argmax(self._last_target_logit).item())
-
-        self._update_acceptance_rate(num_accepted)
-        return accepted, self._lambda
 
     def _draft_generate_cached(
         self, pending_token: int, n: int
     ) -> tuple[list[int], list[mx.array]]:
-        """Generate n candidate tokens using the persistent draft cache.
-
-        Returns:
-            (tokens, captured_hidden_states) — captured is non-empty only
-            when a prefetcher is attached AND the draft model exposes an
-            inner .model attribute for hidden state extraction.
-        """
+        """Generate n candidates, capturing hidden states for prefetch."""
         assert self._draft_cache is not None
 
-        # Determine if we can capture hidden states (pre-lm_head) for prefetch.
-        # mlx-lm models expose .model (transformer) and .lm_head (projection).
         inner_model = getattr(self._draft, "model", None)
         lm_head = getattr(self._draft, "lm_head", None)
         can_capture = (
@@ -246,6 +83,16 @@ class SpeculativeFlashDecoder:
 
         return tokens, captured
 
+    def _after_draft(self, draft_ctx: list[mx.array]) -> None:
+        """Submit bulk prefetch using captured draft hidden states."""
+        if self._prefetcher is not None and draft_ctx:
+            self._submit_draft_prefetch(draft_ctx)
+
+    def _after_verify(self, num_accepted: int) -> None:
+        """Cancel speculative prefetch for rejected tokens."""
+        if self._prefetcher is not None and num_accepted < self._lambda:
+            self._prefetcher.cancel()
+
     def _submit_draft_prefetch(self, draft_hidden_states: list[mx.array]) -> None:
         """Submit bulk prefetch using captured draft hidden states.
 
@@ -265,10 +112,6 @@ class SpeculativeFlashDecoder:
             )
             return
 
-        # Map draft positions to target layers by depth ratio so early layers
-        # get signals from early draft steps and deep layers from late steps.
-        # Deduplicate: with 32 layers and 4 draft steps, ~8 layers share each
-        # draft_idx — reuse the same tensor to avoid redundant predictor calls.
         num_layers = self._prefetcher.num_layers
         num_draft = len(draft_hidden_states)
         draft_to_layers: dict[int, list[int]] = {}
@@ -284,140 +127,6 @@ class SpeculativeFlashDecoder:
         mx.eval(*{id(v): v for v in layer_states.values()}.values())
 
         self._prefetcher.submit_bulk(layer_states)
-
-    # ------------------------------------------------------------------
-    # Stateless API (backward compatibility)
-    # ------------------------------------------------------------------
-
-    def _draft_generate(self, prompt: mx.array, n: int) -> list[int]:
-        """Generate n candidate tokens with the draft model.
-
-        Creates a fresh KV cache per call so the prompt is processed once
-        and each subsequent token is O(1). The cache is discarded after
-        the call to avoid accumulating stale state across generate_step
-        calls (proper cross-step caching requires offset tracking).
-
-        Args:
-            prompt: (1, seq_len) input token IDs.
-            n: Number of tokens to generate.
-
-        Returns:
-            List of generated token IDs, length n.
-        """
-        tokens: list[int] = []
-
-        # Try to create a per-call KV cache for O(1) decode steps
-        cache = None
-        if make_prompt_cache is not None:
-            try:
-                cache = make_prompt_cache(self._draft)
-            except (TypeError, AttributeError):
-                pass
-
-        if cache is not None:
-            # Prefill: process the full prompt
-            logits = self._draft(prompt, cache=cache)
-            next_logits = logits[:, -1, :]
-            mx.eval(next_logits)
-            next_token = int(mx.argmax(next_logits, axis=-1).item())
-            tokens.append(next_token)
-
-            # Decode: each step only processes the new token
-            for _ in range(n - 1):
-                inp = mx.array([[next_token]])
-                logits = self._draft(inp, cache=cache)
-                next_logits = logits[:, -1, :]
-                mx.eval(next_logits)
-                next_token = int(mx.argmax(next_logits, axis=-1).item())
-                tokens.append(next_token)
-        else:
-            # Fallback: no KV cache, rebuild full sequence each step
-            for _ in range(n):
-                if tokens:
-                    current = mx.concatenate([prompt, mx.array([tokens])], axis=1)
-                else:
-                    current = prompt
-                logits = self._draft(current)
-                next_logits = logits[:, -1, :]
-                mx.eval(next_logits)
-                next_token = int(mx.argmax(next_logits, axis=-1).item())
-                tokens.append(next_token)
-
-        return tokens
-
-    def _verify(
-        self,
-        draft_tokens: list[int],
-        target_logits: mx.array,
-    ) -> list[int]:
-        """Verify draft tokens against target model logits.
-
-        Uses greedy speculative decoding: accept draft token if it matches
-        the target's greedy choice. On first mismatch, return the target's
-        preferred token instead.
-
-        Args:
-            draft_tokens: list of draft token IDs, length lambda.
-            target_logits: (lambda+1, vocab) target model logits
-                           (positions correspond to verifying each draft
-                           token + one extra for the bonus token).
-
-        Returns:
-            List of accepted token IDs (1 to lambda+1 tokens).
-        """
-        n = len(draft_tokens)
-
-        # Vectorized argmax: single GPU kernel for all positions
-        target_choices = mx.argmax(target_logits, axis=-1)  # (lambda+1,)
-        mx.eval(target_choices)
-
-        accepted: list[int] = []
-        for i in range(n):
-            target_token = int(target_choices[i].item())
-            if draft_tokens[i] == target_token:
-                accepted.append(draft_tokens[i])
-            else:
-                accepted.append(target_token)
-                return accepted
-
-        # All draft tokens accepted — add bonus token
-        accepted.append(int(target_choices[n].item()))
-        return accepted
-
-    def generate_step(
-        self,
-        prompt: mx.array,
-    ) -> tuple[list[int], int]:
-        """One speculative decoding step (stateless, no cross-step caching).
-
-        For cached inference, use ``prefill()`` + ``step()`` instead.
-
-        Args:
-            prompt: (1, seq_len) input token IDs.
-
-        Returns:
-            (accepted_tokens, num_draft_generated).
-        """
-        # 1. Draft model generates lambda candidates
-        draft_tokens = self._draft_generate(prompt, self._lambda)
-
-        # 2. Target model verifies all candidates + 1 in one pass
-        draft_ids = mx.array([draft_tokens])
-        combined = mx.concatenate([prompt, draft_ids], axis=1)
-        target_out = self._target(combined)  # (1, seq+lambda, vocab)
-        mx.eval(target_out)
-
-        # Extract target logits at the verification positions
-        seq_len = prompt.shape[1]
-        target_logits = target_out[
-            0, seq_len - 1 : seq_len + self._lambda, :
-        ]  # (lambda+1, vocab)
-
-        # 3. Verify
-        accepted = self._verify(draft_tokens, target_logits)
-
-        self._update_acceptance_rate(len(accepted))
-        return accepted, self._lambda
 
     @property
     def effective_window_size(self) -> int:

--- a/olmlx/engine/flash/speculative_stream.py
+++ b/olmlx/engine/flash/speculative_stream.py
@@ -1,156 +1,16 @@
-"""Streaming adapter for speculative decoding.
+"""Streaming adapter for speculative decoding (Flash compatibility shim).
 
-Bridges SpeculativeFlashDecoder into the CancellableStream / StreamToken
-contract used by the inference pipeline.
+Re-exports from the base module for backward compatibility.
 """
 
-from __future__ import annotations
+from olmlx.engine.speculative_stream import (
+    TokenizerProtocol,
+    async_speculative_stream,
+    speculative_stream_generate,
+)
 
-import logging
-import threading
-import time
-from collections.abc import Generator
-from typing import Any, Protocol
-
-import mlx.core as mx
-
-from olmlx.engine.flash.speculative import SpeculativeFlashDecoder
-from olmlx.utils.streaming import StreamToken
-
-logger = logging.getLogger(__name__)
-
-
-class TokenizerProtocol(Protocol):
-    """Protocol for tokenizer with decode method."""
-
-    def decode(self, token_ids: list[int]) -> str: ...
-
-
-def speculative_stream_generate(
-    decoder: SpeculativeFlashDecoder,
-    prompt_tokens: list[int],
-    max_tokens: int,
-    cancel_event: threading.Event,
-    eos_token_id: int | None = None,
-    tokenizer: TokenizerProtocol | None = None,
-) -> Generator[StreamToken, None, None]:
-    """Sync generator that yields StreamToken objects for speculative decoding.
-
-    Args:
-        decoder: SpeculativeFlashDecoder with prefill/step API.
-        prompt_tokens: Token IDs for the prompt.
-        max_tokens: Maximum number of tokens to generate.
-        cancel_event: Set to stop generation.
-        eos_token_id: Stop generation when this token is produced.
-        tokenizer: Tokenizer for incremental text decoding. If None, text is empty.
-    """
-    prompt_arr = mx.array([prompt_tokens])
-    prompt_len = len(prompt_tokens)
-
-    t0 = time.perf_counter()
-    first_token = decoder.prefill(prompt_arr)
-    prefill_elapsed = time.perf_counter() - t0
-    prompt_tps_val = prompt_len / max(prefill_elapsed, 1e-9)
-
-    generated: list[int] = [first_token]
-    gen_count = 1
-
-    # Incremental text decoding: decode full sequence and diff against previous length.
-    prev_text_len = 0
-    if tokenizer is not None:
-        full_text = tokenizer.decode(generated)
-        new_text = full_text
-        prev_text_len = len(full_text)
-    else:
-        new_text = ""
-
-    yield StreamToken(
-        text=new_text,
-        token=first_token,
-        prompt_tokens=prompt_len,
-        generation_tokens=gen_count,
-        prompt_tps=prompt_tps_val,
-        generation_tps=gen_count / max(prefill_elapsed, 1e-9),
-    )
-
-    if (
-        eos_token_id is not None and first_token == eos_token_id
-    ) or cancel_event.is_set():
-        return
-
-    while gen_count < max_tokens:
-        if cancel_event.is_set():
-            break
-
-        accepted, _ = decoder.step()
-
-        for token in accepted:
-            if cancel_event.is_set() or gen_count >= max_tokens:
-                break
-
-            gen_count += 1
-            generated.append(token)
-            gen_elapsed = time.perf_counter() - t0
-
-            # Decode full sequence and diff to get new text.
-            # O(n) per token; a suffix-based approach could improve this for
-            # very long sequences, but BPE boundary handling is subtle.
-            if tokenizer is not None:
-                full_text = tokenizer.decode(generated)
-                new_text = full_text[prev_text_len:]
-                prev_text_len = len(full_text)
-            else:
-                new_text = ""
-
-            finish = None
-            if eos_token_id is not None and token == eos_token_id:
-                finish = "stop"
-            elif gen_count >= max_tokens:
-                finish = "length"
-
-            yield StreamToken(
-                text=new_text,
-                token=token,
-                prompt_tokens=prompt_len,
-                generation_tokens=gen_count,
-                prompt_tps=prompt_tps_val,
-                generation_tps=gen_count / max(gen_elapsed, 1e-9),
-                finish_reason=finish,
-            )
-
-            if finish is not None:
-                return
-
-
-def async_speculative_stream(
-    decoder: SpeculativeFlashDecoder,
-    tokenizer: Any,
-    prompt: str | list[int],
-    max_tokens: int,
-) -> Any:
-    """Create a CancellableStream for speculative decoding.
-
-    Matches the interface of async_mlx_stream from utils/streaming.py.
-    """
-    from olmlx.utils.streaming import CancellableStream
-
-    if isinstance(prompt, str):
-        prompt_tokens = tokenizer.encode(prompt)
-    else:
-        prompt_tokens = prompt
-
-    eos_token_id = getattr(tokenizer, "eos_token_id", None)
-
-    def gen_factory(cancel_event: threading.Event):
-        return speculative_stream_generate(
-            decoder,
-            prompt_tokens,
-            max_tokens=max_tokens,
-            cancel_event=cancel_event,
-            eos_token_id=eos_token_id,
-            tokenizer=tokenizer,
-        )
-
-    stream = CancellableStream(gen_factory)
-    stream.start()
-    return stream
+__all__ = [
+    "TokenizerProtocol",
+    "async_speculative_stream",
+    "speculative_stream_generate",
+]

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1845,7 +1845,7 @@ async def _stream_completion(
             )
 
         if lm.is_speculative:
-            from olmlx.engine.flash.speculative_stream import async_speculative_stream
+            from olmlx.engine.speculative_stream import async_speculative_stream
 
             # Speculative decoding uses greedy argmax; sampling params are not supported.
             _sampling_keys = {
@@ -2087,7 +2087,7 @@ async def _full_completion_inner(
         elif lm.is_speculative:
             import threading
 
-            from olmlx.engine.flash.speculative_stream import (
+            from olmlx.engine.speculative_stream import (
                 speculative_stream_generate,
             )
 

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -1211,6 +1211,124 @@ class ModelManager:
             f"found at {spectral_path}. Run 'olmlx spectral prepare <model>' first."
         )
 
+    def _resolve_draft_path(self, hf_path: str) -> str:
+        """Download a draft model if needed and return the local path."""
+        if self.store is not None:
+            local_dir = self.store.ensure_downloaded(hf_path)
+            return str(local_dir)
+        return hf_path
+
+    @staticmethod
+    def _check_vocab_match(target: Any, draft: Any) -> None:
+        """Raise ValueError if target and draft vocab sizes differ."""
+        target_vocab = getattr(getattr(target, "args", None), "vocab_size", None)
+        draft_vocab = getattr(getattr(draft, "args", None), "vocab_size", None)
+        if (
+            target_vocab is not None
+            and draft_vocab is not None
+            and target_vocab != draft_vocab
+        ):
+            raise ValueError(
+                f"Draft model vocab_size ({draft_vocab}) does not match "
+                f"target model vocab_size ({target_vocab}). "
+                f"Speculative decoding requires matching vocabularies."
+            )
+
+    def _load_dflash_decoder(
+        self, target_model: Any, hf_path: str, model_exp: Any
+    ) -> Any:
+        """Load a dflash draft model and create a DFlashDecoder."""
+        from olmlx.engine.dflash.adapters import get_adapter
+        from olmlx.engine.dflash.decoder import DFlashDecoder
+        from olmlx.engine.dflash.draft_model import DFlashDraftModel, DraftConfig
+
+        if not model_exp.dflash_draft_model:
+            raise ValueError(
+                "dflash requires dflash_draft_model to be set "
+                "(OLMLX_EXPERIMENTAL_DFLASH_DRAFT_MODEL)"
+            )
+
+        logger.info("Loading dflash draft model %s", model_exp.dflash_draft_model)
+        load_path = self._resolve_draft_path(model_exp.dflash_draft_model)
+
+        config_file = Path(load_path) / "config.json"
+        if not config_file.exists():
+            raise FileNotFoundError(
+                f"DFlash draft model config not found at {config_file}"
+            )
+
+        draft_cfg_dict = json.loads(config_file.read_text())
+        target_hidden_size = getattr(
+            getattr(target_model, "args", None), "hidden_size", None
+        )
+        draft_config = DraftConfig(
+            hidden_size=draft_cfg_dict["hidden_size"],
+            num_attention_heads=draft_cfg_dict["num_attention_heads"],
+            num_layers=draft_cfg_dict["num_layers"],
+            target_layer_ids=draft_cfg_dict["target_layer_ids"],
+            vocab_size=draft_cfg_dict["vocab_size"],
+            target_hidden_size=target_hidden_size or draft_cfg_dict.get("hidden_size"),
+        )
+
+        draft_model = DFlashDraftModel(draft_config)
+        weights_file = Path(load_path) / "model.safetensors"
+        if weights_file.exists():
+            draft_model.load_weights(str(weights_file))
+            logger.info("Loaded dflash draft weights from %s", weights_file)
+
+        # Detect model type for adapter selection
+        target_config_file = None
+        if self.store is not None:
+            target_local = self.store.local_path(hf_path)
+            target_config_file = target_local / "config.json"
+        if target_config_file is not None and target_config_file.exists():
+            target_cfg = json.loads(target_config_file.read_text())
+            model_type = target_cfg.get("model_type", "")
+        else:
+            model_type = draft_cfg_dict.get("target_model_type", "qwen3")
+
+        adapter = get_adapter(model_type)
+
+        return DFlashDecoder(
+            target_model=target_model,
+            draft_model=draft_model,
+            adapter=adapter,
+            draft_config=draft_config,
+            block_size=model_exp.dflash_block_size,
+        )
+
+    def _load_speculative_decoder(
+        self, target_model: Any, hf_path: str, model_exp: Any
+    ) -> Any:
+        """Load a draft model and create a SpeculativeDecoder."""
+        from olmlx.engine.speculative import SpeculativeDecoder
+
+        if not model_exp.speculative_draft_model:
+            raise ValueError(
+                "speculative requires speculative_draft_model to be set "
+                "(OLMLX_EXPERIMENTAL_SPECULATIVE_DRAFT_MODEL)"
+            )
+
+        logger.info(
+            "Loading draft model %s for speculative decoding",
+            model_exp.speculative_draft_model,
+        )
+        load_path = self._resolve_draft_path(model_exp.speculative_draft_model)
+
+        import mlx_lm
+
+        draft_model, _draft_tokenizer = _load_with_model_type_fallback(
+            mlx_lm, load_path, lazy=False
+        )
+
+        self._check_vocab_match(target_model, draft_model)
+
+        return SpeculativeDecoder(
+            draft_model=draft_model,
+            target_model=target_model,
+            num_speculative_tokens=model_exp.speculative_tokens,
+        )
+
     def _is_flash_enabled(self, model_exp: Any) -> bool:
         return model_exp.flash
 
@@ -1479,7 +1597,17 @@ class ModelManager:
                 )
 
         # Text or unknown — try mlx-lm first, fall back to mlx-vlm
-        return (*self._try_lm_then_vlm(load_path, hf_path), None)
+        model, tokenizer, is_vlm, caps = self._try_lm_then_vlm(load_path, hf_path)
+
+        if model_exp.dflash:
+            decoder = self._load_dflash_decoder(model, hf_path, model_exp)
+            return model, tokenizer, is_vlm, caps, decoder
+
+        if model_exp.speculative:
+            decoder = self._load_speculative_decoder(model, hf_path, model_exp)
+            return model, tokenizer, is_vlm, caps, decoder
+
+        return model, tokenizer, is_vlm, caps, None
 
     def _load_model_and_shard(
         self, hf_path: str, model_exp: Any = None

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -1261,6 +1261,19 @@ class ModelManager:
             )
 
         draft_cfg_dict = json.loads(config_file.read_text())
+        _required = [
+            "hidden_size",
+            "num_attention_heads",
+            "num_layers",
+            "target_layer_ids",
+            "vocab_size",
+        ]
+        missing = [k for k in _required if k not in draft_cfg_dict]
+        if missing:
+            raise ValueError(
+                f"DFlash draft config at {config_file} is missing "
+                f"required keys: {missing}"
+            )
         target_hidden_size = getattr(
             getattr(target_model, "args", None), "hidden_size", None
         )
@@ -1274,14 +1287,20 @@ class ModelManager:
         )
 
         draft_model = DFlashDraftModel(draft_config)
-        weights_file = Path(load_path) / "model.safetensors"
-        if not weights_file.exists():
+        draft_dir = Path(load_path)
+        weight_files = sorted(draft_dir.glob("model*.safetensors"))
+        if not weight_files:
             raise FileNotFoundError(
-                f"DFlash draft model weights not found at {weights_file}. "
+                f"DFlash draft model weights not found in {draft_dir}. "
                 "A pre-trained dflash draft model is required."
             )
-        draft_model.load_weights(str(weights_file))
-        logger.info("Loaded dflash draft weights from %s", weights_file)
+        for wf in weight_files:
+            draft_model.load_weights(str(wf))
+        logger.info(
+            "Loaded dflash draft weights from %s (%d file(s))",
+            draft_dir,
+            len(weight_files),
+        )
 
         # Detect model type for adapter selection
         target_config_file = None

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -1223,11 +1223,14 @@ class ModelManager:
         """Raise ValueError if target and draft vocab sizes differ."""
         target_vocab = getattr(getattr(target, "args", None), "vocab_size", None)
         draft_vocab = getattr(getattr(draft, "args", None), "vocab_size", None)
-        if (
-            target_vocab is not None
-            and draft_vocab is not None
-            and target_vocab != draft_vocab
-        ):
+        if target_vocab is None or draft_vocab is None:
+            logger.warning(
+                "Could not verify vocab compatibility: target_vocab=%s draft_vocab=%s",
+                target_vocab,
+                draft_vocab,
+            )
+            return
+        if target_vocab != draft_vocab:
             raise ValueError(
                 f"Draft model vocab_size ({draft_vocab}) does not match "
                 f"target model vocab_size ({target_vocab}). "
@@ -1608,6 +1611,7 @@ class ModelManager:
             for name, flag in [
                 ("dflash", model_exp.dflash),
                 ("speculative", model_exp.speculative),
+                ("flash_speculative", model_exp.flash_speculative),
             ]
             if flag
         ]

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -1272,9 +1272,13 @@ class ModelManager:
 
         draft_model = DFlashDraftModel(draft_config)
         weights_file = Path(load_path) / "model.safetensors"
-        if weights_file.exists():
-            draft_model.load_weights(str(weights_file))
-            logger.info("Loaded dflash draft weights from %s", weights_file)
+        if not weights_file.exists():
+            raise FileNotFoundError(
+                f"DFlash draft model weights not found at {weights_file}. "
+                "A pre-trained dflash draft model is required."
+            )
+        draft_model.load_weights(str(weights_file))
+        logger.info("Loaded dflash draft weights from %s", weights_file)
 
         # Detect model type for adapter selection
         target_config_file = None
@@ -1598,6 +1602,19 @@ class ModelManager:
 
         # Text or unknown — try mlx-lm first, fall back to mlx-vlm
         model, tokenizer, is_vlm, caps = self._try_lm_then_vlm(load_path, hf_path)
+
+        enabled = [
+            name
+            for name, flag in [
+                ("dflash", model_exp.dflash),
+                ("speculative", model_exp.speculative),
+            ]
+            if flag
+        ]
+        if len(enabled) > 1:
+            raise ValueError(
+                f"Only one speculative decoder can be active at a time; got: {enabled}"
+            )
 
         if model_exp.dflash:
             decoder = self._load_dflash_decoder(model, hf_path, model_exp)

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -1295,7 +1295,7 @@ class ModelManager:
                 "A pre-trained dflash draft model is required."
             )
         for wf in weight_files:
-            draft_model.load_weights(str(wf))
+            draft_model.load_weights(str(wf), strict=False)
         logger.info(
             "Loaded dflash draft weights from %s (%d file(s))",
             draft_dir,
@@ -1311,7 +1311,14 @@ class ModelManager:
             target_cfg = json.loads(target_config_file.read_text())
             model_type = target_cfg.get("model_type", "")
         else:
-            model_type = draft_cfg_dict.get("target_model_type", "qwen3")
+            model_type = draft_cfg_dict.get("target_model_type", "")
+
+        if not model_type:
+            raise ValueError(
+                "Cannot determine target model_type for dflash adapter selection. "
+                "Set 'target_model_type' in the draft model's config.json or "
+                "ensure the target model's config.json contains 'model_type'."
+            )
 
         adapter = get_adapter(model_type)
 

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -1,0 +1,314 @@
+"""Model-agnostic speculative decoding.
+
+Uses a small draft model for fast candidate generation, then verifies
+candidates with the target model in a single forward pass.
+
+This base class contains the core algorithm without Flash-specific
+dependencies. See engine/flash/speculative.py for the Flash-aware
+subclass that adds prefetching and neuron window sizing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import mlx.core as mx
+import mlx.nn as nn
+
+try:
+    from mlx_lm.models.cache import make_prompt_cache, trim_prompt_cache
+except ImportError:
+    make_prompt_cache = None  # type: ignore[assignment]
+    trim_prompt_cache = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+def verify_draft_greedy(
+    draft_tokens: list[int],
+    target_logits: mx.array,
+) -> list[int]:
+    """Verify draft tokens against target model logits (greedy).
+
+    Accept draft tokens that match the target's greedy argmax. On first
+    mismatch, return the target's preferred token instead.
+
+    Args:
+        draft_tokens: list of draft token IDs, length n.
+        target_logits: (n+1, vocab) target model logits.
+
+    Returns:
+        List of accepted token IDs (1 to n+1 tokens).
+    """
+    n = len(draft_tokens)
+
+    target_choices = mx.argmax(target_logits, axis=-1)
+    mx.eval(target_choices)
+
+    accepted: list[int] = []
+    for i in range(n):
+        target_token = int(target_choices[i].item())
+        if draft_tokens[i] == target_token:
+            accepted.append(draft_tokens[i])
+        else:
+            accepted.append(target_token)
+            return accepted
+
+    # All draft tokens accepted — add bonus token
+    accepted.append(int(target_choices[n].item()))
+    return accepted
+
+
+class SpeculativeDecoder:
+    """Speculative decoding with a draft model.
+
+    The draft model generates lambda candidate tokens autoregressively.
+    The target model verifies all candidates in one forward pass.
+    Accepted tokens are returned; on rejection, the target's preferred
+    token replaces the first rejected position.
+
+    Supports two modes:
+    - Stateless: ``generate_step(prompt)`` — no cross-step caching
+    - Cached: ``prefill(prompt)`` then ``step()`` — persistent KV caches
+
+    Not thread-safe: one decoder instance must serve one request at a time.
+    """
+
+    def __init__(
+        self,
+        draft_model: nn.Module,
+        target_model: nn.Module,
+        num_speculative_tokens: int = 4,
+        acceptance_rate_ema: float = 0.9,
+    ):
+        if trim_prompt_cache is None:
+            raise RuntimeError(
+                "trim_prompt_cache is unavailable (mlx-lm import missing); "
+                "speculative decoding requires it for correct cache trimming"
+            )
+        self._draft = draft_model
+        self._target = target_model
+        self._lambda = num_speculative_tokens
+        self._alpha = 0.5  # initial acceptance rate estimate
+        self._alpha_ema = acceptance_rate_ema
+
+        # Persistent KV cache state (populated by prefill/step)
+        self._target_cache: list | None = None
+        self._draft_cache: list | None = None
+        self._cache_seq_len: int = 0
+        self._last_target_logit: mx.array | None = None
+        self._pending_token: int | None = None
+
+    def _update_acceptance_rate(self, num_accepted: int) -> None:
+        """Update the rolling acceptance rate via EMA."""
+        num_accepted_draft = (
+            min(num_accepted - 1, self._lambda) if num_accepted > 0 else 0
+        )
+        acceptance = num_accepted_draft / max(self._lambda, 1)
+        self._alpha = self._alpha_ema * self._alpha + (1 - self._alpha_ema) * acceptance
+
+    # ------------------------------------------------------------------
+    # Cached API: prefill() + step()
+    # ------------------------------------------------------------------
+
+    def reset(self) -> None:
+        self._target_cache = None
+        self._draft_cache = None
+        self._cache_seq_len = 0
+        self._last_target_logit = None
+        self._pending_token = None
+
+    def prefill(self, prompt: mx.array) -> int:
+        """Process the prompt through both models, populating KV caches.
+
+        Args:
+            prompt: (1, seq_len) input token IDs.
+
+        Returns:
+            The first generated token (from target model's greedy argmax).
+        """
+        self.reset()
+
+        if make_prompt_cache is None or trim_prompt_cache is None:
+            raise RuntimeError(
+                "mlx_lm.models.cache not available; cannot use cached speculative decoding"
+            )
+
+        self._target_cache = make_prompt_cache(self._target)
+        self._draft_cache = make_prompt_cache(self._draft)
+
+        target_out = self._target(prompt, cache=self._target_cache)
+        self._last_target_logit = target_out[0, -1, :]
+        mx.eval(self._last_target_logit)
+
+        # Populate draft cache (logits discarded — only cache state needed).
+        draft_logits = self._draft(prompt, cache=self._draft_cache)
+        mx.eval(draft_logits)
+
+        self._cache_seq_len = prompt.shape[1]
+
+        first_token = int(mx.argmax(self._last_target_logit).item())
+        self._pending_token = first_token
+        return first_token
+
+    def step(self) -> tuple[list[int], int]:
+        """One speculative decoding step using persistent KV caches.
+
+        Must call ``prefill()`` first to populate caches.
+
+        Returns:
+            (accepted_tokens, num_draft_generated).
+        """
+        assert self._target_cache is not None, "Call prefill() before step()"
+        assert self._draft_cache is not None, "Call prefill() before step()"
+        assert self._pending_token is not None, "Call prefill() before step()"
+
+        pending_token = self._pending_token
+
+        # 1. Draft: feed pending token, then generate lambda candidates
+        draft_tokens, draft_ctx = self._draft_generate_cached(
+            pending_token, self._lambda
+        )
+
+        # Hook for subclasses (e.g. Flash prefetcher submission)
+        self._after_draft(draft_ctx)
+
+        # 2. Target: feed [pending, D1, ..., D_lambda] in one pass.
+        all_tokens = mx.array([[pending_token] + draft_tokens])
+        target_out = self._target(all_tokens, cache=self._target_cache)
+        mx.eval(target_out)
+
+        verification_logits = target_out[0]  # (lambda+1, vocab)
+
+        # 3. Verify draft tokens against target logits
+        accepted = self._verify(draft_tokens, verification_logits)
+        num_accepted = len(accepted)
+
+        # Hook for subclasses (e.g. Flash prefetch cancellation)
+        self._after_verify(num_accepted)
+
+        # 4. Trim caches to the position after the last accepted token.
+        trim_target = max(self._lambda + 1 - num_accepted, 0)
+        trim_draft = max(self._lambda - num_accepted, 0)
+
+        if trim_target > 0 and trim_prompt_cache is not None:
+            trim_prompt_cache(self._target_cache, trim_target)
+        if trim_draft > 0 and trim_prompt_cache is not None:
+            trim_prompt_cache(self._draft_cache, trim_draft)
+
+        # On full acceptance, align draft cache with target cache.
+        if num_accepted > self._lambda:
+            last_draft = mx.array([[draft_tokens[-1]]])
+            align_logits = self._draft(last_draft, cache=self._draft_cache)
+            mx.eval(align_logits)
+
+        # 5. Update state
+        self._cache_seq_len += num_accepted
+        assert num_accepted >= 1, "step(): _verify() must return at least 1 token"
+        self._last_target_logit = verification_logits[num_accepted - 1]
+        mx.eval(self._last_target_logit)
+        self._pending_token = int(mx.argmax(self._last_target_logit).item())
+
+        self._update_acceptance_rate(num_accepted)
+        return accepted, self._lambda
+
+    def _draft_generate_cached(
+        self, pending_token: int, n: int
+    ) -> tuple[list[int], list[mx.array]]:
+        """Generate n candidate tokens using the persistent draft cache.
+
+        Returns:
+            (tokens, context) — context is empty in the base class;
+            subclasses may return captured hidden states.
+        """
+        assert self._draft_cache is not None
+
+        next_token = pending_token
+        tokens: list[int] = []
+
+        for _ in range(n):
+            inp = mx.array([[next_token]])
+            logits = self._draft(inp, cache=self._draft_cache)
+            next_logits = logits[:, -1, :]
+            mx.eval(next_logits)
+            next_token = int(mx.argmax(next_logits, axis=-1).item())
+            tokens.append(next_token)
+
+        return tokens, []
+
+    def _after_draft(self, draft_ctx: list[mx.array]) -> None:
+        """Hook called after draft generation. Override for prefetch submission."""
+
+    def _after_verify(self, num_accepted: int) -> None:
+        """Hook called after verification. Override for prefetch cancellation."""
+
+    # ------------------------------------------------------------------
+    # Stateless API
+    # ------------------------------------------------------------------
+
+    def _draft_generate(self, prompt: mx.array, n: int) -> list[int]:
+        """Generate n candidate tokens with fresh KV cache (stateless)."""
+        tokens: list[int] = []
+
+        cache = None
+        if make_prompt_cache is not None:
+            try:
+                cache = make_prompt_cache(self._draft)
+            except (TypeError, AttributeError):
+                pass
+
+        if cache is not None:
+            logits = self._draft(prompt, cache=cache)
+            next_logits = logits[:, -1, :]
+            mx.eval(next_logits)
+            next_token = int(mx.argmax(next_logits, axis=-1).item())
+            tokens.append(next_token)
+
+            for _ in range(n - 1):
+                inp = mx.array([[next_token]])
+                logits = self._draft(inp, cache=cache)
+                next_logits = logits[:, -1, :]
+                mx.eval(next_logits)
+                next_token = int(mx.argmax(next_logits, axis=-1).item())
+                tokens.append(next_token)
+        else:
+            for _ in range(n):
+                if tokens:
+                    current = mx.concatenate([prompt, mx.array([tokens])], axis=1)
+                else:
+                    current = prompt
+                logits = self._draft(current)
+                next_logits = logits[:, -1, :]
+                mx.eval(next_logits)
+                next_token = int(mx.argmax(next_logits, axis=-1).item())
+                tokens.append(next_token)
+
+        return tokens
+
+    def _verify(
+        self,
+        draft_tokens: list[int],
+        target_logits: mx.array,
+    ) -> list[int]:
+        """Verify draft tokens against target model logits (greedy)."""
+        return verify_draft_greedy(draft_tokens, target_logits)
+
+    def generate_step(
+        self,
+        prompt: mx.array,
+    ) -> tuple[list[int], int]:
+        """One speculative decoding step (stateless, no cross-step caching)."""
+        draft_tokens = self._draft_generate(prompt, self._lambda)
+
+        draft_ids = mx.array([draft_tokens])
+        combined = mx.concatenate([prompt, draft_ids], axis=1)
+        target_out = self._target(combined)
+        mx.eval(target_out)
+
+        seq_len = prompt.shape[1]
+        target_logits = target_out[0, seq_len - 1 : seq_len + self._lambda, :]
+
+        accepted = self._verify(draft_tokens, target_logits)
+
+        self._update_acceptance_rate(len(accepted))
+        return accepted, self._lambda

--- a/olmlx/engine/speculative_stream.py
+++ b/olmlx/engine/speculative_stream.py
@@ -1,0 +1,153 @@
+"""Streaming adapter for speculative decoding.
+
+Bridges SpeculativeDecoder into the CancellableStream / StreamToken
+contract used by the inference pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Generator
+from typing import Any, Protocol
+
+import mlx.core as mx
+
+from olmlx.engine.speculative import SpeculativeDecoder
+from olmlx.utils.streaming import StreamToken
+
+logger = logging.getLogger(__name__)
+
+
+class TokenizerProtocol(Protocol):
+    """Protocol for tokenizer with decode method."""
+
+    def decode(self, token_ids: list[int]) -> str: ...
+
+
+def speculative_stream_generate(
+    decoder: SpeculativeDecoder,
+    prompt_tokens: list[int],
+    max_tokens: int,
+    cancel_event: threading.Event,
+    eos_token_id: int | None = None,
+    tokenizer: TokenizerProtocol | None = None,
+) -> Generator[StreamToken, None, None]:
+    """Sync generator that yields StreamToken objects for speculative decoding.
+
+    Args:
+        decoder: SpeculativeDecoder (or subclass) with prefill/step API.
+        prompt_tokens: Token IDs for the prompt.
+        max_tokens: Maximum number of tokens to generate.
+        cancel_event: Set to stop generation.
+        eos_token_id: Stop generation when this token is produced.
+        tokenizer: Tokenizer for incremental text decoding. If None, text is empty.
+    """
+    prompt_arr = mx.array([prompt_tokens])
+    prompt_len = len(prompt_tokens)
+
+    t0 = time.perf_counter()
+    first_token = decoder.prefill(prompt_arr)
+    prefill_elapsed = time.perf_counter() - t0
+    prompt_tps_val = prompt_len / max(prefill_elapsed, 1e-9)
+
+    generated: list[int] = [first_token]
+    gen_count = 1
+
+    # Incremental text decoding: decode full sequence and diff against previous length.
+    prev_text_len = 0
+    if tokenizer is not None:
+        full_text = tokenizer.decode(generated)
+        new_text = full_text
+        prev_text_len = len(full_text)
+    else:
+        new_text = ""
+
+    yield StreamToken(
+        text=new_text,
+        token=first_token,
+        prompt_tokens=prompt_len,
+        generation_tokens=gen_count,
+        prompt_tps=prompt_tps_val,
+        generation_tps=gen_count / max(prefill_elapsed, 1e-9),
+    )
+
+    if (
+        eos_token_id is not None and first_token == eos_token_id
+    ) or cancel_event.is_set():
+        return
+
+    while gen_count < max_tokens:
+        if cancel_event.is_set():
+            break
+
+        accepted, _ = decoder.step()
+
+        for token in accepted:
+            if cancel_event.is_set() or gen_count >= max_tokens:
+                break
+
+            gen_count += 1
+            generated.append(token)
+            gen_elapsed = time.perf_counter() - t0
+
+            if tokenizer is not None:
+                full_text = tokenizer.decode(generated)
+                new_text = full_text[prev_text_len:]
+                prev_text_len = len(full_text)
+            else:
+                new_text = ""
+
+            finish = None
+            if eos_token_id is not None and token == eos_token_id:
+                finish = "stop"
+            elif gen_count >= max_tokens:
+                finish = "length"
+
+            yield StreamToken(
+                text=new_text,
+                token=token,
+                prompt_tokens=prompt_len,
+                generation_tokens=gen_count,
+                prompt_tps=prompt_tps_val,
+                generation_tps=gen_count / max(gen_elapsed, 1e-9),
+                finish_reason=finish,
+            )
+
+            if finish is not None:
+                return
+
+
+def async_speculative_stream(
+    decoder: SpeculativeDecoder,
+    tokenizer: Any,
+    prompt: str | list[int],
+    max_tokens: int,
+) -> Any:
+    """Create a CancellableStream for speculative decoding.
+
+    Matches the interface of async_mlx_stream from utils/streaming.py.
+    """
+    from olmlx.utils.streaming import CancellableStream
+
+    if isinstance(prompt, str):
+        prompt_tokens = tokenizer.encode(prompt)
+    else:
+        prompt_tokens = prompt
+
+    eos_token_id = getattr(tokenizer, "eos_token_id", None)
+
+    def gen_factory(cancel_event: threading.Event):
+        return speculative_stream_generate(
+            decoder,
+            prompt_tokens,
+            max_tokens=max_tokens,
+            cancel_event=cancel_event,
+            eos_token_id=eos_token_id,
+            tokenizer=tokenizer,
+        )
+
+    stream = CancellableStream(gen_factory)
+    stream.start()
+    return stream

--- a/olmlx/engine/speculative_stream.py
+++ b/olmlx/engine/speculative_stream.py
@@ -10,7 +10,7 @@ import logging
 import threading
 import time
 from collections.abc import Generator
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol
 
 import mlx.core as mx
 
@@ -25,7 +25,6 @@ class TokenizerProtocol(Protocol):
     def decode(self, token_ids: list[int]) -> str: ...
 
 
-@runtime_checkable
 class SpeculativeDecoderProtocol(Protocol):
     """Structural protocol for any speculative decoder (SpeculativeDecoder, DFlashDecoder)."""
 

--- a/olmlx/engine/speculative_stream.py
+++ b/olmlx/engine/speculative_stream.py
@@ -10,11 +10,10 @@ import logging
 import threading
 import time
 from collections.abc import Generator
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 import mlx.core as mx
 
-from olmlx.engine.speculative import SpeculativeDecoder
 from olmlx.utils.streaming import StreamToken
 
 logger = logging.getLogger(__name__)
@@ -26,8 +25,17 @@ class TokenizerProtocol(Protocol):
     def decode(self, token_ids: list[int]) -> str: ...
 
 
+@runtime_checkable
+class SpeculativeDecoderProtocol(Protocol):
+    """Structural protocol for any speculative decoder (SpeculativeDecoder, DFlashDecoder)."""
+
+    def prefill(self, prompt: mx.array) -> int: ...
+    def step(self) -> tuple[list[int], int]: ...
+    def reset(self) -> None: ...
+
+
 def speculative_stream_generate(
-    decoder: SpeculativeDecoder,
+    decoder: SpeculativeDecoderProtocol,
     prompt_tokens: list[int],
     max_tokens: int,
     cancel_event: threading.Event,
@@ -120,7 +128,7 @@ def speculative_stream_generate(
 
 
 def async_speculative_stream(
-    decoder: SpeculativeDecoder,
+    decoder: SpeculativeDecoderProtocol,
     tokenizer: Any,
     prompt: str | list[int],
     max_tokens: int,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -168,3 +168,70 @@ class TestResolveExperimental:
         result = resolve_experimental(base, {"flash": True})
         assert result.flash is True
         assert result.kv_cache_quant is None
+
+
+class TestSpeculativeConfig:
+    """Tests for standalone speculative decoding config fields."""
+
+    def test_speculative_defaults(self, monkeypatch):
+        monkeypatch.delenv("OLMLX_EXPERIMENTAL_SPECULATIVE", raising=False)
+        monkeypatch.delenv("OLMLX_EXPERIMENTAL_SPECULATIVE_DRAFT_MODEL", raising=False)
+        monkeypatch.delenv("OLMLX_EXPERIMENTAL_SPECULATIVE_TOKENS", raising=False)
+        s = ExperimentalSettings()
+        assert s.speculative is False
+        assert s.speculative_draft_model is None
+        assert s.speculative_tokens == 4
+
+    def test_speculative_env_override(self, monkeypatch):
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_SPECULATIVE", "true")
+        monkeypatch.setenv(
+            "OLMLX_EXPERIMENTAL_SPECULATIVE_DRAFT_MODEL", "Qwen/Qwen3-0.6B"
+        )
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_SPECULATIVE_TOKENS", "6")
+        s = ExperimentalSettings()
+        assert s.speculative is True
+        assert s.speculative_draft_model == "Qwen/Qwen3-0.6B"
+        assert s.speculative_tokens == 6
+
+    def test_speculative_tokens_rejects_zero(self):
+        with pytest.raises(ValidationError):
+            ExperimentalSettings(speculative_tokens=0, _env_file=None)
+
+    def test_speculative_per_model_override(self, monkeypatch):
+        monkeypatch.delenv("OLMLX_EXPERIMENTAL_SPECULATIVE", raising=False)
+        base = ExperimentalSettings()
+        result = resolve_experimental(
+            base,
+            {"speculative": True, "speculative_draft_model": "Qwen/Qwen3-0.6B"},
+        )
+        assert result.speculative is True
+        assert result.speculative_draft_model == "Qwen/Qwen3-0.6B"
+        assert base.speculative is False
+
+
+class TestDFlashConfig:
+    """Tests for dflash config fields."""
+
+    def test_dflash_defaults(self, monkeypatch):
+        monkeypatch.delenv("OLMLX_EXPERIMENTAL_DFLASH", raising=False)
+        monkeypatch.delenv("OLMLX_EXPERIMENTAL_DFLASH_DRAFT_MODEL", raising=False)
+        monkeypatch.delenv("OLMLX_EXPERIMENTAL_DFLASH_BLOCK_SIZE", raising=False)
+        s = ExperimentalSettings()
+        assert s.dflash is False
+        assert s.dflash_draft_model is None
+        assert s.dflash_block_size == 4
+
+    def test_dflash_env_override(self, monkeypatch):
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_DFLASH", "true")
+        monkeypatch.setenv(
+            "OLMLX_EXPERIMENTAL_DFLASH_DRAFT_MODEL", "aryagm/dflash-qwen3"
+        )
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_DFLASH_BLOCK_SIZE", "8")
+        s = ExperimentalSettings()
+        assert s.dflash is True
+        assert s.dflash_draft_model == "aryagm/dflash-qwen3"
+        assert s.dflash_block_size == 8
+
+    def test_dflash_block_size_rejects_zero(self):
+        with pytest.raises(ValidationError):
+            ExperimentalSettings(dflash_block_size=0, _env_file=None)

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -71,7 +71,7 @@ class Qwen3LikeLayer(nn.Module):
         super().__init__()
         self.self_attn = MockAttention(hidden_size)
 
-    def __call__(self, x, cache=None):
+    def __call__(self, x, mask=None, cache=None):
         return self.self_attn(x, cache=cache)
 
 

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -1,0 +1,364 @@
+"""Tests for dflash block-diffusion speculative decoding."""
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from tests.test_flash_speculative import MockModel
+
+
+# ---------------------------------------------------------------------------
+# Adapters
+# ---------------------------------------------------------------------------
+
+
+class TestTargetAdapterInterface:
+    """Test the TargetAdapter abstract interface and registry."""
+
+    def test_adapter_registry_exists(self):
+        from olmlx.engine.dflash.adapters import ADAPTERS
+
+        assert isinstance(ADAPTERS, dict)
+
+    def test_get_adapter_returns_registered(self):
+        from olmlx.engine.dflash.adapters import ADAPTERS, TargetAdapter, get_adapter
+
+        class DummyAdapter(TargetAdapter):
+            def forward_with_hidden(self, model, tokens, cache, target_layer_ids):
+                return None, {}, None
+
+            def snapshot_cache(self, cache):
+                return cache
+
+            def restore_cache(self, cache, snapshot):
+                pass
+
+            def trim_cache(self, cache, num_tokens):
+                pass
+
+        ADAPTERS["dummy"] = DummyAdapter
+        try:
+            adapter = get_adapter("dummy")
+            assert isinstance(adapter, DummyAdapter)
+        finally:
+            del ADAPTERS["dummy"]
+
+    def test_get_adapter_raises_for_unknown(self):
+        from olmlx.engine.dflash.adapters import get_adapter
+
+        with pytest.raises(KeyError, match="no_such_model"):
+            get_adapter("no_such_model")
+
+
+# ---------------------------------------------------------------------------
+# Qwen3 Adapter
+# ---------------------------------------------------------------------------
+
+
+class MockAttention(nn.Module):
+    """Attention with KV cache support for testing."""
+
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.n_heads = 1
+        self.n_kv_heads = 1
+
+    def __call__(self, x, cache=None):
+        if cache is not None:
+            k = v = x.reshape(x.shape[0], 1, -1, x.shape[-1])
+            cache.update_and_fetch(k, v)
+        return x
+
+
+class Qwen3LikeLayer(nn.Module):
+    """Minimal Qwen3-like layer with KV cache support."""
+
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.self_attn = MockAttention(hidden_size)
+
+    def __call__(self, x, cache=None):
+        return self.self_attn(x, cache=cache)
+
+
+class Qwen3LikeModel(nn.Module):
+    """Minimal Qwen3-like model for testing adapter."""
+
+    def __init__(self, vocab_size: int, hidden_size: int, num_layers: int = 4):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(vocab_size, hidden_size)
+        self.layers = [Qwen3LikeLayer(hidden_size) for _ in range(num_layers)]
+        self.norm = nn.RMSNorm(hidden_size)
+
+    def __call__(self, input_ids, cache=None):
+        h = self.embed_tokens(input_ids)
+        for i, layer in enumerate(self.layers):
+            h = layer(h, cache=cache[i] if cache is not None else None)
+        return self.norm(h)
+
+
+class TestQwen3Adapter:
+    def test_registered_in_adapters(self):
+        from olmlx.engine.dflash.adapters import ADAPTERS
+
+        assert "qwen3" in ADAPTERS
+
+    def test_forward_with_hidden_extracts_layers(self):
+        from olmlx.engine.dflash.adapters import get_adapter
+
+        adapter = get_adapter("qwen3")
+        vocab_size, hidden_size, num_layers = 32, 16, 4
+        model = Qwen3LikeModel(vocab_size, hidden_size, num_layers)
+
+        tokens = mx.array([[1, 2, 3]])
+        target_layer_ids = [1, 3]
+
+        logits, hidden_states, cache = adapter.forward_with_hidden(
+            model, tokens, cache=None, target_layer_ids=target_layer_ids
+        )
+
+        # Should return hidden states for requested layers
+        assert set(hidden_states.keys()) == {1, 3}
+        for layer_id in target_layer_ids:
+            assert hidden_states[layer_id].shape == (1, 3, hidden_size)
+
+    def test_trim_cache(self):
+        from mlx_lm.models.cache import make_prompt_cache
+
+        from olmlx.engine.dflash.adapters import get_adapter
+
+        adapter = get_adapter("qwen3")
+        model = MockModel(vocab_size=32, hidden_size=16, num_layers=2)
+        cache = make_prompt_cache(model)
+
+        tokens = mx.array([[1, 2, 3, 4, 5]])
+        model(tokens, cache=cache)
+        assert cache[0].offset == 5
+
+        adapter.trim_cache(cache, 2)
+        assert cache[0].offset == 3
+
+
+# ---------------------------------------------------------------------------
+# Draft Model
+# ---------------------------------------------------------------------------
+
+
+class TestDFlashDraftModel:
+    def test_draft_config_from_dict(self):
+        from olmlx.engine.dflash.draft_model import DraftConfig
+
+        cfg = DraftConfig(
+            hidden_size=256,
+            num_attention_heads=4,
+            num_layers=2,
+            target_layer_ids=[1, 3],
+            vocab_size=32000,
+        )
+        assert cfg.hidden_size == 256
+        assert cfg.target_layer_ids == [1, 3]
+
+    def test_draft_model_forward(self):
+        from olmlx.engine.dflash.draft_model import DFlashDraftModel, DraftConfig
+
+        cfg = DraftConfig(
+            hidden_size=32,
+            num_attention_heads=2,
+            num_layers=1,
+            target_layer_ids=[0],
+            vocab_size=64,
+            target_hidden_size=16,
+        )
+        draft = DFlashDraftModel(cfg)
+
+        # Simulate target hidden states from 1 layer
+        target_hidden = {0: mx.random.normal((1, 3, 16))}
+        current_tokens = mx.array([[1, 2, 3]])
+
+        logits = draft(current_tokens, target_hidden)
+        mx.eval(logits)
+
+        # Output should be (1, 3, vocab_size)
+        assert logits.shape == (1, 3, 64)
+
+    def test_draft_model_projects_target_hidden(self):
+        """Draft model should project target hidden_size to draft hidden_size."""
+        from olmlx.engine.dflash.draft_model import DFlashDraftModel, DraftConfig
+
+        cfg = DraftConfig(
+            hidden_size=32,
+            num_attention_heads=2,
+            num_layers=1,
+            target_layer_ids=[0, 2],
+            vocab_size=64,
+            target_hidden_size=48,  # different from draft hidden_size
+        )
+        draft = DFlashDraftModel(cfg)
+
+        target_hidden = {
+            0: mx.random.normal((1, 3, 48)),
+            2: mx.random.normal((1, 3, 48)),
+        }
+        logits = draft(mx.array([[1, 2, 3]]), target_hidden)
+        mx.eval(logits)
+        assert logits.shape == (1, 3, 64)
+
+
+# ---------------------------------------------------------------------------
+# DFlash Decoder
+# ---------------------------------------------------------------------------
+
+
+class TestDFlashDecoder:
+    @pytest.fixture()
+    def decoder_components(self):
+        """Create a minimal dflash decoder for testing."""
+        from olmlx.engine.dflash.adapters import get_adapter
+        from olmlx.engine.dflash.draft_model import DFlashDraftModel, DraftConfig
+
+        vocab_size, hidden_size = 32, 16
+        num_layers = 4
+
+        # Target: Qwen3-like model with lm_head
+        target_inner = Qwen3LikeModel(vocab_size, hidden_size, num_layers)
+
+        class TargetWithHead(nn.Module):
+            def __init__(self, inner, vocab_size, hidden_size):
+                super().__init__()
+                self.model = inner
+                self.layers = inner.layers  # expose for make_prompt_cache
+                self.lm_head = nn.Linear(hidden_size, vocab_size, bias=False)
+
+            def __call__(self, input_ids, cache=None):
+                h = self.model(input_ids, cache=cache)
+                return self.lm_head(h)
+
+        target = TargetWithHead(target_inner, vocab_size, hidden_size)
+
+        # Draft config
+        cfg = DraftConfig(
+            hidden_size=16,
+            num_attention_heads=2,
+            num_layers=1,
+            target_layer_ids=[1, 3],
+            vocab_size=vocab_size,
+            target_hidden_size=hidden_size,
+        )
+        draft = DFlashDraftModel(cfg)
+        adapter = get_adapter("qwen3")
+
+        return target, draft, adapter, cfg
+
+    def test_decoder_creation(self, decoder_components):
+        from olmlx.engine.dflash.decoder import DFlashDecoder
+
+        target, draft, adapter, cfg = decoder_components
+        decoder = DFlashDecoder(
+            target_model=target,
+            draft_model=draft,
+            adapter=adapter,
+            draft_config=cfg,
+            block_size=3,
+        )
+        assert decoder._block_size == 3
+
+    def test_prefill_returns_token(self, decoder_components):
+        from olmlx.engine.dflash.decoder import DFlashDecoder
+
+        target, draft, adapter, cfg = decoder_components
+        decoder = DFlashDecoder(
+            target_model=target,
+            draft_model=draft,
+            adapter=adapter,
+            draft_config=cfg,
+            block_size=3,
+        )
+        prompt = mx.array([[1, 2, 3]])
+        first_token = decoder.prefill(prompt)
+
+        assert isinstance(first_token, int)
+        assert 0 <= first_token < 32
+
+    def test_step_returns_accepted_tokens(self, decoder_components):
+        from olmlx.engine.dflash.decoder import DFlashDecoder
+
+        target, draft, adapter, cfg = decoder_components
+        decoder = DFlashDecoder(
+            target_model=target,
+            draft_model=draft,
+            adapter=adapter,
+            draft_config=cfg,
+            block_size=3,
+        )
+        prompt = mx.array([[1, 2, 3]])
+        decoder.prefill(prompt)
+
+        accepted, num_draft = decoder.step()
+
+        assert len(accepted) >= 1
+        assert num_draft == 3
+        assert all(isinstance(t, int) for t in accepted)
+
+    def test_reset_clears_state(self, decoder_components):
+        from olmlx.engine.dflash.decoder import DFlashDecoder
+
+        target, draft, adapter, cfg = decoder_components
+        decoder = DFlashDecoder(
+            target_model=target,
+            draft_model=draft,
+            adapter=adapter,
+            draft_config=cfg,
+        )
+        prompt = mx.array([[1, 2, 3]])
+        decoder.prefill(prompt)
+        decoder.step()
+
+        decoder.reset()
+        assert decoder._cache is None
+        assert decoder._cache_seq_len == 0
+
+    def test_multi_step_consistency(self, decoder_components):
+        from olmlx.engine.dflash.decoder import DFlashDecoder
+
+        target, draft, adapter, cfg = decoder_components
+        decoder = DFlashDecoder(
+            target_model=target,
+            draft_model=draft,
+            adapter=adapter,
+            draft_config=cfg,
+            block_size=2,
+        )
+        prompt = mx.array([[1, 2, 3]])
+        decoder.prefill(prompt)
+
+        for _ in range(3):
+            accepted, _ = decoder.step()
+            assert len(accepted) >= 1
+
+    def test_compatible_with_speculative_stream(self, decoder_components):
+        """DFlashDecoder should work with speculative_stream_generate."""
+        import threading
+
+        from olmlx.engine.dflash.decoder import DFlashDecoder
+        from olmlx.engine.speculative_stream import speculative_stream_generate
+
+        target, draft, adapter, cfg = decoder_components
+        decoder = DFlashDecoder(
+            target_model=target,
+            draft_model=draft,
+            adapter=adapter,
+            draft_config=cfg,
+            block_size=2,
+        )
+
+        cancel = threading.Event()
+        responses = list(
+            speculative_stream_generate(
+                decoder, [1, 2, 3], max_tokens=5, cancel_event=cancel
+            )
+        )
+
+        assert len(responses) >= 1
+        for resp in responses:
+            assert hasattr(resp, "token")
+            assert 0 <= resp.token < 32

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -27,12 +27,6 @@ class TestTargetAdapterInterface:
             def forward_with_hidden(self, model, tokens, cache, target_layer_ids):
                 return None, {}, None
 
-            def snapshot_cache(self, cache):
-                return cache
-
-            def restore_cache(self, cache, snapshot):
-                pass
-
             def trim_cache(self, cache, num_tokens):
                 pass
 

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -102,8 +102,17 @@ class TestQwen3Adapter:
 
         adapter = get_adapter("qwen3")
         vocab_size, hidden_size, num_layers = 32, 16, 4
-        model = Qwen3LikeModel(vocab_size, hidden_size, num_layers)
+        inner = Qwen3LikeModel(vocab_size, hidden_size, num_layers)
 
+        # Wrap with lm_head (adapter requires it)
+        class ModelWithHead(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.model = inner
+                self.layers = inner.layers
+                self.lm_head = nn.Linear(hidden_size, vocab_size, bias=False)
+
+        model = ModelWithHead()
         tokens = mx.array([[1, 2, 3]])
         target_layer_ids = [1, 3]
 
@@ -111,10 +120,20 @@ class TestQwen3Adapter:
             model, tokens, cache=None, target_layer_ids=target_layer_ids
         )
 
-        # Should return hidden states for requested layers
         assert set(hidden_states.keys()) == {1, 3}
         for layer_id in target_layer_ids:
             assert hidden_states[layer_id].shape == (1, 3, hidden_size)
+        assert logits.shape == (1, 3, vocab_size)
+
+    def test_forward_with_hidden_raises_without_lm_head(self):
+        from olmlx.engine.dflash.adapters import get_adapter
+
+        adapter = get_adapter("qwen3")
+        model = Qwen3LikeModel(32, 16, 4)  # no lm_head
+        tokens = mx.array([[1, 2, 3]])
+
+        with pytest.raises(RuntimeError, match="no lm_head"):
+            adapter.forward_with_hidden(model, tokens, cache=None, target_layer_ids=[1])
 
     def test_trim_cache(self):
         from mlx_lm.models.cache import make_prompt_cache

--- a/tests/test_flash_speculative.py
+++ b/tests/test_flash_speculative.py
@@ -334,7 +334,7 @@ class TestSpeculativeKVCache:
 
     def test_prefill_raises_when_trim_prompt_cache_is_none(self):
         """prefill() should raise early when trim_prompt_cache is None."""
-        import olmlx.engine.flash.speculative as spec_mod
+        import olmlx.engine.speculative as spec_mod
 
         vocab_size, hidden_size = 32, 16
         draft = MockDraftModel(vocab_size, hidden_size)
@@ -392,7 +392,7 @@ class TestTrimPromptCacheNoneGuard:
 
     def test_init_raises_when_trim_prompt_cache_is_none(self, monkeypatch):
         """Construction must fail early when trim_prompt_cache is None."""
-        import olmlx.engine.flash.speculative as spec_mod
+        import olmlx.engine.speculative as spec_mod
 
         monkeypatch.setattr(spec_mod, "trim_prompt_cache", None)
 

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -2223,3 +2223,189 @@ class TestEvictLruIfNeeded:
         manager._loaded["old"] = old
         manager._evict_lru_if_needed()
         assert "old" not in manager._loaded
+
+
+class TestSpeculativeLoading:
+    """Tests for standalone speculative decoder loading in _load_model."""
+
+    def test_load_model_creates_speculative_decoder(self, monkeypatch):
+        """When speculative is enabled, _load_model should return a SpeculativeDecoder."""
+        from olmlx.config import ExperimentalSettings
+        from olmlx.engine.speculative import SpeculativeDecoder
+
+        target_model = MagicMock()
+        target_model.args.vocab_size = 32000
+        target_tokenizer = MagicMock()
+        caps = TemplateCaps()
+
+        draft_model = MagicMock()
+        draft_model.args.vocab_size = 32000
+
+        registry = MagicMock()
+        store = MagicMock()
+        store.ensure_downloaded.return_value = Path("/tmp/test-draft")
+
+        manager = ModelManager(registry, store)
+        monkeypatch.setattr(
+            manager,
+            "_try_lm_then_vlm",
+            lambda *a, **kw: (target_model, target_tokenizer, False, caps),
+        )
+        monkeypatch.setattr(manager, "_detect_model_kind", lambda *a: "text")
+        monkeypatch.setattr(manager, "_is_flash_enabled", lambda *a: False)
+        monkeypatch.setattr(manager, "_is_flash_moe_enabled", lambda *a: False)
+
+        mock_mlx_lm = MagicMock()
+        mock_mlx_lm.load.return_value = (draft_model, MagicMock())
+        monkeypatch.setitem(__import__("sys").modules, "mlx_lm", mock_mlx_lm)
+
+        model_exp = ExperimentalSettings(
+            speculative=True,
+            speculative_draft_model="test/draft-model",
+            speculative_tokens=5,
+            _env_file=None,
+        )
+
+        model, tok, is_vlm, caps_out, decoder = manager._load_model(
+            "test/target-model", model_exp=model_exp
+        )
+
+        assert isinstance(decoder, SpeculativeDecoder)
+        assert decoder._lambda == 5
+        assert model is target_model
+
+    def test_load_model_rejects_vocab_mismatch(self, monkeypatch):
+        """Should raise ValueError when draft/target vocab sizes differ."""
+        from olmlx.config import ExperimentalSettings
+
+        target_model = MagicMock()
+        target_model.args.vocab_size = 32000
+
+        draft_model = MagicMock()
+        draft_model.args.vocab_size = 64000
+
+        registry = MagicMock()
+        store = MagicMock()
+        store.ensure_downloaded.return_value = Path("/tmp/test-draft")
+
+        manager = ModelManager(registry, store)
+        monkeypatch.setattr(
+            manager,
+            "_try_lm_then_vlm",
+            lambda *a, **kw: (target_model, MagicMock(), False, TemplateCaps()),
+        )
+        monkeypatch.setattr(manager, "_detect_model_kind", lambda *a: "text")
+        monkeypatch.setattr(manager, "_is_flash_enabled", lambda *a: False)
+        monkeypatch.setattr(manager, "_is_flash_moe_enabled", lambda *a: False)
+
+        mock_mlx_lm = MagicMock()
+        mock_mlx_lm.load.return_value = (draft_model, MagicMock())
+        monkeypatch.setitem(__import__("sys").modules, "mlx_lm", mock_mlx_lm)
+
+        model_exp = ExperimentalSettings(
+            speculative=True,
+            speculative_draft_model="test/draft-model",
+            _env_file=None,
+        )
+
+        with pytest.raises(ValueError, match="vocab_size"):
+            manager._load_model("test/target-model", model_exp=model_exp)
+
+    def test_load_model_requires_draft_model_path(self, monkeypatch):
+        """Should raise ValueError when speculative is enabled but no draft model."""
+        from olmlx.config import ExperimentalSettings
+
+        registry = MagicMock()
+        store = MagicMock()
+
+        manager = ModelManager(registry, store)
+        monkeypatch.setattr(
+            manager,
+            "_try_lm_then_vlm",
+            lambda *a, **kw: (MagicMock(), MagicMock(), False, TemplateCaps()),
+        )
+        monkeypatch.setattr(manager, "_detect_model_kind", lambda *a: "text")
+        monkeypatch.setattr(manager, "_is_flash_enabled", lambda *a: False)
+        monkeypatch.setattr(manager, "_is_flash_moe_enabled", lambda *a: False)
+
+        model_exp = ExperimentalSettings(
+            speculative=True,
+            speculative_draft_model=None,
+            _env_file=None,
+        )
+
+        with pytest.raises(ValueError, match="speculative_draft_model"):
+            manager._load_model("test/target-model", model_exp=model_exp)
+
+
+class TestDFlashLoading:
+    """Tests for dflash decoder loading in _load_model."""
+
+    def test_load_model_requires_dflash_draft_model(self, monkeypatch):
+        """Should raise ValueError when dflash is enabled but no draft model."""
+        from olmlx.config import ExperimentalSettings
+
+        registry = MagicMock()
+        store = MagicMock()
+
+        manager = ModelManager(registry, store)
+        monkeypatch.setattr(
+            manager,
+            "_try_lm_then_vlm",
+            lambda *a, **kw: (MagicMock(), MagicMock(), False, TemplateCaps()),
+        )
+        monkeypatch.setattr(manager, "_detect_model_kind", lambda *a: "text")
+        monkeypatch.setattr(manager, "_is_flash_enabled", lambda *a: False)
+        monkeypatch.setattr(manager, "_is_flash_moe_enabled", lambda *a: False)
+
+        model_exp = ExperimentalSettings(
+            dflash=True,
+            dflash_draft_model=None,
+            _env_file=None,
+        )
+
+        with pytest.raises(ValueError, match="dflash_draft_model"):
+            manager._load_model("test/target-model", model_exp=model_exp)
+
+    def test_load_model_creates_dflash_decoder(self, monkeypatch):
+        """When dflash is enabled, _load_model should return a DFlashDecoder."""
+        from olmlx.config import ExperimentalSettings
+        from olmlx.engine.dflash.decoder import DFlashDecoder
+
+        target_model = MagicMock()
+        target_model.args.vocab_size = 32000
+
+        registry = MagicMock()
+        store = MagicMock()
+        store.ensure_downloaded.return_value = Path("/tmp/test-dflash-draft")
+        store.local_path.return_value = Path("/tmp/test-target")
+
+        manager = ModelManager(registry, store)
+        monkeypatch.setattr(
+            manager,
+            "_try_lm_then_vlm",
+            lambda *a, **kw: (target_model, MagicMock(), False, TemplateCaps()),
+        )
+        monkeypatch.setattr(manager, "_detect_model_kind", lambda *a: "text")
+        monkeypatch.setattr(manager, "_is_flash_enabled", lambda *a: False)
+        monkeypatch.setattr(manager, "_is_flash_moe_enabled", lambda *a: False)
+
+        # Mock _load_dflash_decoder to verify it's called
+        mock_decoder = MagicMock(spec=DFlashDecoder)
+        monkeypatch.setattr(
+            manager,
+            "_load_dflash_decoder",
+            lambda *a, **kw: mock_decoder,
+        )
+
+        model_exp = ExperimentalSettings(
+            dflash=True,
+            dflash_draft_model="test/dflash-draft",
+            _env_file=None,
+        )
+
+        model, tok, is_vlm, caps_out, decoder = manager._load_model(
+            "test/target-model", model_exp=model_exp
+        )
+
+        assert decoder is mock_decoder

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -1,0 +1,157 @@
+"""Tests for model-agnostic speculative decoder (engine/speculative.py)."""
+
+import mlx.core as mx
+import pytest
+
+from tests.test_flash_speculative import MockModel
+
+
+class TestSpeculativeDecoder:
+    """Tests for the base SpeculativeDecoder class (no Flash dependencies)."""
+
+    @pytest.fixture()
+    def decoder(self):
+        from olmlx.engine.speculative import SpeculativeDecoder
+
+        vocab_size, hidden_size = 32, 16
+        draft = MockModel(vocab_size, hidden_size)
+        target = MockModel(vocab_size, hidden_size)
+        return SpeculativeDecoder(
+            draft_model=draft,
+            target_model=target,
+            num_speculative_tokens=4,
+        )
+
+    @pytest.fixture()
+    def shared_decoder(self):
+        """Decoder with shared weights so draft and target always agree."""
+        from olmlx.engine.speculative import SpeculativeDecoder
+
+        vocab_size, hidden_size = 32, 16
+        draft = MockModel(vocab_size, hidden_size)
+        target = MockModel(vocab_size, hidden_size)
+        target.embed.weight = draft.embed.weight
+        target.lm_head.weight = draft.lm_head.weight
+        for i in range(len(draft.layers)):
+            target.layers[i] = draft.layers[i]
+        return SpeculativeDecoder(
+            draft_model=draft,
+            target_model=target,
+            num_speculative_tokens=3,
+        )
+
+    def test_init(self, decoder):
+        assert decoder._lambda == 4
+        assert 0 < decoder._alpha <= 1.0
+
+    def test_no_prefetcher_attribute(self, decoder):
+        """Base class should not have a _prefetcher attribute."""
+        assert not hasattr(decoder, "_prefetcher")
+
+    def test_prefill_creates_caches(self, shared_decoder):
+        prompt = mx.array([[1, 2, 3, 4, 5]])
+        first_token = shared_decoder.prefill(prompt)
+
+        assert shared_decoder._target_cache is not None
+        assert shared_decoder._draft_cache is not None
+        assert shared_decoder._cache_seq_len == 5
+        assert isinstance(first_token, int)
+        assert 0 <= first_token < 32
+
+    def test_step_returns_accepted_tokens(self, shared_decoder):
+        prompt = mx.array([[1, 2, 3]])
+        shared_decoder.prefill(prompt)
+
+        accepted, num_draft = shared_decoder.step()
+
+        assert len(accepted) >= 1
+        assert num_draft == 3
+        assert all(isinstance(t, int) for t in accepted)
+
+    def test_verify_rejects_divergent_tokens(self):
+        from olmlx.engine.speculative import SpeculativeDecoder
+
+        vocab_size = 8
+        target_probs = mx.zeros((4, vocab_size))
+        target_probs = target_probs.at[:, 7].add(100.0)
+
+        decoder = SpeculativeDecoder.__new__(SpeculativeDecoder)
+        decoder._lambda = 3
+        decoder._alpha = 0.5
+        decoder._alpha_ema = 0.9
+
+        draft_tokens = [0, 0, 0]
+        accepted = decoder._verify(draft_tokens, target_probs)
+
+        assert len(accepted) >= 1
+        assert accepted[0] == 7
+
+    def test_full_acceptance_with_shared_weights(self, shared_decoder):
+        prompt = mx.array([[1, 2, 3]])
+        shared_decoder.prefill(prompt)
+
+        accepted, _ = shared_decoder.step()
+        assert len(accepted) == 4  # 3 draft + 1 bonus
+
+    def test_cache_trimmed_on_rejection(self):
+        from olmlx.engine.speculative import SpeculativeDecoder
+
+        vocab_size, hidden_size = 32, 16
+        draft = MockModel(vocab_size, hidden_size)
+        target = MockModel(vocab_size, hidden_size)
+        decoder = SpeculativeDecoder(
+            draft_model=draft,
+            target_model=target,
+            num_speculative_tokens=4,
+        )
+
+        prompt = mx.array([[1, 2, 3]])
+        decoder.prefill(prompt)
+        accepted, _ = decoder.step()
+
+        assert decoder._cache_seq_len == 3 + len(accepted)
+        assert decoder._target_cache[0].offset == decoder._cache_seq_len
+
+    def test_reset_clears_state(self, shared_decoder):
+        prompt = mx.array([[1, 2, 3]])
+        shared_decoder.prefill(prompt)
+        shared_decoder.step()
+
+        shared_decoder.reset()
+
+        assert shared_decoder._target_cache is None
+        assert shared_decoder._draft_cache is None
+        assert shared_decoder._cache_seq_len == 0
+        assert shared_decoder._last_target_logit is None
+
+    def test_generate_step_stateless(self, shared_decoder):
+        prompt = mx.array([[1, 2, 3]])
+        accepted, num_draft = shared_decoder.generate_step(prompt)
+
+        assert len(accepted) >= 1
+        assert num_draft == 3
+
+    def test_multi_step_consistency(self):
+        from olmlx.engine.speculative import SpeculativeDecoder
+
+        vocab_size, hidden_size = 32, 16
+        draft = MockModel(vocab_size, hidden_size)
+        target = MockModel(vocab_size, hidden_size)
+        decoder = SpeculativeDecoder(
+            draft_model=draft,
+            target_model=target,
+            num_speculative_tokens=3,
+        )
+
+        prompt = mx.array([[1, 2, 3, 4, 5]])
+        decoder.prefill(prompt)
+
+        for _ in range(5):
+            accepted, _ = decoder.step()
+            assert len(accepted) >= 1
+            assert decoder._target_cache[0].offset == decoder._cache_seq_len
+
+    def test_acceptance_rate_in_valid_range(self, decoder):
+        prompt = mx.array([[1, 2, 3]])
+        decoder.generate_step(prompt)
+        assert 0 <= decoder._alpha <= 1.0

--- a/tests/test_speculative_stream_base.py
+++ b/tests/test_speculative_stream_base.py
@@ -1,0 +1,69 @@
+"""Tests for model-agnostic speculative streaming (engine/speculative_stream.py)."""
+
+import threading
+
+import pytest
+
+from tests.test_flash_speculative import MockModel
+
+
+class TestSpeculativeStreamBase:
+    """Verify that the base speculative_stream module works with SpeculativeDecoder."""
+
+    @pytest.fixture()
+    def shared_decoder(self):
+        from olmlx.engine.speculative import SpeculativeDecoder
+
+        vocab_size, hidden_size = 32, 16
+        draft = MockModel(vocab_size, hidden_size)
+        target = MockModel(vocab_size, hidden_size)
+        target.embed.weight = draft.embed.weight
+        target.lm_head.weight = draft.lm_head.weight
+        for i in range(len(draft.layers)):
+            target.layers[i] = draft.layers[i]
+        return SpeculativeDecoder(
+            draft_model=draft,
+            target_model=target,
+            num_speculative_tokens=3,
+        )
+
+    def test_stream_yields_tokens(self, shared_decoder):
+        from olmlx.engine.speculative_stream import speculative_stream_generate
+
+        cancel = threading.Event()
+        responses = list(
+            speculative_stream_generate(
+                shared_decoder, [1, 2, 3], max_tokens=5, cancel_event=cancel
+            )
+        )
+
+        assert len(responses) >= 1
+        for resp in responses:
+            assert hasattr(resp, "text")
+            assert hasattr(resp, "token")
+
+    def test_stream_respects_max_tokens(self, shared_decoder):
+        from olmlx.engine.speculative_stream import speculative_stream_generate
+
+        cancel = threading.Event()
+        responses = list(
+            speculative_stream_generate(
+                shared_decoder, [1, 2, 3], max_tokens=8, cancel_event=cancel
+            )
+        )
+
+        assert len(responses) <= 8
+
+    def test_async_stream_importable(self):
+        from olmlx.engine.speculative_stream import async_speculative_stream
+
+        assert callable(async_speculative_stream)
+
+    def test_flash_module_reexports(self):
+        """Flash speculative_stream module should re-export from base."""
+        from olmlx.engine.speculative_stream import speculative_stream_generate as base
+        from olmlx.engine.flash.speculative_stream import (
+            speculative_stream_generate as flash,
+        )
+
+        assert base is flash


### PR DESCRIPTION
## Summary

- Decouples speculative decoding from Flash inference so any model can use a draft model for faster generation
- Adds dflash-style block-diffusion decoding as an alternative speculative strategy, conditioned on target hidden states
- Extracts `SpeculativeDecoder` base class with `SpeculativeFlashDecoder` as subclass (preserves existing Flash+speculative behavior)

Closes #213

## Changes

**Phase 1 — Standard speculative decoding:**
- `engine/speculative.py` — `SpeculativeDecoder` base class + shared `verify_draft_greedy()` function
- `engine/speculative_stream.py` — streaming adapter (extracted from flash module)
- `engine/flash/speculative.py` — `SpeculativeFlashDecoder` subclass with prefetch hooks
- `config.py` — `OLMLX_EXPERIMENTAL_SPECULATIVE`, `_DRAFT_MODEL`, `_TOKENS`
- `model_manager.py` — `_load_speculative_decoder()`, `_resolve_draft_path()`, `_check_vocab_match()`

**Phase 2 — DFlash block-diffusion:**
- `engine/dflash/adapters.py` — `TargetAdapter` ABC + `Qwen3Adapter` (hidden state extraction + cache trim)
- `engine/dflash/draft_model.py` — `DFlashDraftModel` with cross-attention over target hidden states
- `engine/dflash/decoder.py` — `DFlashDecoder` (trim-based rollback, single target pass per step)
- `config.py` — `OLMLX_EXPERIMENTAL_DFLASH`, `_DRAFT_MODEL`, `_BLOCK_SIZE`

## Test plan

- [ ] `uv run pytest tests/test_speculative.py` — 11 tests for base SpeculativeDecoder
- [ ] `uv run pytest tests/test_speculative_stream_base.py` — 4 tests for streaming adapter
- [ ] `uv run pytest tests/test_dflash.py` — 15 tests for adapters, draft model, decoder
- [ ] `uv run pytest tests/test_flash_speculative.py tests/test_speculative_stream.py` — existing Flash tests still pass
- [ ] `uv run pytest tests/test_config.py` — config field defaults, env overrides, validation
- [ ] `uv run pytest tests/test_model_manager.py::TestSpeculativeLoading tests/test_model_manager.py::TestDFlashLoading` — model loading
- [ ] Full suite: 2000 tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)