### PR TITLE
fix(bench): pass worker server port via OLMLX_PORT env, not --port

### DIFF
--- a/olmlx/bench/worker.py
+++ b/olmlx/bench/worker.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import subprocess
 import sys
 import time
@@ -135,11 +136,13 @@ def main():
     prompts = json.loads(args.prompts_json.read_text())
 
     # Start olmlx serve inside this subprocess (inherits env vars set by runner)
-    cmd = [sys.executable, "-m", "olmlx", "serve", "--port", str(args.port)]
+    cmd = [sys.executable, "-m", "olmlx", "serve"]
+    env = {**os.environ, "OLMLX_PORT": str(args.port)}
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.DEVNULL,
         stderr=sys.stderr,
+        env=env,
     )
 
     try:


### PR DESCRIPTION
## Summary
- `olmlx/bench/worker.py` launched the per-scenario server with `olmlx serve --port <N>`, but `serve` has no `--port` arg. argparse exited with code 2, so every bench scenario recorded `{"error": "Server failed to start (exit=2)"}` and `0.0 tok/s`.
- Fix: drop the `--port` CLI arg and pass the port via the `OLMLX_PORT` env var in the subprocess env. `Settings.port` (prefix `OLMLX_`) already picks this up, and the worker's default `11435` continues to avoid colliding with a user-run server on `11434`.

## Test plan
- [ ] `uv run olmlx bench run --model <small-model>` — scenarios report real tok/s instead of all-FAILED
- [ ] `uv run olmlx serve` on `11434` concurrently — bench worker still comes up on `11435` without conflict
- [ ] `uv run ruff check olmlx/bench/worker.py && uv run ruff format --check olmlx/bench/worker.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)