### PR TITLE
Fix deferred cleanup lock isolation across event loops (Bug #243)

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -225,13 +225,13 @@ _generation_streams = _resolve_generation_streams()
 # crashes or corruption.  A single global lock is an intentional trade-off:
 # we sacrifice parallelism for stability on Apple Silicon.
 #
-# On Python 3.11+ asyncio.Lock binds to a loop lazily (at first acquire), so
-# the same instance can be shared across loops as long as it is never acquired
-# on one while still held by another.  Test isolation relies on
-# ``_reset_inference_state()`` force-releasing it between tests, not on
-# recreating it per-loop like ``_deferred_cleanup_locks`` below.
+# On Python 3.10+ asyncio.Lock binds to a loop lazily (at first acquire, via
+# get_running_loop() — see bpo-39529), so the same instance can be shared
+# across loops as long as it is never acquired on one while still held by
+# another.  Test isolation relies on ``_reset_inference_state()``
+# force-releasing it between tests, not on recreating it per-loop like
+# ``_deferred_cleanup_locks`` below.
 _inference_lock = asyncio.Lock()
-_deferred_cleanup_task: asyncio.Task | None = None
 # A lock that was acquired on loop A (e.g. a test that crashed without
 # releasing it) causes deadlock or "Future attached to a different loop"
 # errors when another loop inherits it.  Per-loop keys ensure each test loop
@@ -239,6 +239,12 @@ _deferred_cleanup_task: asyncio.Task | None = None
 # loops get garbage-collected without leaking.
 _deferred_cleanup_locks: weakref.WeakKeyDictionary[
     asyncio.AbstractEventLoop, asyncio.Lock
+] = weakref.WeakKeyDictionary()
+# Tasks are also keyed per-loop: a task bound to loop A cannot be cancelled or
+# awaited from loop B (RuntimeError on Python 3.10+).  Keeping this per-loop
+# keeps the reset path consistent with the lock scoping.
+_deferred_cleanup_tasks: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, asyncio.Task
 ] = weakref.WeakKeyDictionary()
 # Tracks requests waiting for _inference_lock (not the _await_deferred_cleanup wait).
 _queue_depth = 0
@@ -257,17 +263,18 @@ async def _reset_inference_state() -> None:
     orphaned release calls after the task completes.
     Force-releases _inference_lock if held to prevent test deadlocks.
     """
-    global _deferred_cleanup_task, _queue_depth
-    if _deferred_cleanup_task is not None and not _deferred_cleanup_task.done():
-        _deferred_cleanup_task.cancel()
+    global _queue_depth
+    # Scope the reset to the calling loop so we don't wipe locks/tasks in use
+    # by other loops (e.g. concurrent async test classes under loop_scope=session).
+    loop = asyncio.get_running_loop()
+    task = _deferred_cleanup_tasks.pop(loop, None)
+    if task is not None and not task.done():
+        task.cancel()
         try:
-            await _deferred_cleanup_task
+            await task
         except (asyncio.CancelledError, asyncio.InvalidStateError):
             pass
-    _deferred_cleanup_task = None
-    # Scope the reset to the calling loop so we don't wipe locks in use by
-    # other loops (e.g. concurrent async test classes under loop_scope=session).
-    _deferred_cleanup_locks.pop(asyncio.get_running_loop(), None)
+    _deferred_cleanup_locks.pop(loop, None)
     _queue_depth = 0
     if _inference_lock.locked():
         _inference_lock.release()
@@ -396,17 +403,18 @@ async def _await_deferred_cleanup():
 
     Raises ServerBusyError if cleanup doesn't finish within _DEFERRED_WAIT_TIMEOUT.
     Uses asyncio.wait() to avoid Python 3.11 wait_for race conditions.
-    Uses _deferred_cleanup_lock to prevent TOCTOU races on _deferred_cleanup_task (Bug #119).
+    Uses _deferred_cleanup_lock to prevent TOCTOU races on _deferred_cleanup_tasks (Bug #119).
     """
+    loop = asyncio.get_running_loop()
     async with _get_deferred_cleanup_lock():
-        task = _deferred_cleanup_task
+        task = _deferred_cleanup_tasks.get(loop)
         if task is None or task.done():
             return
     # Wait outside the lock so _cleanup() can acquire it in its finally block
-    # to set _deferred_cleanup_task = None.  Holding the lock here would deadlock.
-    # Race safety: a concurrent _schedule_deferred_inference_cleanup cannot replace
-    # _deferred_cleanup_task while we wait because _inference_lock is held by the
-    # existing cleanup — no new inference (and thus no new cleanup) can be scheduled.
+    # to remove the entry from _deferred_cleanup_tasks.  Holding the lock here
+    # would deadlock.  Race safety: a concurrent _schedule_deferred_inference_cleanup
+    # cannot replace the entry while we wait because _inference_lock is held by
+    # the existing cleanup — no new inference (and thus no new cleanup) can be scheduled.
     logger.info("Waiting for deferred GPU cleanup to complete")
     done, _ = await asyncio.wait({task}, timeout=_DEFERRED_WAIT_TIMEOUT)
     if not done:
@@ -426,14 +434,14 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
     releases the lock anyway (risk of Metal crash on next inference, but
     better than permanent deadlock).
 
