### PR TITLE
feat: add API-surface benchmark script

### DIFF
--- a/olmlx/bench/api_bench.py
+++ b/olmlx/bench/api_bench.py
@@ -163,6 +163,8 @@ class OpenAIChatAdapter:
             "temperature": 0.0,
             "seed": 42,
         }
+        if stream:
+            body["stream_options"] = {"include_usage": True}
         return "/v1/chat/completions", body, dict(_JSON_HEADERS)
 
     def parse_nonstream(self, d):
@@ -176,18 +178,25 @@ class OpenAIChatAdapter:
         )
 
     def iter_stream(self, lines):
+        usage: dict = {}
         for raw in lines:
             raw = raw.strip()
             if not raw or not raw.startswith("data:"):
                 continue
             payload = raw[len("data:") :].strip()
             if payload == "[DONE]":
-                yield StreamEvent(done=True)
+                yield StreamEvent(
+                    done=True,
+                    prompt_tokens=usage.get("prompt_tokens"),
+                    output_tokens=usage.get("completion_tokens"),
+                )
                 return
             try:
                 d = json.loads(payload)
             except json.JSONDecodeError:
                 continue
+            if d.get("usage"):
+                usage = d["usage"]
             choices = d.get("choices") or []
             if not choices:
                 continue
@@ -300,6 +309,7 @@ def run_single(
     max_tokens: int,
     stream: bool,
     timeout: float,
+    run_index: int,
 ) -> RunRecord:
     url_path, body, headers = adapter.build_request(prompt, model, max_tokens, stream)
     url = base_url.rstrip("/") + url_path
