### PR TITLE
fix(turboquant): normalize in float32 to prevent epsilon underflow

### DIFF
--- a/olmlx/engine/turboquant.py
+++ b/olmlx/engine/turboquant.py
@@ -124,8 +124,11 @@ def turboquant_quantize(
 
     # Compute norms in float32 to avoid overflow (float16 max ~65504)
     norms = mx.sqrt(mx.sum(x.astype(mx.float32) ** 2, axis=-1, keepdims=True))
-    # Normalize to unit sphere (avoid division by zero)
-    x_norm = x / mx.maximum(norms.astype(x.dtype), mx.array(1e-8, dtype=x.dtype))
+    # Normalize in float32 — 1e-8 underflows to 0.0 in float16, so the
+    # clamp would vanish and zero-norm rows would produce NaN via 0/0.
+    x_norm = (
+        x.astype(mx.float32) / mx.maximum(norms, mx.array(1e-8, dtype=mx.float32))
+    ).astype(x.dtype)
 
     # Rotate: y = x_norm @ Πᵀ  (equivalent to Π @ x_norm per vector)
     y = x_norm @ rotation.matrix.T

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -240,17 +240,17 @@ class TestQuantizeDequantize:
         rot = TurboQuantRotation(head_dim=64, seed=0)
         x = mx.zeros((1, 1, 1, 64), dtype=mx.float16)
 
-        indices, _ = turboquant_quantize(x, rot, bits=4)
-        unpacked = np.array(unpack_indices(indices, bits=4, head_dim=64))
-
-        # 4-bit Gaussian codebook is symmetric around 0 and sorted ascending.
-        # Zero input (after rotation → still zero) should quantize to the two
-        # centroids straddling 0, i.e. indices 7 and 8.
-        assert np.all((unpacked == 7) | (unpacked == 8)), (
-            "Expected zero-norm float16 input to quantize to center "
-            f"indices 7/8, got unique={np.unique(unpacked)}. "
-            "All-zero indices indicate NaN propagation in normalization."
-        )
+        # Gaussian codebooks are symmetric around 0 and sorted ascending, so
+        # zero input (after rotation → still zero) should quantize to the two
+        # centroids straddling 0: indices 7/8 for 4-bit, 1/2 for 2-bit.
+        for bits, center in [(4, {7, 8}), (2, {1, 2})]:
+            indices, _ = turboquant_quantize(x, rot, bits=bits)
+            unpacked = np.array(unpack_indices(indices, bits=bits, head_dim=64))
+            assert set(np.unique(unpacked).tolist()) <= center, (
+                f"{bits}-bit: expected center indices {center}, "
+                f"got unique={np.unique(unpacked)}. "
+                "All-zero indices indicate NaN propagation in normalization."
+            )
 
     def test_norm_preservation(self):
         """Dequantized vectors should approximately preserve input norms."""

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -219,6 +219,39 @@ class TestQuantizeDequantize:
 
         assert x_hat.shape == x.shape
 
+    def test_zero_norm_float16_quantizes_to_center(self):
+        """Zero-norm float16 input must quantize to center codebook indices.
+
+        Regression for #241. The normalization epsilon was expressed in the
+        input dtype: ``mx.array(1e-8, dtype=float16)`` underflows to 0, so
+        the clamp ``mx.maximum(norms, 0) = norms`` does nothing for zero-norm
+        rows. Division becomes 0/0 = NaN, and ``NaN < inf`` is False, so the
+        quantization loop's ``best_idx`` stays at its default 0 for every
+        coordinate instead of the centroid closest to 0.
+
+        Fix: do normalization in float32 where 1e-8 is representable.
+        """
+        from olmlx.engine.turboquant import (
+            TurboQuantRotation,
+            turboquant_quantize,
+            unpack_indices,
+        )
+
+        rot = TurboQuantRotation(head_dim=64, seed=0)
+        x = mx.zeros((1, 1, 1, 64), dtype=mx.float16)
+
+        indices, _ = turboquant_quantize(x, rot, bits=4)
+        unpacked = np.array(unpack_indices(indices, bits=4, head_dim=64))
+
+        # 4-bit Gaussian codebook is symmetric around 0 and sorted ascending.
+        # Zero input (after rotation → still zero) should quantize to the two
+        # centroids straddling 0, i.e. indices 7 and 8.
+        assert np.all((unpacked == 7) | (unpacked == 8)), (
+            "Expected zero-norm float16 input to quantize to center "
+            f"indices 7/8, got unique={np.unique(unpacked)}. "
+            "All-zero indices indicate NaN propagation in normalization."
+        )
+
     def test_norm_preservation(self):
         """Dequantized vectors should approximately preserve input norms."""
         from olmlx.engine.turboquant import (


### PR DESCRIPTION
## Summary
- Fixes #241. `turboquant_quantize` normalized in the input dtype, so `mx.array(1e-8, dtype=float16)` underflowed to `0.0` and the divide-by-zero clamp disappeared. Zero-norm K/V vectors produced `0/0 = NaN` in `x_norm`; since `NaN < inf` is `False`, every coordinate of `best_idx` stayed at the default `0` instead of the centroid closest to zero.
- Fix mirrors the float32-normalize pattern already used in `spectralquant.py`.
- Adds a regression test that fails before the fix (indices stuck at 0) and passes after (indices at the symmetric center 7/8 of the 4-bit codebook).

## Test plan
- [x] `uv run pytest tests/test_turboquant.py` — 58 passed (was 57 + new regression test)
- [x] `uv run pytest tests/test_spectralquant.py` — 45 passed (no regression in sibling quantizer)
- [x] `uv run ruff check olmlx tests` + `ruff format --check` — clean
- [x] Confirmed the new test fails on `main` with `unique=[0]` and passes on this branch with indices in {7, 8}

🤖 Generated with [Claude Code](https://claude.com/claude-code)