-    Uses _deferred_cleanup_lock to prevent TOCTOU races on _deferred_cleanup_task (Bug #119).
+    Uses _deferred_cleanup_lock to prevent TOCTOU races on _deferred_cleanup_tasks (Bug #119).
     """
-    global _deferred_cleanup_task
-
     lock = _get_inference_lock()
+    loop = asyncio.get_running_loop()
 
     async with _get_deferred_cleanup_lock():
-        if _deferred_cleanup_task is not None and not _deferred_cleanup_task.done():
+        existing = _deferred_cleanup_tasks.get(loop)
+        if existing is not None and not existing.done():
             logger.error(
                 "Deferred inference cleanup already in progress — "
                 "this should not happen while the inference lock is held"
@@ -475,10 +483,9 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
                 lock.release()
                 logger.info("Deferred inference cleanup: lock released")
                 async with _get_deferred_cleanup_lock():
-                    global _deferred_cleanup_task
-                    _deferred_cleanup_task = None
+                    _deferred_cleanup_tasks.pop(loop, None)
 
-        _deferred_cleanup_task = asyncio.create_task(_cleanup())
+        _deferred_cleanup_tasks[loop] = asyncio.create_task(_cleanup())
 
 
 MEMORY_SAFETY_FACTOR = 1.3

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -279,6 +279,9 @@ async def _reset_inference_state() -> None:
     # task may already have run ``_get_deferred_cleanup_lock()`` and left
     # a fresh entry in ``_deferred_cleanup_locks``.
     _deferred_cleanup_locks.pop(loop, None)
+    # ``_queue_depth`` is intentionally global: it tracks waiters on the
+    # global ``_inference_lock``, not per-loop cleanup state, so a per-loop
+    # scope would make no sense here.
     _queue_depth = 0
     if _inference_lock.locked():
         _inference_lock.release()
@@ -488,6 +491,11 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
                 # threads, so this is the "least bad" option vs permanent deadlock.
                 lock.release()
                 logger.info("Deferred inference cleanup: lock released")
+                # If this task is cancelled while ``_get_deferred_cleanup_lock().__aenter__``
+                # awaits the lock, ``CancelledError`` propagates before the body
+                # runs and the pop below is skipped.  ``_reset_inference_state()``
+                # covers that case with its own explicit ``pop`` of both the task
+                # and lock dicts — do not drop those fallback pops.
                 async with _get_deferred_cleanup_lock():
                     # Use the task's own running loop rather than closing over
                     # ``loop`` from the outer scope — ``_cleanup`` runs as a

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -277,6 +277,17 @@ async def _reset_inference_state() -> None:
                 await task
             except (asyncio.CancelledError, asyncio.InvalidStateError):
                 pass
+            except Exception as exc:
+                # Race: the task was about to finish with a non-cancellation
+                # exception when we called ``cancel()``, so ``await task``
+                # re-raises the stored exception instead of ``CancelledError``.
+                # Log and swallow — reset must not propagate user-code
+                # exceptions up to the test teardown fixture.
+                logger.warning(
+                    "Cleanup task raised while being cancelled during reset: %s",
+                    exc,
+                    exc_info=exc,
+                )
         elif not task.cancelled():
             # Consume any stored exception so asyncio doesn't log
             # "Task exception was never retrieved" to stderr.  Also log it

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -456,7 +456,7 @@ async def _await_deferred_cleanup():
     # the inference lock is always released and the next request can proceed.
     # Callers have no need to reject the following inference — the lock state
     # is correct regardless of cleanup outcome.  The log is the signal.
-    (finished_task,) = done
+    finished_task = done.pop()
     if not finished_task.cancelled():
         exc = finished_task.exception()
         if exc is not None:
@@ -479,6 +479,15 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
     lock = _get_inference_lock()
     loop = asyncio.get_running_loop()
 
+    # IMPORTANT: ``create_task(_cleanup())`` must be the last statement in the
+    # ``async with _get_deferred_cleanup_lock()`` block below.  ``_cleanup``'s
+    # finally re-acquires the same lock to pop its dict entry; this works
+    # today because tasks don't preempt — the outer ``async with`` exits and
+    # releases the lock before ``_cleanup`` is first scheduled.  Any ``await``
+    # (even an innocent log call that happens to yield) inserted between
+    # ``create_task`` and the end of the ``async with`` would let the event
+    # loop schedule ``_cleanup`` into a deadlock on the same lock.  Adding
+    # new code here?  Put it *before* the ``async with`` or *after* its exit.
     async with _get_deferred_cleanup_lock():
         existing = _deferred_cleanup_tasks.get(loop)
         if existing is not None and not existing.done():
@@ -556,13 +565,7 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
                     # ``_cleanup`` self-contained.
                     _deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
 
-        # IMPORTANT: ``create_task`` must remain the last statement inside
-        # this ``async with``.  ``_cleanup``'s finally re-acquires the same
-        # lock to pop its dict entry; this works today because tasks don't
-        # preempt — the outer ``async with`` exits and releases the lock
-        # before ``_cleanup`` is first scheduled.  Any ``await`` inserted
-        # after this line while the lock is still held would let the event
-        # loop schedule ``_cleanup`` into a deadlock on the same lock.
+        # See IMPORTANT note at the top of the ``async with`` block.
         _deferred_cleanup_tasks[loop] = asyncio.create_task(_cleanup())
 
 

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -270,27 +270,28 @@ async def _reset_inference_state() -> None:
     # by other loops (e.g. concurrent async test classes under loop_scope=session).
     loop = asyncio.get_running_loop()
     task = _deferred_cleanup_tasks.pop(loop, None)
-    if task is not None and not task.done():
-        task.cancel()
-        try:
-            await task
-        except (asyncio.CancelledError, asyncio.InvalidStateError):
-            pass
-    elif task is not None and not task.cancelled():
-        # Consume any stored exception so asyncio doesn't log
-        # "Task exception was never retrieved" to stderr.  Also log it
-        # ourselves at warning level so fixture-level failures aren't
-        # invisible (``_await_deferred_cleanup`` logs on its own path,
-        # but reset is the only path for tests that aborted earlier).
-        # ``task.exception()`` is safe here — the task is done and not
-        # cancelled, so it can't raise ``InvalidStateError`` or ``CancelledError``.
-        exc = task.exception()
-        if exc is not None:
-            logger.warning(
-                "Deferred cleanup task raised during reset: %s",
-                exc,
-                exc_info=exc,
-            )
+    if task is not None:
+        if not task.done():
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, asyncio.InvalidStateError):
+                pass
+        elif not task.cancelled():
+            # Consume any stored exception so asyncio doesn't log
+            # "Task exception was never retrieved" to stderr.  Also log it
+            # ourselves at warning level so fixture-level failures aren't
+            # invisible (``_await_deferred_cleanup`` logs on its own path,
+            # but reset is the only path for tests that aborted earlier).
+            # ``task.exception()`` is safe here — the task is done and not
+            # cancelled, so it can't raise ``InvalidStateError`` or ``CancelledError``.
+            exc = task.exception()
+            if exc is not None:
+                logger.warning(
+                    "Deferred cleanup task raised during reset: %s",
+                    exc,
+                    exc_info=exc,
+                )
     # Also cleans up any lock entry ``_cleanup``'s finally block may have
     # created.  Both branches above can leave one behind:
     #   - ``if`` (cancel + await): ``_cleanup``'s finally runs during
@@ -505,10 +506,15 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
             # log was missed (it normally fires first on the happy path).
             # ``existing.exception()`` is safe here — the task is done and not
             # cancelled, so it can't raise ``InvalidStateError`` or ``CancelledError``.
+            # Note: if ``_await_deferred_cleanup`` already ran, this is the
+            # second log of the same exception (ERROR there, WARNING here);
+            # the "previously reported above" hint helps operators correlate.
             exc = existing.exception()
             if exc is not None:
                 logger.warning(
-                    "Replaced done cleanup task had raised: %s",
+                    "Replaced done cleanup task had raised "
+                    "(may have been previously reported at ERROR by "
+                    "_await_deferred_cleanup): %s",
                     exc,
                     exc_info=exc,
                 )

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -275,7 +275,7 @@ async def _reset_inference_state() -> None:
             task.cancel()
             try:
                 await task
-            except (asyncio.CancelledError, asyncio.InvalidStateError) as cancel_exc:
+            except asyncio.CancelledError as cancel_exc:
                 # If ``_cleanup`` raised in its body and the cancellation
                 # arrived in its finally (e.g. at ``await lock.acquire()``),
                 # the original exception lives on as ``__context__`` of the

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -461,6 +461,12 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
                 "this should not happen while the inference lock is held"
             )
             return  # do not create a second task; the existing one will release the lock
+        if existing is not None and not existing.cancelled():
+            # ``existing`` is done — replacing the dict entry below drops the
+            # last reference.  Consume any stored exception so asyncio doesn't
+            # log "Task exception was never retrieved" when it's GC'd.
+            with contextlib.suppress(asyncio.InvalidStateError, Exception):
+                existing.exception()
 
         async def _cleanup():
             thread = stream._thread

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -229,10 +229,14 @@ _generation_streams = _resolve_generation_streams()
 # to acquire — its own waiter Future is queued behind a Future whose
 # ``set_result`` would need to run on loop A's (now-gone) scheduler.
 # Test isolation relies on ``_reset_inference_state()`` force-releasing
-# ``_inference_lock`` between tests, which clears both ``_locked`` and the
-# waiter queue, so loop B starts clean.  ``_deferred_cleanup_locks`` below
-# uses a different strategy (per-loop WeakKeyDictionary) because force-
-# releasing a lock held mid-cleanup would be unsafe.
+# ``_inference_lock`` between tests.  Note: ``release()`` only clears
+# ``_locked`` and wakes one pending waiter — it does NOT drain the
+# ``_waiters`` deque.  Stale waiters there are normally cleaned up by the
+# ``finally: self._waiters.remove(fut)`` clause inside cancelled
+# ``acquire()`` calls; tests that need a truly fresh lock instance patch
+# ``_inference_lock`` with ``asyncio.Lock()``.  ``_deferred_cleanup_locks``
+# below uses a different strategy (per-loop WeakKeyDictionary) because
+# force-releasing a lock held mid-cleanup would be unsafe.
 _inference_lock = asyncio.Lock()
 # A lock that was acquired on loop A (e.g. a test that crashed without
 # releasing it) causes deadlock or "Future attached to a different loop"
@@ -353,9 +357,11 @@ def _get_deferred_cleanup_lock() -> asyncio.Lock:
 
     Safe within a single event loop: no await between the lookup and the
     assignment, so no two coroutines on the same loop can both observe
-    ``None`` simultaneously.  WeakKeyDictionary is not thread-safe for
-    concurrent writes from multiple OS threads each running their own
-    loop — this server runs on one thread, so that case doesn't apply.
+    ``None`` simultaneously.  WeakKeyDictionary is not thread-safe in the
+    general case — GC-triggered key-removal callbacks can interleave with
+    ``.get()`` / ``__setitem__`` from another thread.  Safe here because
+    (a) asyncio is single-threaded and (b) on CPython the GIL serialises
+    the GC callback against the dict operations.
 
     Must be called from within a running event loop — uses
     ``asyncio.get_running_loop()``, which raises ``RuntimeError`` if invoked

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -491,7 +491,16 @@ async def _await_deferred_cleanup():
     if not task.cancelled():
         exc = task.exception()
         if exc is not None:
-            logger.error("Deferred inference cleanup raised: %s", exc, exc_info=exc)
+            # ``task.get_name()`` lets operators correlate this entry with the
+            # WARNING fired on the next request from
+            # ``_schedule_deferred_inference_cleanup`` (same task name).
+            logger.error(
+                "Deferred inference cleanup [%s] raised; server state may be "
+                "dirty, consider restart if this persists: %s",
+                task.get_name(),
+                exc,
+                exc_info=exc,
+            )
 
 
 async def _schedule_deferred_inference_cleanup(stream) -> None:
@@ -538,13 +547,15 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
             # cancelled, so it can't raise ``InvalidStateError`` or ``CancelledError``.
             # Note: if ``_await_deferred_cleanup`` already ran, this is the
             # second log of the same exception (ERROR there, WARNING here);
-            # the "previously reported above" hint helps operators correlate.
+            # the matching ``[task name]`` prefix lets operators grep both
+            # entries with one identifier.
             exc = existing.exception()
             if exc is not None:
                 logger.warning(
-                    "Replaced done cleanup task had raised "
+                    "Replaced done cleanup task [%s] had raised "
                     "(may have been previously reported at ERROR by "
                     "_await_deferred_cleanup): %s",
+                    existing.get_name(),
                     exc,
                     exc_info=exc,
                 )
@@ -605,7 +616,13 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
                     _deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
 
         # See IMPORTANT note at the top of the ``async with`` block.
-        _deferred_cleanup_tasks[loop] = asyncio.create_task(_cleanup())
+        # Name the task explicitly so the operator-facing log entries
+        # (ERROR from ``_await_deferred_cleanup``, WARNING from the
+        # next request) share a stable identifier instead of the
+        # auto-generated ``Task-N``.
+        _deferred_cleanup_tasks[loop] = asyncio.create_task(
+            _cleanup(), name=f"deferred-cleanup-{id(stream):x}"
+        )
 
 
 MEMORY_SAFETY_FACTOR = 1.3

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -560,8 +560,23 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
             else:
                 logger.info("Deferred inference cleanup: thread exited cleanly")
         finally:
-            if thread is None or not thread.is_alive():
-                _safe_sync()
+            # ``_safe_sync`` already suppresses errors from its own
+            # ``mx.synchronize`` calls, but wrap defensively so
+            # ``lock.release()`` is truly unconditional — a future refactor
+            # could change ``_safe_sync``'s error handling, and a failure
+            # to release the inference lock would silently deadlock every
+            # subsequent inference.
+            try:
+                if thread is None or not thread.is_alive():
+                    _safe_sync()
+            except Exception as sync_exc:
+                logger.error(
+                    "Deferred inference cleanup: _safe_sync raised; "
+                    "Metal state may be dirty, consider restart if this "
+                    "persists: %s",
+                    sync_exc,
+                    exc_info=sync_exc,
+                )
             # Note: on timeout/abort with thread still alive, releasing the
             # lock risks a Metal crash on the next inference (the stuck thread
             # may still be issuing GPU commands).  Python can't kill CPU-bound

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -224,12 +224,22 @@ _generation_streams = _resolve_generation_streams()
 # lock would still allow interleaved GPU work from different models, risking
 # crashes or corruption.  A single global lock is an intentional trade-off:
 # we sacrifice parallelism for stability on Apple Silicon.
+#
+# On Python 3.11+ asyncio.Lock binds to a loop lazily (at first acquire), so
+# the same instance can be shared across loops as long as it is never acquired
+# on one while still held by another.  Test isolation relies on
+# ``_reset_inference_state()`` force-releasing it between tests, not on
+# recreating it per-loop like ``_deferred_cleanup_locks`` below.
 _inference_lock = asyncio.Lock()
 _deferred_cleanup_task: asyncio.Task | None = None
-# asyncio.Lock binds to the loop at creation time, so tests that create
-# fresh event loops (pytest-asyncio) need a separate lock per loop.
-# WeakKeyDictionary lets closed loops get garbage-collected without leaking.
-_deferred_cleanup_locks: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]" = weakref.WeakKeyDictionary()
+# A lock that was acquired on loop A (e.g. a test that crashed without
+# releasing it) causes deadlock or "Future attached to a different loop"
+# errors when another loop inherits it.  Per-loop keys ensure each test loop
+# starts with a fresh, unlocked lock; WeakKeyDictionary lets closed test
+# loops get garbage-collected without leaking.
+_deferred_cleanup_locks: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, asyncio.Lock
+] = weakref.WeakKeyDictionary()
 # Tracks requests waiting for _inference_lock (not the _await_deferred_cleanup wait).
 _queue_depth = 0
 
@@ -255,7 +265,9 @@ async def _reset_inference_state() -> None:
         except (asyncio.CancelledError, asyncio.InvalidStateError):
             pass
     _deferred_cleanup_task = None
-    _deferred_cleanup_locks.clear()
+    # Scope the reset to the calling loop so we don't wipe locks in use by
+    # other loops (e.g. concurrent async test classes under loop_scope=session).
+    _deferred_cleanup_locks.pop(asyncio.get_running_loop(), None)
     _queue_depth = 0
     if _inference_lock.locked():
         _inference_lock.release()
@@ -274,9 +286,9 @@ def _get_deferred_cleanup_lock() -> asyncio.Lock:
     """Lazily create a deferred cleanup lock keyed by the running event loop
     (Bug #119, Bug #243).
 
-    asyncio.Lock binds to the loop at creation time.  A single cached lock
-    breaks across event loops — once loop A creates it, loop B reuses a lock
-    bound to loop A and fails with "got Future attached to a different loop".
+    A single cached lock breaks across event loops: stale ``_locked=True``
+    state from a test that crashed without releasing it, or waiter Futures
+    whose callbacks would fire on a closed loop, leak into the next test.
     Keying by the running loop keeps each loop's lock isolated; the weak
     dict lets closed test loops get garbage-collected.
 

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -280,9 +280,12 @@ async def _reset_inference_state() -> None:
         with contextlib.suppress(asyncio.InvalidStateError, Exception):
             task.exception()
     # Also cleans up any lock entry ``_cleanup``'s finally block may have
-    # created: the ``task.done()`` path above skips ``await task``, but the
-    # task may already have run ``_get_deferred_cleanup_lock()`` and left
-    # a fresh entry in ``_deferred_cleanup_locks``.
+    # created.  Both branches above can leave one behind:
+    #   - ``if`` (cancel + await): ``_cleanup``'s finally runs during
+    #     ``await task`` and calls ``_get_deferred_cleanup_lock()``, which
+    #     creates a fresh lock entry before popping the task entry.
+    #   - ``elif`` (already-done): we skip ``await task``, but the task
+    #     may already have run its finally and left the same fresh entry.
     _deferred_cleanup_locks.pop(loop, None)
     # ``_queue_depth`` is intentionally global: it tracks waiters on the
     # global ``_inference_lock``, not per-loop cleanup state, so a per-loop
@@ -437,6 +440,11 @@ async def _await_deferred_cleanup():
         )
     # ``asyncio.wait`` returns completed tasks regardless of whether they raised;
     # surface any exception so it isn't silently dropped on the return path.
+    # Log-and-proceed is intentional: ``_cleanup``'s finally runs
+    # ``lock.release()`` unconditionally before any return from this task, so
+    # the inference lock is always released and the next request can proceed.
+    # Callers have no need to reject the following inference — the lock state
+    # is correct regardless of cleanup outcome.  The log is the signal.
     (finished_task,) = done
     if not finished_task.cancelled():
         exc = finished_task.exception()

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -280,16 +280,15 @@ async def _reset_inference_state() -> None:
         # ourselves at warning level so fixture-level failures aren't
         # invisible (``_await_deferred_cleanup`` logs on its own path,
         # but reset is the only path for tests that aborted earlier).
-        try:
-            exc = task.exception()
-            if exc is not None:
-                logger.warning(
-                    "Deferred cleanup task raised during reset: %s",
-                    exc,
-                    exc_info=exc,
-                )
-        except asyncio.InvalidStateError:
-            pass
+        # ``task.exception()`` is safe here — the task is done and not
+        # cancelled, so it can't raise ``InvalidStateError`` or ``CancelledError``.
+        exc = task.exception()
+        if exc is not None:
+            logger.warning(
+                "Deferred cleanup task raised during reset: %s",
+                exc,
+                exc_info=exc,
+            )
     # Also cleans up any lock entry ``_cleanup``'s finally block may have
     # created.  Both branches above can leave one behind:
     #   - ``if`` (cancel + await): ``_cleanup``'s finally runs during
@@ -503,16 +502,15 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
             # log "Task exception was never retrieved" when it's GC'd.  Log it
             # ourselves as a safety net in case the prior ``_await_deferred_cleanup``
             # log was missed (it normally fires first on the happy path).
-            try:
-                exc = existing.exception()
-                if exc is not None:
-                    logger.warning(
-                        "Replaced done cleanup task had raised: %s",
-                        exc,
-                        exc_info=exc,
-                    )
-            except asyncio.InvalidStateError:
-                pass
+            # ``existing.exception()`` is safe here — the task is done and not
+            # cancelled, so it can't raise ``InvalidStateError`` or ``CancelledError``.
+            exc = existing.exception()
+            if exc is not None:
+                logger.warning(
+                    "Replaced done cleanup task had raised: %s",
+                    exc,
+                    exc_info=exc,
+                )
 
         async def _cleanup():
             thread = stream._thread

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -8,6 +8,7 @@ import json
 import logging
 import threading
 import time
+import weakref
 from collections.abc import AsyncGenerator
 from typing import Any, Literal, overload
 
@@ -225,7 +226,10 @@ _generation_streams = _resolve_generation_streams()
 # we sacrifice parallelism for stability on Apple Silicon.
 _inference_lock = asyncio.Lock()
 _deferred_cleanup_task: asyncio.Task | None = None
-_deferred_cleanup_lock: asyncio.Lock | None = None
+# asyncio.Lock binds to the loop at creation time, so tests that create
+# fresh event loops (pytest-asyncio) need a separate lock per loop.
+# WeakKeyDictionary lets closed loops get garbage-collected without leaking.
+_deferred_cleanup_locks: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]" = weakref.WeakKeyDictionary()
 # Tracks requests waiting for _inference_lock (not the _await_deferred_cleanup wait).
 _queue_depth = 0
 
@@ -243,7 +247,7 @@ async def _reset_inference_state() -> None:
     orphaned release calls after the task completes.
     Force-releases _inference_lock if held to prevent test deadlocks.
     """
-    global _deferred_cleanup_task, _deferred_cleanup_lock, _queue_depth
+    global _deferred_cleanup_task, _queue_depth
     if _deferred_cleanup_task is not None and not _deferred_cleanup_task.done():
         _deferred_cleanup_task.cancel()
         try:
@@ -251,7 +255,7 @@ async def _reset_inference_state() -> None:
         except (asyncio.CancelledError, asyncio.InvalidStateError):
             pass
     _deferred_cleanup_task = None
-    _deferred_cleanup_lock = None
+    _deferred_cleanup_locks.clear()
     _queue_depth = 0
     if _inference_lock.locked():
         _inference_lock.release()
@@ -267,19 +271,25 @@ def _get_inference_lock() -> asyncio.Lock:
 
 
 def _get_deferred_cleanup_lock() -> asyncio.Lock:
-    """Lazily create the deferred cleanup lock in the current event loop (Bug #119).
+    """Lazily create a deferred cleanup lock keyed by the running event loop
+    (Bug #119, Bug #243).
 
-    Module-level asyncio.Lock() binds to the loop at creation time, which
-    breaks in tests that create fresh event loops.
+    asyncio.Lock binds to the loop at creation time.  A single cached lock
+    breaks across event loops — once loop A creates it, loop B reuses a lock
+    bound to loop A and fails with "got Future attached to a different loop".
+    Keying by the running loop keeps each loop's lock isolated; the weak
+    dict lets closed test loops get garbage-collected.
 
-    Safe: asyncio is single-threaded; no await between the ``is None`` check
-    and the assignment, so no two coroutines can both observe ``None``
-    simultaneously.
+    Safe: asyncio is single-threaded; no await between the lookup and the
+    assignment, so no two coroutines on the same loop can both observe
+    ``None`` simultaneously.
     """
-    global _deferred_cleanup_lock
-    if _deferred_cleanup_lock is None:
-        _deferred_cleanup_lock = asyncio.Lock()
-    return _deferred_cleanup_lock
+    loop = asyncio.get_running_loop()
+    lock = _deferred_cleanup_locks.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _deferred_cleanup_locks[loop] = lock
+    return lock
 
 
 def _sync_default_stream() -> None:

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -457,9 +457,8 @@ async def _await_deferred_cleanup():
     # the inference lock is always released and the next request can proceed.
     # Callers have no need to reject the following inference — the lock state
     # is correct regardless of cleanup outcome.  The log is the signal.
-    finished_task = next(iter(done))
-    if not finished_task.cancelled():
-        exc = finished_task.exception()
+    if not task.cancelled():
+        exc = task.exception()
         if exc is not None:
             logger.error("Deferred inference cleanup raised: %s", exc, exc_info=exc)
 

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -582,11 +582,11 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
             # the stale-entry path is benign, shielding would complicate
             # cancellation semantics, and the pop is not load-bearing.
             async with _get_deferred_cleanup_lock():
-                # Use the task's own running loop; ``_cleanup`` runs as a
-                # task on the same loop it was created on, so this equals
-                # the outer ``loop``, but ``get_running_loop`` keeps
-                # ``_cleanup`` self-contained.
-                _deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
+                # ``loop`` is captured from the enclosing function;
+                # ``create_task`` binds the task to that loop, so using the
+                # captured value is equivalent to ``asyncio.get_running_loop()``
+                # here and avoids depending on that asyncio invariant.
+                _deferred_cleanup_tasks.pop(loop, None)
 
     # IMPORTANT: ``create_task(_cleanup())`` must remain the last statement
     # in the ``async with _get_deferred_cleanup_lock()`` block below.

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -288,7 +288,7 @@ async def _reset_inference_state() -> None:
                     exc,
                     exc_info=exc,
                 )
-        except (asyncio.InvalidStateError, asyncio.CancelledError):
+        except asyncio.InvalidStateError:
             pass
     # Also cleans up any lock entry ``_cleanup``'s finally block may have
     # created.  Both branches above can leave one behind:
@@ -484,10 +484,11 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
     # finally re-acquires the same lock to pop its dict entry; this works
     # today because tasks don't preempt — the outer ``async with`` exits and
     # releases the lock before ``_cleanup`` is first scheduled.  Any ``await``
-    # (even an innocent log call that happens to yield) inserted between
-    # ``create_task`` and the end of the ``async with`` would let the event
-    # loop schedule ``_cleanup`` into a deadlock on the same lock.  Adding
-    # new code here?  Put it *before* the ``async with`` or *after* its exit.
+    # inserted between ``create_task`` and the end of the ``async with``
+    # would let the event loop schedule ``_cleanup`` into a deadlock on the
+    # same lock.  Adding new code here?  Put it *before* the ``async with``
+    # or *after* its exit.  (Synchronous calls like ``logger.debug`` are
+    # fine — only ``await`` hands control back to the event loop.)
     async with _get_deferred_cleanup_lock():
         existing = _deferred_cleanup_tasks.get(loop)
         if existing is not None and not existing.done():
@@ -510,7 +511,7 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
                         exc,
                         exc_info=exc,
                     )
