### PR TITLE
fix(inference): resolve text args for text_config wrappers in KV estimator

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -443,15 +443,30 @@ def _estimate_kv_cache_bytes(
     # dict; the real attention fields live on ``model.language_model.args``.
     args = getattr(model, "args", None)
     args_owner: Any = model
-    if args is None or hasattr(args, "text_config"):
+    is_wrapper = (
+        args is not None
+        and hasattr(args, "text_config")
+        and not hasattr(args, "num_attention_heads")
+        and not hasattr(args, "kv_lora_rank")
+    )
+    if args is None or is_wrapper:
         lang_model = getattr(model, "language_model", None)
+        inner_args = None
         if lang_model is not None:
             inner_args = getattr(lang_model, "args", None) or getattr(
                 lang_model, "config", None
             )
-            if inner_args is not None:
-                args = inner_args
-                args_owner = lang_model
+        if inner_args is not None:
+            args = inner_args
+            args_owner = lang_model
+        elif is_wrapper:
+            # Fail loudly — otherwise we'd fall through to args.num_attention_heads
+            # on the wrapper itself and crash with an opaque AttributeError.
+            raise AttributeError(
+                "model.args is a text_config wrapper but could not resolve "
+                "inner attention config (model.language_model missing or has "
+                "no 'args'/'config')"
+            )
     if args is None:
         args = getattr(model, "config", None)
     if args is None:

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -439,13 +439,19 @@ def _estimate_kv_cache_bytes(
 
     # mlx-lm text models: model.args
     # mlx-vlm vision-language models: model.language_model.args or .config
+    # Wrapper args (e.g. Qwen3_5_MoE ModelArgs) carry only a ``text_config``
+    # dict; the real attention fields live on ``model.language_model.args``.
     args = getattr(model, "args", None)
-    if args is None:
+    args_owner: Any = model
+    if args is None or hasattr(args, "text_config"):
         lang_model = getattr(model, "language_model", None)
         if lang_model is not None:
-            args = getattr(lang_model, "args", None) or getattr(
+            inner_args = getattr(lang_model, "args", None) or getattr(
                 lang_model, "config", None
             )
+            if inner_args is not None:
+                args = inner_args
+                args_owner = lang_model
     if args is None:
         args = getattr(model, "config", None)
     if args is None:
@@ -494,15 +500,9 @@ def _estimate_kv_cache_bytes(
             _tq_ratio = sq_per_entry / fp16_per_entry
 
     # Try layer introspection for NAS/variable-attention/hybrid models.
-    # Track which sub-model owns the args so we introspect the right layers
-    # (for VLMs, args came from model.language_model — introspect that, not
-    # model.model which could be a vision encoder).
-    lang_model_component = getattr(model, "language_model", None)
-    args_owner = (
-        lang_model_component
-        if (lang_model_component is not None and getattr(model, "args", None) is None)
-        else model
-    )
+    # ``args_owner`` was set above to the component whose args we resolved
+    # (model.language_model for VLMs/wrappers, else model) so we introspect
+    # the correct layer tree and avoid hitting a vision encoder.
     inner = getattr(args_owner, "model", None)
     layers = getattr(inner, "layers", None) if inner is not None else None
     if isinstance(layers, (list, tuple)) and len(layers) > 0:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2512,6 +2512,33 @@ class TestEstimateKvCacheBytes:
         result = _estimate_kv_cache_bytes(model, 1000)
         assert result == int(131_072_000 * _inf_mod.MEMORY_SAFETY_FACTOR)
 
+    def test_vlm_text_config_wrapper_prefers_language_model_args(self):
+        """When model.args is a text_config wrapper (Qwen3.5 MoE pattern), prefer language_model.args.
+
+        Qwen3_5_MoE's top-level ModelArgs only has ``model_type`` and ``text_config``;
+        the real attention config lives at ``model.language_model.args``. The estimator
+        must not blindly use the wrapper, which would AttributeError on num_attention_heads.
+        """
+        model = MagicMock(spec=[])
+        # Wrapper args (mimics Qwen3_5_MoE.ModelArgs): has model_type + text_config,
+        # but NOT num_attention_heads / num_hidden_layers.
+        wrapper = MagicMock(spec=[])
+        wrapper.model_type = "qwen3_5_moe"
+        wrapper.text_config = {"num_hidden_layers": 64}
+        model.args = wrapper
+
+        model.language_model = MagicMock(spec=[])
+        model.language_model.args = self._make_model_args(
+            num_hidden_layers=64,
+            num_attention_heads=32,
+            num_key_value_heads=4,
+            hidden_size=5120,
+            head_dim=256,
+        )
+        # raw = 64 * 2 * 4 * 256 * 1000 * 2 = 262_144_000
+        result = _estimate_kv_cache_bytes(model, 1000)
+        assert result == int(262_144_000 * _inf_mod.MEMORY_SAFETY_FACTOR)
+
     def test_raises_when_no_args_found(self):
         """Raises AttributeError when model has no discoverable args or config."""
         model = MagicMock(spec=[])

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2545,6 +2545,25 @@ class TestEstimateKvCacheBytes:
         with pytest.raises(AttributeError, match="no 'args'"):
             _estimate_kv_cache_bytes(model, 1000)
 
+    def test_wrapper_without_language_model_raises(self):
+        """Wrapper args + no language_model → explicit error (not opaque later crash)."""
+        model = MagicMock(spec=[])
+        wrapper = MagicMock(spec=[])
+        wrapper.text_config = {"num_hidden_layers": 64}
+        model.args = wrapper
+        with pytest.raises(AttributeError, match="text_config wrapper"):
+            _estimate_kv_cache_bytes(model, 1000)
+
+    def test_wrapper_with_empty_language_model_raises(self):
+        """Wrapper args + language_model without args/config → explicit error."""
+        model = MagicMock(spec=[])
+        wrapper = MagicMock(spec=[])
+        wrapper.text_config = {"num_hidden_layers": 64}
+        model.args = wrapper
+        model.language_model = MagicMock(spec=[])
+        with pytest.raises(AttributeError, match="text_config wrapper"):
+            _estimate_kv_cache_bytes(model, 1000)
+
     def test_nas_model_with_per_layer_variable_attention(self):
         """NAS models (nemotron-nas) have per-layer variable attention.
 


### PR DESCRIPTION
## Summary
- `_estimate_kv_cache_bytes` crashed with `AttributeError: 'ModelArgs' object has no attribute 'num_attention_heads'` on Qwen3.5-MoE checkpoints, whose top-level `ModelArgs` only carries `{model_type, text_config}` — the real attention fields live on `model.language_model.args`.
- Detect the wrapper via `hasattr(args, "text_config")` and fall through to the inner args (and track the owner so layer introspection walks the text model, not a vision encoder).
- Adds a regression test (`test_vlm_text_config_wrapper_prefers_language_model_args`).

## Test plan
- [x] `uv run pytest tests/test_inference.py::TestEstimateKvCacheBytes` — 21 passed
- [x] `uv run pytest tests/test_inference.py` — 163 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)