@@ -355,7 +365,12 @@ def run_single(
         if metrics.eval_duration_ns:
             tps = output_tokens / (metrics.eval_duration_ns / 1e9)
         else:
-            decode_ms = (total_ms - (ttft_ms or 0.0)) if stream else total_ms
+            if stream:
+                decode_ms = total_ms - (ttft_ms or 0.0)
+            elif metrics.prompt_eval_duration_ns:
+                decode_ms = ((total_ms * 1e6) - metrics.prompt_eval_duration_ns) / 1e6
+            else:
+                decode_ms = total_ms
             if decode_ms > 0:
                 tps = output_tokens / (decode_ms / 1000.0)
 
@@ -364,7 +379,7 @@ def run_single(
         mode="stream" if stream else "nostream",
         model=model,
         prompt=prompt.name,
-        run_index=-1,
+        run_index=run_index,
         ttft_ms=ttft_ms,
         total_ms=total_ms,
         prompt_tokens=metrics.prompt_tokens,
@@ -542,8 +557,13 @@ def build_arg_parser() -> argparse.ArgumentParser:
     return p
 
 
-def _warmup(client: httpx.Client, base_url: str, model: str, timeout: float) -> None:
-    adapter = OllamaChatAdapter()
+def _warmup(
+    client: httpx.Client,
+    base_url: str,
+    model: str,
+    timeout: float,
+    adapter: ApiAdapter,
+) -> None:
     warm = BenchPrompt(
         name="_warmup",
         category="_warmup",
@@ -582,9 +602,10 @@ def main(argv: list[str] | None = None) -> int:
 
     with httpx.Client() as client:
         for model in models:
+            warmup_adapter = adapters[0]
             for _ in range(max(0, args.warmup)):
-                print(f"[warmup] {model}", file=sys.stderr)
-                _warmup(client, args.url, model, args.timeout)
+                print(f"[warmup] {model} via {warmup_adapter.name}", file=sys.stderr)
+                _warmup(client, args.url, model, args.timeout, warmup_adapter)
             for adapter in adapters:
                 for mode in modes:
                     stream = mode == "stream"
@@ -604,8 +625,8 @@ def main(argv: list[str] | None = None) -> int:
                                 max_tokens,
                                 stream,
                                 args.timeout,
+                                run_index,
                             )
-                            rec.run_index = run_index
                             records.append(rec)
 
     summary = summarize(records)

--- a/olmlx/bench/api_bench.py
+++ b/olmlx/bench/api_bench.py
@@ -89,7 +89,10 @@ class OllamaChatAdapter:
             line = line.strip()
             if not line:
                 continue
-            d = json.loads(line)
+            try:
+                d = json.loads(line)
+            except json.JSONDecodeError:
+                continue
             if d.get("done"):
                 yield StreamEvent(
                     done=True,
@@ -138,7 +141,10 @@ class OllamaGenerateAdapter:
             line = line.strip()
             if not line:
                 continue
-            d = json.loads(line)
+            try:
+                d = json.loads(line)
+            except json.JSONDecodeError:
+                continue
             if d.get("done"):
                 yield StreamEvent(
                     done=True,
@@ -239,6 +245,7 @@ class AnthropicMessagesAdapter:
     def iter_stream(self, lines):
         current_event: str | None = None
         input_tokens: int | None = None
+        saw_done = False
         for raw in lines:
             raw = raw.rstrip("\n").rstrip("\r")
             if raw.startswith("event:"):
@@ -261,11 +268,17 @@ class AnthropicMessagesAdapter:
                             yield StreamEvent(text=text)
                 elif et == "message_delta":
                     usage = d.get("usage") or {}
+                    saw_done = True
                     yield StreamEvent(
                         done=True,
                         prompt_tokens=input_tokens,
                         output_tokens=usage.get("output_tokens"),
                     )
+                    return
+                elif et == "message_stop" and not saw_done:
+                    # Safety net: some responses (e.g. tool-use only) skip message_delta.
+                    yield StreamEvent(done=True, prompt_tokens=input_tokens)
+                    return
             elif raw == "":
                 current_event = None
 
@@ -296,9 +309,12 @@ class RunRecord:
 
 
 def _estimate_tokens(text: str) -> int:
-    # Whitespace split ≈ words; multiply by 1.3 for sub-word tokens.
     words = len(text.split())
-    return int(words * 1.3) if words else max(len(text) // 4, 0)
+    if words == 0:
+        return 0
+    # Use char/4 as a floor so long whitespace-free continuations don't under-count.
+    char_estimate = max(len(text) // 4, 1)
+    return max(int(words * 1.3), char_estimate)
 
 
 def run_single(
@@ -615,12 +631,10 @@ def main(argv: list[str] | None = None) -> int:
 
     with httpx.Client() as client:
         for model in models:
-            for warmup_adapter in adapters:
-                for _ in range(max(0, args.warmup)):
-                    print(
-                        f"[warmup] {model} via {warmup_adapter.name}", file=sys.stderr
-                    )
-                    _warmup(client, args.url, model, args.timeout, warmup_adapter)
+            # One request suffices to load the model into memory; any adapter works.
+            for _ in range(max(0, args.warmup)):
+                print(f"[warmup] {model} via {adapters[0].name}", file=sys.stderr)
+                _warmup(client, args.url, model, args.timeout, adapters[0])
             for adapter in adapters:
                 for mode in modes:
                     stream = mode == "stream"
@@ -667,7 +681,7 @@ def main(argv: list[str] | None = None) -> int:
         out_path.write_text(json.dumps(payload, indent=2))
         print(f"[saved] {out_path}", file=sys.stderr)
 
-    return 1 if records and len(errors) == len(records) else 0
+    return 1 if errors else 0
 
 
 if __name__ == "__main__":

--- a/olmlx/bench/api_bench.py
+++ b/olmlx/bench/api_bench.py
@@ -291,6 +291,7 @@ class RunRecord:
     output_tokens: int | None
     tokens_per_sec: float | None
     tokens_estimated: bool
+    tps_source: str | None
     error: str | None
 
 
@@ -325,12 +326,14 @@ def run_single(
             ) as resp:
                 resp.raise_for_status()
                 agg_text: list[str] = []
+                got_done = False
                 for ev in adapter.iter_stream(resp.iter_lines()):
                     if ev.text and ttft_ns is None:
                         ttft_ns = time.perf_counter_ns() - t_request
                     if ev.text:
                         agg_text.append(ev.text)
                     if ev.done:
+                        got_done = True
                         if ev.prompt_tokens is not None:
                             metrics.prompt_tokens = ev.prompt_tokens
                         if ev.output_tokens is not None:
@@ -341,6 +344,8 @@ def run_single(
                             metrics.eval_duration_ns = ev.eval_duration_ns
                 metrics.text = "".join(agg_text)
             t_end = time.perf_counter_ns()
+            if not got_done:
+                error = "stream ended without done event (truncated?)"
         else:
             resp = client.post(url, json=body, headers=headers, timeout=timeout)
             resp.raise_for_status()
@@ -361,18 +366,25 @@ def run_single(
         estimated = True
 
     tps: float | None = None
-    if output_tokens:
+    tps_source: str | None = None
+    if output_tokens is not None and output_tokens > 0:
         if metrics.eval_duration_ns:
             tps = output_tokens / (metrics.eval_duration_ns / 1e9)
+            tps_source = "eval_duration"
         else:
             if stream:
                 decode_ms = total_ms - (ttft_ms or 0.0)
+                tps_source = "decode_estimate"
             elif metrics.prompt_eval_duration_ns:
                 decode_ms = ((total_ms * 1e6) - metrics.prompt_eval_duration_ns) / 1e6
+                tps_source = "decode_estimate"
             else:
                 decode_ms = total_ms
+                tps_source = "rtt_fallback"
             if decode_ms > 0:
                 tps = output_tokens / (decode_ms / 1000.0)
+            else:
+                tps_source = None
 
     return RunRecord(
         api=adapter.name,
@@ -386,6 +398,7 @@ def run_single(
         output_tokens=output_tokens,
         tokens_per_sec=tps,
         tokens_estimated=estimated,
+        tps_source=tps_source,
         error=error,
     )
 
@@ -602,10 +615,12 @@ def main(argv: list[str] | None = None) -> int:
 
     with httpx.Client() as client:
         for model in models:
-            warmup_adapter = adapters[0]
-            for _ in range(max(0, args.warmup)):
-                print(f"[warmup] {model} via {warmup_adapter.name}", file=sys.stderr)
-                _warmup(client, args.url, model, args.timeout, warmup_adapter)
+            for warmup_adapter in adapters:
+                for _ in range(max(0, args.warmup)):
+                    print(
+                        f"[warmup] {model} via {warmup_adapter.name}", file=sys.stderr
+                    )
+                    _warmup(client, args.url, model, args.timeout, warmup_adapter)
             for adapter in adapters:
                 for mode in modes:
                     stream = mode == "stream"

--- a/olmlx/bench/api_bench.py
+++ b/olmlx/bench/api_bench.py
@@ -1,0 +1,638 @@
+"""Benchmark a running olmlx server across API surfaces.
+
+Targets an already-running server (default http://localhost:11434) and sweeps over
+API surface × streaming mode × model × prompt, reporting TTFT and decode throughput.
+
+Usage:
+    python -m olmlx.bench.api_bench --models qwen3:8b --apis openai-chat,anthropic-messages
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Iterator, Protocol
+
+import httpx
+
+from olmlx.bench.prompts import PROMPTS, BenchPrompt
+
+
+@dataclass
+class StreamEvent:
+    text: str = ""
+    done: bool = False
+    prompt_tokens: int | None = None
+    output_tokens: int | None = None
+    prompt_eval_duration_ns: int | None = None
+    eval_duration_ns: int | None = None
+
+
+@dataclass
+class ApiMetrics:
+    text: str = ""
+    prompt_tokens: int | None = None
+    output_tokens: int | None = None
+    prompt_eval_duration_ns: int | None = None
+    eval_duration_ns: int | None = None
+
+
+class ApiAdapter(Protocol):
+    name: str
+
+    def build_request(
+        self, prompt: BenchPrompt, model: str, max_tokens: int, stream: bool
+    ) -> tuple[str, dict, dict]: ...
+
+    def parse_nonstream(self, resp_json: dict) -> ApiMetrics: ...
+
+    def iter_stream(self, lines: Iterable[str]) -> Iterator[StreamEvent]: ...
+
+
+_JSON_HEADERS = {"Content-Type": "application/json"}
+
+
+class OllamaChatAdapter:
+    name = "ollama-chat"
+
+    def build_request(self, prompt, model, max_tokens, stream):
+        body = {
+            "model": model,
+            "stream": stream,
+            "messages": prompt.messages,
+            "options": {
+                "seed": 42,
+                "temperature": 0.0,
+                "num_predict": max_tokens,
+            },
+        }
+        return "/api/chat", body, dict(_JSON_HEADERS)
+
+    def parse_nonstream(self, d):
+        return ApiMetrics(
+            text=(d.get("message") or {}).get("content", ""),
+            prompt_tokens=d.get("prompt_eval_count"),
+            output_tokens=d.get("eval_count"),
+            prompt_eval_duration_ns=d.get("prompt_eval_duration"),
+            eval_duration_ns=d.get("eval_duration"),
+        )
+
+    def iter_stream(self, lines):
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            d = json.loads(line)
+            if d.get("done"):
+                yield StreamEvent(
+                    done=True,
+                    prompt_tokens=d.get("prompt_eval_count"),
+                    output_tokens=d.get("eval_count"),
+                    prompt_eval_duration_ns=d.get("prompt_eval_duration"),
+                    eval_duration_ns=d.get("eval_duration"),
+                )
+            else:
+                yield StreamEvent(text=(d.get("message") or {}).get("content", ""))
+
+
+class OllamaGenerateAdapter:
+    name = "ollama-generate"
+
+    @staticmethod
+    def _flatten(messages: list[dict]) -> str:
+        return "\n".join(
+            f"{m.get('role', 'user')}: {m.get('content', '')}" for m in messages
+        )
+
+    def build_request(self, prompt, model, max_tokens, stream):
+        body = {
+            "model": model,
+            "stream": stream,
+            "prompt": self._flatten(prompt.messages),
+            "options": {
+                "seed": 42,
+                "temperature": 0.0,
+                "num_predict": max_tokens,
+            },
+        }
+        return "/api/generate", body, dict(_JSON_HEADERS)
+
+    def parse_nonstream(self, d):
+        return ApiMetrics(
+            text=d.get("response", ""),
+            prompt_tokens=d.get("prompt_eval_count"),
+            output_tokens=d.get("eval_count"),
+            prompt_eval_duration_ns=d.get("prompt_eval_duration"),
+            eval_duration_ns=d.get("eval_duration"),
+        )
+
+    def iter_stream(self, lines):
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            d = json.loads(line)
+            if d.get("done"):
+                yield StreamEvent(
+                    done=True,
+                    prompt_tokens=d.get("prompt_eval_count"),
+                    output_tokens=d.get("eval_count"),
+                    prompt_eval_duration_ns=d.get("prompt_eval_duration"),
+                    eval_duration_ns=d.get("eval_duration"),
+                )
+            else:
+                yield StreamEvent(text=d.get("response", ""))
+
+
+class OpenAIChatAdapter:
+    name = "openai-chat"
+
+    def build_request(self, prompt, model, max_tokens, stream):
+        body = {
+            "model": model,
+            "messages": prompt.messages,
+            "stream": stream,
+            "max_tokens": max_tokens,
+            "temperature": 0.0,
+            "seed": 42,
+        }
+        return "/v1/chat/completions", body, dict(_JSON_HEADERS)
+
+    def parse_nonstream(self, d):
+        usage = d.get("usage") or {}
+        choices = d.get("choices") or [{}]
+        msg = (choices[0] or {}).get("message") or {}
+        return ApiMetrics(
+            text=msg.get("content") or "",
+            prompt_tokens=usage.get("prompt_tokens"),
+            output_tokens=usage.get("completion_tokens"),
+        )
+
+    def iter_stream(self, lines):
+        for raw in lines:
+            raw = raw.strip()
+            if not raw or not raw.startswith("data:"):
+                continue
+            payload = raw[len("data:") :].strip()
+            if payload == "[DONE]":
+                yield StreamEvent(done=True)
+                return
+            try:
+                d = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            choices = d.get("choices") or []
+            if not choices:
+                continue
+            delta = (choices[0] or {}).get("delta") or {}
+            text = delta.get("content") or ""
+            if text:
+                yield StreamEvent(text=text)
+
+
+class AnthropicMessagesAdapter:
+    name = "anthropic-messages"
+
+    def build_request(self, prompt, model, max_tokens, stream):
+        body = {
+            "model": model,
+            "messages": prompt.messages,
+            "max_tokens": max_tokens,
+            "stream": stream,
+            "temperature": 0.0,
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+        }
+        return "/v1/messages", body, headers
+
+    def parse_nonstream(self, d):
+        usage = d.get("usage") or {}
+        text_parts = [
+            (block.get("text") or "")
+            for block in (d.get("content") or [])
+            if block.get("type") == "text"
+        ]
+        return ApiMetrics(
+            text="".join(text_parts),
+            prompt_tokens=usage.get("input_tokens"),
+            output_tokens=usage.get("output_tokens"),
+        )
+
+    def iter_stream(self, lines):
+        current_event: str | None = None
+        input_tokens: int | None = None
+        for raw in lines:
+            raw = raw.rstrip("\n").rstrip("\r")
+            if raw.startswith("event:"):
+                current_event = raw.split(":", 1)[1].strip()
+            elif raw.startswith("data:"):
+                payload = raw[len("data:") :].strip()
+                try:
+                    d = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                et = current_event or d.get("type")
+                if et == "message_start":
+                    usage = ((d.get("message") or {}).get("usage")) or {}
+                    input_tokens = usage.get("input_tokens")
+                elif et == "content_block_delta":
+                    delta = d.get("delta") or {}
+                    if delta.get("type") == "text_delta":
+                        text = delta.get("text") or ""
+                        if text:
+                            yield StreamEvent(text=text)
+                elif et == "message_delta":
+                    usage = d.get("usage") or {}
+                    yield StreamEvent(
+                        done=True,
+                        prompt_tokens=input_tokens,
+                        output_tokens=usage.get("output_tokens"),
+                    )
+            elif raw == "":
+                current_event = None
+
+
+ADAPTERS: dict[str, type] = {
+    "ollama-chat": OllamaChatAdapter,
+    "ollama-generate": OllamaGenerateAdapter,
+    "openai-chat": OpenAIChatAdapter,
+    "anthropic-messages": AnthropicMessagesAdapter,
+}
+
+
+@dataclass
+class RunRecord:
+    api: str
+    mode: str
+    model: str
+    prompt: str
+    run_index: int
+    ttft_ms: float | None
+    total_ms: float
+    prompt_tokens: int | None
+    output_tokens: int | None
+    tokens_per_sec: float | None
+    tokens_estimated: bool
+    error: str | None
+
+
+def _estimate_tokens(text: str) -> int:
+    # Whitespace split ≈ words; multiply by 1.3 for sub-word tokens.
+    words = len(text.split())
+    return int(words * 1.3) if words else max(len(text) // 4, 0)
+
+
+def run_single(
+    client: httpx.Client,
+    base_url: str,
+    adapter: ApiAdapter,
+    prompt: BenchPrompt,
+    model: str,
+    max_tokens: int,
+    stream: bool,
+    timeout: float,
+) -> RunRecord:
+    url_path, body, headers = adapter.build_request(prompt, model, max_tokens, stream)
+    url = base_url.rstrip("/") + url_path
+    t_request = time.perf_counter_ns()
+    ttft_ns: int | None = None
+    t_end: int | None = None
+    error: str | None = None
+    metrics = ApiMetrics()
+    try:
+        if stream:
+            with client.stream(
+                "POST", url, json=body, headers=headers, timeout=timeout
+            ) as resp:
+                resp.raise_for_status()
+                agg_text: list[str] = []
+                for ev in adapter.iter_stream(resp.iter_lines()):
+                    if ev.text and ttft_ns is None:
+                        ttft_ns = time.perf_counter_ns() - t_request
+                    if ev.text:
+                        agg_text.append(ev.text)
+                    if ev.done:
+                        if ev.prompt_tokens is not None:
+                            metrics.prompt_tokens = ev.prompt_tokens
+                        if ev.output_tokens is not None:
+                            metrics.output_tokens = ev.output_tokens
+                        if ev.prompt_eval_duration_ns is not None:
+                            metrics.prompt_eval_duration_ns = ev.prompt_eval_duration_ns
+                        if ev.eval_duration_ns is not None:
+                            metrics.eval_duration_ns = ev.eval_duration_ns
+                metrics.text = "".join(agg_text)
+            t_end = time.perf_counter_ns()
+        else:
+            resp = client.post(url, json=body, headers=headers, timeout=timeout)
+            resp.raise_for_status()
+            t_end = time.perf_counter_ns()
+            metrics = adapter.parse_nonstream(resp.json())
+    except Exception as exc:
+        if t_end is None:
+            t_end = time.perf_counter_ns()
+        error = f"{type(exc).__name__}: {exc}"
+
+    total_ms = (t_end - t_request) / 1e6
+    ttft_ms = ttft_ns / 1e6 if ttft_ns is not None else None
+
+    estimated = False
+    output_tokens = metrics.output_tokens
+    if output_tokens is None and metrics.text:
+        output_tokens = _estimate_tokens(metrics.text)
+        estimated = True
+
+    tps: float | None = None
+    if output_tokens:
+        if metrics.eval_duration_ns:
+            tps = output_tokens / (metrics.eval_duration_ns / 1e9)
+        else:
+            decode_ms = (total_ms - (ttft_ms or 0.0)) if stream else total_ms
+            if decode_ms > 0:
+                tps = output_tokens / (decode_ms / 1000.0)
+
+    return RunRecord(
+        api=adapter.name,
+        mode="stream" if stream else "nostream",
+        model=model,
+        prompt=prompt.name,
+        run_index=-1,
+        ttft_ms=ttft_ms,
+        total_ms=total_ms,
+        prompt_tokens=metrics.prompt_tokens,
+        output_tokens=output_tokens,
+        tokens_per_sec=tps,
+        tokens_estimated=estimated,
+        error=error,
+    )
+
+
+def _pick_prompts(csv: str | None) -> list[BenchPrompt]:
+    by_name = {p.name: p for p in PROMPTS}
+    if not csv:
+        return list(PROMPTS)
+    out = []
+    for n in csv.split(","):
+        n = n.strip()
+        if not n:
+            continue
+        if n not in by_name:
+            raise SystemExit(f"unknown prompt: {n} (choices: {sorted(by_name)})")
+        out.append(by_name[n])
+    return out
+
+
+def _pick_apis(csv: str | None) -> list[ApiAdapter]:
+    if not csv:
+        return [cls() for cls in ADAPTERS.values()]
+    out = []
+    for n in csv.split(","):
+        n = n.strip()
+        if not n:
+            continue
+        if n not in ADAPTERS:
+            raise SystemExit(f"unknown api: {n} (choices: {sorted(ADAPTERS)})")
+        out.append(ADAPTERS[n]())
+    return out
+
+
+def _pick_modes(csv: str) -> list[str]:
+    out = []
+    for m in csv.split(","):
+        m = m.strip()
+        if not m:
+            continue
+        if m not in ("stream", "nostream"):
+            raise SystemExit(f"unknown mode: {m} (choices: stream, nostream)")
+        out.append(m)
+    if not out:
+        raise SystemExit("no modes specified")
+    return out
+
+
+def summarize(records: list[RunRecord]) -> list[dict]:
+    groups: dict[tuple, list[RunRecord]] = defaultdict(list)
+    for r in records:
+        if r.error:
+            continue
+        groups[(r.api, r.mode, r.model, r.prompt)].append(r)
+    summary = []
+    for (api, mode, model, prompt), recs in groups.items():
+        ttfts = [r.ttft_ms for r in recs if r.ttft_ms is not None]
+        tpses = [r.tokens_per_sec for r in recs if r.tokens_per_sec is not None]
+        totals = [r.total_ms for r in recs]
+        summary.append(
+            {
+                "api": api,
+                "mode": mode,
+                "model": model,
+                "prompt": prompt,
+                "runs": len(recs),
+                "ttft_p50_ms": statistics.median(ttfts) if ttfts else None,
+                "tps_p50": statistics.median(tpses) if tpses else None,
+                "total_p50_ms": statistics.median(totals) if totals else None,
+            }
+        )
+    return summary
+
+
+def _fmt(v: float | None, d: int = 2) -> str:
+    return "-" if v is None else f"{v:.{d}f}"
+
+
+def _print_table(summary: list[dict], errors: list[RunRecord]) -> None:
+    try:
+        from rich.console import Console
+        from rich.table import Table
+    except ImportError:
+        cols = (
+            "api",
+            "mode",
+            "model",
+            "prompt",
+            "runs",
+            "ttft_p50_ms",
+            "tps_p50",
+            "total_p50_ms",
+        )
+        print("\t".join(cols))
+        for row in summary:
+            print(
+                "\t".join(
+                    _fmt(row[c]) if isinstance(row[c], float) else str(row[c])
+                    for c in cols
+                )
+            )
+        if errors:
+            print(f"\n{len(errors)} errored runs", file=sys.stderr)
+        return
+    console = Console()
+    table = Table(title="olmlx API benchmark")
+    for col in (
+        "api",
+        "mode",
+        "model",
+        "prompt",
+        "runs",
+        "TTFT p50 (ms)",
+        "tok/s p50",
+        "total p50 (ms)",
+    ):
+        table.add_column(col)
+    for row in summary:
+        table.add_row(
+            row["api"],
+            row["mode"],
+            row["model"],
+            row["prompt"],
+            str(row["runs"]),
+            _fmt(row["ttft_p50_ms"]),
+            _fmt(row["tps_p50"]),
+            _fmt(row["total_p50_ms"]),
+        )
+    console.print(table)
+    if errors:
+        console.print(
+            f"[yellow]{len(errors)} errored runs — see JSON output for details[/yellow]"
+        )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m olmlx.bench.api_bench",
+        description="Benchmark a running olmlx server across API surfaces.",
+    )
+    p.add_argument(
+        "--url", default="http://localhost:11434", help="Base URL of running server"
+    )
+    p.add_argument("--models", required=True, help="Comma-separated model names")
+    p.add_argument(
+        "--apis",
+        default=None,
+        help=f"Comma-separated subset of: {','.join(ADAPTERS)}",
+    )
+    p.add_argument(
+        "--modes", default="stream,nostream", help="Comma-separated: stream,nostream"
+    )
+    p.add_argument(
+        "--prompts",
+        default=None,
+        help="Comma-separated prompt names from olmlx.bench.prompts",
+    )
+    p.add_argument("--runs", type=int, default=1, help="Repetitions per cell")
+    p.add_argument(
+        "--max-tokens", type=int, default=None, help="Override per-prompt max_tokens"
+    )
+    p.add_argument(
+        "--warmup", type=int, default=1, help="Warmup iterations per model (discarded)"
+    )
+    p.add_argument("--output", default=None, help="Explicit JSON output path")
+    p.add_argument("--no-json", action="store_true", help="Skip writing JSON")
+    p.add_argument(
+        "--timeout", type=float, default=300.0, help="Per-request timeout seconds"
+    )
+    return p
+
+
+def _warmup(client: httpx.Client, base_url: str, model: str, timeout: float) -> None:
+    adapter = OllamaChatAdapter()
+    warm = BenchPrompt(
+        name="_warmup",
+        category="_warmup",
+        messages=[{"role": "user", "content": "Hi."}],
+        max_tokens=4,
+    )
+    path, body, headers = adapter.build_request(warm, model, 4, stream=False)
+    try:
+        client.post(
+            base_url.rstrip("/") + path, json=body, headers=headers, timeout=timeout
+        )
+    except Exception as exc:  # noqa: BLE001 - warmup failures shouldn't abort the run
+        print(f"[warmup] ignored error: {exc}", file=sys.stderr)
+
+
+def _get_olmlx_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("olmlx")
+    except Exception:
+        return "unknown"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    adapters = _pick_apis(args.apis)
+    prompts = _pick_prompts(args.prompts)
+    models = [m.strip() for m in args.models.split(",") if m.strip()]
+    if not models:
+        raise SystemExit("--models is empty")
+    modes = _pick_modes(args.modes)
+
+    started_at = datetime.now(timezone.utc).isoformat()
+    records: list[RunRecord] = []
+
+    with httpx.Client() as client:
+        for model in models:
+            for _ in range(max(0, args.warmup)):
+                print(f"[warmup] {model}", file=sys.stderr)
+                _warmup(client, args.url, model, args.timeout)
+            for adapter in adapters:
+                for mode in modes:
+                    stream = mode == "stream"
+                    for prompt in prompts:
+                        for run_index in range(args.runs):
+                            max_tokens = args.max_tokens or prompt.max_tokens
+                            print(
+                                f"[run] {adapter.name} {mode} {model} {prompt.name} #{run_index}",
+                                file=sys.stderr,
+                            )
+                            rec = run_single(
+                                client,
+                                args.url,
+                                adapter,
+                                prompt,
+                                model,
+                                max_tokens,
+                                stream,
+                                args.timeout,
+                            )
+                            rec.run_index = run_index
+                            records.append(rec)
+
+    summary = summarize(records)
+    errors = [r for r in records if r.error]
+    _print_table(summary, errors)
+
+    if not args.no_json:
+        if args.output:
+            out_path = Path(args.output)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+        else:
+            out_dir = Path.home() / ".olmlx" / "bench"
+            out_dir.mkdir(parents=True, exist_ok=True)
+            ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            out_path = out_dir / f"api_bench_{ts}.json"
+        payload = {
+            "olmlx_version": _get_olmlx_version(),
+            "server_url": args.url,
+            "started_at": started_at,
+            "records": [asdict(r) for r in records],
+            "summary": summary,
+        }
+        out_path.write_text(json.dumps(payload, indent=2))
+        print(f"[saved] {out_path}", file=sys.stderr)
+
+    return 1 if records and len(errors) == len(records) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_api_bench.py
+++ b/tests/test_api_bench.py
@@ -1,0 +1,329 @@
+"""Tests for olmlx.bench.api_bench — adapter request shapes and stream parsing."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from olmlx.bench.api_bench import (
+    ADAPTERS,
+    AnthropicMessagesAdapter,
+    OllamaChatAdapter,
+    OllamaGenerateAdapter,
+    OpenAIChatAdapter,
+    RunRecord,
+    _estimate_tokens,
+    _pick_apis,
+    _pick_modes,
+    _pick_prompts,
+    summarize,
+)
+from olmlx.bench.prompts import BenchPrompt
+
+
+@pytest.fixture
+def simple_prompt() -> BenchPrompt:
+    return BenchPrompt(
+        name="t",
+        category="test",
+        messages=[{"role": "user", "content": "hello"}],
+        max_tokens=32,
+    )
+
+
+class TestOllamaChatAdapter:
+    def test_build_request_shape(self, simple_prompt):
+        path, body, headers = OllamaChatAdapter().build_request(
+            simple_prompt, "qwen3:8b", 64, stream=True
+        )
+        assert path == "/api/chat"
+        assert body["model"] == "qwen3:8b"
+        assert body["stream"] is True
+        assert body["messages"] == simple_prompt.messages
+        assert body["options"]["num_predict"] == 64
+        assert body["options"]["temperature"] == 0.0
+        assert headers["Content-Type"] == "application/json"
+
+    def test_parse_nonstream(self):
+        resp = {
+            "message": {"role": "assistant", "content": "hi there"},
+            "prompt_eval_count": 5,
+            "eval_count": 2,
+            "prompt_eval_duration": 1_000_000,
+            "eval_duration": 2_000_000,
+        }
+        m = OllamaChatAdapter().parse_nonstream(resp)
+        assert m.text == "hi there"
+        assert m.prompt_tokens == 5
+        assert m.output_tokens == 2
+        assert m.prompt_eval_duration_ns == 1_000_000
+        assert m.eval_duration_ns == 2_000_000
+
+    def test_iter_stream(self):
+        lines = [
+            json.dumps(
+                {"message": {"role": "assistant", "content": "he"}, "done": False}
+            ),
+            json.dumps(
+                {"message": {"role": "assistant", "content": "llo"}, "done": False}
+            ),
+            json.dumps(
+                {
+                    "message": {"role": "assistant", "content": ""},
+                    "done": True,
+                    "prompt_eval_count": 7,
+                    "eval_count": 3,
+                    "eval_duration": 500_000_000,
+                    "prompt_eval_duration": 100_000_000,
+                }
+            ),
+        ]
+        events = list(OllamaChatAdapter().iter_stream(iter(lines)))
+        texts = [e.text for e in events if e.text]
+        assert texts == ["he", "llo"]
+        done = [e for e in events if e.done]
+        assert len(done) == 1
+        assert done[0].output_tokens == 3
+        assert done[0].prompt_tokens == 7
+        assert done[0].eval_duration_ns == 500_000_000
+
+
+class TestOllamaGenerateAdapter:
+    def test_flatten_multi_turn(self):
+        msgs = [
+            {"role": "user", "content": "A"},
+            {"role": "assistant", "content": "B"},
+            {"role": "user", "content": "C"},
+        ]
+        out = OllamaGenerateAdapter._flatten(msgs)
+        assert "user: A" in out
+        assert "assistant: B" in out
+        assert out.endswith("user: C")
+
+    def test_build_request(self, simple_prompt):
+        path, body, _ = OllamaGenerateAdapter().build_request(
+            simple_prompt, "m", 16, stream=False
+        )
+        assert path == "/api/generate"
+        assert "prompt" in body
+        assert body["stream"] is False
+        assert body["options"]["num_predict"] == 16
+
+    def test_iter_stream(self):
+        lines = [
+            json.dumps({"response": "foo", "done": False}),
+            json.dumps(
+                {"response": "", "done": True, "eval_count": 1, "prompt_eval_count": 2}
+            ),
+        ]
+        events = list(OllamaGenerateAdapter().iter_stream(iter(lines)))
+        assert [e.text for e in events if e.text] == ["foo"]
+        done = [e for e in events if e.done][0]
+        assert done.output_tokens == 1
+        assert done.prompt_tokens == 2
+
+
+class TestOpenAIChatAdapter:
+    def test_build_request(self, simple_prompt):
+        path, body, _ = OpenAIChatAdapter().build_request(
+            simple_prompt, "m", 32, stream=True
+        )
+        assert path == "/v1/chat/completions"
+        assert body["stream"] is True
+        assert body["max_tokens"] == 32
+        assert body["messages"] == simple_prompt.messages
+
+    def test_parse_nonstream(self):
+        resp = {
+            "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
+        }
+        m = OpenAIChatAdapter().parse_nonstream(resp)
+        assert m.text == "ok"
+        assert m.prompt_tokens == 3
+        assert m.output_tokens == 4
+
+    def test_iter_stream_terminates_on_done(self):
+        lines = [
+            "data: " + json.dumps({"choices": [{"delta": {"content": "he"}}]}),
+            "",
+            "data: " + json.dumps({"choices": [{"delta": {"content": "llo"}}]}),
+            "",
+            "data: [DONE]",
+            "",
+        ]
+        events = list(OpenAIChatAdapter().iter_stream(iter(lines)))
+        assert [e.text for e in events if e.text] == ["he", "llo"]
+        assert events[-1].done is True
+
+    def test_iter_stream_skips_empty_deltas(self):
+        lines = [
+            "data: " + json.dumps({"choices": [{"delta": {"role": "assistant"}}]}),
+            "data: " + json.dumps({"choices": [{"delta": {"content": "x"}}]}),
+            "data: [DONE]",
+        ]
+        events = list(OpenAIChatAdapter().iter_stream(iter(lines)))
+        texts = [e.text for e in events if e.text]
+        assert texts == ["x"]
+
+
+class TestAnthropicMessagesAdapter:
+    def test_build_request(self, simple_prompt):
+        path, body, headers = AnthropicMessagesAdapter().build_request(
+            simple_prompt, "m", 64, stream=True
+        )
+        assert path == "/v1/messages"
+        assert body["max_tokens"] == 64
+        assert body["stream"] is True
+        assert headers.get("anthropic-version")
+
+    def test_parse_nonstream_concats_text_blocks(self):
+        resp = {
+            "content": [
+                {"type": "text", "text": "he"},
+                {"type": "tool_use", "id": "t1", "name": "f", "input": {}},
+                {"type": "text", "text": "llo"},
+            ],
+            "usage": {"input_tokens": 5, "output_tokens": 9},
+        }
+        m = AnthropicMessagesAdapter().parse_nonstream(resp)
+        assert m.text == "hello"
+        assert m.prompt_tokens == 5
+        assert m.output_tokens == 9
+
+    def test_iter_stream_sse(self):
+        def sse(event, data):
+            return [f"event: {event}", "data: " + json.dumps(data), ""]
+
+        lines: list[str] = []
+        lines += sse(
+            "message_start",
+            {
+                "type": "message_start",
+                "message": {"usage": {"input_tokens": 11, "output_tokens": 0}},
+            },
+        )
+        lines += sse(
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+        )
+        lines += sse(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "he"},
+            },
+        )
+        lines += sse(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "llo"},
+            },
+        )
+        lines += sse("content_block_stop", {"type": "content_block_stop", "index": 0})
+        lines += sse(
+            "message_delta",
+            {"type": "message_delta", "delta": {}, "usage": {"output_tokens": 22}},
+        )
+        lines += sse("message_stop", {"type": "message_stop"})
+
+        events = list(AnthropicMessagesAdapter().iter_stream(iter(lines)))
+        texts = [e.text for e in events if e.text]
+        assert texts == ["he", "llo"]
+        done = [e for e in events if e.done]
+        assert len(done) == 1
+        assert done[0].prompt_tokens == 11
+        assert done[0].output_tokens == 22
+
+
+class TestHelpers:
+    def test_estimate_tokens_nonempty(self):
+        assert _estimate_tokens("hello world foo") >= 1
+
+    def test_estimate_tokens_empty(self):
+        assert _estimate_tokens("") == 0
+
+    def test_pick_apis_default(self):
+        all_apis = _pick_apis(None)
+        assert {a.name for a in all_apis} == set(ADAPTERS.keys())
+
+    def test_pick_apis_subset(self):
+        apis = _pick_apis("openai-chat,anthropic-messages")
+        assert [a.name for a in apis] == ["openai-chat", "anthropic-messages"]
+
+    def test_pick_apis_unknown(self):
+        with pytest.raises(SystemExit):
+            _pick_apis("bogus-api")
+
+    def test_pick_prompts_all(self):
+        assert len(_pick_prompts(None)) >= 6
+
+    def test_pick_prompts_subset(self):
+        chosen = _pick_prompts("factual,coding")
+        assert [p.name for p in chosen] == ["factual", "coding"]
+
+    def test_pick_prompts_unknown(self):
+        with pytest.raises(SystemExit):
+            _pick_prompts("nope")
+
+    def test_pick_modes(self):
+        assert _pick_modes("stream,nostream") == ["stream", "nostream"]
+
+    def test_pick_modes_unknown(self):
+        with pytest.raises(SystemExit):
+            _pick_modes("blocking")
+
+
+class TestSummarize:
+    def _rec(
+        self,
+        api="openai-chat",
+        mode="stream",
+        model="m",
+        prompt="p",
+        ttft=10.0,
+        tps=50.0,
+        total=200.0,
+        error=None,
+    ):
+        return RunRecord(
+            api=api,
+            mode=mode,
+            model=model,
+            prompt=prompt,
+            run_index=0,
+            ttft_ms=ttft,
+            total_ms=total,
+            prompt_tokens=10,
+            output_tokens=20,
+            tokens_per_sec=tps,
+            tokens_estimated=False,
+            error=error,
+        )
+
+    def test_groups_by_api_mode_model_prompt(self):
+        recs = [
+            self._rec(ttft=10, tps=40),
+            self._rec(ttft=20, tps=60),
+            self._rec(api="ollama-chat", ttft=5, tps=100),
+        ]
+        s = summarize(recs)
+        assert len(s) == 2
+        openai = next(r for r in s if r["api"] == "openai-chat")
+        assert openai["runs"] == 2
+        assert openai["ttft_p50_ms"] == 15.0
+        assert openai["tps_p50"] == 50.0
+
+    def test_excludes_errored(self):
+        recs = [self._rec(), self._rec(error="boom")]
+        s = summarize(recs)
+        assert len(s) == 1
+        assert s[0]["runs"] == 1

--- a/tests/test_api_bench.py
+++ b/tests/test_api_bench.py
@@ -306,6 +306,7 @@ class TestSummarize:
             output_tokens=20,
             tokens_per_sec=tps,
             tokens_estimated=False,
+            tps_source="eval_duration",
             error=error,
         )
 


### PR DESCRIPTION
## Summary
- New `olmlx.bench.api_bench` module that targets an already-running olmlx server and benchmarks across all four API surfaces (Ollama `/api/chat`, Ollama `/api/generate`, OpenAI `/v1/chat/completions`, Anthropic `/v1/messages`) in both streaming and non-streaming modes.
- Reports TTFT, tokens/sec, and prompt-eval counts per (api, mode, model, prompt) cell as a Rich table and a JSON file under `~/.olmlx/bench/`.
- Complements the existing `olmlx.bench.runner` (which spawns its own embedded server and only exercises `/api/chat`) by enabling direct comparison across surfaces against a user-controlled server.

Run with:
```bash
uv run olmlx  # terminal 1
uv run python -m olmlx.bench.api_bench --models qwen3:8b --runs 3
```

## Test plan
- [x] `uv run pytest tests/test_api_bench.py` — 25 tests pass (adapter request shapes, NDJSON + SSE stream parsing, helpers, summarization)
- [x] `uv run ruff check` and `uv run ruff format --check` pass
- [x] `python -m olmlx.bench.api_bench --help` renders cleanly
- [ ] End-to-end smoke run against a live olmlx server with `--apis ollama-chat,openai-chat,anthropic-messages --prompts factual --runs 2` — JSON written, table prints, streaming TTFT < total for all cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)