-            except (asyncio.InvalidStateError, asyncio.CancelledError):
+            except asyncio.InvalidStateError:
                 pass
 
         async def _cleanup():

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -352,6 +352,13 @@ def _get_deferred_cleanup_lock() -> asyncio.Lock:
     ``None`` simultaneously.  WeakKeyDictionary is not thread-safe for
     concurrent writes from multiple OS threads each running their own
     loop — this server runs on one thread, so that case doesn't apply.
+
+    Must be called from within a running event loop — uses
+    ``asyncio.get_running_loop()``, which raises ``RuntimeError`` if invoked
+    from synchronous code.  All callers (``_await_deferred_cleanup``,
+    ``_schedule_deferred_inference_cleanup``, ``_cleanup``'s finally) run
+    inside running loops.  Test code accessing this directly must do so
+    from an ``async def`` test or via ``loop.run_until_complete``.
     """
     loop = asyncio.get_running_loop()
     lock = _deferred_cleanup_locks.get(loop)

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -224,13 +224,15 @@ _generation_streams = _resolve_generation_streams()
 # lock would still allow interleaved GPU work from different models, risking
 # crashes or corruption.  A single global lock is an intentional trade-off:
 # we sacrifice parallelism for stability on Apple Silicon.
-#
-# On Python 3.10+ asyncio.Lock binds to a loop lazily (at first acquire, via
-# get_running_loop() — see bpo-39529), so the same instance can be shared
-# across loops as long as it is never acquired on one while still held by
-# another.  Test isolation relies on ``_reset_inference_state()``
-# force-releasing it between tests, not on recreating it per-loop like
-# ``_deferred_cleanup_locks`` below.
+# A lock acquired on loop A and never released leaves ``_locked = True`` and
+# a dead ``Future`` at the head of ``_waiters``.  Loop B then deadlocks trying
+# to acquire — its own waiter Future is queued behind a Future whose
+# ``set_result`` would need to run on loop A's (now-gone) scheduler.
+# Test isolation relies on ``_reset_inference_state()`` force-releasing
+# ``_inference_lock`` between tests, which clears both ``_locked`` and the
+# waiter queue, so loop B starts clean.  ``_deferred_cleanup_locks`` below
+# uses a different strategy (per-loop WeakKeyDictionary) because force-
+# releasing a lock held mid-cleanup would be unsafe.
 _inference_lock = asyncio.Lock()
 # A lock that was acquired on loop A (e.g. a test that crashed without
 # releasing it) causes deadlock or "Future attached to a different loop"
@@ -455,7 +457,7 @@ async def _await_deferred_cleanup():
     # the inference lock is always released and the next request can proceed.
     # Callers have no need to reject the following inference — the lock state
     # is correct regardless of cleanup outcome.  The log is the signal.
-    finished_task = done.pop()
+    finished_task = next(iter(done))
     if not finished_task.cancelled():
         exc = finished_task.exception()
         if exc is not None:
@@ -546,16 +548,19 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
                 # threads, so this is the "least bad" option vs permanent deadlock.
                 lock.release()
                 logger.info("Deferred inference cleanup: lock released")
-                # If this task is cancelled while ``_get_deferred_cleanup_lock().__aenter__``
-                # awaits the lock, ``CancelledError`` propagates before the body
-                # runs and the pop below is skipped.  In production that leaves a
-                # stale done/cancelled entry in ``_deferred_cleanup_tasks``, which
-                # is harmless: ``_inference_lock`` was already released above so a
-                # new inference can proceed; ``_await_deferred_cleanup`` returns
-                # immediately for ``task.done() == True``; and the next
+                # Any ``CancelledError`` delivered at the ``__aenter__`` ``await``
+                # below (cancellation during the acquire, or re-cancellation while
+                # this finally is running) skips the pop.  In production that
+                # leaves a stale done/cancelled entry in ``_deferred_cleanup_tasks``,
+                # which is harmless: ``_inference_lock`` was already released
+                # above so a new inference can proceed; ``_await_deferred_cleanup``
+                # returns immediately for ``task.done() == True``; and the next
                 # ``_schedule_deferred_inference_cleanup`` overwrites the entry.
                 # In tests, ``_reset_inference_state`` pops both dicts explicitly
                 # to keep per-test state clean — do not drop those fallback pops.
+                # We deliberately do *not* wrap this with ``asyncio.shield`` —
+                # the stale-entry path is benign, shielding would complicate
+                # cancellation semantics, and the pop is not load-bearing.
                 async with _get_deferred_cleanup_lock():
                     # Use the task's own running loop rather than closing over
                     # ``loop`` from the outer scope — ``_cleanup`` runs as a

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -435,6 +435,13 @@ async def _await_deferred_cleanup():
         raise ServerBusyError(
             f"Server busy: deferred GPU cleanup did not complete within {_DEFERRED_WAIT_TIMEOUT}s"
         )
+    # ``asyncio.wait`` returns completed tasks regardless of whether they raised;
+    # surface any exception so it isn't silently dropped on the return path.
+    (finished_task,) = done
+    if not finished_task.cancelled():
+        exc = finished_task.exception()
+        if exc is not None:
+            logger.error("Deferred inference cleanup raised: %s", exc, exc_info=exc)
 
 
 async def _schedule_deferred_inference_cleanup(stream) -> None:
@@ -504,9 +511,14 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
                 logger.info("Deferred inference cleanup: lock released")
                 # If this task is cancelled while ``_get_deferred_cleanup_lock().__aenter__``
                 # awaits the lock, ``CancelledError`` propagates before the body
-                # runs and the pop below is skipped.  ``_reset_inference_state()``
-                # covers that case with its own explicit ``pop`` of both the task
-                # and lock dicts — do not drop those fallback pops.
+                # runs and the pop below is skipped.  In production that leaves a
+                # stale done/cancelled entry in ``_deferred_cleanup_tasks``, which
+                # is harmless: ``_inference_lock`` was already released above so a
+                # new inference can proceed; ``_await_deferred_cleanup`` returns
+                # immediately for ``task.done() == True``; and the next
+                # ``_schedule_deferred_inference_cleanup`` overwrites the entry.
+                # In tests, ``_reset_inference_state`` pops both dicts explicitly
+                # to keep per-test state clean — do not drop those fallback pops.
                 async with _get_deferred_cleanup_lock():
                     # Use the task's own running loop rather than closing over
                     # ``loop`` from the outer scope — ``_cleanup`` runs as a

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -275,8 +275,17 @@ async def _reset_inference_state() -> None:
             task.cancel()
             try:
                 await task
-            except (asyncio.CancelledError, asyncio.InvalidStateError):
-                pass
+            except (asyncio.CancelledError, asyncio.InvalidStateError) as cancel_exc:
+                # If ``_cleanup`` raised in its body and the cancellation
+                # arrived in its finally (e.g. at ``await lock.acquire()``),
+                # the original exception lives on as ``__context__`` of the
+                # ``CancelledError``.  Surface it so it isn't lost.
+                if cancel_exc.__context__ is not None:
+                    logger.warning(
+                        "Cleanup exception masked by cancellation during reset: %s",
+                        cancel_exc.__context__,
+                        exc_info=cancel_exc.__context__,
+                    )
             except Exception as exc:
                 # Race: the task was about to finish with a non-cancellation
                 # exception when we called ``cancel()``, so ``await task``
@@ -464,11 +473,14 @@ async def _await_deferred_cleanup():
         )
     # ``asyncio.wait`` returns completed tasks regardless of whether they raised;
     # surface any exception so it isn't silently dropped on the return path.
-    # Log-and-proceed is intentional: ``_cleanup``'s finally runs
-    # ``lock.release()`` unconditionally before any return from this task, so
-    # the inference lock is always released and the next request can proceed.
-    # Callers have no need to reject the following inference — the lock state
-    # is correct regardless of cleanup outcome.  The log is the signal.
+    # Log-and-proceed is the same trade-off as the force-release in
+    # ``_reset_inference_state``: if ``_cleanup`` raised, ``_safe_sync`` may
+    # not have completed, so the next inference can run on top of dirty Metal
+    # state (risking a Metal crash on the next request).  We accept that risk
+    # because the alternative — refusing the next request — is also lose:
+    # ``_inference_lock`` is already released and recovery would require
+    # restarting the server.  The ERROR log is the only signal to the operator
+    # that the cleanup failed; the request stream itself shows no failure.
     if not task.cancelled():
         exc = task.exception()
         if exc is not None:

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -276,9 +276,20 @@ async def _reset_inference_state() -> None:
             pass
     elif task is not None and not task.cancelled():
         # Consume any stored exception so asyncio doesn't log
-        # "Task exception was never retrieved" to stderr.
-        with contextlib.suppress(asyncio.InvalidStateError, Exception):
-            task.exception()
+        # "Task exception was never retrieved" to stderr.  Also log it
+        # ourselves at warning level so fixture-level failures aren't
+        # invisible (``_await_deferred_cleanup`` logs on its own path,
+        # but reset is the only path for tests that aborted earlier).
+        try:
+            exc = task.exception()
+            if exc is not None:
+                logger.warning(
+                    "Deferred cleanup task raised during reset: %s",
+                    exc,
+                    exc_info=exc,
+                )
+        except (asyncio.InvalidStateError, asyncio.CancelledError):
+            pass
     # Also cleans up any lock entry ``_cleanup``'s finally block may have
     # created.  Both branches above can leave one behind:
     #   - ``if`` (cancel + await): ``_cleanup``'s finally runs during
@@ -479,9 +490,19 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
         if existing is not None and not existing.cancelled():
             # ``existing`` is done — replacing the dict entry below drops the
             # last reference.  Consume any stored exception so asyncio doesn't
-            # log "Task exception was never retrieved" when it's GC'd.
-            with contextlib.suppress(asyncio.InvalidStateError, Exception):
-                existing.exception()
+            # log "Task exception was never retrieved" when it's GC'd.  Log it
+            # ourselves as a safety net in case the prior ``_await_deferred_cleanup``
+            # log was missed (it normally fires first on the happy path).
+            try:
+                exc = existing.exception()
+                if exc is not None:
+                    logger.warning(
+                        "Replaced done cleanup task had raised: %s",
+                        exc,
+                        exc_info=exc,
+                    )
+            except (asyncio.InvalidStateError, asyncio.CancelledError):
+                pass
 
         async def _cleanup():
             thread = stream._thread

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -279,8 +279,12 @@ async def _reset_inference_state() -> None:
                 # If ``_cleanup`` raised in its body and the cancellation
                 # arrived in its finally (e.g. at ``await lock.acquire()``),
                 # the original exception lives on as ``__context__`` of the
-                # ``CancelledError``.  Surface it so it isn't lost.
-                if cancel_exc.__context__ is not None:
+                # ``CancelledError``.  Surface it so it isn't lost.  Nested
+                # cancellation (``__context__`` is itself a ``CancelledError``)
+                # is not an application error and shouldn't trigger this log.
+                if cancel_exc.__context__ is not None and not isinstance(
+                    cancel_exc.__context__, asyncio.CancelledError
+                ):
                     logger.warning(
                         "Cleanup exception masked by cancellation during reset: %s",
                         cancel_exc.__context__,

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -244,7 +244,7 @@ _deferred_cleanup_locks: weakref.WeakKeyDictionary[
 # awaited from loop B (RuntimeError on Python 3.10+).  Keeping this per-loop
 # keeps the reset path consistent with the lock scoping.
 _deferred_cleanup_tasks: weakref.WeakKeyDictionary[
-    asyncio.AbstractEventLoop, asyncio.Task
+    asyncio.AbstractEventLoop, asyncio.Task[None]
 ] = weakref.WeakKeyDictionary()
 # Tracks requests waiting for _inference_lock (not the _await_deferred_cleanup wait).
 _queue_depth = 0
@@ -274,6 +274,10 @@ async def _reset_inference_state() -> None:
             await task
         except (asyncio.CancelledError, asyncio.InvalidStateError):
             pass
+    # Also cleans up any lock entry ``_cleanup``'s finally block may have
+    # created: the ``task.done()`` path above skips ``await task``, but the
+    # task may already have run ``_get_deferred_cleanup_lock()`` and left
+    # a fresh entry in ``_deferred_cleanup_locks``.
     _deferred_cleanup_locks.pop(loop, None)
     _queue_depth = 0
     if _inference_lock.locked():
@@ -485,13 +489,13 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
                 lock.release()
                 logger.info("Deferred inference cleanup: lock released")
                 async with _get_deferred_cleanup_lock():
-                    _deferred_cleanup_tasks.pop(loop, None)
+                    # Use the task's own running loop rather than closing over
+                    # ``loop`` from the outer scope — ``_cleanup`` runs as a
+                    # task on the same loop it was created on, so these are
+                    # always equal, but using ``get_running_loop`` keeps
+                    # ``_cleanup`` self-contained.
+                    _deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
 
-        # ``_cleanup`` closes over ``loop``; ``create_task`` binds the task to
-        # the loop it's created on, so ``asyncio.get_running_loop()`` inside
-        # ``_cleanup`` (via ``_get_deferred_cleanup_lock``) equals this ``loop``
-        # at execution time.  Hoisting ``_cleanup`` to module level would break
-        # that invariant.
         _deferred_cleanup_tasks[loop] = asyncio.create_task(_cleanup())
 
 

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -299,9 +299,11 @@ def _get_deferred_cleanup_lock() -> asyncio.Lock:
     Keying by the running loop keeps each loop's lock isolated; the weak
     dict lets closed test loops get garbage-collected.
 
-    Safe: asyncio is single-threaded; no await between the lookup and the
+    Safe within a single event loop: no await between the lookup and the
     assignment, so no two coroutines on the same loop can both observe
-    ``None`` simultaneously.
+    ``None`` simultaneously.  WeakKeyDictionary is not thread-safe for
+    concurrent writes from multiple OS threads each running their own
+    loop — this server runs on one thread, so that case doesn't apply.
     """
     loop = asyncio.get_running_loop()
     lock = _deferred_cleanup_locks.get(loop)
@@ -485,6 +487,11 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
                 async with _get_deferred_cleanup_lock():
                     _deferred_cleanup_tasks.pop(loop, None)
 
+        # ``_cleanup`` closes over ``loop``; ``create_task`` binds the task to
+        # the loop it's created on, so ``asyncio.get_running_loop()`` inside
+        # ``_cleanup`` (via ``_get_deferred_cleanup_lock``) equals this ``loop``
+        # at execution time.  Hoisting ``_cleanup`` to module level would break
+        # that invariant.
         _deferred_cleanup_tasks[loop] = asyncio.create_task(_cleanup())
 
 

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -274,6 +274,11 @@ async def _reset_inference_state() -> None:
             await task
         except (asyncio.CancelledError, asyncio.InvalidStateError):
             pass
+    elif task is not None and not task.cancelled():
+        # Consume any stored exception so asyncio doesn't log
+        # "Task exception was never retrieved" to stderr.
+        with contextlib.suppress(asyncio.InvalidStateError, Exception):
+            task.exception()
     # Also cleans up any lock entry ``_cleanup``'s finally block may have
     # created: the ``task.done()`` path above skips ``await task``, but the
     # task may already have run ``_get_deferred_cleanup_lock()`` and left
@@ -504,6 +509,13 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
                     # ``_cleanup`` self-contained.
                     _deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
 
+        # IMPORTANT: ``create_task`` must remain the last statement inside
+        # this ``async with``.  ``_cleanup``'s finally re-acquires the same
+        # lock to pop its dict entry; this works today because tasks don't
+        # preempt — the outer ``async with`` exits and releases the lock
+        # before ``_cleanup`` is first scheduled.  Any ``await`` inserted
+        # after this line while the lock is still held would let the event
+        # loop schedule ``_cleanup`` into a deadlock on the same lock.
         _deferred_cleanup_tasks[loop] = asyncio.create_task(_cleanup())
 
 

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -4,6 +4,7 @@ import contextlib
 import dataclasses
 import gc
 import importlib
+import itertools
 import json
 import logging
 import threading
@@ -252,6 +253,10 @@ _deferred_cleanup_locks: weakref.WeakKeyDictionary[
 _deferred_cleanup_tasks: weakref.WeakKeyDictionary[
     asyncio.AbstractEventLoop, asyncio.Task[None]
 ] = weakref.WeakKeyDictionary()
+# Monotonic counter for cleanup-task names so the ERROR/WARNING log entries
+# that key on ``task.get_name()`` have a collision-free identifier even when
+# successive stream objects happen to reuse the same memory address.
+_cleanup_counter = itertools.count()
 # Tracks requests waiting for _inference_lock (not the _await_deferred_cleanup wait).
 _queue_depth = 0
 
@@ -529,16 +534,67 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
     lock = _get_inference_lock()
     loop = asyncio.get_running_loop()
 
-    # IMPORTANT: ``create_task(_cleanup())`` must be the last statement in the
-    # ``async with _get_deferred_cleanup_lock()`` block below.  ``_cleanup``'s
-    # finally re-acquires the same lock to pop its dict entry; this works
-    # today because tasks don't preempt — the outer ``async with`` exits and
-    # releases the lock before ``_cleanup`` is first scheduled.  Any ``await``
-    # inserted between ``create_task`` and the end of the ``async with``
-    # would let the event loop schedule ``_cleanup`` into a deadlock on the
-    # same lock.  Adding new code here?  Put it *before* the ``async with``
-    # or *after* its exit.  (Synchronous calls like ``logger.debug`` are
-    # fine — only ``await`` hands control back to the event loop.)
+    async def _cleanup():
+        thread = stream._thread
+        deadline = time.monotonic() + _DEFERRED_CLEANUP_TIMEOUT
+        try:
+            while thread is not None and thread.is_alive():
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.error(
+                        "Deferred inference cleanup: thread still alive after %ds — "
+                        "releasing lock anyway (risk of Metal crash on next inference)",
+                        _DEFERRED_CLEANUP_TIMEOUT,
+                    )
+                    break
+                try:
+                    wait = min(30, remaining)
+                    await asyncio.to_thread(thread.join, wait)
+                except BaseException as exc:
+                    logger.warning(
+                        "Deferred inference cleanup: poll loop aborted (%s) — "
+                        "releasing lock (thread may still be alive)",
+                        type(exc).__name__,
+                    )
+                    break  # finally will release the lock
+            else:
+                logger.info("Deferred inference cleanup: thread exited cleanly")
+        finally:
+            if thread is None or not thread.is_alive():
+                _safe_sync()
+            # Note: on timeout/abort with thread still alive, releasing the
+            # lock risks a Metal crash on the next inference (the stuck thread
+            # may still be issuing GPU commands).  Python can't kill CPU-bound
+            # threads, so this is the "least bad" option vs permanent deadlock.
+            lock.release()
+            logger.info("Deferred inference cleanup: lock released")
+            # Any ``CancelledError`` delivered at the ``__aenter__`` ``await``
+            # below (cancellation during the acquire, or re-cancellation while
+            # this finally is running) skips the pop.  In production that
+            # leaves a stale done/cancelled entry in ``_deferred_cleanup_tasks``,
+            # which is harmless: ``_inference_lock`` was already released
+            # above so a new inference can proceed; ``_await_deferred_cleanup``
+            # returns immediately for ``task.done() == True``; and the next
+            # ``_schedule_deferred_inference_cleanup`` overwrites the entry.
+            # In tests, ``_reset_inference_state`` pops both dicts explicitly
+            # to keep per-test state clean — do not drop those fallback pops.
+            # We deliberately do *not* wrap this with ``asyncio.shield`` —
+            # the stale-entry path is benign, shielding would complicate
+            # cancellation semantics, and the pop is not load-bearing.
+            async with _get_deferred_cleanup_lock():
+                # Use the task's own running loop; ``_cleanup`` runs as a
+                # task on the same loop it was created on, so this equals
+                # the outer ``loop``, but ``get_running_loop`` keeps
+                # ``_cleanup`` self-contained.
+                _deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
+
+    # IMPORTANT: ``create_task(_cleanup())`` must remain the last statement
+    # in the ``async with _get_deferred_cleanup_lock()`` block below.
+    # ``_cleanup``'s finally re-acquires the same lock to pop its dict entry;
+    # this works because tasks don't preempt — the outer ``async with`` exits
+    # and releases the lock before ``_cleanup`` is first scheduled.  Any
+    # ``await`` inserted between ``create_task`` and end-of-block would let
+    # the event loop schedule ``_cleanup`` into a deadlock on the same lock.
     async with _get_deferred_cleanup_lock():
         existing = _deferred_cleanup_tasks.get(loop)
         if existing is not None and not existing.done():
@@ -570,68 +626,13 @@ async def _schedule_deferred_inference_cleanup(stream) -> None:
                     exc_info=exc,
                 )
 
-        async def _cleanup():
-            thread = stream._thread
-            deadline = time.monotonic() + _DEFERRED_CLEANUP_TIMEOUT
-            try:
-                while thread is not None and thread.is_alive():
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
-                        logger.error(
-                            "Deferred inference cleanup: thread still alive after %ds — "
-                            "releasing lock anyway (risk of Metal crash on next inference)",
-                            _DEFERRED_CLEANUP_TIMEOUT,
-                        )
-                        break
-                    try:
-                        wait = min(30, remaining)
-                        await asyncio.to_thread(thread.join, wait)
-                    except BaseException as exc:
-                        logger.warning(
-                            "Deferred inference cleanup: poll loop aborted (%s) — "
-                            "releasing lock (thread may still be alive)",
-                            type(exc).__name__,
-                        )
-                        break  # finally will release the lock
-                else:
-                    logger.info("Deferred inference cleanup: thread exited cleanly")
-            finally:
-                if thread is None or not thread.is_alive():
-                    _safe_sync()
-                # Note: on timeout/abort with thread still alive, releasing the
-                # lock risks a Metal crash on the next inference (the stuck thread
-                # may still be issuing GPU commands).  Python can't kill CPU-bound
-                # threads, so this is the "least bad" option vs permanent deadlock.
-                lock.release()
-                logger.info("Deferred inference cleanup: lock released")
-                # Any ``CancelledError`` delivered at the ``__aenter__`` ``await``
-                # below (cancellation during the acquire, or re-cancellation while
-                # this finally is running) skips the pop.  In production that
-                # leaves a stale done/cancelled entry in ``_deferred_cleanup_tasks``,
-                # which is harmless: ``_inference_lock`` was already released
-                # above so a new inference can proceed; ``_await_deferred_cleanup``
-                # returns immediately for ``task.done() == True``; and the next
-                # ``_schedule_deferred_inference_cleanup`` overwrites the entry.
-                # In tests, ``_reset_inference_state`` pops both dicts explicitly
-                # to keep per-test state clean — do not drop those fallback pops.
-                # We deliberately do *not* wrap this with ``asyncio.shield`` —
-                # the stale-entry path is benign, shielding would complicate
-                # cancellation semantics, and the pop is not load-bearing.
-                async with _get_deferred_cleanup_lock():
-                    # Use the task's own running loop rather than closing over
-                    # ``loop`` from the outer scope — ``_cleanup`` runs as a
-                    # task on the same loop it was created on, so these are
-                    # always equal, but using ``get_running_loop`` keeps
-                    # ``_cleanup`` self-contained.
-                    _deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
-
-        # See IMPORTANT note at the top of the ``async with`` block.
-        # Name the task explicitly so the operator-facing log entries
-        # (ERROR from ``_await_deferred_cleanup``, WARNING from the
-        # next request) share a stable identifier instead of the
-        # auto-generated ``Task-N``.
+        # Name the task from a module-level monotonic counter so the
+        # operator-facing log entries (ERROR from ``_await_deferred_cleanup``,
+        # WARNING from the next request) share a collision-free identifier.
+        # ``id(stream)`` would be reused after GC and could collide between
+        # successive requests.
         _deferred_cleanup_tasks[loop] = asyncio.create_task(
-            _cleanup(), name=f"deferred-cleanup-{id(stream):x}"
+            _cleanup(), name=f"deferred-cleanup-{next(_cleanup_counter)}"
         )
 
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2530,18 +2530,18 @@ class TestAwaitDeferredCleanup:
         async def stuck_cleanup():
             await asyncio.sleep(999)
 
-        _inf_mod._deferred_cleanup_tasks[asyncio.get_running_loop()] = (
-            asyncio.create_task(stuck_cleanup())
-        )
+        loop = asyncio.get_running_loop()
+        stuck_task = asyncio.create_task(stuck_cleanup())
+        _inf_mod._deferred_cleanup_tasks[loop] = stuck_task
         try:
             with patch("olmlx.engine.inference._DEFERRED_WAIT_TIMEOUT", 0.05):
                 with pytest.raises(ServerBusyError, match="did not complete"):
                     await _await_deferred_cleanup()
         finally:
-            _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop()).cancel()
+            stuck_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop())
-            _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
+                await stuck_task
+            _inf_mod._deferred_cleanup_tasks.pop(loop, None)
 
     @pytest.mark.asyncio
     async def test_does_not_cancel_cleanup_task(self):
