### PR TITLE
feat: configurable Metal sync_mode at inference-lock boundaries

### DIFF
--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     prompt_cache_disk_max_gb: Annotated[float, Field(gt=0)] = 10.0
     inference_queue_timeout: Annotated[float, Field(gt=0)] | None = 300.0
     inference_timeout: Annotated[float, Field(gt=0)] | None = None
+    sync_mode: Literal["full", "minimal", "none"] = "full"
     max_tokens_limit: Annotated[int, Field(gt=0)] = 131072
     cors_origins: list[str] = ["http://localhost:*", "http://127.0.0.1:*"]
     anthropic_models: dict[str, str] = {}

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -4,6 +4,11 @@ from typing import Annotated, Literal
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
+#: Metal sync behavior at inference-lock boundaries. Single source of truth
+#: shared by ``Settings.sync_mode``, ``ModelConfig.sync_mode``, and
+#: ``_lock_boundary_sync`` — keep them in lockstep.
+SyncMode = Literal["full", "minimal", "none"]
+
 
 class Settings(BaseSettings):
     model_config = {"env_prefix": "OLMLX_", "env_file": ".env", "extra": "ignore"}
@@ -25,7 +30,7 @@ class Settings(BaseSettings):
     prompt_cache_disk_max_gb: Annotated[float, Field(gt=0)] = 10.0
     inference_queue_timeout: Annotated[float, Field(gt=0)] | None = 300.0
     inference_timeout: Annotated[float, Field(gt=0)] | None = None
