### PR TITLE
ci: cancel superseded runs and merge ruff jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,22 +8,22 @@ permissions:
   contents: read
   statuses: write
 
-jobs:
-  lint:
-    name: Ruff Lint
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Ruff lint
-        run: uv sync --no-editable && uv run ruff check .
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-  format:
-    name: Ruff Format
+jobs:
+  checks:
+    name: Ruff
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install dependencies
+        run: uv sync --no-editable
+      - name: Ruff lint
+        run: uv run ruff check .
       - name: Ruff format check
-        run: uv sync --no-editable && uv run ruff format --check .
+        run: uv run ruff format --check .
 
   test:
     name: Tests


### PR DESCRIPTION
## Summary
- Add a `concurrency` group so new pushes to a PR cancel in-flight CI for the same ref.
- Merge the separate Ruff lint and format jobs into one `checks` job sharing a single `uv sync` and runner slot.

## Context
Investigated slow CI runs (often 10+ minutes). Tests themselves run in ~2min locally with coverage; the bulk of wall time on recent runs was **queue wait for the self-hosted runner** (jobs serialize since only one runner is available, and stale runs from earlier pushes competed for it). These two changes reduce queue contention without any infra changes.

## Test plan
- [ ] CI runs green on this PR
- [ ] Pushing a second commit cancels the first run