@@ -2560,9 +2560,9 @@ class TestAwaitDeferredCleanup:
                 task_was_cancelled = True
                 raise
 
-        _inf_mod._deferred_cleanup_tasks[asyncio.get_running_loop()] = (
-            asyncio.create_task(slow_cleanup())
-        )
+        loop = asyncio.get_running_loop()
+        slow_task = asyncio.create_task(slow_cleanup())
+        _inf_mod._deferred_cleanup_tasks[loop] = slow_task
         try:
             with patch("olmlx.engine.inference._DEFERRED_WAIT_TIMEOUT", 0.05):
                 with pytest.raises(Exception):
@@ -2570,10 +2570,10 @@ class TestAwaitDeferredCleanup:
             # The task should NOT have been cancelled by shield
             assert not task_was_cancelled
         finally:
-            _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop()).cancel()
+            slow_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop())
-            _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
+                await slow_task
+            _inf_mod._deferred_cleanup_tasks.pop(loop, None)
 
 
 class TestEstimateKvCacheBytes:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2440,9 +2440,6 @@ class TestDeferredInferenceCleanup:
         mock_thread.join = MagicMock()
         mock_stream._thread = mock_thread
 
-        # Reset lazy lock for this test's event loop
-        _inf_mod._deferred_cleanup_lock = None
-
         # Manually acquire the lock to simulate _stream_completion holding it
         await _inference_lock.acquire()
 