-    sync_mode: Literal["full", "minimal", "none"] = "full"
+    sync_mode: SyncMode = "full"
     max_tokens_limit: Annotated[int, Field(gt=0)] = 131072
     cors_origins: list[str] = ["http://localhost:*", "http://127.0.0.1:*"]
     anthropic_models: dict[str, str] = {}

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -729,14 +729,20 @@ async def _inference_locked(
         raise
     # Sync the default Metal stream so any pending GPU work from the previous
     # inference completes before we start a new one.
-    _lock_boundary_sync(sync_mode)
+    try:
+        _lock_boundary_sync(sync_mode)
+    except BaseException:
+        lock.release()
+        raise
     try:
         yield
     finally:
         # Sync again on exit to ensure this inference's GPU work is fully
         # complete before releasing the lock to the next caller.
-        _lock_boundary_sync(sync_mode)
-        lock.release()
+        try:
+            _lock_boundary_sync(sync_mode)
+        finally:
+            lock.release()
 
 
 @contextlib.contextmanager
@@ -1895,7 +1901,11 @@ async def _stream_completion(
         lock.release()
         raise
     # Sync default stream before starting — same purpose as _inference_locked entry.
-    _lock_boundary_sync(lm.sync_mode)
+    try:
+        _lock_boundary_sync(lm.sync_mode)
+    except BaseException:
+        lock.release()
+        raise
 
     # Everything after lock acquisition must be in try/finally so the lock is
     # always released — even if the generator is closed at a yield point
@@ -2154,8 +2164,10 @@ async def _stream_completion(
             await _schedule_deferred_inference_cleanup(stream)
         else:
             # Normal path — thread exited, safe to sync and release.
-            _lock_boundary_sync(lm.sync_mode)
-            lock.release()
+            try:
+                _lock_boundary_sync(lm.sync_mode)
+            finally:
+                lock.release()
 
 
 async def _full_completion(

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -282,24 +282,62 @@ def _get_deferred_cleanup_lock() -> asyncio.Lock:
     return _deferred_cleanup_lock
 
 
-def _safe_sync():
-    """Synchronize Metal GPU state, suppressing and logging any errors.
-
-    Also syncs the generation stream (mlx_lm/mlx_vlm use a separate stream
-    from the default stream). This is critical to prevent 'command encoder
-    already encoding' errors when the background inference thread is still
-    writing to the GPU while a new request tries to start.
-    """
+def _sync_default_stream() -> None:
     try:
         mx.synchronize()
     except Exception:
         logger.debug("mx.synchronize() failed", exc_info=True)
 
+
+def _sync_generation_streams() -> None:
     for stream in _generation_streams:
         try:
             mx.synchronize(stream)
         except Exception:
             logger.debug("generation_stream sync failed", exc_info=True)
+
+
+def _safe_sync():
+    """Synchronize Metal GPU state unconditionally, suppressing and logging errors.
+
+    Syncs both the default stream and the generation stream (mlx_lm/mlx_vlm
+    use a separate stream from the default). Callers rely on this being
+    unconditional — notably cache-eviction and deferred-cleanup paths,
+    which must sync regardless of ``settings.sync_mode``.
+    """
+    _sync_default_stream()
+    _sync_generation_streams()
+
+
+SyncMode = Literal["full", "minimal", "none"]
+
+
+def _lock_boundary_sync(mode: SyncMode | None = None) -> None:
+    """Sync Metal GPU state at inference-lock entry/exit with configurable scope.
+
+    ``mode`` resolves per call (not cached) so a per-model override wins over
+    the global default. Values:
+
+    - ``"full"`` (default): identical to ``_safe_sync`` — sync default + all
+      generation streams.
+    - ``"minimal"``: sync the default stream only; skip the generation-stream
+      loop. Safe because ``_generate_sync`` and mlx_lm's ``stream_generate``
+      already synchronize the generation stream from inside the worker thread
+      before it exits.
+    - ``"none"``: skip lock-boundary sync entirely. Only safe when the
+      inference paths relied upon (``_generate_sync`` → ``asyncio.to_thread``
+      return, or streaming ``drain_and_join``) have produced their own
+      per-request sync.
+
+    Cache-eviction and deferred-cleanup paths keep calling ``_safe_sync``
+    directly — they are not lock-boundary calls and must always synchronize.
+    """
+    effective = mode if mode is not None else settings.sync_mode
+    if effective == "none":
+        return
+    _sync_default_stream()
+    if effective == "full":
+        _sync_generation_streams()
 
 
 class ServerBusyError(RuntimeError):
@@ -657,8 +695,17 @@ async def _acquire_inference_lock(timeout_override: float | None = None):
 
 
 @contextlib.asynccontextmanager
-async def _inference_locked(timeout_override: float | None = None):
-    """Async context manager that acquires the inference lock with Metal sync on entry/exit."""
+async def _inference_locked(
+    timeout_override: float | None = None,
+    *,
+    sync_mode: SyncMode | None = None,
+):
+    """Async context manager that acquires the inference lock with Metal sync on entry/exit.
+
+    ``sync_mode`` controls lock-boundary sync behavior (see
+    ``_lock_boundary_sync``). ``None`` defers to the global
+    ``settings.sync_mode``.
+    """
     global _queue_depth
     lock = _get_inference_lock()
     await _await_deferred_cleanup()
@@ -680,13 +727,13 @@ async def _inference_locked(timeout_override: float | None = None):
         raise
     # Sync the default Metal stream so any pending GPU work from the previous
     # inference completes before we start a new one.
-    _safe_sync()
+    _lock_boundary_sync(sync_mode)
     try:
         yield
     finally:
         # Sync again on exit to ensure this inference's GPU work is fully
         # complete before releasing the lock to the next caller.
-        _safe_sync()
+        _lock_boundary_sync(sync_mode)
         lock.release()
 
 
@@ -1846,7 +1893,7 @@ async def _stream_completion(
         lock.release()
         raise
     # Sync default stream before starting — same purpose as _inference_locked entry.
-    _safe_sync()
+    _lock_boundary_sync(lm.sync_mode)
 
     # Everything after lock acquisition must be in try/finally so the lock is
     # always released — even if the generator is closed at a yield point
@@ -2105,7 +2152,7 @@ async def _stream_completion(
             await _schedule_deferred_inference_cleanup(stream)
         else:
             # Normal path — thread exited, safe to sync and release.
-            _safe_sync()
+            _lock_boundary_sync(lm.sync_mode)
             lock.release()
 
 
@@ -2122,7 +2169,7 @@ async def _full_completion(
     # cannot be safely cancelled (releasing the lock while Metal is still
     # running causes concurrent command buffer access).  Streaming handles
     # this via CancellableStream.cancel() + drain_and_join().
-    async with _inference_locked(lm.inference_queue_timeout):
+    async with _inference_locked(lm.inference_queue_timeout, sync_mode=lm.sync_mode):
         with _inference_ref(lm):
             return await _full_completion_inner(
                 lm, prompt, max_tokens, gen_kwargs, stats, images, has_tools=has_tools
@@ -2493,7 +2540,7 @@ async def generate_embeddings(
     """Generate embeddings using the model's hidden states or embed_tokens layer."""
     lm = await manager.ensure_loaded(model_name, keep_alive)
 
-    async with _inference_locked(lm.inference_queue_timeout):
+    async with _inference_locked(lm.inference_queue_timeout, sync_mode=lm.sync_mode):
         with _inference_ref(lm):
             embeddings = []
 

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -2598,7 +2598,11 @@ async def generate_embeddings(
 
                 embeddings.append(embedding.tolist())
 
-            # Defensive sync — _inference_locked exit also syncs, but this
-            # ensures embedding tensors are fully evaluated before .tolist().
+            # Load-bearing when sync_mode="none": this function runs
+            # synchronously under _inference_locked with no worker thread,
+            # so the lock-boundary exit sync may be skipped. This
+            # mx.synchronize() is then the only Metal sync before the lock
+            # is released — do not remove without providing an equivalent
+            # barrier.
             mx.synchronize()
             return embeddings

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -2602,9 +2602,12 @@ async def generate_embeddings(
             # synchronously under _inference_locked with no worker thread,
             # so the lock-boundary exit sync may be skipped. This sync is
             # then the only Metal barrier before the lock is released —
-            # do not remove without providing an equivalent barrier. Use
-            # _sync_default_stream() so a Metal exception is suppressed
-            # and logged rather than surfaced as a 500 after the
-            # embeddings have already been computed and .tolist()'d.
-            _sync_default_stream()
+            # do not remove without providing an equivalent barrier.
+            # Suppress+log rather than raise: the embeddings have already
+            # been .tolist()'d so the caller should still get the result;
+            # a Metal error here will surface on the next request.
+            try:
+                mx.synchronize()
+            except Exception:
+                logger.debug("embeddings post-compute sync failed", exc_info=True)
             return embeddings

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -741,6 +741,12 @@ async def _inference_locked(
         # complete before releasing the lock to the next caller.
         try:
             _lock_boundary_sync(sync_mode)
+        except BaseException:
+            # Do NOT re-raise: that would mask any exception propagating
+            # from the yield body. Fall back to _safe_sync() so unknown
+            # modes fail-safe (sync anyway) instead of fail-open (no sync).
+            logger.error("exit _lock_boundary_sync failed", exc_info=True)
+            _safe_sync()
         finally:
             lock.release()
 
@@ -2166,6 +2172,17 @@ async def _stream_completion(
             # Normal path — thread exited, safe to sync and release.
             try:
                 _lock_boundary_sync(lm.sync_mode)
+            except BaseException:
+                # Don't re-raise: a stream-body exception is already mid-
+                # propagation through the outer finally, and masking it
+                # with an unknown-mode ValueError would erase the cause.
+                # Fall back to _safe_sync() so we still sync before
+                # releasing the lock.
+                logger.error(
+                    "exit _lock_boundary_sync failed in _stream_completion",
+                    exc_info=True,
+                )
+                _safe_sync()
             finally:
                 lock.release()
 
@@ -2609,5 +2626,12 @@ async def generate_embeddings(
             try:
                 mx.synchronize()
             except Exception:
-                logger.debug("embeddings post-compute sync failed", exc_info=True)
+                # WARNING, not DEBUG: under sync_mode="none" this is the
+                # only Metal barrier in the path; a silent failure here
+                # typically surfaces as an uncatchable Metal crash on the
+                # next inference. Operators need to see it now, not after.
+                logger.warning(
+                    "embeddings post-compute sync failed — next inference may crash",
+                    exc_info=True,
+                )
             return embeddings

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -321,10 +321,24 @@ def _lock_boundary_sync(mode: SyncMode | None = None) -> None:
       loop. Safe because ``_generate_sync`` and mlx_lm's ``stream_generate``
       already synchronize the generation stream from inside the worker thread
       before it exits.
-    - ``"none"``: skip lock-boundary sync entirely. Only safe when the
-      inference paths relied upon (``_generate_sync`` → ``asyncio.to_thread``
-      return, or streaming ``drain_and_join``) have produced their own
-      per-request sync.
+    - ``"none"``: skip lock-boundary sync entirely. Safety depends on
+      per-path guarantees that Metal work is complete before the lock
+      releases:
+
+      * ``_full_completion`` has ``_generate_sync`` → ``asyncio.to_thread``
+        which blocks until the worker thread returns, and the thread
+        calls ``mx.synchronize(generation_stream)`` before exit (see
+        ``_generate_sync`` body below).
+      * ``_stream_completion`` waits for ``drain_and_join``; mlx_lm's
+        ``stream_generate`` synchronizes the generation stream inside
+        its worker thread before exit. **This is an assumption about
+        mlx_lm internals** — if that guarantee ever changes upstream,
+        streaming under ``sync_mode="none"`` can reintroduce the
+        "command encoder already encoding" Metal crash that the
+        lock-boundary sync was added to prevent.
+      * ``generate_embeddings`` runs synchronously with no worker thread
+        and has its own load-bearing ``mx.synchronize()`` fallback
+        specifically because the above assumption doesn't apply there.
 
     Cache-eviction and deferred-cleanup paths keep calling ``_safe_sync``
     directly — they are not lock-boundary calls and must always synchronize.
@@ -732,6 +746,12 @@ async def _inference_locked(
     try:
         _lock_boundary_sync(sync_mode)
     except BaseException:
+        # BaseException (not ValueError): this handler re-raises, so
+        # KeyboardInterrupt / SystemExit from mx.synchronize must be
+        # caught here long enough to release the lock before they
+        # propagate. Asymmetric with the exit handler below, which
+        # narrows to ValueError because it suppresses (the broader catch
+        # there would silently swallow shutdown signals).
         lock.release()
         raise
     try:
@@ -1913,6 +1933,10 @@ async def _stream_completion(
     try:
         _lock_boundary_sync(lm.sync_mode)
     except BaseException:
+        # BaseException (re-raise path): see _inference_locked entry for
+        # the rationale. Summary: must release the lock on any exception,
+        # including KeyboardInterrupt / SystemExit, so the shutdown
+        # signal can propagate without leaving the lock held.
         lock.release()
         raise
 

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -741,10 +741,13 @@ async def _inference_locked(
         # complete before releasing the lock to the next caller.
         try:
             _lock_boundary_sync(sync_mode)
-        except BaseException:
+        except ValueError:
             # Do NOT re-raise: that would mask any exception propagating
             # from the yield body. Fall back to _safe_sync() so unknown
             # modes fail-safe (sync anyway) instead of fail-open (no sync).
+            # Narrow to ValueError (not BaseException) so KeyboardInterrupt /
+            # SystemExit from mx.synchronize still propagate — those must
+            # not be silently swallowed during shutdown.
             logger.error("exit _lock_boundary_sync failed", exc_info=True)
             _safe_sync()
         finally:
@@ -2172,12 +2175,14 @@ async def _stream_completion(
             # Normal path — thread exited, safe to sync and release.
             try:
                 _lock_boundary_sync(lm.sync_mode)
-            except BaseException:
+            except ValueError:
                 # Don't re-raise: a stream-body exception is already mid-
                 # propagation through the outer finally, and masking it
                 # with an unknown-mode ValueError would erase the cause.
                 # Fall back to _safe_sync() so we still sync before
-                # releasing the lock.
+                # releasing the lock. Narrow to ValueError so interrupt
+                # signals (KeyboardInterrupt / SystemExit) from
+                # mx.synchronize propagate instead of being swallowed.
                 logger.error(
                     "exit _lock_boundary_sync failed in _stream_completion",
                     exc_info=True,

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -2600,9 +2600,11 @@ async def generate_embeddings(
 
             # Load-bearing when sync_mode="none": this function runs
             # synchronously under _inference_locked with no worker thread,
-            # so the lock-boundary exit sync may be skipped. This
-            # mx.synchronize() is then the only Metal sync before the lock
-            # is released — do not remove without providing an equivalent
-            # barrier.
-            mx.synchronize()
+            # so the lock-boundary exit sync may be skipped. This sync is
+            # then the only Metal barrier before the lock is released —
+            # do not remove without providing an equivalent barrier. Use
+            # _sync_default_stream() so a Metal exception is suppressed
+            # and logged rather than surfaced as a 500 after the
+            # embeddings have already been computed and .tolist()'d.
+            _sync_default_stream()
             return embeddings

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -19,7 +19,7 @@ from olmlx.engine.model_manager import (
     ModelManager,
     parse_keep_alive,
 )
-from olmlx.config import settings
+from olmlx.config import SyncMode, settings
 from olmlx.utils import memory as memory_utils
 
 try:
@@ -309,9 +309,6 @@ def _safe_sync():
     _sync_generation_streams()
 
 
-SyncMode = Literal["full", "minimal", "none"]
-
-
 def _lock_boundary_sync(mode: SyncMode | None = None) -> None:
     """Sync Metal GPU state at inference-lock entry/exit with configurable scope.
 
@@ -335,9 +332,14 @@ def _lock_boundary_sync(mode: SyncMode | None = None) -> None:
     effective = mode if mode is not None else settings.sync_mode
     if effective == "none":
         return
-    _sync_default_stream()
+    if effective == "minimal":
+        _sync_default_stream()
+        return
     if effective == "full":
+        _sync_default_stream()
         _sync_generation_streams()
+        return
+    raise ValueError(f"Unknown sync_mode: {effective!r}")
 
 
 class ServerBusyError(RuntimeError):

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -320,7 +320,10 @@ def _lock_boundary_sync(mode: SyncMode | None = None) -> None:
     - ``"minimal"``: sync the default stream only; skip the generation-stream
       loop. Safe because ``_generate_sync`` and mlx_lm's ``stream_generate``
       already synchronize the generation stream from inside the worker thread
-      before it exits.
+      before it exits. **Same mlx_lm-internals assumption as ``"none"`` for
+      the generation stream** — if mlx_lm ever drops that guarantee,
+      ``"minimal"`` streaming is as unsafe as ``"none"`` for the
+      generation-stream part (the default stream is still synced here).
     - ``"none"``: skip lock-boundary sync entirely. Safety depends on
       per-path guarantees that Metal work is complete before the lock
       releases:
@@ -2660,7 +2663,7 @@ async def generate_embeddings(
                 # typically surfaces as an uncatchable Metal crash on the
                 # next inference. Operators need to see it now, not after.
                 logger.warning(
-                    "embeddings post-compute sync failed — next inference may crash",
+                    "embeddings post-compute sync failed — next inference will crash",
                     exc_info=True,
                 )
             return embeddings

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -12,11 +12,11 @@ import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 import mlx.core as mx
 
-from olmlx.config import experimental as global_experimental
+from olmlx.config import SyncMode, experimental as global_experimental
 from olmlx.config import resolve_experimental, settings
 from olmlx.engine.registry import ModelRegistry
 from olmlx.utils import memory as memory_utils
@@ -520,7 +520,7 @@ class LoadedModel:
     default_options: dict = field(default_factory=dict)
     inference_queue_timeout: float | None = None
     inference_timeout: float | None = None
-    sync_mode: Literal["full", "minimal", "none"] | None = None
+    sync_mode: SyncMode | None = None
 
     def __post_init__(self):
         if self.prompt_cache_store is None:

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -12,7 +12,7 @@ import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import mlx.core as mx
 
@@ -520,6 +520,7 @@ class LoadedModel:
     default_options: dict = field(default_factory=dict)
     inference_queue_timeout: float | None = None
     inference_timeout: float | None = None
+    sync_mode: Literal["full", "minimal", "none"] | None = None
 
     def __post_init__(self):
         if self.prompt_cache_store is None:
@@ -906,6 +907,7 @@ class ModelManager:
                         default_options=dict(model_config.options),
                         inference_queue_timeout=model_config.inference_queue_timeout,
                         inference_timeout=model_config.inference_timeout,
+                        sync_mode=model_config.sync_mode,
                     )
                     self._probe_cache_trim_support(lm)
                     self._loaded[normalized] = lm

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -8,11 +8,11 @@ import threading
 import dataclasses
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, get_args
 
 import logging
 
-from olmlx.config import settings
+from olmlx.config import SyncMode, settings
 
 logger = logging.getLogger(__name__)
 
@@ -132,15 +132,15 @@ def _validate_timeout(name: str, value: Any) -> float:
     return float(value)
 
 
-_VALID_SYNC_MODES: frozenset[str] = frozenset({"full", "minimal", "none"})
+_VALID_SYNC_MODES: frozenset[str] = frozenset(get_args(SyncMode))
 
 
-def _validate_sync_mode(value: Any) -> str:
+def _validate_sync_mode(value: Any) -> SyncMode:
     if not isinstance(value, str) or value not in _VALID_SYNC_MODES:
         raise ValueError(
             f"'sync_mode' must be one of {sorted(_VALID_SYNC_MODES)}, got {value!r}"
         )
-    return value
+    return value  # type: ignore[return-value]
 
 
 def _validate_keep_alive(value: str) -> None:
@@ -179,7 +179,7 @@ class ModelConfig:
     #: "minimal" (skip mlx_lm/mlx_vlm generation-stream sync), or "none"
     #: (skip lock-boundary sync entirely). None means use the global
     #: ``settings.sync_mode``.
-    sync_mode: Literal["full", "minimal", "none"] | None = None
+    sync_mode: SyncMode | None = None
     #: Unrecognized keys from the JSON entry, preserved for round-trip fidelity.
     _extra: dict[str, Any] = field(default_factory=dict, repr=False)
 

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -8,7 +8,7 @@ import threading
 import dataclasses
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import logging
 
@@ -132,6 +132,17 @@ def _validate_timeout(name: str, value: Any) -> float:
     return float(value)
 
 
+_VALID_SYNC_MODES: frozenset[str] = frozenset({"full", "minimal", "none"})
+
+
+def _validate_sync_mode(value: Any) -> str:
+    if not isinstance(value, str) or value not in _VALID_SYNC_MODES:
+        raise ValueError(
+            f"'sync_mode' must be one of {sorted(_VALID_SYNC_MODES)}, got {value!r}"
+        )
+    return value
+
+
 def _validate_keep_alive(value: str) -> None:
     """Validate keep_alive format at parse time."""
     import re
@@ -164,6 +175,11 @@ class ModelConfig:
     keep_alive: str | None = None
     inference_queue_timeout: float | None = None
     inference_timeout: float | None = None
+    #: Metal sync behavior at inference lock boundaries: "full" (default),
+    #: "minimal" (skip mlx_lm/mlx_vlm generation-stream sync), or "none"
+    #: (skip lock-boundary sync entirely). None means use the global
+    #: ``settings.sync_mode``.
+    sync_mode: Literal["full", "minimal", "none"] | None = None
     #: Unrecognized keys from the JSON entry, preserved for round-trip fidelity.
     _extra: dict[str, Any] = field(default_factory=dict, repr=False)
 
@@ -202,6 +218,12 @@ class ModelConfig:
                 if it_raw is not None
                 else None
             )
+            sync_mode_raw = entry.get("sync_mode")
+            sync_mode = (
+                _validate_sync_mode(sync_mode_raw)
+                if sync_mode_raw is not None
+                else None
+            )
             extra = {k: v for k, v in entry.items() if k not in _KNOWN_CONFIG_KEYS}
             return cls(
                 hf_path=hf_path,
@@ -210,6 +232,7 @@ class ModelConfig:
                 keep_alive=keep_alive,
                 inference_queue_timeout=inference_queue_timeout,
                 inference_timeout=inference_timeout,
+                sync_mode=sync_mode,
                 _extra=extra,
             )
         raise TypeError(
@@ -224,6 +247,7 @@ class ModelConfig:
             and self.keep_alive is None
             and self.inference_queue_timeout is None
             and self.inference_timeout is None
+            and self.sync_mode is None
             and not self._extra
         ):
             return self.hf_path
@@ -239,6 +263,8 @@ class ModelConfig:
             result["inference_queue_timeout"] = self.inference_queue_timeout
         if self.inference_timeout is not None:
             result["inference_timeout"] = self.inference_timeout
+        if self.sync_mode is not None:
+            result["sync_mode"] = self.sync_mode
         # Filter known keys defensively — from_entry() already excludes them,
         # but _extra can be set directly via ModelConfig construction.
         result.update(

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2082,6 +2082,39 @@ class TestInferenceLocked:
             for call in mock_mx.synchronize.call_args_list:
                 assert call.args == ()
 
+    @pytest.mark.asyncio
+    async def test_lock_released_if_entry_sync_raises(self):
+        """If entry _lock_boundary_sync raises, the inference lock must be released."""
+        assert not _inference_lock.locked()
+        with patch(
+            "olmlx.engine.inference._lock_boundary_sync",
+            side_effect=ValueError("boom"),
+        ):
+            with pytest.raises(ValueError, match="boom"):
+                async with _inference_locked():
+                    pass
+        assert not _inference_lock.locked()
+
+    @pytest.mark.asyncio
+    async def test_lock_released_if_exit_sync_raises(self):
+        """If exit _lock_boundary_sync raises in the finally block, lock must
+        still be released (inner try/finally)."""
+        assert not _inference_lock.locked()
+        calls = {"n": 0}
+
+        def side_effect(*_a, **_kw):
+            calls["n"] += 1
+            if calls["n"] == 2:  # only raise on exit sync
+                raise ValueError("exit boom")
+
+        with patch(
+            "olmlx.engine.inference._lock_boundary_sync", side_effect=side_effect
+        ):
+            with pytest.raises(ValueError, match="exit boom"):
+                async with _inference_locked():
+                    pass
+        assert not _inference_lock.locked()
+
 
 class TestInferenceLockedWaitsDeferredCleanup:
     @pytest.mark.asyncio

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2022,6 +2022,14 @@ class TestLockBoundarySync:
             _lock_boundary_sync("full")  # should not raise
             _lock_boundary_sync("minimal")  # should not raise
 
+    def test_unknown_mode_raises(self):
+        """Unknown modes must raise ValueError instead of silently falling
+        through to a default — prevents silent drift if a new mode is added
+        to SyncMode without updating this helper."""
+        with patch("olmlx.engine.inference.mx"):
+            with pytest.raises(ValueError, match="Unknown sync_mode"):
+                _lock_boundary_sync("sometimes")  # type: ignore[arg-type]
+
 
 class TestInferenceLocked:
     @pytest.mark.asyncio
@@ -3017,6 +3025,7 @@ class TestKvCachePreflightCheck:
         lm.active_refs = 0
         lm.inference_timeout = None
         lm.inference_queue_timeout = None
+        lm.sync_mode = None
         return lm
 
     @pytest.mark.asyncio
@@ -3060,6 +3069,7 @@ class TestKvCachePreflightCheck:
                 mock_settings.memory_limit_fraction = 0.5  # 12GB limit
                 mock_settings.prompt_cache = False
                 mock_settings.inference_timeout = None
+                mock_settings.sync_mode = "full"
 
                 gen = _inf_mod._stream_completion(
                     mock_lm, list(range(22000)), 512, {}, stats
@@ -3131,6 +3141,7 @@ class TestKvCachePreflightCheck:
                 mock_settings.prompt_cache = False
                 mock_settings.default_keep_alive = "5m"
                 mock_settings.inference_timeout = None
+                mock_settings.sync_mode = "full"
 
                 gen = _inf_mod._stream_completion(
                     mock_lm, list(range(100)), 512, {}, stats
@@ -3703,6 +3714,7 @@ class TestInferenceTimeout:
             mock_settings.inference_timeout = None
             mock_settings.prompt_cache = False
             mock_settings.memory_limit_fraction = 0.9
+            mock_settings.sync_mode = "full"
             gen = await generate_completion(
                 mock_manager,
                 "qwen3",
@@ -3764,6 +3776,7 @@ class TestInferenceTimeout:
             mock_settings.inference_timeout = 0.1  # Global 100ms timeout
             mock_settings.prompt_cache = False
             mock_settings.memory_limit_fraction = 0.9
+            mock_settings.sync_mode = "full"
             gen = await generate_completion(
                 mock_manager,
                 "qwen3",

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1856,6 +1856,31 @@ class TestGenerateEmbeddings:
         result = await generate_embeddings(mock_manager, "qwen3", ["hello", "world"])
         assert len(result) == 2
 
+    @pytest.mark.asyncio
+    async def test_sync_mode_none_still_syncs_metal(self, mock_manager):
+        """With lm.sync_mode='none', the lock-boundary sync is skipped, but
+        the inline load-bearing mx.synchronize() at the tail of
+        generate_embeddings must still run — it's the only Metal barrier
+        before the inference lock is released. Guards against a future
+        refactor that wraps that call in a `sync_mode != "none"` check.
+        """
+        import mlx.core as mx
+
+        self._setup_tokenizer(mock_manager)
+
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.sync_mode = "none"
+        model = lm.model
+        model.model = MagicMock()
+        model.model.embed_tokens = MagicMock(return_value=mx.zeros((1, 3, 4)))
+
+        with patch.object(_inf_mod.mx, "synchronize") as mock_sync:
+            result = await generate_embeddings(mock_manager, "qwen3", ["hello"])
+        assert len(result) == 1
+        # sync_mode="none" skips entry + exit _lock_boundary_sync, so the
+        # only synchronize() call should be the inline load-bearing one.
+        assert mock_sync.call_count == 1
+
 
 class TestStreamCancellationHoldsLock:
     @pytest.mark.asyncio
@@ -3954,7 +3979,7 @@ class TestStreamCompletionLockLeakOnSyncFailure:
             mock_settings.inference_timeout = None
             mock_settings.prompt_cache = False
             mock_settings.memory_limit_fraction = 0.9
-            mock_settings.sync_mode = "full"  # per-model None override wins
+            mock_settings.sync_mode = "full"  # per-model "none" wins over global "full"
             gen = await generate_completion(mock_manager, "qwen3", "Hello", stream=True)
             async for _ in gen:
                 pass

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2128,9 +2128,11 @@ class TestInferenceLocked:
         assert not _inference_lock.locked()
 
     @pytest.mark.asyncio
-    async def test_lock_released_if_exit_sync_raises(self):
-        """If exit _lock_boundary_sync raises in the finally block, lock must
-        still be released (inner try/finally)."""
+    async def test_exit_sync_raise_is_suppressed_and_safe_sync_runs(self):
+        """If exit _lock_boundary_sync raises (unknown mode), the error must
+        be caught, _safe_sync() must run as a fail-safe fallback, and the
+        lock must be released. No exception should propagate from an
+        otherwise-successful body."""
         assert not _inference_lock.locked()
         calls = {"n": 0}
 
@@ -2139,12 +2141,44 @@ class TestInferenceLocked:
             if calls["n"] == 2:  # only raise on exit sync
                 raise ValueError("exit boom")
 
-        with patch(
-            "olmlx.engine.inference._lock_boundary_sync", side_effect=side_effect
+        with (
+            patch(
+                "olmlx.engine.inference._lock_boundary_sync", side_effect=side_effect
+            ),
+            patch("olmlx.engine.inference._safe_sync") as mock_safe_sync,
         ):
-            with pytest.raises(ValueError, match="exit boom"):
+            # No exception should escape — the exit-sync raise is caught.
+            async with _inference_locked():
+                pass
+        assert not _inference_lock.locked()
+        mock_safe_sync.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exit_sync_raise_does_not_mask_body_exception(self):
+        """If both the body and exit _lock_boundary_sync raise, the body's
+        exception must propagate (not the sync ValueError). Python's
+        default finally-semantics would replace the body exception with
+        the sync one — this test guards against that regression."""
+        assert not _inference_lock.locked()
+        calls = {"n": 0}
+
+        def side_effect(*_a, **_kw):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise ValueError("exit boom")
+
+        class BodyError(RuntimeError):
+            pass
+
+        with (
+            patch(
+                "olmlx.engine.inference._lock_boundary_sync", side_effect=side_effect
+            ),
+            patch("olmlx.engine.inference._safe_sync"),
+        ):
+            with pytest.raises(BodyError, match="body failed"):
                 async with _inference_locked():
-                    pass
+                    raise BodyError("body failed")
         assert not _inference_lock.locked()
 
 
@@ -3920,10 +3954,11 @@ class TestStreamCompletionLockLeakOnSyncFailure:
         assert not _inference_lock.locked()
 
     @pytest.mark.asyncio
-    async def test_lock_released_if_exit_sync_raises(self, mock_manager):
-        """If _lock_boundary_sync raises during the normal-cleanup path after
-        the stream drains, the inference lock must still be released via the
-        inner try/finally."""
+    async def test_exit_sync_raise_is_suppressed_and_safe_sync_runs(self, mock_manager):
+        """If exit _lock_boundary_sync raises during normal cleanup, the
+        streaming path must catch it, run _safe_sync() as a fail-safe
+        fallback, and release the lock. No exception should propagate
+        from a successful stream body."""
         assert not _inference_lock.locked()
         call_count = {"n": 0}
 
@@ -3943,6 +3978,7 @@ class TestStreamCompletionLockLeakOnSyncFailure:
             patch(
                 "olmlx.engine.inference._lock_boundary_sync", side_effect=side_effect
             ),
+            patch("olmlx.engine.inference._safe_sync") as mock_safe_sync,
         ):
             mock_settings.inference_queue_timeout = None
             mock_settings.inference_timeout = None
@@ -3950,12 +3986,13 @@ class TestStreamCompletionLockLeakOnSyncFailure:
             mock_settings.memory_limit_fraction = 0.9
             mock_settings.sync_mode = "full"
             gen = await generate_completion(mock_manager, "qwen3", "Hello", stream=True)
-            with pytest.raises(ValueError, match="exit boom"):
-                async for _ in gen:
-                    pass
+            # No exception should escape — the exit-sync raise is caught.
+            async for _ in gen:
+                pass
         assert not _inference_lock.locked()
         # Entry + exit = exactly 2 lock_boundary_sync calls in the success path.
         assert call_count["n"] == 2
+        mock_safe_sync.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_sync_mode_none_skips_lock_boundary_sync(self, mock_manager):

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -3825,3 +3825,102 @@ class TestInferenceTimeout:
         assert done_chunk.get("done_reason") == "timeout"
         text_chunks = [c for c in chunks if not c.get("done")]
         assert 0 < len(text_chunks) < 20
+
+
+class TestStreamCompletionLockLeakOnSyncFailure:
+    """_stream_completion must release the inference lock even if a
+    _lock_boundary_sync call raises. Mirrors the _inference_locked lock-leak
+    regression tests."""
+
+    def _mock_stream(self, n_tokens: int = 3):
+        mock_stream = MagicMock(spec=CancellableStream)
+        mock_stream.drain_and_join = AsyncMock()
+        mock_stream._thread = None
+        tokens = [
+            StreamToken(
+                text=f"tok{i}",
+                token=i,
+                prompt_tokens=5,
+                generation_tokens=i + 1,
+                prompt_tps=100.0,
+                generation_tps=50.0,
+            )
+            for i in range(n_tokens)
+        ]
+        token_iter = iter(tokens)
+
+        async def anext_impl():
+            try:
+                return next(token_iter)
+            except StopIteration:
+                raise StopAsyncIteration
+
+        mock_stream.__aiter__ = lambda self: self
+        mock_stream.__anext__ = lambda self: anext_impl()
+        return mock_stream
+
+    @pytest.mark.asyncio
+    async def test_lock_released_if_entry_sync_raises(self, mock_manager):
+        """If _lock_boundary_sync raises on stream entry, the inference lock
+        must not leak."""
+        assert not _inference_lock.locked()
+        with (
+            patch("olmlx.engine.inference.mx"),
+            patch("olmlx.engine.inference.settings") as mock_settings,
+            patch(
+                "olmlx.engine.inference.async_mlx_stream",
+                return_value=self._mock_stream(),
+            ),
+            patch(
+                "olmlx.engine.inference._lock_boundary_sync",
+                side_effect=ValueError("entry boom"),
+            ),
+        ):
+            mock_settings.inference_queue_timeout = None
+            mock_settings.inference_timeout = None
+            mock_settings.prompt_cache = False
+            mock_settings.memory_limit_fraction = 0.9
+            mock_settings.sync_mode = "full"
+            gen = await generate_completion(mock_manager, "qwen3", "Hello", stream=True)
+            with pytest.raises(ValueError, match="entry boom"):
+                async for _ in gen:
+                    pass
+        assert not _inference_lock.locked()
+
+    @pytest.mark.asyncio
+    async def test_lock_released_if_exit_sync_raises(self, mock_manager):
+        """If _lock_boundary_sync raises during the normal-cleanup path after
+        the stream drains, the inference lock must still be released via the
+        inner try/finally."""
+        assert not _inference_lock.locked()
+        call_count = {"n": 0}
+
+        def side_effect(*_a, **_kw):
+            call_count["n"] += 1
+            # Let entry sync pass; raise only on exit sync (second call).
+            if call_count["n"] >= 2:
+                raise ValueError("exit boom")
+
+        with (
+            patch("olmlx.engine.inference.mx"),
+            patch("olmlx.engine.inference.settings") as mock_settings,
+            patch(
+                "olmlx.engine.inference.async_mlx_stream",
+                return_value=self._mock_stream(),
+            ),
+            patch(
+                "olmlx.engine.inference._lock_boundary_sync", side_effect=side_effect
+            ),
+        ):
+            mock_settings.inference_queue_timeout = None
+            mock_settings.inference_timeout = None
+            mock_settings.prompt_cache = False
+            mock_settings.memory_limit_fraction = 0.9
+            mock_settings.sync_mode = "full"
+            gen = await generate_completion(mock_manager, "qwen3", "Hello", stream=True)
+            with pytest.raises(ValueError, match="exit boom"):
+                async for _ in gen:
+                    pass
+        assert not _inference_lock.locked()
+        # Entry + exit = exactly 2 lock_boundary_sync calls in the success path.
+        assert call_count["n"] == 2

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1877,9 +1877,14 @@ class TestGenerateEmbeddings:
         with patch.object(_inf_mod.mx, "synchronize") as mock_sync:
             result = await generate_embeddings(mock_manager, "qwen3", ["hello"])
         assert len(result) == 1
-        # sync_mode="none" skips entry + exit _lock_boundary_sync, so the
-        # only synchronize() call should be the inline load-bearing one.
-        assert mock_sync.call_count == 1
+        # Under sync_mode="none" the lock-boundary _lock_boundary_sync() calls
+        # are no-ops (they return before calling mx.synchronize), so any
+        # synchronize() we observe here must come from the inline
+        # load-bearing fallback at the tail of generate_embeddings. Use
+        # >= 1 rather than == N — the meaningful invariant is "at least one
+        # Metal barrier fired", not an exact count that future defensive
+        # syncs added elsewhere in the call chain would silently break.
+        assert mock_sync.call_count >= 1
 
 
 class TestStreamCancellationHoldsLock:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2016,11 +2016,18 @@ class TestLockBoundarySync:
             assert mock_mx.synchronize.call_count == 1
 
     def test_suppresses_exceptions(self):
-        """Exceptions from mx.synchronize must not propagate."""
-        with patch("olmlx.engine.inference.mx") as mock_mx:
+        """Exceptions from mx.synchronize must not propagate — covers both the
+        default-stream and generation-stream suppression paths."""
+        mock_stream = MagicMock()
+        with (
+            patch("olmlx.engine.inference.mx") as mock_mx,
+            patch("olmlx.engine.inference._generation_streams", [mock_stream]),
+        ):
             mock_mx.synchronize.side_effect = RuntimeError("Metal error")
-            _lock_boundary_sync("full")  # should not raise
-            _lock_boundary_sync("minimal")  # should not raise
+            _lock_boundary_sync("full")  # exercises default + generation stream loop
+            _lock_boundary_sync("minimal")  # exercises default only
+            # Exactly: 1 default + 1 generation (full) + 1 default (minimal) = 3
+            assert mock_mx.synchronize.call_count == 3
 
     def test_unknown_mode_raises(self):
         """Unknown modes must raise ValueError instead of silently falling

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2023,8 +2023,10 @@ class TestLockBoundarySync:
             _lock_boundary_sync("none")
             assert mock_mx.synchronize.call_count == 0
 
-    def test_none_mode_falls_back_to_global_setting(self):
-        """mode=None should resolve to settings.sync_mode."""
+    def test_null_mode_falls_back_to_global_setting(self):
+        """mode=None (Python None sentinel, not the "none" SyncMode string)
+        should resolve to settings.sync_mode. The two are opposite: None
+        inherits the global, "none" skips all sync."""
         mock_stream = MagicMock()
         with (
             patch("olmlx.engine.inference.mx") as mock_mx,

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -3931,3 +3931,32 @@ class TestStreamCompletionLockLeakOnSyncFailure:
         assert not _inference_lock.locked()
         # Entry + exit = exactly 2 lock_boundary_sync calls in the success path.
         assert call_count["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_sync_mode_none_skips_lock_boundary_sync(self, mock_manager):
+        """With lm.sync_mode='none', the streaming path must not call
+        mx.synchronize at either lock-boundary site. Independent of the
+        equivalent _inference_locked test because _stream_completion
+        manages its own lock entry/exit.
+        """
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.sync_mode = "none"
+        mock_mx = MagicMock()
+        with (
+            patch("olmlx.engine.inference.mx", mock_mx),
+            patch("olmlx.engine.inference.settings") as mock_settings,
+            patch(
+                "olmlx.engine.inference.async_mlx_stream",
+                return_value=self._mock_stream(),
+            ),
+        ):
+            mock_settings.inference_queue_timeout = None
+            mock_settings.inference_timeout = None
+            mock_settings.prompt_cache = False
+            mock_settings.memory_limit_fraction = 0.9
+            mock_settings.sync_mode = "full"  # per-model None override wins
+            gen = await generate_completion(mock_manager, "qwen3", "Hello", stream=True)
+            async for _ in gen:
+                pass
+        assert not _inference_lock.locked()
+        assert mock_mx.synchronize.call_count == 0

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -18,6 +18,7 @@ from olmlx.engine.inference import (
     _inject_tools_into_system,
     _normalize_tool_calls_in_messages,
     _apply_chat_template_text,
+    _lock_boundary_sync,
     _safe_sync,
     _schedule_deferred_inference_cleanup,
     generate_chat,
@@ -1964,6 +1965,64 @@ class TestSafeSync:
             _safe_sync()  # should not raise
 
 
+class TestLockBoundarySync:
+    def test_full_matches_safe_sync(self):
+        """'full' mode: sync default + every generation stream."""
+        mock_stream = MagicMock()
+        with (
+            patch("olmlx.engine.inference.mx") as mock_mx,
+            patch("olmlx.engine.inference._generation_streams", [mock_stream]),
+        ):
+            _lock_boundary_sync("full")
+            assert mock_mx.synchronize.call_count == 2
+            mock_mx.synchronize.assert_any_call(mock_stream)
+
+    def test_minimal_skips_generation_streams(self):
+        """'minimal' mode: sync default stream only, skip generation streams."""
+        mock_stream = MagicMock()
+        with (
+            patch("olmlx.engine.inference.mx") as mock_mx,
+            patch("olmlx.engine.inference._generation_streams", [mock_stream]),
+        ):
+            _lock_boundary_sync("minimal")
+            assert mock_mx.synchronize.call_count == 1
+            mock_mx.synchronize.assert_called_once_with()
+
+    def test_none_skips_all_sync(self):
+        """'none' mode: skip sync entirely at lock boundaries."""
+        mock_stream = MagicMock()
+        with (
+            patch("olmlx.engine.inference.mx") as mock_mx,
+            patch("olmlx.engine.inference._generation_streams", [mock_stream]),
+        ):
+            _lock_boundary_sync("none")
+            assert mock_mx.synchronize.call_count == 0
+
+    def test_none_mode_falls_back_to_global_setting(self):
+        """mode=None should resolve to settings.sync_mode."""
+        mock_stream = MagicMock()
+        with (
+            patch("olmlx.engine.inference.mx") as mock_mx,
+            patch("olmlx.engine.inference._generation_streams", [mock_stream]),
+            patch("olmlx.engine.inference.settings") as mock_settings,
+        ):
+            mock_settings.sync_mode = "none"
+            _lock_boundary_sync(None)
+            assert mock_mx.synchronize.call_count == 0
+
+            mock_mx.reset_mock()
+            mock_settings.sync_mode = "minimal"
+            _lock_boundary_sync(None)
+            assert mock_mx.synchronize.call_count == 1
+
+    def test_suppresses_exceptions(self):
+        """Exceptions from mx.synchronize must not propagate."""
+        with patch("olmlx.engine.inference.mx") as mock_mx:
+            mock_mx.synchronize.side_effect = RuntimeError("Metal error")
+            _lock_boundary_sync("full")  # should not raise
+            _lock_boundary_sync("minimal")  # should not raise
+
+
 class TestInferenceLocked:
     @pytest.mark.asyncio
     async def test_acquires_and_releases_lock(self):
@@ -1991,6 +2050,29 @@ class TestInferenceLocked:
                 pass
             # Called at least twice: entry sync + exit sync
             assert mock_mx.synchronize.call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_sync_mode_none_skips_lock_boundary_sync(self):
+        """sync_mode='none' should skip both entry and exit lock-boundary syncs."""
+        with patch("olmlx.engine.inference.mx") as mock_mx:
+            async with _inference_locked(sync_mode="none"):
+                pass
+            assert mock_mx.synchronize.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_sync_mode_minimal_syncs_default_only(self):
+        """sync_mode='minimal' should sync default stream only on entry+exit."""
+        mock_stream = MagicMock()
+        with (
+            patch("olmlx.engine.inference.mx") as mock_mx,
+            patch("olmlx.engine.inference._generation_streams", [mock_stream]),
+        ):
+            async with _inference_locked(sync_mode="minimal"):
+                pass
+            # 1 default sync on entry + 1 default sync on exit, no generation streams
+            assert mock_mx.synchronize.call_count == 2
+            for call in mock_mx.synchronize.call_args_list:
+                assert call.args == ()
 
 
 class TestInferenceLockedWaitsDeferredCleanup:

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -209,12 +209,15 @@ class TestDrainAndJoinBlocksNewInference:
         )
 
     def test_eviction_uses_safe_sync_not_lock_boundary_sync(self):
-        """Eviction paths must use _safe_sync (unconditional) — not _lock_boundary_sync.
+        """Eviction and deferred-cleanup paths must use _safe_sync (unconditional)
+        — not _lock_boundary_sync.
 
         _lock_boundary_sync honors per-model/global sync_mode and can be
         'none', which would silently skip the post-eviction sync needed to
-        reclaim freed Metal buffers (Bug #120). Guard against a future edit
-        that unifies the call sites.
+        reclaim freed Metal buffers (Bug #120). The deferred cleanup path
+        holds the inference lock while the worker thread may still be using
+        the GPU and *must* sync before releasing the lock. Guard against a
+        future edit that unifies the call sites.
         """
         import inspect
 
@@ -224,18 +227,20 @@ class TestDrainAndJoinBlocksNewInference:
                 "_kv_cache_preflight_check",
                 inspect.getsource(_inf_mod._kv_cache_preflight_check),
             ),
+            (
+                "_schedule_deferred_inference_cleanup",
+                inspect.getsource(_inf_mod._schedule_deferred_inference_cleanup),
+            ),
         ]
         for func_name, source in sources:
-            assert "mx.clear_cache" in source, (
-                f"{func_name}: expected mx.clear_cache() in eviction path"
-            )
             assert "_safe_sync" in source, (
-                f"{func_name}: eviction path must call _safe_sync() (Bug #120)"
+                f"{func_name}: must call _safe_sync() (Bug #120 / "
+                f"deferred-cleanup correctness)"
             )
             assert "_lock_boundary_sync" not in source, (
-                f"{func_name}: eviction path must NOT use _lock_boundary_sync — "
+                f"{func_name}: must NOT use _lock_boundary_sync — "
                 f"that helper honors sync_mode='none' and would silently skip "
-                f"the post-eviction Metal sync needed to reclaim freed buffers"
+                f"the Metal sync needed here"
             )
 
 

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -226,7 +226,14 @@ class TestDrainAndJoinBlocksNewInference:
 
         def names_referenced(fn):
             """Return the set of names referenced in fn's bytecode, including
-            any nested (closure / inner-function) code objects."""
+            any nested (closure / inner-function) code objects.
+
+            Note: CPython-specific. ``co_names`` contains names used by
+            LOAD_GLOBAL / LOAD_ATTR bytecode instructions — it catches
+            direct references like ``_safe_sync(...)`` but not aliases
+            (e.g. ``sync_fn = _safe_sync; sync_fn(...)``). Good enough
+            for the patterns this guard is intended to catch.
+            """
             seen = set()
             stack = [fn.__code__]
             while stack:

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -208,6 +208,36 @@ class TestDrainAndJoinBlocksNewInference:
             "Expected at least one evict_all_to_disk call across completion functions"
         )
 
+    def test_eviction_uses_safe_sync_not_lock_boundary_sync(self):
+        """Eviction paths must use _safe_sync (unconditional) — not _lock_boundary_sync.
+
+        _lock_boundary_sync honors per-model/global sync_mode and can be
+        'none', which would silently skip the post-eviction sync needed to
+        reclaim freed Metal buffers (Bug #120). Guard against a future edit
+        that unifies the call sites.
+        """
+        import inspect
+
+        sources = [
+            ("_setup_prompt_cache", inspect.getsource(_inf_mod._setup_prompt_cache)),
+            (
+                "_kv_cache_preflight_check",
+                inspect.getsource(_inf_mod._kv_cache_preflight_check),
+            ),
+        ]
+        for func_name, source in sources:
+            assert "mx.clear_cache" in source, (
+                f"{func_name}: expected mx.clear_cache() in eviction path"
+            )
+            assert "_safe_sync" in source, (
+                f"{func_name}: eviction path must call _safe_sync() (Bug #120)"
+            )
+            assert "_lock_boundary_sync" not in source, (
+                f"{func_name}: eviction path must NOT use _lock_boundary_sync — "
+                f"that helper honors sync_mode='none' and would silently skip "
+                f"the post-eviction Metal sync needed to reclaim freed buffers"
+            )
+
 
 # ---------------------------------------------------------------------------
 # Bug #123: Prompt cache state corruption on mid-stream disconnect

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -264,6 +264,91 @@ class TestDrainAndJoinBlocksNewInference:
                 f"the Metal sync needed here"
             )
 
+    @pytest.mark.asyncio
+    async def test_eviction_still_syncs_under_sync_mode_none(self, mock_manager):
+        """Integration guard: under lm.sync_mode='none' (where lock-boundary
+        syncs are skipped), the memory-pressure eviction path must still
+        call mx.synchronize() via _safe_sync. This complements the static
+        bytecode test by exercising the code path functionally — catches
+        regressions like aliasing or indirect dispatch that bytecode
+        introspection would miss.
+        """
+        from unittest.mock import AsyncMock, patch
+        from olmlx.engine.inference import generate_chat
+        from olmlx.engine.model_manager import CachedPromptState
+
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.sync_mode = "none"
+        lm.tokenizer.apply_chat_template = MagicMock(return_value="prompt")
+        lm.tokenizer.bos_token = None
+        lm.tokenizer.encode = MagicMock(return_value=[10, 20, 30])
+        lm.prompt_cache_store.set(
+            "", CachedPromptState(tokens=[10, 20, 30], cache=[MagicMock()])
+        )
+
+        # Minimal stream so generate_chat returns.
+        from olmlx.utils.streaming import CancellableStream, StreamToken
+
+        mock_stream = MagicMock(spec=CancellableStream)
+        mock_stream.drain_and_join = AsyncMock()
+        mock_stream._thread = None
+        token_iter = iter(
+            [
+                StreamToken(
+                    text="hi",
+                    token=1,
+                    prompt_tokens=3,
+                    generation_tokens=1,
+                    prompt_tps=100.0,
+                    generation_tps=50.0,
+                )
+            ]
+        )
+
+        async def anext_impl():
+            try:
+                return next(token_iter)
+            except StopIteration:
+                raise StopAsyncIteration
+
+        mock_stream.__aiter__ = lambda self: self
+        mock_stream.__anext__ = lambda self: anext_impl()
+
+        mock_mx = MagicMock()
+        with (
+            patch("olmlx.engine.inference.mx", mock_mx),
+            patch("olmlx.engine.inference.async_mlx_stream", return_value=mock_stream),
+            patch(
+                "olmlx.engine.inference.make_prompt_cache",
+                MagicMock(return_value=[MagicMock()]),
+            ),
+            patch("olmlx.engine.inference.settings") as mock_settings,
+            patch("olmlx.utils.memory.is_memory_pressure_high", return_value=True),
+        ):
+            mock_settings.prompt_cache = True
+            mock_settings.prompt_cache_max_tokens = 32768
+            mock_settings.default_keep_alive = "5m"
+            mock_settings.inference_timeout = None
+            mock_settings.memory_limit_fraction = 0.9
+            mock_settings.sync_mode = "full"  # per-model "none" still wins
+            gen = await generate_chat(
+                mock_manager,
+                "qwen3",
+                [{"role": "user", "content": "hi"}],
+                stream=True,
+            )
+            async for _ in gen:
+                pass
+
+        # Eviction must have run (memory pressure → clear_cache call)
+        mock_mx.clear_cache.assert_called()
+        # And despite sync_mode="none" skipping the lock-boundary sync, the
+        # eviction path's _safe_sync() must still have produced a
+        # synchronize() call.
+        assert mock_mx.synchronize.call_count >= 1, (
+            "eviction path under sync_mode='none' must still sync (Bug #120)"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Bug #123: Prompt cache state corruption on mid-stream disconnect

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -218,27 +218,41 @@ class TestDrainAndJoinBlocksNewInference:
         holds the inference lock while the worker thread may still be using
         the GPU and *must* sync before releasing the lock. Guard against a
         future edit that unifies the call sites.
-        """
-        import inspect
 
-        sources = [
-            ("_setup_prompt_cache", inspect.getsource(_inf_mod._setup_prompt_cache)),
-            (
-                "_kv_cache_preflight_check",
-                inspect.getsource(_inf_mod._kv_cache_preflight_check),
-            ),
+        Uses bytecode-level name introspection rather than source text so
+        nested helpers, refactors, or docstring references to the names
+        don't produce false positives/negatives.
+        """
+
+        def names_referenced(fn):
+            """Return the set of names referenced in fn's bytecode, including
+            any nested (closure / inner-function) code objects."""
+            seen = set()
+            stack = [fn.__code__]
+            while stack:
+                code = stack.pop()
+                seen.update(code.co_names)
+                for const in code.co_consts:
+                    if hasattr(const, "co_names"):
+                        stack.append(const)
+            return seen
+
+        funcs = [
+            ("_setup_prompt_cache", _inf_mod._setup_prompt_cache),
+            ("_kv_cache_preflight_check", _inf_mod._kv_cache_preflight_check),
             (
                 "_schedule_deferred_inference_cleanup",
-                inspect.getsource(_inf_mod._schedule_deferred_inference_cleanup),
+                _inf_mod._schedule_deferred_inference_cleanup,
             ),
         ]
-        for func_name, source in sources:
-            assert "_safe_sync" in source, (
-                f"{func_name}: must call _safe_sync() (Bug #120 / "
+        for func_name, fn in funcs:
+            names = names_referenced(fn)
+            assert "_safe_sync" in names, (
+                f"{func_name}: must reference _safe_sync (Bug #120 / "
                 f"deferred-cleanup correctness)"
             )
-            assert "_lock_boundary_sync" not in source, (
-                f"{func_name}: must NOT use _lock_boundary_sync — "
+            assert "_lock_boundary_sync" not in names, (
+                f"{func_name}: must NOT reference _lock_boundary_sync — "
                 f"that helper honors sync_mode='none' and would silently skip "
                 f"the Metal sync needed here"
             )

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -494,6 +494,7 @@ class TestNonTrimmableModelSkipsTrim:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -559,6 +560,7 @@ class TestNonTrimmableModelSkipsTrim:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -169,6 +169,7 @@ class TestCacheCreatedOnFirstRequest:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -235,6 +236,7 @@ class TestCacheReusedOnPrefixMatch:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -325,6 +327,7 @@ class TestNonTrimmableCacheFallback:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -621,6 +624,7 @@ class TestCacheMissCreatesFresh:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -691,6 +695,7 @@ class TestCacheInvalidatedOnCancel:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -751,6 +756,7 @@ class TestCacheDisabledViaConfig:
             mock_settings.prompt_cache = False
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -816,6 +822,7 @@ class TestVlmUsesCache:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -866,6 +873,7 @@ class TestVlmUsesCache:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -935,6 +943,7 @@ class TestCacheTokenCountLogging:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -996,6 +1005,7 @@ class TestCacheStatsInCacheInfoChunk:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -1085,6 +1095,7 @@ class TestCacheExactMatchTrimAlignment:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -1148,6 +1159,7 @@ class TestLockReleasedOnCacheInfoDisconnect:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -1217,6 +1229,7 @@ class TestNoneTokenWarning:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -1289,6 +1302,7 @@ class TestSingleTokenPromptCacheEdgeCase:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -1349,6 +1363,7 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
             mock_settings.prompt_cache_max_tokens = 6
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -1409,6 +1424,7 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
             mock_settings.prompt_cache_max_tokens = 4
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -1466,6 +1482,7 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
             mock_settings.prompt_cache_max_tokens = 5
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -1507,6 +1524,7 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
             mock_settings.prompt_cache_max_tokens = 20
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -1589,6 +1607,7 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
             mock_settings.prompt_cache_max_tokens = 4
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -1675,6 +1694,7 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
             mock_settings.prompt_cache_max_tokens = 3
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -1731,6 +1751,7 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
             mock_settings.prompt_cache_max_tokens = 6
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             # Trim failure is post-generation bookkeeping — should not kill
             # the response. Generation completes, final done chunk emitted.
             chunks = []
@@ -1796,6 +1817,7 @@ class TestCacheTrimmedWhenExceedsTokenLimit:
             mock_settings.prompt_cache_max_tokens = 6
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             chunks = []
             gen = await generate_chat(
                 mock_manager,
@@ -1847,6 +1869,7 @@ class TestCacheStoredWhenWithinTokenLimit:
             mock_settings.prompt_cache_max_tokens = 20
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -1897,6 +1920,7 @@ class TestCacheStoredWhenLimitDisabled:
             mock_settings.prompt_cache_max_tokens = None
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -1954,6 +1978,7 @@ class TestCacheSkippedOnMemoryPressure:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -2019,6 +2044,7 @@ class TestCacheRebuiltAfterPressureResolves:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -2127,6 +2153,7 @@ class TestMultiCacheBehavior:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -2192,6 +2219,7 @@ class TestMultiCacheBehavior:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -2248,6 +2276,7 @@ class TestMultiCacheBehavior:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",
@@ -2307,6 +2336,7 @@ class TestMultiCacheBehavior:
             mock_settings.prompt_cache_max_tokens = 32768
             mock_settings.default_keep_alive = "5m"
             mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
             gen = await generate_chat(
                 mock_manager,
                 "qwen3",

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -412,6 +412,46 @@ class TestModelConfig:
         with pytest.raises(TypeError, match="str or dict"):
             ModelConfig.from_entry(42)
 
+    def test_from_string_sync_mode_default_none(self):
+        """String entries default sync_mode to None (inherit global)."""
+        mc = ModelConfig.from_entry("org/model")
+        assert mc.sync_mode is None
+
+    def test_from_dict_with_sync_mode(self):
+        """sync_mode is parsed from dict entries."""
+        for value in ("full", "minimal", "none"):
+            mc = ModelConfig.from_entry({"hf_path": "org/model", "sync_mode": value})
+            assert mc.sync_mode == value
+
+    def test_from_dict_invalid_sync_mode_rejected(self):
+        """Unknown sync_mode values are rejected."""
+        with pytest.raises(ValueError, match="sync_mode"):
+            ModelConfig.from_entry({"hf_path": "org/model", "sync_mode": "sometimes"})
+
+    def test_from_dict_non_string_sync_mode_rejected(self):
+        """Non-string sync_mode values are rejected."""
+        with pytest.raises(ValueError, match="sync_mode"):
+            ModelConfig.from_entry({"hf_path": "org/model", "sync_mode": 1})
+
+    def test_to_entry_with_sync_mode(self):
+        """sync_mode is serialized when set."""
+        mc = ModelConfig(hf_path="org/model", sync_mode="minimal")
+        entry = mc.to_entry()
+        assert isinstance(entry, dict)
+        assert entry["sync_mode"] == "minimal"
+
+    def test_to_entry_omits_none_sync_mode(self):
+        """sync_mode=None and no other overrides → plain string."""
+        mc = ModelConfig(hf_path="org/model")
+        assert mc.to_entry() == "org/model"
+
+    def test_sync_mode_round_trip(self):
+        """from_entry → to_entry → from_entry preserves sync_mode."""
+        entry_in = {"hf_path": "org/model", "sync_mode": "none"}
+        mc1 = ModelConfig.from_entry(entry_in)
+        mc2 = ModelConfig.from_entry(mc1.to_entry())
+        assert mc2.sync_mode == "none"
+
     def test_to_entry_plain(self):
         """ModelConfig with no overrides serializes to plain string."""
         mc = ModelConfig(hf_path="org/model")


### PR DESCRIPTION
## Summary
- Adds a `sync_mode` knob (`full` | `minimal` | `none`, default `full`) configurable globally via `OLMLX_SYNC_MODE` and per-model in `models.json`, so small/fast models can skip the redundant mlx_lm/mlx_vlm generation-stream sync at every inference-lock entry/exit.
- Only lock-boundary calls (4 sites) use the new `_lock_boundary_sync(mode)`. Cache-eviction and deferred-cleanup paths still call `_safe_sync()` unconditionally so Bug #120 Metal-buffer reclamation stays intact regardless of `sync_mode` — a regression test guards this.
- Closes #229.

## Design notes
- `_generate_sync` (`inference.py:2202`) and mlx_lm's `stream_generate` thread already sync the generation stream before the worker thread returns; the lock-boundary generation-stream sync is defense-in-depth. `minimal` drops it; `none` skips lock-boundary sync entirely and relies on the thread-level sync + `drain_and_join`.
- Per-model config flows `ModelConfig.sync_mode` → `LoadedModel.sync_mode` → `_inference_locked(sync_mode=lm.sync_mode)` / `_lock_boundary_sync(lm.sync_mode)`, mirroring the existing `inference_queue_timeout` / `inference_timeout` threading.
- Typed as `Literal["full", "minimal", "none"] | None` throughout.

### Example

```json
{
  "fast-small": {
    "hf_path": "mlx-community/Llama-3.2-1B-Instruct-4bit",
    "sync_mode": "minimal"
  }
}
```

## Test plan
- [x] `uv run pytest tests/test_inference.py tests/test_inference_bugs.py tests/test_registry.py tests/test_model_manager.py` — 418 passed
- [x] `uv run pytest` — full suite, 2052 passed
- [x] `uv run ruff check olmlx tests` + `uv run ruff format --check olmlx tests` — clean
- [ ] Smoke-test an end-to-end request with `"sync_mode": "minimal"` and with `"sync_mode": "none"` on a small model; confirm no "command encoder already encoding" errors under back-to-back requests
- [ ] Verify memory-pressure eviction path still syncs (eviction regression test covers the static guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)