### PR TITLE
Fix bench hang, OOM guard, and add SIGUSR1 faulthandler

### DIFF
--- a/olmlx/app.py
+++ b/olmlx/app.py
@@ -31,6 +31,14 @@ logger = logging.getLogger("olmlx")
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # SIGUSR1 dumps Python stacks of all threads to stderr — use
+    # `kill -USR1 <pid>` to diagnose hangs without needing sudo/py-spy.
+    import faulthandler
+    import signal
+    import sys
+
+    faulthandler.register(signal.SIGUSR1, file=sys.stderr, all_threads=True)
+
     # Startup
     registry = ModelRegistry()
     registry.load()

--- a/olmlx/bench/api_bench.py
+++ b/olmlx/bench/api_bench.py
@@ -608,6 +608,24 @@ def _warmup(
         print(f"[warmup] ignored error: {exc}", file=sys.stderr)
 
 
+def _unload(client: httpx.Client, base_url: str, model: str, timeout: float) -> None:
+    """Free server VRAM between models so a long sweep doesn't OOM."""
+    try:
+        resp = client.post(
+            base_url.rstrip("/") + "/api/unload",
+            json={"model": model},
+            headers=_JSON_HEADERS,
+            timeout=timeout,
+        )
+        if resp.status_code >= 400:
+            print(
+                f"[unload] {model}: HTTP {resp.status_code} {resp.text[:200]}",
+                file=sys.stderr,
+            )
+    except Exception as exc:  # noqa: BLE001 - unload best-effort
+        print(f"[unload] ignored error: {exc}", file=sys.stderr)
+
+
 def _get_olmlx_version() -> str:
     try:
         from importlib.metadata import version
@@ -657,6 +675,14 @@ def main(argv: list[str] | None = None) -> int:
                                 run_index,
                             )
                             records.append(rec)
+            model_recs = [r for r in records if r.model == model]
+            model_summary = summarize(model_recs)
+            model_errors = [r for r in model_recs if r.error]
+            print(f"\n=== per-model results: {model} ===", file=sys.stderr)
+            _print_table(model_summary, model_errors)
+            print("=== end per-model ===\n", file=sys.stderr)
+            print(f"[unload] {model}", file=sys.stderr)
+            _unload(client, args.url, model, args.timeout)
 
     summary = summarize(records)
     errors = [r for r in records if r.error]

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -188,6 +188,7 @@ def _strip_thinking_streaming(text: str, state: dict) -> str:
                 if longest_partial:
                     out_parts.append(buf[:-longest_partial])
                     buf = buf[-longest_partial:]
+                    break
                 else:
                     out_parts.append(buf)
                     buf = ""

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -66,6 +66,28 @@ class TestStripThinkingStreaming:
         assert "thinking" not in full
         assert "visible" in full
 
+    def test_passthrough_partial_think_prefix_does_not_hang(self):
+        """Regression: a buffer equal to a prefix of ``<think>`` must not loop.
+
+        In passthrough phase, when the buffered tail is itself a prefix of
+        ``<think>`` (e.g. just ``"<"``), the function used to retain the
+        tail in ``buf`` without shrinking, causing the inner ``while buf:``
+        loop to spin forever and wedge the server.
+        """
+        # First chunk long enough to exit detect phase into passthrough.
+        long_chunk = "x" * 250
+        state: dict = {}
+        _strip_thinking_streaming(long_chunk, state)
+        # Now feed a bare "<" — a legitimate prefix of "<think>".
+        out = _strip_thinking_streaming("<", state)
+        # Must return without hanging; the "<" is held for the next chunk.
+        assert out == ""
+        assert state["buffer"] == "<"
+        # Follow-up chunk that is NOT a think tag must flush cleanly.
+        out2 = _strip_thinking_streaming(" hello", state)
+        assert out2 == "< hello"
+        assert state["buffer"] == ""
+
 
 class TestOpenAIRouter:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Four independent fixes surfaced while debugging a multi-model bench sweep that had earlier OOM'd and rebooted the machine:

- **fix(openai):** `_strip_thinking_streaming` had an infinite loop when the passthrough buffer equaled a prefix of `<think>` (e.g. a lone `"<"` token). Inner `while buf:` re-assigned the same tail to `buf` and spun at 100% CPU appending empty strings — wedging the server event loop. Fix: one `break` plus a regression test that would hang without it.
- **fix(inference):** `_estimate_kv_cache_bytes` raised `AttributeError: 'ModelArgs' object has no attribute 'num_attention_heads'` for Qwen3.5 MoE and similar models that expose a thin `text_config` wrapper as `model.args`. The caller swallowed the error and logged `"KV cache pre-flight check skipped — OOM protection inactive"` on every request — silently disabling the memory guard and letting oversized models load until the box OOM'd. Fix: detect wrapper args by the absence of `num_hidden_layers` and unwrap to `model.language_model.args`; layer-introspection owner follows the same unwrap so layers are read from the right sub-model. Regression test added.
- **feat(bench):** unload models between sweeps (`POST /api/unload`) so long multi-model runs don't accumulate VRAM. Also print a per-model summary table so partial results survive an interruption.
- **chore(app):** register `SIGUSR1` faulthandler at lifespan startup. `kill -USR1 <pid>` now dumps Python stacks of all threads to stderr — how we pinpointed the openai.py infinite loop without sudo/py-spy.

## Test plan

- [x] `uv run pytest tests/test_inference.py tests/test_routers_openai.py` — 205 passed
- [x] `uv run ruff check` + `ruff format --check` on all touched files — clean
- [x] Reproduced the openai.py hang on Qwen3.5-35B-A3B-4bit, verified fix unblocks the sweep
- [x] Confirmed `pre-flight check skipped` warning count drops from 49 per run to 0 after the inference fix
- [x] Bench sweep progresses past the previously-wedged model cleanly with the OOM guard active

🤖 Generated with [Claude Code](https://claude.com/claude-code)