@@ -2463,9 +2460,6 @@ class TestDeferredInferenceCleanup:
         mock_thread.is_alive.side_effect = [True, False, False]
         mock_thread.join = MagicMock()
         mock_stream._thread = mock_thread
-
-        # Reset lazy lock for this test's event loop
-        _inf_mod._deferred_cleanup_lock = None
 
         await _inference_lock.acquire()
         assert _inference_lock.locked()

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2200,12 +2200,14 @@ class TestInferenceLockedWaitsDeferredCleanup:
             await asyncio.sleep(0.05)
             completed = True
 
-        _inf_mod._deferred_cleanup_task = asyncio.create_task(cleanup())
+        _inf_mod._deferred_cleanup_tasks[asyncio.get_running_loop()] = (
+            asyncio.create_task(cleanup())
+        )
         with patch("olmlx.engine.inference.mx"):
             async with _inference_locked():
                 pass
         assert completed
-        _inf_mod._deferred_cleanup_task = None
+        _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
 
     @pytest.mark.asyncio
     async def test_waits_for_deferred_cleanup_post_lock(self):
@@ -2222,10 +2224,12 @@ class TestInferenceLockedWaitsDeferredCleanup:
 
         async def acquire_then_inject(timeout_override=None):
             await original_acquire(timeout_override)
