### PR TITLE
fix(flash-moe): read quantization from raw config for text_config wrappers

### DIFF
--- a/olmlx/engine/flash/moe_bundler.py
+++ b/olmlx/engine/flash/moe_bundler.py
@@ -417,8 +417,10 @@ def bundle_moe_experts(
     index_path = model_dir / "model.safetensors.index.json"
     index = json.loads(index_path.read_text()) if index_path.exists() else None
 
-    # Detect quantization from config
-    quant_config = config.get("quantization")
+    # Detect quantization from config. mlx-community checkpoints with a
+    # `text_config` wrapper (e.g. Qwen3.5-35B-A3B-4bit) keep `quantization`
+    # at the top level, not under `text_config`, so check both.
+    quant_config = config.get("quantization") or raw_config.get("quantization")
 
     moe_layers = _detect_moe_layers(config)
     if not moe_layers:

--- a/tests/test_flash_moe_bundler.py
+++ b/tests/test_flash_moe_bundler.py
@@ -332,6 +332,43 @@ class TestBundleMoeExperts:
         ).reshape(gate_biases_orig.shape)
         np.testing.assert_array_equal(gate_biases_read, gate_biases_orig)
 
+    def test_bundle_quantization_with_text_config_wrapper(self, tmp_path):
+        """Models with a top-level `text_config` (e.g. Qwen3.5-35B-A3B-4bit) keep
+        `quantization` at the root. The bundler must still pick up bits/group_size.
+        """
+        hidden, inter, experts = 64, 32, 4
+        model_dir = _make_synthetic_moe_weights(
+            hidden, inter, experts, 1, 0, tmp_path, quantized=True
+        )
+
+        # Rewrite config: move architecture fields under `text_config`,
+        # leave `quantization` at the top level (mlx-community layout).
+        cfg_path = model_dir / "config.json"
+        flat = json.loads(cfg_path.read_text())
+        quantization = flat.pop("quantization")
+        wrapped = {"text_config": flat, "quantization": quantization}
+        cfg_path.write_text(json.dumps(wrapped))
+
+        output_dir = tmp_path / "flash_moe"
+
+        from olmlx.engine.flash.moe_bundler import (
+            MOE_HEADER_SIZE,
+            bundle_moe_experts,
+            parse_moe_header,
+        )
+
+        layouts = bundle_moe_experts(model_dir, output_dir)
+        layout = layouts[0]
+
+        with open(layout.file_path, "rb") as f:
+            header = parse_moe_header(f.read(MOE_HEADER_SIZE))
+
+        assert header["is_quantized"] is True
+        assert header["bits"] == 4
+        assert header["group_size"] == 32
+        assert layout.bits == 4
+        assert layout.group_size == 32
+
     def test_bundle_offset_table_sequential(self, tmp_path):
         """Offsets should be sequential, each expert_byte_size apart."""
         hidden, inter, experts = 64, 32, 8


### PR DESCRIPTION
## Summary
- Flash-MoE bundler missed `quantization` for mlx-community checkpoints with a `text_config` wrapper (e.g. `Qwen3.5-35B-A3B-4bit`), writing `bits=0, group_size=0` into `.flashexperts` headers and causing `gather_qmm` to fail at inference with a shape mismatch.
- Fix: fall back to `raw_config["quantization"]` when the unwrapped `config` doesn't carry it.
- Adds a regression test that mirrors the Qwen3.5 config layout (architecture under `text_config`, `quantization` at top level).

Existing bundles for affected models need to be regenerated — delete `~/.olmlx/models/<model>/flash_moe/` and re-run `olmlx flash prepare <model>`.

## Test plan
- [x] `uv run pytest tests/test_flash_moe_bundler.py` (26 passed, new test fails without the fix)
- [x] `uv run pytest tests/test_flash_moe.py tests/test_flash_moe_model.py tests/test_flash_moe_weight_store.py` (39 passed)
- [x] `uv run ruff check` / `format --check` clean
- [ ] Regenerate Qwen3.5-35B-A3B-4bit flash_moe bundle and confirm `/api/chat` returns successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)