### PR TITLE
fix(distributed): close already-ready worker sockets on Phase-2 failure

### DIFF
--- a/olmlx/engine/distributed.py
+++ b/olmlx/engine/distributed.py
@@ -181,34 +181,37 @@ class DistributedCoordinator:
                     f"({len(pending)}/{expected} connected)"
                 )
 
-        # Phase 2: wait for "ready" message from each worker
-        for i, conn in enumerate(pending):
-            remaining = timeout - (time.monotonic() - start)
-            if remaining <= 0:
-                for s in pending[i:]:
-                    s.close()
-                raise TimeoutError(
-                    f"Timed out waiting for workers to report ready "
-                    f"({len(self._workers)}/{expected} ready)"
-                )
-            conn.settimeout(remaining)
-            try:
-                msg = _recv_message(conn)
+        # Phase 2: wait for "ready" message from each worker.
+        # On any failure we must close BOTH the not-yet-processed sockets in
+        # pending[i:] AND the already-ready sockets accumulated in self._workers
+        # — otherwise FDs leak locally and the peer worker stays connected-but-
+        # idle until its own timeout fires (Issue #240).
+        i = 0
+        try:
+            for i, conn in enumerate(pending):
+                remaining = timeout - (time.monotonic() - start)
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"Timed out waiting for workers to report ready "
+                        f"({len(self._workers)}/{expected} ready)"
+                    )
+                conn.settimeout(remaining)
+                try:
+                    msg = _recv_message(conn)
+                except socket.timeout:
+                    raise TimeoutError(
+                        f"Timed out waiting for workers to report ready "
+                        f"({len(self._workers)}/{expected} ready)"
+                    )
                 if msg is None or msg.get("action") != "ready":
-                    for s in pending[i:]:
-                        s.close()
                     raise RuntimeError(
                         f"Worker {i + 1} sent unexpected message instead of ready: {msg}"
                     )
                 # Validate shared secret if configured
-                if self._secret is not None:
-                    if msg.get("secret") != self._secret:
-                        for s in pending[i:]:
-                            s.close()
-                        raise RuntimeError(
-                            f"Worker {i + 1} provided invalid secret — "
-                            f"rejecting connection"
-                        )
+                if self._secret is not None and msg.get("secret") != self._secret:
+                    raise RuntimeError(
+                        f"Worker {i + 1} provided invalid secret — rejecting connection"
+                    )
                 self._workers.append(conn)
                 conn.settimeout(None)  # blocking recv for inference loop
                 logger.info(
@@ -216,13 +219,19 @@ class DistributedCoordinator:
                     len(self._workers),
                     expected,
                 )
-            except socket.timeout:
-                for s in pending[i:]:
+        except BaseException:
+            for s in pending[i:]:
+                try:
                     s.close()
-                raise TimeoutError(
-                    f"Timed out waiting for workers to report ready "
-                    f"({len(self._workers)}/{expected} ready)"
-                )
+                except Exception:
+                    pass
+            for w in self._workers:
+                try:
+                    w.close()
+                except Exception:
+                    pass
+            self._workers.clear()
+            raise
         # Issue 12: Close server socket — no more connections expected
         self._server.close()
         logger.info("All workers connected, server socket closed")

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -684,6 +684,11 @@ class TestProtocolViolation:
                 "Already-ready worker socket leaked: coordinator did not close "
                 "it when a later worker failed Phase-2 handshake"
             )
+            # Also verify bad_sock (closed via pending[i:] cleanup path) sees EOF
+            bad_sock.settimeout(2.0)
+            assert bad_sock.recv(4) == b"", (
+                "Failing worker socket leaked: coordinator did not close it via pending[i:] cleanup"
+            )
             # And self._workers must be cleared so coordinator.close() is a no-op
             # on those sockets (which would have been a double-close otherwise).
             assert coordinator._workers == []

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -653,6 +653,45 @@ class TestProtocolViolation:
             coordinator.close()
             t.join(timeout=5.0)
 
+    def test_already_ready_workers_closed_on_late_failure(self):
+        """Issue #240: Phase-2 failure on a later worker must close sockets of
+        workers that already reported ready. Otherwise FDs leak locally and the
+        peer worker stays connected-but-idle until its own timeout fires.
+        """
+        from olmlx.engine.distributed import DistributedCoordinator, _send_message
+
+        coordinator = DistributedCoordinator(world_size=3, port=0)
+        actual_port = coordinator.port
+
+        # Connect both workers synchronously before wait_for_workers so accept
+        # order (which determines pending[] order in Phase 2) is deterministic:
+        # ready_sock is pending[0], bad_sock is pending[1].
+        ready_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        bad_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        ready_sock.connect(("127.0.0.1", actual_port))
+        _send_message(ready_sock, {"action": "ready"})
+        bad_sock.connect(("127.0.0.1", actual_port))
+        _send_message(bad_sock, {"action": "wrong"})
+
+        try:
+            with pytest.raises(RuntimeError, match="unexpected message"):
+                coordinator.wait_for_workers(timeout=5.0)
+
+            # The coordinator must have closed ready_sock — recv on the peer
+            # end returns b"" once the FIN arrives.
+            ready_sock.settimeout(2.0)
+            assert ready_sock.recv(4) == b"", (
+                "Already-ready worker socket leaked: coordinator did not close "
+                "it when a later worker failed Phase-2 handshake"
+            )
+            # And self._workers must be cleared so coordinator.close() is a no-op
+            # on those sockets (which would have been a double-close otherwise).
+            assert coordinator._workers == []
+        finally:
+            ready_sock.close()
+            bad_sock.close()
+            coordinator.close()
+
 
 class TestServerSocketClose:
     """Issue 12: Server socket closed after wait_for_workers."""


### PR DESCRIPTION
## Summary
- Fixes #240. `DistributedCoordinator.wait_for_workers()` Phase-2 already moved each successfully-handshaked worker into `self._workers` as it iterated, but every failure path (timeout, wrong message, bad secret) only closed `pending[i:]` and re-raised. Workers `0..i-1` were left as dangling FDs locally and connected-but-idle sockets on the remote workers until their own timeouts fired.
- Wrapped Phase-2 in a single `try/except` that on any exception closes both the not-yet-processed `pending` sockets and every socket already moved into `self._workers`, then clears `self._workers` before re-raising. Caller-side `coordinator.close()` remains safe (close on an already-closed socket is a no-op via the existing `try/except`).
- Phase-1 was already leak-free (`self._workers` is empty until Phase-2 starts) so it is unchanged.

## Test plan
- [x] Added regression test `TestProtocolViolation::test_already_ready_workers_closed_on_late_failure` — connects two workers (first sends `ready`, second sends `wrong`), asserts the first worker's peer socket sees EOF (`recv() == b""`) and `self._workers` is cleared. Verified the test fails on `main` (recv times out) and passes on this branch.
- [x] `uv run pytest tests/test_distributed.py` — 67 passed (was 66 + new regression).
- [x] `uv run ruff check olmlx/engine/distributed.py tests/test_distributed.py` + `ruff format --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)