-            _inf_mod._deferred_cleanup_task = asyncio.create_task(cleanup())
+            _inf_mod._deferred_cleanup_tasks[asyncio.get_running_loop()] = (
+                asyncio.create_task(cleanup())
+            )
 
         with patch("olmlx.engine.inference.mx"):
-            _inf_mod._deferred_cleanup_task = None
+            _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
             with patch(
                 "olmlx.engine.inference._acquire_inference_lock",
                 side_effect=acquire_then_inject,
@@ -2233,7 +2237,7 @@ class TestInferenceLockedWaitsDeferredCleanup:
                 async with _inference_locked():
                     pass
             assert cleanup_done.is_set()
-        _inf_mod._deferred_cleanup_task = None
+        _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
 
 
 class TestAcquireInferenceLockTimeoutOverride:
@@ -2241,7 +2245,7 @@ class TestAcquireInferenceLockTimeoutOverride:
     async def test_timeout_override_used_instead_of_global(self):
         """timeout_override should take precedence over settings.inference_queue_timeout."""
         fresh_lock = asyncio.Lock()
-        _inf_mod._deferred_cleanup_task = None
+        _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
         with patch("olmlx.engine.inference._inference_lock", fresh_lock):
             # Hold the lock so acquire will block
             await fresh_lock.acquire()
@@ -2254,7 +2258,7 @@ class TestAcquireInferenceLockTimeoutOverride:
     async def test_timeout_override_none_falls_through_to_global(self):
         """When timeout_override is None, global setting is used."""
         fresh_lock = asyncio.Lock()
-        _inf_mod._deferred_cleanup_task = None
+        _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
         with (
             patch("olmlx.engine.inference._inference_lock", fresh_lock),
             patch("olmlx.engine.inference.settings") as mock_settings,
@@ -2269,7 +2273,7 @@ class TestAcquireInferenceLockTimeoutOverride:
     async def test_inference_locked_passes_timeout_override(self):
         """_inference_locked() should pass timeout_override to _acquire_inference_lock."""
         fresh_lock = asyncio.Lock()
-        _inf_mod._deferred_cleanup_task = None
+        _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
         with (
             patch("olmlx.engine.inference._inference_lock", fresh_lock),
             patch("olmlx.engine.inference.mx"),
@@ -2288,7 +2292,7 @@ class TestQueueDepth:
         # Use a fresh lock to avoid event loop binding issues
         fresh_lock = asyncio.Lock()
         _inf_mod._queue_depth = 0
-        _inf_mod._deferred_cleanup_task = None
+        _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
         with (
             patch("olmlx.engine.inference.mx"),
             patch("olmlx.engine.inference._inference_lock", fresh_lock),
@@ -2317,7 +2321,7 @@ class TestInferenceQueueTimeout:
 
         fresh_lock = asyncio.Lock()
         _inf_mod._queue_depth = 0
-        _inf_mod._deferred_cleanup_task = None
+        _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
         with (
             patch("olmlx.engine.inference.mx"),
             patch("olmlx.engine.inference._inference_lock", fresh_lock),
@@ -2340,7 +2344,7 @@ class TestStreamCompletionQueueTimeout:
 
         fresh_lock = asyncio.Lock()
         _inf_mod._queue_depth = 0
-        _inf_mod._deferred_cleanup_task = None
+        _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
         with (
             patch("olmlx.engine.inference.mx"),
             patch("olmlx.engine.inference._inference_lock", fresh_lock),
@@ -2423,7 +2427,7 @@ class TestStreamCompletionFallbackJoinLogging:
             "deferring Metal sync" in record.message for record in caplog.records
         )
         # Wait for deferred cleanup task to complete and release the lock
-        await _inf_mod._deferred_cleanup_task
+        await _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop())
         assert not _inference_lock.locked(), (
             "_inference_lock must be released by deferred cleanup task"
         )
@@ -2445,7 +2449,7 @@ class TestDeferredInferenceCleanup:
 
         with patch("olmlx.engine.inference._safe_sync") as mock_safe_sync:
             await _schedule_deferred_inference_cleanup(mock_stream)
-            await _inf_mod._deferred_cleanup_task
+            await _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop())
 
         # _safe_sync should have been called (after thread exited)
         mock_safe_sync.assert_called_once()
@@ -2469,7 +2473,7 @@ class TestDeferredInferenceCleanup:
             # Task is running — lock should still be held initially
             assert _inference_lock.locked()
             # Wait for deferred task to complete
-            await _inf_mod._deferred_cleanup_task
+            await _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop())
 
         assert not _inference_lock.locked()
 
@@ -2480,7 +2484,7 @@ class TestAwaitDeferredCleanup:
         """Should return immediately when no deferred cleanup task exists."""
         from olmlx.engine.inference import _await_deferred_cleanup
 
-        _inf_mod._deferred_cleanup_task = None
+        _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
         await _await_deferred_cleanup()  # should not raise
 
     @pytest.mark.asyncio
@@ -2490,9 +2494,9 @@ class TestAwaitDeferredCleanup:
 
         done_task = asyncio.create_task(asyncio.sleep(0))
         await done_task  # let it finish
-        _inf_mod._deferred_cleanup_task = done_task
+        _inf_mod._deferred_cleanup_tasks[asyncio.get_running_loop()] = done_task
         await _await_deferred_cleanup()  # should not raise
-        _inf_mod._deferred_cleanup_task = None
+        _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
 
     @pytest.mark.asyncio
     async def test_waits_for_running_task(self):
@@ -2506,10 +2510,12 @@ class TestAwaitDeferredCleanup:
             await asyncio.sleep(0.05)
             completed = True
 
-        _inf_mod._deferred_cleanup_task = asyncio.create_task(slow_cleanup())
+        _inf_mod._deferred_cleanup_tasks[asyncio.get_running_loop()] = (
+            asyncio.create_task(slow_cleanup())
+        )
         await _await_deferred_cleanup()
         assert completed
-        _inf_mod._deferred_cleanup_task = None
+        _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
 
     @pytest.mark.asyncio
     async def test_raises_on_timeout(self):
@@ -2524,16 +2530,18 @@ class TestAwaitDeferredCleanup:
         async def stuck_cleanup():
             await asyncio.sleep(999)
 
-        _inf_mod._deferred_cleanup_task = asyncio.create_task(stuck_cleanup())
+        _inf_mod._deferred_cleanup_tasks[asyncio.get_running_loop()] = (
+            asyncio.create_task(stuck_cleanup())
+        )
         try:
             with patch("olmlx.engine.inference._DEFERRED_WAIT_TIMEOUT", 0.05):
                 with pytest.raises(ServerBusyError, match="did not complete"):
                     await _await_deferred_cleanup()
         finally:
-            _inf_mod._deferred_cleanup_task.cancel()
+            _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop()).cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await _inf_mod._deferred_cleanup_task
-            _inf_mod._deferred_cleanup_task = None
+                await _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop())
+            _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
 
     @pytest.mark.asyncio
     async def test_does_not_cancel_cleanup_task(self):
@@ -2552,7 +2560,9 @@ class TestAwaitDeferredCleanup:
                 task_was_cancelled = True
                 raise
 
-        _inf_mod._deferred_cleanup_task = asyncio.create_task(slow_cleanup())
+        _inf_mod._deferred_cleanup_tasks[asyncio.get_running_loop()] = (
+            asyncio.create_task(slow_cleanup())
+        )
         try:
             with patch("olmlx.engine.inference._DEFERRED_WAIT_TIMEOUT", 0.05):
                 with pytest.raises(Exception):
@@ -2560,10 +2570,10 @@ class TestAwaitDeferredCleanup:
             # The task should NOT have been cancelled by shield
             assert not task_was_cancelled
         finally:
-            _inf_mod._deferred_cleanup_task.cancel()
+            _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop()).cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await _inf_mod._deferred_cleanup_task
-            _inf_mod._deferred_cleanup_task = None
+                await _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop())
+            _inf_mod._deferred_cleanup_tasks.pop(asyncio.get_running_loop(), None)
 
 
 class TestEstimateKvCacheBytes:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2427,7 +2427,9 @@ class TestStreamCompletionFallbackJoinLogging:
             "deferring Metal sync" in record.message for record in caplog.records
         )
         # Wait for deferred cleanup task to complete and release the lock
-        await _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop())
+        task = _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop())
+        assert task is not None, "expected a running cleanup task"
+        await task
         assert not _inference_lock.locked(), (
             "_inference_lock must be released by deferred cleanup task"
         )
@@ -2449,7 +2451,9 @@ class TestDeferredInferenceCleanup:
 
         with patch("olmlx.engine.inference._safe_sync") as mock_safe_sync:
             await _schedule_deferred_inference_cleanup(mock_stream)
-            await _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop())
+            task = _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop())
+            assert task is not None, "expected a running cleanup task"
+            await task
 
         # _safe_sync should have been called (after thread exited)
         mock_safe_sync.assert_called_once()
@@ -2473,7 +2477,9 @@ class TestDeferredInferenceCleanup:
             # Task is running — lock should still be held initially
             assert _inference_lock.locked()
             # Wait for deferred task to complete
-            await _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop())
+            task = _inf_mod._deferred_cleanup_tasks.get(asyncio.get_running_loop())
+            assert task is not None, "expected a running cleanup task"
+            await task
 
         assert not _inference_lock.locked()
 

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -322,6 +322,7 @@ class TestDeferredCleanupLockPerLoop:
         try:
             loop_b.run_until_complete(acquire_with_timeout())
         finally:
+            _inf_mod._deferred_cleanup_locks.pop(loop_b, None)
             loop_b.close()
 
 

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -164,6 +164,57 @@ class TestDeferredCleanupLock:
 
 
 # ---------------------------------------------------------------------------
+# Bug #243: _deferred_cleanup_lock cached globally — breaks across event loops
+# ---------------------------------------------------------------------------
+class TestDeferredCleanupLockPerLoop:
+    """_get_deferred_cleanup_lock must return a lock bound to the running loop."""
+
+    def test_separate_locks_for_separate_loops(self):
+        """A fresh event loop must receive a lock bound to itself, not a stale one."""
+        import asyncio
+
+        _inf_mod._deferred_cleanup_locks.clear()
+
+        loop_a = asyncio.new_event_loop()
+        try:
+            lock_a = loop_a.run_until_complete(self._get_lock())
+        finally:
+            loop_a.close()
+
+        loop_b = asyncio.new_event_loop()
+        try:
+            lock_b = loop_b.run_until_complete(self._get_lock())
+            # The acquire must succeed on loop B's own lock; if we leaked
+            # loop A's lock, this would raise "attached to a different loop".
+            loop_b.run_until_complete(self._acquire_and_release(lock_b))
+        finally:
+            loop_b.close()
+
+        assert lock_a is not lock_b, (
+            "Each event loop must receive its own lock (Bug #243)"
+        )
+
+    @staticmethod
+    async def _get_lock():
+        return _inf_mod._get_deferred_cleanup_lock()
+
+    @staticmethod
+    async def _acquire_and_release(lock):
+        async with lock:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_same_loop_returns_same_lock(self):
+        """Within a single event loop, repeated calls must return the same lock."""
+        _inf_mod._deferred_cleanup_locks.clear()
+        lock1 = _inf_mod._get_deferred_cleanup_lock()
+        lock2 = _inf_mod._get_deferred_cleanup_lock()
+        assert lock1 is lock2, (
+            "Repeated calls on the same loop must return the same lock"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Bug #120: GPU memory not freed on client disconnect during long prefill
 # ---------------------------------------------------------------------------
 class TestDrainAndJoinBlocksNewInference:

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -218,6 +218,40 @@ class TestDeferredCleanupLockPerLoop:
             "Repeated calls on the same loop must return the same lock"
         )
 
+    def test_stale_locked_lock_not_inherited(self):
+        """A lock acquired on a closed loop must not block a fresh loop.
+
+        This is the actual Bug #243 failure mode: if loop A acquires the
+        deferred cleanup lock and closes without releasing it, a pre-fix
+        module would cache that locked instance and loop B would deadlock
+        on its next acquire.  The fix keys locks by loop, so loop B gets
+        a fresh, unlocked lock.
+        """
+        import asyncio
+
+        async def acquire_no_release():
+            lock = _inf_mod._get_deferred_cleanup_lock()
+            await lock.acquire()  # intentionally never released
+
+        loop_a = asyncio.new_event_loop()
+        try:
+            loop_a.run_until_complete(acquire_no_release())
+        finally:
+            loop_a.close()  # closed with the lock still "held"
+
+        async def acquire_with_timeout():
+            lock = _inf_mod._get_deferred_cleanup_lock()
+            # Pre-fix: inherits loop A's locked instance → times out.
+            # Post-fix: loop B gets a fresh unlocked lock → returns immediately.
+            await asyncio.wait_for(lock.acquire(), timeout=0.5)
+            lock.release()
+
+        loop_b = asyncio.new_event_loop()
+        try:
+            loop_b.run_until_complete(acquire_with_timeout())
+        finally:
+            loop_b.close()
+
 
 # ---------------------------------------------------------------------------
 # Bug #120: GPU memory not freed on client disconnect during long prefill

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -1,5 +1,6 @@
 """Tests for inference engine bug fixes (#118, #119, #120, #123, #124, #125)."""
 
+import contextlib
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -324,6 +325,43 @@ class TestDeferredCleanupLockPerLoop:
         finally:
             _inf_mod._deferred_cleanup_locks.pop(loop_b, None)
             loop_b.close()
+
+    @pytest.mark.asyncio
+    async def test_reset_consumes_and_logs_done_task_exception(self, caplog):
+        """``_reset_inference_state`` must consume + log a stored exception
+        on the ``done and not cancelled`` branch.
+
+        Covers the ``elif task.done() and not task.cancelled()`` path that
+        otherwise leaks "Task exception was never retrieved" warnings to
+        stderr at GC time and silently swallows fixture-level failures.
+        """
+        import asyncio
+        import logging
+
+        loop = asyncio.get_running_loop()
+
+        async def boom():
+            raise RuntimeError("synthetic cleanup failure")
+
+        task = asyncio.create_task(boom())
+        # Let it run + transition to done with a stored exception.
+        with contextlib.suppress(RuntimeError):
+            await task
+        assert task.done() and not task.cancelled()
+
+        _inf_mod._deferred_cleanup_tasks[loop] = task
+        with caplog.at_level(logging.WARNING, logger="olmlx.engine.inference"):
+            await _inf_mod._reset_inference_state()
+
+        assert _inf_mod._deferred_cleanup_tasks.get(loop) is None, (
+            "reset must remove the loop's entry"
+        )
+        assert any(
+            "Deferred cleanup task raised during reset" in r.message
+            and "synthetic cleanup failure" in str(r.exc_info[1])
+            for r in caplog.records
+            if r.exc_info is not None
+        ), "reset must log the stored exception with exc_info"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -285,6 +285,11 @@ class TestDeferredCleanupLockPerLoop:
         try:
             loop_a.run_until_complete(acquire_no_release())
         finally:
+            # Explicit pop for consistency with
+            # ``test_separate_tasks_for_separate_loops``; WeakKeyDictionary
+            # would also GC the entry when loop_a is collected, but being
+            # explicit avoids a latent dependency on GC timing.
+            _inf_mod._deferred_cleanup_locks.pop(loop_a, None)
             loop_a.close()  # closed with the lock still "held"
 
         async def acquire_with_timeout():

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -363,6 +363,44 @@ class TestDeferredCleanupLockPerLoop:
             if r.exc_info is not None
         ), "reset must log the stored exception with exc_info"
 
+    @pytest.mark.asyncio
+    async def test_reset_surfaces_cancel_masked_exception(self, caplog):
+        """When ``_reset_inference_state`` cancels a task whose body raised
+        and whose finally block awaits, ``CancelledError`` carries the
+        original exception as ``__context__``.  The reset path must surface
+        that masked exception so it isn't silently lost.
+        """
+        import asyncio
+        import logging
+
+        loop = asyncio.get_running_loop()
+        body_started = asyncio.Event()
+        finally_blocker = asyncio.Event()
+
+        async def cleanup_with_masked_error():
+            try:
+                body_started.set()
+                raise RuntimeError("real cleanup failure")
+            finally:
+                # Block here so reset can deliver CancelledError into the
+                # finally — the original RuntimeError becomes __context__.
+                await finally_blocker.wait()
+
+        task = asyncio.create_task(cleanup_with_masked_error())
+        _inf_mod._deferred_cleanup_tasks[loop] = task
+        await body_started.wait()
+
+        with caplog.at_level(logging.WARNING, logger="olmlx.engine.inference"):
+            await _inf_mod._reset_inference_state()
+
+        assert _inf_mod._deferred_cleanup_tasks.get(loop) is None
+        assert any(
+            "masked by cancellation" in r.message
+            and "real cleanup failure" in str(r.exc_info[1])
+            for r in caplog.records
+            if r.exc_info is not None
+        ), "reset must surface the __context__ exception under cancellation"
+
 
 # ---------------------------------------------------------------------------
 # Bug #120: GPU memory not freed on client disconnect during long prefill

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -1,6 +1,5 @@
 """Tests for inference engine bug fixes (#118, #119, #120, #123, #124, #125)."""
 
-import contextlib
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -345,8 +344,12 @@ class TestDeferredCleanupLockPerLoop:
 
         task = asyncio.create_task(boom())
         # Let it run + transition to done with a stored exception.
-        with contextlib.suppress(RuntimeError):
+        try:
             await task
+        except RuntimeError as exc:
+            assert str(exc) == "synthetic cleanup failure", (
+                f"unexpected error from test fixture: {exc}"
+            )
         assert task.done() and not task.cancelled()
 
         _inf_mod._deferred_cleanup_tasks[loop] = task

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -432,6 +432,39 @@ class TestDeferredCleanupLockPerLoop:
             _inf_mod._deferred_cleanup_tasks.pop(loop, None)
             _inf_mod._deferred_cleanup_locks.pop(loop, None)
 
+    @pytest.mark.asyncio
+    async def test_reset_cleans_up_after_cleanup_finally_recancelled(self):
+        """If ``_cleanup``'s ``async with _get_deferred_cleanup_lock()`` in
+        the finally block is itself interrupted by a second cancel, the
+        task entry is left behind and the cleanup's own pop is skipped.
+        ``_reset_inference_state`` must still leave both module dicts clean.
+        """
+        import asyncio
+
+        loop = asyncio.get_running_loop()
+
+        # Simulate ``_cleanup``'s state at the point its finally is about to
+        # run: the dict has the task entry, and the lock dict has an entry
+        # (because the finally would have called ``_get_deferred_cleanup_lock``).
+        # We insert a "task" that's already done, then a stale lock entry,
+        # then call reset and assert both are cleared.
+        async def already_done():
+            return None
+
+        task = asyncio.create_task(already_done())
+        await task  # let it transition to done
+        _inf_mod._deferred_cleanup_tasks[loop] = task
+        _ = _inf_mod._get_deferred_cleanup_lock()  # populates _deferred_cleanup_locks
+
+        await _inf_mod._reset_inference_state()
+
+        assert _inf_mod._deferred_cleanup_tasks.get(loop) is None, (
+            "reset must remove the task entry"
+        )
+        assert _inf_mod._deferred_cleanup_locks.get(loop) is None, (
+            "reset must remove the lock entry even if cleanup's own pop was skipped"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Bug #120: GPU memory not freed on client disconnect during long prefill

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -401,6 +401,37 @@ class TestDeferredCleanupLockPerLoop:
             if r.exc_info is not None
         ), "reset must surface the __context__ exception under cancellation"
 
+    @pytest.mark.asyncio
+    async def test_await_deferred_cleanup_logs_task_exception(self, caplog):
+        """``_await_deferred_cleanup`` must log the stored exception of a
+        task that finished with a non-cancel error.  Without the log, the
+        exception is silently dropped after ``asyncio.wait`` returns and
+        the next request runs on potentially dirty Metal state with no
+        operator signal.
+        """
+        import asyncio
+        import logging
+
+        async def boom():
+            raise RuntimeError("cleanup exploded")
+
+        loop = asyncio.get_running_loop()
+        task = asyncio.create_task(boom())
+        _inf_mod._deferred_cleanup_tasks[loop] = task
+        try:
+            with caplog.at_level(logging.ERROR, logger="olmlx.engine.inference"):
+                await _inf_mod._await_deferred_cleanup()
+
+            assert any(
+                "Deferred inference cleanup" in r.message
+                and "cleanup exploded" in str(r.exc_info[1])
+                for r in caplog.records
+                if r.exc_info is not None
+            ), "_await_deferred_cleanup must log the task's exception at ERROR"
+        finally:
+            _inf_mod._deferred_cleanup_tasks.pop(loop, None)
+            _inf_mod._deferred_cleanup_locks.pop(loop, None)
+
 
 # ---------------------------------------------------------------------------
 # Bug #120: GPU memory not freed on client disconnect during long prefill

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -167,13 +167,25 @@ class TestDeferredCleanupLock:
 # Bug #243: _deferred_cleanup_lock cached globally — breaks across event loops
 # ---------------------------------------------------------------------------
 class TestDeferredCleanupLockPerLoop:
-    """_get_deferred_cleanup_lock must return a lock bound to the running loop."""
+    """_get_deferred_cleanup_lock must return a lock bound to the running loop.
+
+    The multi-loop test is deliberately ``def``, not ``async def`` — its whole
+    point is to exercise two separate ``asyncio.new_event_loop()`` instances,
+    which cannot be done from inside a single running loop.  The autouse
+    fixture below guarantees a clean ``_deferred_cleanup_locks`` dict even
+    for sync tests (pytest-asyncio doesn't drive async autouse fixtures for
+    non-async tests).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_lock_state(self):
+        _inf_mod._deferred_cleanup_locks.clear()
+        yield
+        _inf_mod._deferred_cleanup_locks.clear()
 
     def test_separate_locks_for_separate_loops(self):
         """A fresh event loop must receive a lock bound to itself, not a stale one."""
         import asyncio
-
-        _inf_mod._deferred_cleanup_locks.clear()
 
         loop_a = asyncio.new_event_loop()
         try:
@@ -206,7 +218,6 @@ class TestDeferredCleanupLockPerLoop:
     @pytest.mark.asyncio
     async def test_same_loop_returns_same_lock(self):
         """Within a single event loop, repeated calls must return the same lock."""
-        _inf_mod._deferred_cleanup_locks.clear()
         lock1 = _inf_mod._get_deferred_cleanup_lock()
         lock2 = _inf_mod._get_deferred_cleanup_lock()
         assert lock1 is lock2, (

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -240,6 +240,16 @@ class TestDeferredCleanupLockPerLoop:
         try:
             loop_a.run_until_complete(register_task_and_abandon())
         finally:
+            # Drain the pending ``never()`` task to avoid leaking it on a
+            # closed loop (ResourceWarning under Py 3.12+ filterwarnings=error).
+            pending = asyncio.all_tasks(loop_a)
+            for t in pending:
+                t.cancel()
+            if pending:
+                loop_a.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+            _inf_mod._deferred_cleanup_tasks.pop(loop_a, None)
             loop_a.close()
 
         async def await_cleanup_on_fresh_loop():

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -217,11 +217,19 @@ class TestDeferredCleanupLockPerLoop:
     @pytest.mark.asyncio
     async def test_same_loop_returns_same_lock(self):
         """Within a single event loop, repeated calls must return the same lock."""
-        lock1 = _inf_mod._get_deferred_cleanup_lock()
-        lock2 = _inf_mod._get_deferred_cleanup_lock()
-        assert lock1 is lock2, (
-            "Repeated calls on the same loop must return the same lock"
-        )
+        import asyncio
+
+        try:
+            lock1 = _inf_mod._get_deferred_cleanup_lock()
+            lock2 = _inf_mod._get_deferred_cleanup_lock()
+            assert lock1 is lock2, (
+                "Repeated calls on the same loop must return the same lock"
+            )
+        finally:
+            # Explicit cleanup matches the sibling tests in this class;
+            # the autouse ``_reset_inference_state`` fixture would also
+            # handle this, but being explicit keeps the pattern uniform.
+            _inf_mod._deferred_cleanup_locks.pop(asyncio.get_running_loop(), None)
 
     def test_separate_tasks_for_separate_loops(self):
         """A task registered on loop A must be invisible to loop B.

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -185,6 +185,11 @@ class TestDeferredCleanupLockPerLoop:
         try:
             lock_a = loop_a.run_until_complete(self._get_lock())
         finally:
+            # Explicit pop matches ``test_stale_locked_lock_not_inherited``
+            # and ``test_separate_tasks_for_separate_loops``; ``lock_a``
+            # keeps the lock alive so WeakKeyDictionary would hold the
+            # entry for the rest of this test otherwise.
+            _inf_mod._deferred_cleanup_locks.pop(loop_a, None)
             loop_a.close()
 
         loop_b = asyncio.new_event_loop()

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -218,6 +218,44 @@ class TestDeferredCleanupLockPerLoop:
             "Repeated calls on the same loop must return the same lock"
         )
 
+    def test_separate_tasks_for_separate_loops(self):
+        """A task registered on loop A must be invisible to loop B.
+
+        ``_await_deferred_cleanup`` only observes the calling loop's task.
+        If ``_deferred_cleanup_tasks`` were a single global like pre-fix,
+        loop B would try to ``asyncio.wait`` on loop A's foreign task and
+        raise ``RuntimeError: Task is attached to a different loop``.
+        """
+        import asyncio
+
+        async def register_task_and_abandon():
+            async def never():
+                await asyncio.sleep(999)
+
+            _inf_mod._deferred_cleanup_tasks[asyncio.get_running_loop()] = (
+                asyncio.create_task(never())
+            )
+
+        loop_a = asyncio.new_event_loop()
+        try:
+            loop_a.run_until_complete(register_task_and_abandon())
+        finally:
+            loop_a.close()
+
+        async def await_cleanup_on_fresh_loop():
+            # Loop B has no task registered.  _await_deferred_cleanup must
+            # return immediately (task for this loop is None) rather than
+            # touching loop A's orphaned task.
+            await _inf_mod._await_deferred_cleanup()
+
+        loop_b = asyncio.new_event_loop()
+        try:
+            loop_b.run_until_complete(
+                asyncio.wait_for(await_cleanup_on_fresh_loop(), timeout=0.5)
+            )
+        finally:
+            loop_b.close()
+
     def test_stale_locked_lock_not_inherited(self):
         """A lock acquired on a closed loop must not block a fresh loop.
 

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -279,6 +279,10 @@ class TestDeferredCleanupLockPerLoop:
                 asyncio.wait_for(await_cleanup_on_fresh_loop(), timeout=0.5)
             )
         finally:
+            # ``_await_deferred_cleanup`` called ``_get_deferred_cleanup_lock``
+            # which created an entry for loop_b.  Pop explicitly to keep the
+            # class-wide cleanup pattern uniform.
+            _inf_mod._deferred_cleanup_locks.pop(loop_b, None)
             loop_b.close()
 
     def test_stale_locked_lock_not_inherited(self):

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -171,17 +171,11 @@ class TestDeferredCleanupLockPerLoop:
 
     The multi-loop test is deliberately ``def``, not ``async def`` — its whole
     point is to exercise two separate ``asyncio.new_event_loop()`` instances,
-    which cannot be done from inside a single running loop.  The autouse
-    fixture below guarantees a clean ``_deferred_cleanup_locks`` dict even
-    for sync tests (pytest-asyncio doesn't drive async autouse fixtures for
-    non-async tests).
+    which cannot be done from inside a single running loop.  No fixture
+    teardown is needed: both loops are freshly constructed objects, so they
+    cannot have pre-existing entries in the WeakKeyDictionary, and the loops
+    are closed at the end of the test so their entries are eligible for GC.
     """
-
-    @pytest.fixture(autouse=True)
-    def _clean_lock_state(self):
-        _inf_mod._deferred_cleanup_locks.clear()
-        yield
-        _inf_mod._deferred_cleanup_locks.clear()
 
     def test_separate_locks_for_separate_loops(self):
         """A fresh event loop must receive a lock bound to itself, not a stale one."""

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -171,10 +171,10 @@ class TestDeferredCleanupLockPerLoop:
 
     The multi-loop test is deliberately ``def``, not ``async def`` — its whole
     point is to exercise two separate ``asyncio.new_event_loop()`` instances,
-    which cannot be done from inside a single running loop.  No fixture
-    teardown is needed: both loops are freshly constructed objects, so they
-    cannot have pre-existing entries in the WeakKeyDictionary, and the loops
-    are closed at the end of the test so their entries are eligible for GC.
+    which cannot be done from inside a single running loop.  Each test pops
+    its own entries from the module dicts explicitly: the loop locals stay
+    alive until the test returns, and WeakKeyDictionary only collects entries
+    once the key goes out of scope, so ``loop.close()`` alone isn't sufficient.
     """
 
     def test_separate_locks_for_separate_loops(self):
@@ -185,10 +185,11 @@ class TestDeferredCleanupLockPerLoop:
         try:
             lock_a = loop_a.run_until_complete(self._get_lock())
         finally:
-            # Explicit pop matches ``test_stale_locked_lock_not_inherited``
-            # and ``test_separate_tasks_for_separate_loops``; ``lock_a``
-            # keeps the lock alive so WeakKeyDictionary would hold the
-            # entry for the rest of this test otherwise.
+            # Explicit pop so loop_a's entry doesn't persist for the rest of
+            # this test while ``loop_a`` is still in scope (WeakKeyDictionary
+            # holds weak refs to *keys*; a live local variable keeps the key
+            # alive).  Matches ``test_stale_locked_lock_not_inherited`` and
+            # ``test_separate_tasks_for_separate_loops``.
             _inf_mod._deferred_cleanup_locks.pop(loop_a, None)
             loop_a.close()
 
@@ -199,6 +200,7 @@ class TestDeferredCleanupLockPerLoop:
             # loop A's lock, this would raise "attached to a different loop".
             loop_b.run_until_complete(self._acquire_and_release(lock_b))
         finally:
+            _inf_mod._deferred_cleanup_locks.pop(loop_b, None)
             loop_b.close()
 
         assert lock_a is not lock_b, (


### PR DESCRIPTION
## Summary
Fix a critical bug where the deferred cleanup lock was cached globally, causing failures when multiple event loops were used (common in pytest-asyncio tests). The lock is now keyed per event loop using a WeakKeyDictionary to prevent cross-loop interference.

## Key Changes
- **Changed `_deferred_cleanup_lock` to `_deferred_cleanup_locks`**: Replaced a single global `asyncio.Lock` with a `WeakKeyDictionary` that maps event loops to their own locks
- **Updated `_get_deferred_cleanup_lock()`**: Now retrieves or creates a lock specific to the running event loop, preventing "attached to a different loop" errors
- **Updated `_reset_inference_state()`**: Changed to clear the locks dictionary instead of resetting a single lock
- **Removed manual lock resets in tests**: Eliminated the need for `_inf_mod._deferred_cleanup_lock = None` in test setup since each loop now gets its own lock automatically

## Implementation Details
- Uses `weakref.WeakKeyDictionary` to allow closed event loops to be garbage-collected without manual cleanup
- Maintains thread-safety: asyncio is single-threaded, so the lookup-and-create pattern is safe without additional synchronization
- Backward compatible: the public API (`_get_deferred_cleanup_lock()`) remains unchanged
- Fixes both Bug #119 (lazy lock creation) and Bug #243 (cross-loop isolation)

## Testing
Added comprehensive test coverage in `TestDeferredCleanupLockPerLoop`:
- Verifies separate locks are created for separate event loops
- Confirms locks can be acquired/released on their own loops without cross-loop errors
- Validates that repeated calls within the same loop return the same lock instance

https://claude.ai/code/session_01ANYyPaDzpNU69JhjFxCAJ7