### PR TITLE
fix(spectralquant): support hybrid SSM+attention models in calibration

### DIFF
--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -48,10 +48,12 @@ def _is_attention_cache_state(state: Any) -> bool:
 
 
 def _resolve_cache_owner(inner: Any, model: Any) -> Any:
-    # `make_prompt_cache` defers to `make_cache()` on the passed object. For
-    # hybrid models (e.g. Qwen3Next SSM+attention), only the top-level model
-    # exposes `make_cache` with the correct per-layer cache types — the bare
-    # backbone would yield uniform KVCaches and break SSM layers.
+    # `make_prompt_cache` defers to `make_cache()` on the passed object. When
+    # the top-level model defines `make_cache`, it's always the authoritative
+    # source for per-layer cache types — required for hybrid SSM+attention
+    # architectures (Qwen3Next) and harmless for homogeneous ones. Falling back
+    # to the backbone preserves legacy behavior for models that don't define
+    # `make_cache` at the top level.
     if hasattr(model, "make_cache"):
         return model
     return inner
@@ -409,14 +411,16 @@ def calibrate_model(
     # Guard: if no KV vectors were collected, fail early with a clear message
     total_collected = sum(tokens_collected.values())
     if total_collected == 0:
-        detail = (
-            f" First forward-pass error: {type(first_exc).__name__}: {first_exc}"
-            if first_exc
-            else ""
-        )
+        if first_exc:
+            raise RuntimeError(
+                "No KV vectors were collected during calibration. "
+                f"First forward-pass error: {type(first_exc).__name__}: {first_exc}"
+            )
         raise RuntimeError(
             "No KV vectors were collected during calibration. "
-            "All forward passes failed — check that the model loads correctly." + detail
+            "No attention-layer cache entries were found — the model may have no "
+            "attention layers, or all attention layers fell outside the "
+            "calibration window."
         )
 
     if progress_callback:

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -26,16 +26,18 @@ def _resolve_config_holder(inner: Any, model: Any) -> Any:
     # Some architectures (e.g. Qwen3Next) expose the config namespace only on
     # the top-level model, not on the backbone returned by `_get_backbone`.
     # mlx-lm models expose it as `.args`; some mlx-vlm LanguageModel wrappers
-    # expose it as `.config`. Accept either so the guard is no stricter than
-    # the `_detect_head_dim` fallback that follows. Use `is not None` rather
-    # than `hasattr`: partially-constructed wrappers may set `self.args = None`
-    # as a class attribute, which would pass `hasattr` but yield a `None`
+    # expose it as `.config`. Prefer `.args` across both holders before falling
+    # back to `.config` — otherwise an unrelated `.config` on `inner` (e.g.
+    # inherited from a framework mixin) could shadow the real `.args` on
+    # `model`, defeating the Qwen3Next fix. Use `is not None` rather than
+    # `hasattr`: partially-constructed wrappers may set `self.args = None` as
+    # a class attribute, which would pass `hasattr` but yield a `None`
     # namespace downstream and silently miscalibrate.
     for obj in (inner, model):
-        if (
-            getattr(obj, "args", None) is not None
-            or getattr(obj, "config", None) is not None
-        ):
+        if getattr(obj, "args", None) is not None:
+            return obj
+    for obj in (inner, model):
+        if getattr(obj, "config", None) is not None:
             return obj
     raise RuntimeError(
         "Cannot detect model configuration: neither the backbone nor the "
@@ -69,8 +71,8 @@ def _build_empty_collection_error(first_exc: Exception | None) -> RuntimeError:
     """
     if first_exc is not None:
         err = RuntimeError(
-            "No KV vectors were collected during calibration. "
-            f"First forward-pass error: {type(first_exc).__name__}: {first_exc}"
+            "No KV vectors were collected during calibration — "
+            "see cause above for the forward-pass error."
         )
         err.__cause__ = first_exc
         err.__suppress_context__ = True

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -423,6 +423,7 @@ def calibrate_model(
             if first_exc is None:
                 first_exc = exc
             logger.debug("Skipping sample %d: %s", sample_idx, exc)
+            del prompt_cache
             continue
         mx.eval([c.state for c in prompt_cache if hasattr(c, "state")])
 

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -50,14 +50,14 @@ def _config_namespace(cfg_holder: Any) -> Any:
 
 
 def _is_attention_cache_state(state: Any, expected_head_dim: int) -> bool:
-    # Hybrid models (e.g. Qwen3Next) mix attention caches with SSM caches.
-    # Attention caches hold 4D (B, n_kv_heads, seq, head_dim) tensors.
-    # For Qwen3Next the SSM conv state is 3D at index 0 and rejected directly,
-    # but Mamba2-family hybrids (Falcon-H1, Zamba2) expose 4D recurrent states
-    # (B, n_heads, d_head, d_state) which would pass a pure ndim check — and
-    # chunked-scan Mamba2 variants can even have a non-trivial chunk axis in
-    # slot 2. We additionally require the last axis to match the expected
-    # attention head dimension, which SSM states won't satisfy.
+    # Shape sanity check: attention caches hold 4D (B, n_kv_heads, seq, head_dim)
+    # tensors. After prefill the real seq axis is ≥ 2 (the `len(tokens) < 2`
+    # guard in `calibrate_model` enforces this), so per-step SSM recurrent
+    # states with seq==1 are rejected. A last-axis match against the expected
+    # head_dim filters most SSM shapes. This is a secondary guard only — the
+    # call site additionally checks `isinstance(cache_entry, KVCache)` to
+    # catch the residual case where a 4D SSM state happens to match both
+    # constraints (e.g. a Mamba2 variant with d_state == head_dim).
     if not state or len(state) < 2:
         return False
     keys = state[0]
@@ -66,7 +66,7 @@ def _is_attention_cache_state(state: Any, expected_head_dim: int) -> bool:
     shape = getattr(keys, "shape", None)
     if shape is None or len(shape) != 4:
         return False
-    return shape[0] == 1 and shape[2] >= 1 and shape[3] == expected_head_dim
+    return shape[0] == 1 and shape[2] >= 2 and shape[3] == expected_head_dim
 
 
 def _resolve_cache_owner(inner: Any, model: Any) -> Any:
@@ -375,7 +375,7 @@ def calibrate_model(
     # KV cache, then extracting the cached tensors.  This captures keys and
     # values *after* rotary positional embeddings — the actual distribution
     # that gets stored in the KV cache at inference time.
-    from mlx_lm.models.cache import make_prompt_cache
+    from mlx_lm.models.cache import KVCache, make_prompt_cache
 
     cache_model = _resolve_cache_owner(inner, model)
     first_exc: Exception | None = None
@@ -407,6 +407,12 @@ def calibrate_model(
         # Extract K/V from each layer's cache
         for layer_idx in range(min(num_layers, len(prompt_cache))):
             cache_entry = prompt_cache[layer_idx]
+            # Primary filter: must be a standard attention KV cache. Hybrid
+            # models (Qwen3Next, Falcon-H1, Zamba2) mix these with SSM cache
+            # types whose `.state` may coincidentally match the attention
+            # shape (e.g. Mamba2 with d_state == head_dim).
+            if not isinstance(cache_entry, KVCache):
+                continue
             state = cache_entry.state if hasattr(cache_entry, "state") else None
             if not _is_attention_cache_state(state, head_dim):
                 continue

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -36,15 +36,22 @@ def _resolve_config_holder(inner: Any, model: Any) -> Any:
 
 def _is_attention_cache_state(state: Any) -> bool:
     # Hybrid models (e.g. Qwen3Next) mix attention caches with SSM caches.
-    # Only the attention layers hold 4D KV tensors we can calibrate on.
-    # Note: this is a shape-based heuristic keyed on state[0]. For Qwen3Next,
-    # SSM entries expose the 3D conv state at index 0, so they are correctly
-    # rejected; a future hybrid architecture whose non-attention cache puts a
-    # 4D tensor first would bypass this guard.
+    # Attention caches hold 4D (B, n_kv_heads, seq, head_dim) tensors.
+    # For Qwen3Next the SSM conv state is 3D at index 0 and rejected directly,
+    # but Mamba2-family hybrids (Falcon-H1, Zamba2) expose 4D recurrent states
+    # (B, n_heads, d_head, d_state) which would pass a pure ndim check. The
+    # secondary shape discriminant below rejects them: calibration always runs
+    # with batch size 1, and the real seq axis is > 1 after prefill, while
+    # Mamba2 per-step states have a short "seq" slot.
     if not state or len(state) < 2:
         return False
     keys = state[0]
-    return hasattr(keys, "ndim") and keys.ndim == 4
+    if not (hasattr(keys, "ndim") and keys.ndim == 4):
+        return False
+    shape = getattr(keys, "shape", None)
+    if shape is None or len(shape) != 4:
+        return False
+    return shape[0] == 1 and shape[2] > 1
 
 
 def _resolve_cache_owner(inner: Any, model: Any) -> Any:
@@ -314,7 +321,7 @@ def calibrate_model(
     layers = inner.layers
     num_layers = len(layers)
     cfg_holder = _resolve_config_holder(inner, model)
-    head_dim = _detect_head_dim(cfg_holder)
+    head_dim = _detect_head_dim(cfg_holder, layers_hint=inner)
 
     # Determine number of KV heads
     n_kv_heads = getattr(cfg_holder.args, "num_key_value_heads", None)

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -26,9 +26,15 @@ def _resolve_config_holder(inner: Any, model: Any) -> Any:
     # the top-level model, not on the backbone returned by `_get_backbone`.
     # mlx-lm models expose it as `.args`; some mlx-vlm LanguageModel wrappers
     # expose it as `.config`. Accept either so the guard is no stricter than
-    # the `_detect_head_dim` fallback that follows.
+    # the `_detect_head_dim` fallback that follows. Use `is not None` rather
+    # than `hasattr`: partially-constructed wrappers may set `self.args = None`
+    # as a class attribute, which would pass `hasattr` but yield a `None`
+    # namespace downstream and silently miscalibrate.
     for obj in (inner, model):
-        if hasattr(obj, "args") or hasattr(obj, "config"):
+        if (
+            getattr(obj, "args", None) is not None
+            or getattr(obj, "config", None) is not None
+        ):
             return obj
     raise RuntimeError(
         "Cannot detect model configuration: neither the backbone nor the "
@@ -331,6 +337,7 @@ def calibrate_model(
     cfg_holder = _resolve_config_holder(inner, model)
     cfg_ns = _config_namespace(cfg_holder)
     head_dim = _detect_head_dim(cfg_holder, layers_hint=inner)
+    logger.debug("calibrate_model: resolved head_dim=%d", head_dim)
 
     # Determine number of KV heads
     n_kv_heads = getattr(cfg_ns, "num_key_value_heads", None)

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -21,6 +21,31 @@ from olmlx.engine.spectralquant import allocate_bits, fit_codebook
 logger = logging.getLogger(__name__)
 
 
+def _resolve_config_holder(inner: Any, model: Any) -> Any:
+    # Some architectures (e.g. Qwen3Next) expose `.args` only on the top-level
+    # model, not on the backbone returned by `_get_backbone`.
+    return inner if hasattr(inner, "args") else model
+
+
+def _is_attention_cache_state(state: Any) -> bool:
+    # Hybrid models (e.g. Qwen3Next) mix attention caches with SSM caches.
+    # Only the attention layers hold 4D KV tensors we can calibrate on.
+    if not state or len(state) < 2:
+        return False
+    keys = state[0]
+    return hasattr(keys, "ndim") and keys.ndim == 4
+
+
+def _resolve_cache_owner(inner: Any, model: Any) -> Any:
+    # `make_prompt_cache` defers to `make_cache()` on the passed object.  For
+    # hybrid models (e.g. Qwen3Next SSM+attention), only the top-level model
+    # knows the correct per-layer cache types — the bare backbone would yield
+    # uniform KVCaches and break SSM layers.
+    if hasattr(model, "make_cache") or hasattr(model, "layers"):
+        return model
+    return inner
+
+
 def compute_covariance(data: mx.array) -> mx.array:
     """Compute centered sample covariance matrix.
 
@@ -275,20 +300,13 @@ def calibrate_model(
     inner = _get_backbone(model)
     layers = inner.layers
     num_layers = len(layers)
-    head_dim = _detect_head_dim(inner)
+    cfg_holder = _resolve_config_holder(inner, model)
+    head_dim = _detect_head_dim(cfg_holder)
 
     # Determine number of KV heads
-    n_kv_heads = getattr(
-        inner.args if hasattr(inner, "args") else model.args,
-        "num_key_value_heads",
-        None,
-    )
+    n_kv_heads = getattr(cfg_holder.args, "num_key_value_heads", None)
     if n_kv_heads is None:
-        n_kv_heads = getattr(
-            inner.args if hasattr(inner, "args") else model.args,
-            "num_attention_heads",
-            1,
-        )
+        n_kv_heads = getattr(cfg_holder.args, "num_attention_heads", 1)
 
     if progress_callback:
         progress_callback("Generating calibration data", 0.05)
@@ -323,7 +341,8 @@ def calibrate_model(
     # that gets stored in the KV cache at inference time.
     from mlx_lm.models.cache import make_prompt_cache
 
-    cache_model = inner if hasattr(inner, "layers") else model
+    cache_model = _resolve_cache_owner(inner, model)
+    first_exc: Exception | None = None
     for sample_idx, text in enumerate(texts):
         tokens = _encode_tokens(tokenizer, text)
         if len(tokens) > 512:
@@ -335,6 +354,8 @@ def calibrate_model(
         try:
             model(input_ids, cache=prompt_cache)
         except Exception as exc:
+            if first_exc is None:
+                first_exc = exc
             logger.debug("Skipping sample %d: %s", sample_idx, exc)
             continue
         mx.eval([c.state for c in prompt_cache if hasattr(c, "state")])
@@ -343,7 +364,7 @@ def calibrate_model(
         for layer_idx in range(min(num_layers, len(prompt_cache))):
             cache_entry = prompt_cache[layer_idx]
             state = cache_entry.state if hasattr(cache_entry, "state") else None
-            if not state or len(state) < 2:
+            if not _is_attention_cache_state(state):
                 continue
             # KVCache.state returns [keys, values] with shape
             # (1, n_kv_heads, seq_len, head_dim)
@@ -377,9 +398,14 @@ def calibrate_model(
     # Guard: if no KV vectors were collected, fail early with a clear message
     total_collected = sum(tokens_collected.values())
     if total_collected == 0:
+        detail = (
+            f" First forward-pass error: {type(first_exc).__name__}: {first_exc}"
+            if first_exc
+            else ""
+        )
         raise RuntimeError(
             "No KV vectors were collected during calibration. "
-            "All forward passes failed — check that the model loads correctly."
+            "All forward passes failed — check that the model loads correctly." + detail
         )
 
     if progress_callback:

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -24,7 +24,14 @@ logger = logging.getLogger(__name__)
 def _resolve_config_holder(inner: Any, model: Any) -> Any:
     # Some architectures (e.g. Qwen3Next) expose `.args` only on the top-level
     # model, not on the backbone returned by `_get_backbone`.
-    return inner if hasattr(inner, "args") else model
+    if hasattr(inner, "args"):
+        return inner
+    if hasattr(model, "args"):
+        return model
+    raise RuntimeError(
+        "Cannot detect model configuration: neither the backbone nor the "
+        "top-level model exposes '.args'. Unsupported architecture."
+    )
 
 
 def _is_attention_cache_state(state: Any) -> bool:

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -22,27 +22,42 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_config_holder(inner: Any, model: Any) -> Any:
-    # Some architectures (e.g. Qwen3Next) expose `.args` only on the top-level
-    # model, not on the backbone returned by `_get_backbone`.
-    if hasattr(inner, "args"):
-        return inner
-    if hasattr(model, "args"):
-        return model
+    # Some architectures (e.g. Qwen3Next) expose the config namespace only on
+    # the top-level model, not on the backbone returned by `_get_backbone`.
+    # mlx-lm models expose it as `.args`; some mlx-vlm LanguageModel wrappers
+    # expose it as `.config`. Accept either so the guard is no stricter than
+    # the `_detect_head_dim` fallback that follows.
+    for obj in (inner, model):
+        if hasattr(obj, "args") or hasattr(obj, "config"):
+            return obj
     raise RuntimeError(
         "Cannot detect model configuration: neither the backbone nor the "
-        "top-level model exposes '.args'. Unsupported architecture."
+        "top-level model exposes '.args' or '.config'. Unsupported architecture."
     )
 
 
-def _is_attention_cache_state(state: Any) -> bool:
+def _config_namespace(cfg_holder: Any) -> Any:
+    # Return the `.args` or `.config` object carrying architecture fields.
+    ns = getattr(cfg_holder, "args", None)
+    if ns is not None:
+        return ns
+    ns = getattr(cfg_holder, "config", None)
+    if ns is not None:
+        return ns
+    raise RuntimeError(
+        "Config holder exposes neither '.args' nor '.config'. Unsupported architecture."
+    )
+
+
+def _is_attention_cache_state(state: Any, expected_head_dim: int) -> bool:
     # Hybrid models (e.g. Qwen3Next) mix attention caches with SSM caches.
     # Attention caches hold 4D (B, n_kv_heads, seq, head_dim) tensors.
     # For Qwen3Next the SSM conv state is 3D at index 0 and rejected directly,
     # but Mamba2-family hybrids (Falcon-H1, Zamba2) expose 4D recurrent states
-    # (B, n_heads, d_head, d_state) which would pass a pure ndim check. The
-    # secondary shape discriminant below rejects them: calibration always runs
-    # with batch size 1, and the real seq axis is > 1 after prefill, while
-    # Mamba2 per-step states have a short "seq" slot.
+    # (B, n_heads, d_head, d_state) which would pass a pure ndim check — and
+    # chunked-scan Mamba2 variants can even have a non-trivial chunk axis in
+    # slot 2. We additionally require the last axis to match the expected
+    # attention head dimension, which SSM states won't satisfy.
     if not state or len(state) < 2:
         return False
     keys = state[0]
@@ -51,7 +66,7 @@ def _is_attention_cache_state(state: Any) -> bool:
     shape = getattr(keys, "shape", None)
     if shape is None or len(shape) != 4:
         return False
-    return shape[0] == 1 and shape[2] > 1
+    return shape[0] == 1 and shape[2] >= 1 and shape[3] == expected_head_dim
 
 
 def _resolve_cache_owner(inner: Any, model: Any) -> Any:
@@ -321,12 +336,13 @@ def calibrate_model(
     layers = inner.layers
     num_layers = len(layers)
     cfg_holder = _resolve_config_holder(inner, model)
+    cfg_ns = _config_namespace(cfg_holder)
     head_dim = _detect_head_dim(cfg_holder, layers_hint=inner)
 
     # Determine number of KV heads
-    n_kv_heads = getattr(cfg_holder.args, "num_key_value_heads", None)
+    n_kv_heads = getattr(cfg_ns, "num_key_value_heads", None)
     if n_kv_heads is None:
-        n_kv_heads = getattr(cfg_holder.args, "num_attention_heads", 1)
+        n_kv_heads = getattr(cfg_ns, "num_attention_heads", 1)
 
     if progress_callback:
         progress_callback("Generating calibration data", 0.05)
@@ -365,6 +381,14 @@ def calibrate_model(
     first_exc: Exception | None = None
     for sample_idx, text in enumerate(texts):
         tokens = _encode_tokens(tokenizer, text)
+        if len(tokens) < 2:
+            # Single-token prefills produce (1, n_kv, 1, head_dim) caches that
+            # are easy to confuse with per-step SSM states, and carry no
+            # meaningful KV statistics anyway. Skip them.
+            logger.debug(
+                "Skipping sample %d: too short (%d tokens)", sample_idx, len(tokens)
+            )
+            continue
         if len(tokens) > 512:
             tokens = tokens[:512]
         input_ids = mx.array([tokens])
@@ -384,7 +408,7 @@ def calibrate_model(
         for layer_idx in range(min(num_layers, len(prompt_cache))):
             cache_entry = prompt_cache[layer_idx]
             state = cache_entry.state if hasattr(cache_entry, "state") else None
-            if not _is_attention_cache_state(state):
+            if not _is_attention_cache_state(state, head_dim):
                 continue
             # KVCache.state returns [keys, values] with shape
             # (1, n_kv_heads, seq_len, head_dim)

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -50,15 +50,37 @@ def _config_namespace(cfg_holder: Any) -> Any:
     return args if args is not None else getattr(cfg_holder, "config", None)
 
 
+def _build_empty_collection_error(first_exc: Exception | None) -> RuntimeError:
+    """Build the error raised when calibration collected zero KV vectors.
+
+    Chains `first_exc` via `__cause__` (equivalent to `raise ... from first_exc`)
+    so the full traceback is preserved when a forward-pass failure is the
+    root cause. When no forward-pass errors occurred, reports that no
+    attention-layer cache entries were found.
+    """
+    if first_exc is not None:
+        err = RuntimeError(
+            "No KV vectors were collected during calibration. "
+            f"First forward-pass error: {type(first_exc).__name__}: {first_exc}"
+        )
+        err.__cause__ = first_exc
+        return err
+    return RuntimeError(
+        "No KV vectors were collected during calibration. "
+        "No attention-layer cache entries were found — the model may have no "
+        "attention layers, or all attention layers fell outside the "
+        "calibration window."
+    )
+
+
 def _is_attention_cache_state(state: Any, expected_head_dim: int) -> bool:
-    # Shape sanity check: attention caches hold 4D (B, n_kv_heads, seq, head_dim)
-    # tensors. After prefill the real seq axis is ≥ 2 (the `len(tokens) < 2`
-    # guard in `calibrate_model` enforces this), so per-step SSM recurrent
-    # states with seq==1 are rejected. A last-axis match against the expected
-    # head_dim filters most SSM shapes. This is a secondary guard only — the
-    # call site additionally checks `isinstance(cache_entry, KVCache)` to
-    # catch the residual case where a 4D SSM state happens to match both
-    # constraints (e.g. a Mamba2 variant with d_state == head_dim).
+    # Secondary shape check for confirmed KVCache entries (primary filter is
+    # `isinstance(cache_entry, KVCache)` at the call site). Guards against:
+    # - empty caches not yet populated (len(state) < 2)
+    # - non-4D tensors (should not happen in practice)
+    # - caches seeded with < 2 tokens (seq < 2; already excluded by the
+    #   `len(tokens) < 2` guard above, but kept as a defensive check)
+    # - head_dim mismatch (e.g. model weights loaded with a mismatched config)
     if not state or len(state) < 2:
         return False
     keys = state[0]
@@ -448,17 +470,7 @@ def calibrate_model(
     # Guard: if no KV vectors were collected, fail early with a clear message
     total_collected = sum(tokens_collected.values())
     if total_collected == 0:
-        if first_exc:
-            raise RuntimeError(
-                "No KV vectors were collected during calibration. "
-                f"First forward-pass error: {type(first_exc).__name__}: {first_exc}"
-            ) from first_exc
-        raise RuntimeError(
-            "No KV vectors were collected during calibration. "
-            "No attention-layer cache entries were found — the model may have no "
-            "attention layers, or all attention layers fell outside the "
-            "calibration window."
-        )
+        raise _build_empty_collection_error(first_exc)
 
     if progress_callback:
         progress_callback("Running eigenspectral analysis", 0.5)

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -435,7 +435,7 @@ def calibrate_model(
             # shape (e.g. Mamba2 with d_state == head_dim).
             if not isinstance(cache_entry, KVCache):
                 continue
-            state = cache_entry.state if hasattr(cache_entry, "state") else None
+            state = cache_entry.state
             if not _is_attention_cache_state(state, head_dim):
                 continue
             # KVCache.state returns [keys, values] with shape

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -53,10 +53,11 @@ def _config_namespace(cfg_holder: Any) -> Any:
 def _build_empty_collection_error(first_exc: Exception | None) -> RuntimeError:
     """Build the error raised when calibration collected zero KV vectors.
 
-    Chains `first_exc` via `__cause__` (equivalent to `raise ... from first_exc`)
-    so the full traceback is preserved when a forward-pass failure is the
-    root cause. When no forward-pass errors occurred, reports that no
-    attention-layer cache entries were found.
+    Chains `first_exc` via `__cause__` and sets `__suppress_context__=True` so
+    the behavior matches `raise ... from first_exc`: the traceback shows the
+    forward-pass cause and nothing else. Without suppression, raising this
+    from inside an `except` block in the future would also surface the
+    unrelated implicit `__context__`.
     """
     if first_exc is not None:
         err = RuntimeError(
@@ -64,6 +65,7 @@ def _build_empty_collection_error(first_exc: Exception | None) -> RuntimeError:
             f"First forward-pass error: {type(first_exc).__name__}: {first_exc}"
         )
         err.__cause__ = first_exc
+        err.__suppress_context__ = True
         return err
     return RuntimeError(
         "No KV vectors were collected during calibration. "

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -415,7 +415,7 @@ def calibrate_model(
             raise RuntimeError(
                 "No KV vectors were collected during calibration. "
                 f"First forward-pass error: {type(first_exc).__name__}: {first_exc}"
-            )
+            ) from first_exc
         raise RuntimeError(
             "No KV vectors were collected during calibration. "
             "No attention-layer cache entries were found — the model may have no "

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -40,7 +40,8 @@ def _config_namespace(cfg_holder: Any) -> Any:
     # Return the `.args` or `.config` object carrying architecture fields.
     # Precondition: caller has verified via `_resolve_config_holder` that one
     # of these exists, so no validation is needed here.
-    return getattr(cfg_holder, "args", None) or getattr(cfg_holder, "config", None)
+    args = getattr(cfg_holder, "args", None)
+    return args if args is not None else getattr(cfg_holder, "config", None)
 
 
 def _is_attention_cache_state(state: Any, expected_head_dim: int) -> bool:
@@ -57,9 +58,7 @@ def _is_attention_cache_state(state: Any, expected_head_dim: int) -> bool:
     keys = state[0]
     if not (hasattr(keys, "ndim") and keys.ndim == 4):
         return False
-    shape = getattr(keys, "shape", None)
-    if shape is None or len(shape) != 4:
-        return False
+    shape = keys.shape
     return shape[2] >= 2 and shape[3] == expected_head_dim
 
 

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import mlx.core as mx
 import numpy as np
+from mlx_lm.models.cache import KVCache
 
 from olmlx.engine.spectralquant import allocate_bits, fit_codebook
 
@@ -44,10 +45,17 @@ def _resolve_config_holder(inner: Any, model: Any) -> Any:
 
 def _config_namespace(cfg_holder: Any) -> Any:
     # Return the `.args` or `.config` object carrying architecture fields.
-    # Precondition: caller has verified via `_resolve_config_holder` that one
-    # of these exists, so no validation is needed here.
+    # `_resolve_config_holder` normally enforces that one of these is present,
+    # but raise explicitly here so the function's contract is enforceable in
+    # isolation (matches the `_detect_head_dim` pattern in turboquant_cache).
     args = getattr(cfg_holder, "args", None)
-    return args if args is not None else getattr(cfg_holder, "config", None)
+    result = args if args is not None else getattr(cfg_holder, "config", None)
+    if result is None:
+        raise RuntimeError(
+            f"_config_namespace: {type(cfg_holder).__name__} has neither "
+            "'.args' nor '.config'"
+        )
+    return result
 
 
 def _build_empty_collection_error(first_exc: Exception | None) -> RuntimeError:
@@ -75,14 +83,20 @@ def _build_empty_collection_error(first_exc: Exception | None) -> RuntimeError:
     )
 
 
-def _is_attention_cache_state(state: Any, expected_head_dim: int) -> bool:
-    # Secondary shape check for confirmed KVCache entries (primary filter is
-    # `isinstance(cache_entry, KVCache)` at the call site). Guards against:
+def _is_attention_cache(cache_entry: Any, expected_head_dim: int) -> bool:
+    # Combined filter: must be a standard KVCache (not an SSM cache type such
+    # as ArraysCache) AND expose a plausible 4D attention state. The isinstance
+    # guard is load-bearing — shape alone cannot reject Mamba2 states where
+    # `d_state == head_dim`. Keeping both checks inside this function means
+    # the signature enforces the full contract and a future refactor can't
+    # accidentally drop the type guard. Also guards against:
     # - empty caches not yet populated (len(state) < 2)
-    # - non-4D tensors (should not happen in practice)
     # - caches seeded with < 2 tokens (seq < 2; already excluded by the
-    #   `len(tokens) < 2` guard above, but kept as a defensive check)
+    #   `len(tokens) < 2` guard in `calibrate_model`, but kept as defense)
     # - head_dim mismatch (e.g. model weights loaded with a mismatched config)
+    if not isinstance(cache_entry, KVCache):
+        return False
+    state: Any = cache_entry.state
     if not state or len(state) < 2:
         return False
     keys = state[0]
@@ -399,7 +413,7 @@ def calibrate_model(
     # KV cache, then extracting the cached tensors.  This captures keys and
     # values *after* rotary positional embeddings — the actual distribution
     # that gets stored in the KV cache at inference time.
-    from mlx_lm.models.cache import KVCache, make_prompt_cache
+    from mlx_lm.models.cache import make_prompt_cache
 
     cache_model = _resolve_cache_owner(inner, model)
     first_exc: Exception | None = None
@@ -432,15 +446,11 @@ def calibrate_model(
         # Extract K/V from each layer's cache
         for layer_idx in range(min(num_layers, len(prompt_cache))):
             cache_entry = prompt_cache[layer_idx]
-            # Primary filter: must be a standard attention KV cache. Hybrid
-            # models (Qwen3Next, Falcon-H1, Zamba2) mix these with SSM cache
-            # types whose `.state` may coincidentally match the attention
-            # shape (e.g. Mamba2 with d_state == head_dim).
-            if not isinstance(cache_entry, KVCache):
+            # Combined type + shape filter. Rejects SSM cache types (ArraysCache,
+            # etc.) and KVCaches whose state doesn't match attention shape.
+            if not _is_attention_cache(cache_entry, head_dim):
                 continue
             state = cache_entry.state
-            if not _is_attention_cache_state(state, head_dim):
-                continue
             # KVCache.state returns [keys, values] with shape
             # (1, n_kv_heads, seq_len, head_dim)
             cached_keys = state[0]  # (1, n_kv_heads, seq, head_dim)

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -506,7 +506,7 @@ def calibrate_model(
             for head_idx in range(n_kv_heads):
                 all_chunks.extend(kv_collectors[layer_idx][head_idx][kind])
             if not all_chunks:
-                logger.warning(
+                logger.debug(
                     "No KV data for layer %d %s, skipping",
                     layer_idx,
                     kind,

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -30,6 +30,10 @@ def _resolve_config_holder(inner: Any, model: Any) -> Any:
 def _is_attention_cache_state(state: Any) -> bool:
     # Hybrid models (e.g. Qwen3Next) mix attention caches with SSM caches.
     # Only the attention layers hold 4D KV tensors we can calibrate on.
+    # Note: this is a shape-based heuristic keyed on state[0]. For Qwen3Next,
+    # SSM entries expose the 3D conv state at index 0, so they are correctly
+    # rejected; a future hybrid architecture whose non-attention cache puts a
+    # 4D tensor first would bypass this guard.
     if not state or len(state) < 2:
         return False
     keys = state[0]
@@ -37,11 +41,11 @@ def _is_attention_cache_state(state: Any) -> bool:
 
 
 def _resolve_cache_owner(inner: Any, model: Any) -> Any:
-    # `make_prompt_cache` defers to `make_cache()` on the passed object.  For
+    # `make_prompt_cache` defers to `make_cache()` on the passed object. For
     # hybrid models (e.g. Qwen3Next SSM+attention), only the top-level model
-    # knows the correct per-layer cache types — the bare backbone would yield
-    # uniform KVCaches and break SSM layers.
-    if hasattr(model, "make_cache") or hasattr(model, "layers"):
+    # exposes `make_cache` with the correct per-layer cache types — the bare
+    # backbone would yield uniform KVCaches and break SSM layers.
+    if hasattr(model, "make_cache"):
         return model
     return inner
 

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -38,15 +38,9 @@ def _resolve_config_holder(inner: Any, model: Any) -> Any:
 
 def _config_namespace(cfg_holder: Any) -> Any:
     # Return the `.args` or `.config` object carrying architecture fields.
-    ns = getattr(cfg_holder, "args", None)
-    if ns is not None:
-        return ns
-    ns = getattr(cfg_holder, "config", None)
-    if ns is not None:
-        return ns
-    raise RuntimeError(
-        "Config holder exposes neither '.args' nor '.config'. Unsupported architecture."
-    )
+    # Precondition: caller has verified via `_resolve_config_holder` that one
+    # of these exists, so no validation is needed here.
+    return getattr(cfg_holder, "args", None) or getattr(cfg_holder, "config", None)
 
 
 def _is_attention_cache_state(state: Any, expected_head_dim: int) -> bool:
@@ -66,7 +60,7 @@ def _is_attention_cache_state(state: Any, expected_head_dim: int) -> bool:
     shape = getattr(keys, "shape", None)
     if shape is None or len(shape) != 4:
         return False
-    return shape[0] == 1 and shape[2] >= 2 and shape[3] == expected_head_dim
+    return shape[2] >= 2 and shape[3] == expected_head_dim
 
 
 def _resolve_cache_owner(inner: Any, model: Any) -> Any:

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -265,8 +265,13 @@ def _detect_head_dim(model: Any, layers_hint: Any = None) -> int:
     fallback when `model` itself is a wrapper whose first layer isn't an
     attention layer (e.g. hybrid SSM+attention backbones).
     """
-    # Prefer explicit head_dim from model args or config
-    model_cfg = getattr(model, "args", None) or getattr(model, "config", None)
+    # Prefer explicit head_dim from model args or config. Use `is not None`
+    # rather than `or` so a falsy-but-present `.args` isn't silently skipped;
+    # this matches `_resolve_config_holder` / `_config_namespace` in the
+    # spectralquant calibrator.
+    model_cfg = getattr(model, "args", None)
+    if model_cfg is None:
+        model_cfg = getattr(model, "config", None)
     if model_cfg is None:
         raise RuntimeError("TurboQuant: model has no 'args' or 'config' attribute")
 

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -254,12 +254,16 @@ class TurboQuantKVCache(_BaseCache):
         return self._key_indices is None or self.offset == 0
 
 
-def _detect_head_dim(model: Any) -> int:
+def _detect_head_dim(model: Any, layers_hint: Any = None) -> int:
     """Detect head_dim from model args/config or K projection layer shape.
 
     Handles models where head_dim != hidden_size // num_attention_heads
     (e.g. Gemma 3, Phi-3/4).  Falls back to model.config when model.args
     is missing (e.g. mlx-vlm gemma4 LanguageModel).
+
+    `layers_hint`: optional object exposing `.layers` to use for the weight-shape
+    fallback when `model` itself is a wrapper whose first layer isn't an
+    attention layer (e.g. hybrid SSM+attention backbones).
     """
     # Prefer explicit head_dim from model args or config
     model_cfg = getattr(model, "args", None) or getattr(model, "config", None)
@@ -276,18 +280,24 @@ def _detect_head_dim(model: Any) -> int:
         if "head_dim" in text_config:
             return text_config["head_dim"]
 
-    # Derive from K projection weight shape: k_proj.weight is (n_kv_heads * head_dim, hidden_size)
-    try:
-        layer = model.layers[0]
-        k_proj = layer.self_attn.k_proj
-        weight = k_proj.weight
-        if isinstance(weight, mx.array):
-            kv_out_dim = weight.shape[0]
-            n_kv_heads = getattr(model_cfg, "num_key_value_heads", None)
-            if n_kv_heads:
-                return kv_out_dim // n_kv_heads
-    except (AttributeError, IndexError):
-        pass
+    # Derive from K projection weight shape: k_proj.weight is (n_kv_heads * head_dim, hidden_size).
+    # For hybrid backbones the first layer may be SSM; iterate to find an attention layer.
+    layer_sources = [s for s in (layers_hint, model) if s is not None]
+    for src in layer_sources:
+        src_layers = getattr(src, "layers", None)
+        if src_layers is None:
+            continue
+        try:
+            for layer in src_layers:
+                k_proj = getattr(getattr(layer, "self_attn", None), "k_proj", None)
+                weight = getattr(k_proj, "weight", None)
+                if isinstance(weight, mx.array):
+                    kv_out_dim = weight.shape[0]
+                    n_kv_heads = getattr(model_cfg, "num_key_value_heads", None)
+                    if n_kv_heads:
+                        return kv_out_dim // n_kv_heads
+        except (AttributeError, IndexError, TypeError):
+            continue
 
     # Derive from text_config hidden_size // num_attention_heads
     if isinstance(text_config, dict):

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -287,8 +287,8 @@ def _detect_head_dim(model: Any, layers_hint: Any = None) -> int:
         src_layers = getattr(src, "layers", None)
         if src_layers is None:
             continue
-        try:
-            for layer in src_layers:
+        for layer in src_layers:
+            try:
                 k_proj = getattr(getattr(layer, "self_attn", None), "k_proj", None)
                 weight = getattr(k_proj, "weight", None)
                 if isinstance(weight, mx.array):
@@ -296,8 +296,8 @@ def _detect_head_dim(model: Any, layers_hint: Any = None) -> int:
                     n_kv_heads = getattr(model_cfg, "num_key_value_heads", None)
                     if n_kv_heads:
                         return kv_out_dim // n_kv_heads
-        except (AttributeError, IndexError, TypeError):
-            continue
+            except (AttributeError, IndexError, TypeError):
+                continue
 
     # Derive from text_config hidden_size // num_attention_heads
     if isinstance(text_config, dict):

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -282,7 +282,10 @@ def _detect_head_dim(model: Any, layers_hint: Any = None) -> int:
 
     # Derive from K projection weight shape: k_proj.weight is (n_kv_heads * head_dim, hidden_size).
     # For hybrid backbones the first layer may be SSM; iterate to find an attention layer.
-    layer_sources = [s for s in (layers_hint, model) if s is not None]
+    # Deduplicate: when `layers_hint is model` (common legacy path), avoid scanning layers twice.
+    layer_sources = list(
+        dict.fromkeys(s for s in (layers_hint, model) if s is not None)
+    )
     for src in layer_sources:
         src_layers = getattr(src, "layers", None)
         if src_layers is None:

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -282,10 +282,14 @@ def _detect_head_dim(model: Any, layers_hint: Any = None) -> int:
 
     # Derive from K projection weight shape: k_proj.weight is (n_kv_heads * head_dim, hidden_size).
     # For hybrid backbones the first layer may be SSM; iterate to find an attention layer.
-    # Deduplicate: when `layers_hint is model` (common legacy path), avoid scanning layers twice.
-    layer_sources = list(
-        dict.fromkeys(s for s in (layers_hint, model) if s is not None)
-    )
+    # Deduplicate by identity: when `layers_hint is model` (common legacy path), avoid
+    # scanning layers twice. Uses `is` rather than a set so custom `__eq__`/`__hash__`
+    # on wrapper classes can't trip the check.
+    layer_sources: list[Any] = []
+    if layers_hint is not None:
+        layer_sources.append(layers_hint)
+    if model is not layers_hint:
+        layer_sources.append(model)
     for src in layer_sources:
         src_layers = getattr(src, "layers", None)
         if src_layers is None:

--- a/tests/test_spectralquant.py
+++ b/tests/test_spectralquant.py
@@ -741,52 +741,72 @@ class TestSpectralConfig:
         model = MagicMock(spec=["layers", "make_cache"])
         assert _resolve_cache_owner(inner, model) is model
 
-    def test_is_attention_cache_state_4d(self):
-        """Only 4D (B, n_kv, seq, head_dim) states matching head_dim are attention caches."""
-        from olmlx.engine.spectralquant_calibrate import _is_attention_cache_state
+    def test_is_attention_cache_accepts_kvcache_with_valid_state(self):
+        """A KVCache with 4D state matching head_dim is accepted."""
+        from unittest.mock import MagicMock
+
+        from mlx_lm.models.cache import KVCache
+
+        from olmlx.engine.spectralquant_calibrate import _is_attention_cache
 
         ok_keys = mx.zeros((1, 2, 16, 256))
         ok_vals = mx.zeros((1, 2, 16, 256))
-        assert _is_attention_cache_state([ok_keys, ok_vals], 256) is True
+        cache = MagicMock(spec=KVCache)
+        cache.state = [ok_keys, ok_vals]
+        assert _is_attention_cache(cache, 256) is True
 
-    def test_is_attention_cache_state_ssm_3d(self):
-        """Qwen3Next SSM cache: conv state (index 0) is 3D, so the entry is skipped."""
-        from olmlx.engine.spectralquant_calibrate import _is_attention_cache_state
+    def test_is_attention_cache_rejects_non_kvcache_type(self):
+        """An SSM-style cache (e.g. ArraysCache) is rejected regardless of shape."""
+        from unittest.mock import MagicMock
 
-        ssm_conv = mx.zeros((1, 3, 8192))  # conv state
+        from olmlx.engine.spectralquant_calibrate import _is_attention_cache
+
+        ok_keys = mx.zeros((1, 2, 16, 256))
+        ok_vals = mx.zeros((1, 2, 16, 256))
+        # Not a KVCache — simulates ArraysCache or similar SSM cache type.
+        cache = MagicMock(spec=[])
+        cache.state = [ok_keys, ok_vals]
+        assert _is_attention_cache(cache, 256) is False
+
+    def test_is_attention_cache_rejects_kvcache_ssm_3d_state(self):
+        """Qwen3Next-like 3D first-element state is rejected even on a KVCache."""
+        from unittest.mock import MagicMock
+
+        from mlx_lm.models.cache import KVCache
+
+        from olmlx.engine.spectralquant_calibrate import _is_attention_cache
+
+        ssm_conv = mx.zeros((1, 3, 8192))  # conv state (3D)
         ssm_hid = mx.zeros((1, 32, 128, 128))
-        assert _is_attention_cache_state([ssm_conv, ssm_hid], 256) is False
+        cache = MagicMock(spec=KVCache)
+        cache.state = [ssm_conv, ssm_hid]
+        assert _is_attention_cache(cache, 256) is False
 
-    def test_is_attention_cache_state_mamba2_4d_rejected(self):
-        """Mamba2 per-step recurrent state (B, n_heads, 1, d_state) is 4D but seq==1."""
-        from olmlx.engine.spectralquant_calibrate import _is_attention_cache_state
+    def test_is_attention_cache_rejects_per_step_seq_equals_one(self):
+        """A per-step state with seq==1 is rejected by the shape check."""
+        from unittest.mock import MagicMock
 
-        mamba_state = mx.zeros((1, 8, 1, 128))
-        mamba_extra = mx.zeros((1, 8, 1, 128))
-        # d_state=128 coincides with head_dim=128, so seq==1 is what rejects it.
-        assert _is_attention_cache_state([mamba_state, mamba_extra], 128) is False
+        from mlx_lm.models.cache import KVCache
 
-    def test_is_attention_cache_state_mamba2_chunked_scan_rejected(self):
-        """Chunked-scan Mamba2 state may have seq>1, but d_state mismatches head_dim."""
-        from olmlx.engine.spectralquant_calibrate import _is_attention_cache_state
+        from olmlx.engine.spectralquant_calibrate import _is_attention_cache
 
-        # Chunked SSM state: d_state is typically 16-64, not the attention head_dim.
-        ssm_chunked = mx.zeros((1, 8, 32, 64))  # seq==32 (chunk), d_state==64
-        ssm_extra = mx.zeros((1, 8, 32, 64))
-        assert _is_attention_cache_state([ssm_chunked, ssm_extra], 256) is False
+        per_step = mx.zeros((1, 8, 1, 128))
+        cache = MagicMock(spec=KVCache)
+        cache.state = [per_step, per_step]
+        assert _is_attention_cache(cache, 128) is False
 
-    def test_is_attention_cache_state_shape_filter_cannot_reject_matching_d_state(self):
-        """Document the shape-filter gap: a chunked SSM state where `d_state == head_dim`
-        and `seq >= 2` passes the shape check. Safety relies entirely on the
-        `isinstance(cache_entry, KVCache)` primary filter at the call site. This
-        test locks the contract so a future refactor that calls
-        `_is_attention_cache_state` without the isinstance guard fails loudly.
-        """
-        from olmlx.engine.spectralquant_calibrate import _is_attention_cache_state
+    def test_is_attention_cache_rejects_head_dim_mismatch(self):
+        """A KVCache whose last-axis size doesn't match head_dim is rejected."""
+        from unittest.mock import MagicMock
 
-        # Hypothetical chunked SSM with d_state=128 colliding with head_dim=128.
-        chunked = mx.zeros((1, 8, 32, 128))
-        assert _is_attention_cache_state([chunked, chunked], 128) is True
+        from mlx_lm.models.cache import KVCache
+
+        from olmlx.engine.spectralquant_calibrate import _is_attention_cache
+
+        mismatched = mx.zeros((1, 8, 32, 64))  # head_dim=64 in the state
+        cache = MagicMock(spec=KVCache)
+        cache.state = [mismatched, mismatched]
+        assert _is_attention_cache(cache, 256) is False  # expect 256, got 64
 
     def test_resolve_config_holder_accepts_config_attribute(self):
         """VL LanguageModel wrappers may expose `.config` instead of `.args`."""

--- a/tests/test_spectralquant.py
+++ b/tests/test_spectralquant.py
@@ -742,12 +742,12 @@ class TestSpectralConfig:
         assert _resolve_cache_owner(inner, model) is model
 
     def test_is_attention_cache_state_4d(self):
-        """Only 4D (B, n_kv, seq, head_dim) states are attention caches we calibrate."""
+        """Only 4D (B, n_kv, seq, head_dim) states matching head_dim are attention caches."""
         from olmlx.engine.spectralquant_calibrate import _is_attention_cache_state
 
         ok_keys = mx.zeros((1, 2, 16, 256))
         ok_vals = mx.zeros((1, 2, 16, 256))
-        assert _is_attention_cache_state([ok_keys, ok_vals]) is True
+        assert _is_attention_cache_state([ok_keys, ok_vals], 256) is True
 
     def test_is_attention_cache_state_ssm_3d(self):
         """Qwen3Next SSM cache: conv state (index 0) is 3D, so the entry is skipped."""
@@ -755,20 +755,57 @@ class TestSpectralConfig:
 
         ssm_conv = mx.zeros((1, 3, 8192))  # conv state
         ssm_hid = mx.zeros((1, 32, 128, 128))
-        assert _is_attention_cache_state([ssm_conv, ssm_hid]) is False
+        assert _is_attention_cache_state([ssm_conv, ssm_hid], 256) is False
 
     def test_is_attention_cache_state_mamba2_4d_rejected(self):
-        """Mamba2 recurrent state (B, n_heads, d_head, d_state) is 4D but has seq=d_head.
-
-        For Mamba2 hybrids the "seq" axis is actually d_head (small), so the
-        shape discriminant rejects the entry. We simulate a per-step state with
-        seq==1 to ensure the shape-based filter catches it.
-        """
+        """Mamba2 per-step recurrent state (B, n_heads, 1, d_state) is 4D but seq==1."""
         from olmlx.engine.spectralquant_calibrate import _is_attention_cache_state
 
-        mamba_state = mx.zeros((1, 8, 1, 128))  # per-step state, seq-like axis == 1
+        mamba_state = mx.zeros((1, 8, 1, 128))
         mamba_extra = mx.zeros((1, 8, 1, 128))
-        assert _is_attention_cache_state([mamba_state, mamba_extra]) is False
+        # d_state=128 coincides with head_dim=128, so seq==1 is what rejects it.
+        assert _is_attention_cache_state([mamba_state, mamba_extra], 128) is False
+
+    def test_is_attention_cache_state_mamba2_chunked_scan_rejected(self):
+        """Chunked-scan Mamba2 state may have seq>1, but d_state mismatches head_dim."""
+        from olmlx.engine.spectralquant_calibrate import _is_attention_cache_state
+
+        # Chunked SSM state: d_state is typically 16-64, not the attention head_dim.
+        ssm_chunked = mx.zeros((1, 8, 32, 64))  # seq==32 (chunk), d_state==64
+        ssm_extra = mx.zeros((1, 8, 32, 64))
+        assert _is_attention_cache_state([ssm_chunked, ssm_extra], 256) is False
+
+    def test_resolve_config_holder_accepts_config_attribute(self):
+        """VL LanguageModel wrappers may expose `.config` instead of `.args`."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.spectralquant_calibrate import _resolve_config_holder
+
+        inner = MagicMock(spec=["layers"])  # no .args, no .config
+        model = MagicMock(spec=[])
+        model.config = MagicMock(spec=[])
+        assert _resolve_config_holder(inner, model) is model
+
+    def test_config_namespace_prefers_args(self):
+        """When both .args and .config exist, prefer .args (mlx-lm idiom)."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.spectralquant_calibrate import _config_namespace
+
+        holder = MagicMock(spec=[])
+        holder.args = "args-ns"
+        holder.config = "config-ns"
+        assert _config_namespace(holder) == "args-ns"
+
+    def test_config_namespace_falls_back_to_config(self):
+        """When only .config exists, return it."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.spectralquant_calibrate import _config_namespace
+
+        holder = MagicMock(spec=[])
+        holder.config = "config-ns"
+        assert _config_namespace(holder) == "config-ns"
 
     def test_resolve_cache_owner_ignores_layers_without_make_cache(self):
         """Without make_cache on the top-level model, route to backbone regardless of .layers."""

--- a/tests/test_spectralquant.py
+++ b/tests/test_spectralquant.py
@@ -718,6 +718,70 @@ class TestSpectralConfig:
         s = ExperimentalSettings(kv_cache_quant="turboquant:4")
         assert s.kv_cache_quant == "turboquant:4"
 
+    def test_resolve_config_holder_prefers_inner_when_it_has_args(self):
+        """When backbone (inner) has .args, use it — matches pre-existing behavior."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.spectralquant_calibrate import _resolve_config_holder
+
+        inner = MagicMock(spec=[])
+        inner.args = MagicMock(spec=[])
+        model = MagicMock(spec=[])
+        model.args = MagicMock(spec=[])
+
+        assert _resolve_config_holder(inner, model) is inner
+
+    def test_resolve_cache_owner_prefers_model_with_make_cache(self):
+        """Qwen3Next: top-level has hybrid make_cache(); backbone only has layers."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.spectralquant_calibrate import _resolve_cache_owner
+
+        inner = MagicMock(spec=["layers"])
+        model = MagicMock(spec=["layers", "make_cache"])
+        assert _resolve_cache_owner(inner, model) is model
+
+    def test_is_attention_cache_state_4d(self):
+        """Only 4D (B, n_kv, seq, head_dim) states are attention caches we calibrate."""
+        from olmlx.engine.spectralquant_calibrate import _is_attention_cache_state
+
+        ok_keys = mx.zeros((1, 2, 16, 256))
+        ok_vals = mx.zeros((1, 2, 16, 256))
+        assert _is_attention_cache_state([ok_keys, ok_vals]) is True
+
+    def test_is_attention_cache_state_ssm_3d(self):
+        """Qwen3Next SSM caches yield 3D state; must be skipped."""
+        from olmlx.engine.spectralquant_calibrate import _is_attention_cache_state
+
+        ssm_conv = mx.zeros((1, 3, 8192))  # conv state
+        ssm_hid = mx.zeros((1, 32, 128, 128))
+        assert _is_attention_cache_state([ssm_conv, ssm_hid]) is False
+
+    def test_resolve_cache_owner_falls_back_to_inner(self):
+        """When top-level model has neither make_cache nor layers, use the backbone."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.spectralquant_calibrate import _resolve_cache_owner
+
+        inner = MagicMock(spec=["layers"])
+        model = MagicMock(spec=[])
+        assert _resolve_cache_owner(inner, model) is inner
+
+    def test_resolve_config_holder_falls_back_to_model(self):
+        """Qwen3Next regression: backbone has no .args, so calibrate must use model.args."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.spectralquant_calibrate import _resolve_config_holder
+
+        inner = MagicMock(spec=["layers"])  # no .args
+        model = MagicMock(spec=[])
+        model.args = MagicMock(spec=[])
+        model.args.head_dim = 256
+
+        holder = _resolve_config_holder(inner, model)
+        assert holder is model
+        assert holder.args.head_dim == 256
+
     def test_disk_cache_guard(self):
         """SpectralQuantKVCache should block disk serialization."""
         from olmlx.engine.model_manager import _is_serializable_cache

--- a/tests/test_spectralquant.py
+++ b/tests/test_spectralquant.py
@@ -757,18 +757,8 @@ class TestSpectralConfig:
         ssm_hid = mx.zeros((1, 32, 128, 128))
         assert _is_attention_cache_state([ssm_conv, ssm_hid]) is False
 
-    def test_resolve_cache_owner_falls_back_to_inner(self):
-        """When top-level model has no make_cache, use the backbone."""
-        from unittest.mock import MagicMock
-
-        from olmlx.engine.spectralquant_calibrate import _resolve_cache_owner
-
-        inner = MagicMock(spec=["layers"])
-        model = MagicMock(spec=[])
-        assert _resolve_cache_owner(inner, model) is inner
-
     def test_resolve_cache_owner_ignores_layers_without_make_cache(self):
-        """Model exposing only .layers (no make_cache) should still route to backbone."""
+        """Without make_cache on the top-level model, route to backbone regardless of .layers."""
         from unittest.mock import MagicMock
 
         from olmlx.engine.spectralquant_calibrate import _resolve_cache_owner

--- a/tests/test_spectralquant.py
+++ b/tests/test_spectralquant.py
@@ -819,6 +819,21 @@ class TestSpectralConfig:
         model.config = MagicMock(spec=[])
         assert _resolve_config_holder(inner, model) is model
 
+    def test_resolve_config_holder_prefers_args_over_inner_config(self):
+        """If inner has only `.config` and model has `.args`, prefer model — `.args`
+        wins across both holders before `.config` is considered. Otherwise an
+        unrelated `.config` on the backbone (framework mixin, etc.) would shadow
+        the real config namespace and defeat the Qwen3Next fix."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.spectralquant_calibrate import _resolve_config_holder
+
+        inner = MagicMock(spec=[])
+        inner.config = MagicMock(spec=[])  # noisy, unrelated config attribute
+        model = MagicMock(spec=[])
+        model.args = MagicMock(spec=[])  # the real config lives here
+        assert _resolve_config_holder(inner, model) is model
+
     def test_config_namespace_prefers_args(self):
         """When both .args and .config exist, prefer .args (mlx-lm idiom)."""
         from unittest.mock import MagicMock
@@ -842,7 +857,9 @@ class TestSpectralConfig:
 
     def test_build_empty_collection_error_chains_first_exc(self):
         """First forward-pass exception must be chained via __cause__ (and suppress
-        context) so the behavior matches `raise ... from first_exc`."""
+        context) so the behavior matches `raise ... from first_exc`. The message
+        body refers to the cause rather than duplicating its text — Python's
+        traceback format already prints both."""
         from olmlx.engine.spectralquant_calibrate import _build_empty_collection_error
 
         original = ValueError("synthetic forward-pass failure")
@@ -850,8 +867,9 @@ class TestSpectralConfig:
         assert isinstance(err, RuntimeError)
         assert err.__cause__ is original
         assert err.__suppress_context__ is True
-        assert "ValueError" in str(err)
-        assert "synthetic forward-pass failure" in str(err)
+        # The message references the cause rather than embedding its text.
+        assert "see cause" in str(err)
+        assert "synthetic forward-pass failure" not in str(err)
 
     def test_build_empty_collection_error_no_exc(self):
         """Without a forward-pass error, the message reports no attention caches found."""

--- a/tests/test_spectralquant.py
+++ b/tests/test_spectralquant.py
@@ -750,7 +750,7 @@ class TestSpectralConfig:
         assert _is_attention_cache_state([ok_keys, ok_vals]) is True
 
     def test_is_attention_cache_state_ssm_3d(self):
-        """Qwen3Next SSM caches yield 3D state; must be skipped."""
+        """Qwen3Next SSM cache: conv state (index 0) is 3D, so the entry is skipped."""
         from olmlx.engine.spectralquant_calibrate import _is_attention_cache_state
 
         ssm_conv = mx.zeros((1, 3, 8192))  # conv state
@@ -758,13 +758,23 @@ class TestSpectralConfig:
         assert _is_attention_cache_state([ssm_conv, ssm_hid]) is False
 
     def test_resolve_cache_owner_falls_back_to_inner(self):
-        """When top-level model has neither make_cache nor layers, use the backbone."""
+        """When top-level model has no make_cache, use the backbone."""
         from unittest.mock import MagicMock
 
         from olmlx.engine.spectralquant_calibrate import _resolve_cache_owner
 
         inner = MagicMock(spec=["layers"])
         model = MagicMock(spec=[])
+        assert _resolve_cache_owner(inner, model) is inner
+
+    def test_resolve_cache_owner_ignores_layers_without_make_cache(self):
+        """Model exposing only .layers (no make_cache) should still route to backbone."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.spectralquant_calibrate import _resolve_cache_owner
+
+        inner = MagicMock(spec=["layers"])
+        model = MagicMock(spec=["layers"])
         assert _resolve_cache_owner(inner, model) is inner
 
     def test_resolve_config_holder_falls_back_to_model(self):

--- a/tests/test_spectralquant.py
+++ b/tests/test_spectralquant.py
@@ -807,6 +807,26 @@ class TestSpectralConfig:
         holder.config = "config-ns"
         assert _config_namespace(holder) == "config-ns"
 
+    def test_build_empty_collection_error_chains_first_exc(self):
+        """First forward-pass exception must be chained via __cause__ so the traceback survives."""
+        from olmlx.engine.spectralquant_calibrate import _build_empty_collection_error
+
+        original = ValueError("synthetic forward-pass failure")
+        err = _build_empty_collection_error(original)
+        assert isinstance(err, RuntimeError)
+        assert err.__cause__ is original
+        assert "ValueError" in str(err)
+        assert "synthetic forward-pass failure" in str(err)
+
+    def test_build_empty_collection_error_no_exc(self):
+        """Without a forward-pass error, the message reports no attention caches found."""
+        from olmlx.engine.spectralquant_calibrate import _build_empty_collection_error
+
+        err = _build_empty_collection_error(None)
+        assert isinstance(err, RuntimeError)
+        assert err.__cause__ is None
+        assert "No attention-layer cache entries" in str(err)
+
     def test_resolve_cache_owner_ignores_layers_without_make_cache(self):
         """Without make_cache on the top-level model, route to backbone regardless of .layers."""
         from unittest.mock import MagicMock

--- a/tests/test_spectralquant.py
+++ b/tests/test_spectralquant.py
@@ -792,6 +792,17 @@ class TestSpectralConfig:
         assert holder is model
         assert holder.args.head_dim == 256
 
+    def test_resolve_config_holder_raises_when_neither_has_args(self):
+        """Unsupported architecture: surface a clear error instead of a cryptic AttributeError."""
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.spectralquant_calibrate import _resolve_config_holder
+
+        inner = MagicMock(spec=["layers"])
+        model = MagicMock(spec=[])
+        with pytest.raises(RuntimeError, match="Unsupported architecture"):
+            _resolve_config_holder(inner, model)
+
     def test_disk_cache_guard(self):
         """SpectralQuantKVCache should block disk serialization."""
         from olmlx.engine.model_manager import _is_serializable_cache

--- a/tests/test_spectralquant.py
+++ b/tests/test_spectralquant.py
@@ -757,6 +757,19 @@ class TestSpectralConfig:
         ssm_hid = mx.zeros((1, 32, 128, 128))
         assert _is_attention_cache_state([ssm_conv, ssm_hid]) is False
 
+    def test_is_attention_cache_state_mamba2_4d_rejected(self):
+        """Mamba2 recurrent state (B, n_heads, d_head, d_state) is 4D but has seq=d_head.
+
+        For Mamba2 hybrids the "seq" axis is actually d_head (small), so the
+        shape discriminant rejects the entry. We simulate a per-step state with
+        seq==1 to ensure the shape-based filter catches it.
+        """
+        from olmlx.engine.spectralquant_calibrate import _is_attention_cache_state
+
+        mamba_state = mx.zeros((1, 8, 1, 128))  # per-step state, seq-like axis == 1
+        mamba_extra = mx.zeros((1, 8, 1, 128))
+        assert _is_attention_cache_state([mamba_state, mamba_extra]) is False
+
     def test_resolve_cache_owner_ignores_layers_without_make_cache(self):
         """Without make_cache on the top-level model, route to backbone regardless of .layers."""
         from unittest.mock import MagicMock

--- a/tests/test_spectralquant.py
+++ b/tests/test_spectralquant.py
@@ -775,6 +775,19 @@ class TestSpectralConfig:
         ssm_extra = mx.zeros((1, 8, 32, 64))
         assert _is_attention_cache_state([ssm_chunked, ssm_extra], 256) is False
 
+    def test_is_attention_cache_state_shape_filter_cannot_reject_matching_d_state(self):
+        """Document the shape-filter gap: a chunked SSM state where `d_state == head_dim`
+        and `seq >= 2` passes the shape check. Safety relies entirely on the
+        `isinstance(cache_entry, KVCache)` primary filter at the call site. This
+        test locks the contract so a future refactor that calls
+        `_is_attention_cache_state` without the isinstance guard fails loudly.
+        """
+        from olmlx.engine.spectralquant_calibrate import _is_attention_cache_state
+
+        # Hypothetical chunked SSM with d_state=128 colliding with head_dim=128.
+        chunked = mx.zeros((1, 8, 32, 128))
+        assert _is_attention_cache_state([chunked, chunked], 128) is True
+
     def test_resolve_config_holder_accepts_config_attribute(self):
         """VL LanguageModel wrappers may expose `.config` instead of `.args`."""
         from unittest.mock import MagicMock
@@ -808,13 +821,15 @@ class TestSpectralConfig:
         assert _config_namespace(holder) == "config-ns"
 
     def test_build_empty_collection_error_chains_first_exc(self):
-        """First forward-pass exception must be chained via __cause__ so the traceback survives."""
+        """First forward-pass exception must be chained via __cause__ (and suppress
+        context) so the behavior matches `raise ... from first_exc`."""
         from olmlx.engine.spectralquant_calibrate import _build_empty_collection_error
 
         original = ValueError("synthetic forward-pass failure")
         err = _build_empty_collection_error(original)
         assert isinstance(err, RuntimeError)
         assert err.__cause__ is original
+        assert err.__suppress_context__ is True
         assert "ValueError" in str(err)
         assert "synthetic forward-pass failure" in str(err)
 

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -730,6 +730,40 @@ class TestMakeTurboQuantCache:
         r1 = np.array(cache[1].rotation_key.matrix)
         assert not np.allclose(r0, r1)
 
+    def test_head_dim_iterates_past_ssm_layer_via_hint(self):
+        """Hybrid models: _detect_head_dim must iterate past SSM layers to find k_proj.
+
+        Qwen3Next-style layout: layer 0 is an SSM layer (no self_attn), layer 1
+        is an attention layer with k_proj. `layers_hint` lets the weight-shape
+        fallback walk the backbone rather than the hybrid wrapper.
+        """
+        from unittest.mock import MagicMock
+
+        from olmlx.engine.turboquant_cache import _detect_head_dim
+
+        class FakeArgs:
+            num_key_value_heads = 4
+            # Intentionally omit head_dim so the k_proj fallback is required.
+
+        # SSM layer: explicitly has no self_attn attribute
+        ssm_layer = MagicMock(spec=["linear_attn"])
+        # Attention layer with a valid k_proj weight
+        attn_layer = MagicMock()
+        attn_layer.self_attn = MagicMock(spec=[])
+        attn_layer.self_attn.k_proj = MagicMock()
+        # k_proj output dim = num_kv_heads * head_dim = 4 * 128 = 512
+        attn_layer.self_attn.k_proj.weight = mx.zeros((512, 2048))
+
+        backbone = MagicMock()
+        backbone.layers = [ssm_layer, attn_layer]
+
+        # Config holder (top-level model) has args but no .layers
+        cfg_holder = MagicMock(spec=[])
+        cfg_holder.args = FakeArgs()
+
+        head_dim = _detect_head_dim(cfg_holder, layers_hint=backbone)
+        assert head_dim == 128
+
     def test_head_dim_fallback_from_k_proj(self):
         """When model.args.head_dim is missing, derive from k_proj weight shape."""
         from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary

Spectral calibration crashed on Qwen3Next (and would fail similarly on any hybrid SSM+attention model) in three places:

- `_detect_head_dim` was called with the backbone, which for Qwen3Next lacks `.args` — raised `RuntimeError: model has no 'args' or 'config' attribute`.
- `make_prompt_cache` was called on the backbone. The backbone has no `make_cache()`, so the fallback produced a uniform list of `KVCache`s. Qwen3Next's SSM layers need `ArraysCache`, and the forward pass crashed inside `create_ssm_mask` with an unrelated-looking `TypeError` about `create_attention_mask` args.
- The KV-collection loop assumed 4D `(B, n_kv, seq, head_dim)` state; SSM layers expose 3D state and would either silently crash or produce junk.

All three were masked by a bare `except Exception` that routed the first real error to `logger.debug` and then raised a generic "check that the model loads correctly" message.

## Changes

- Extract three helpers in `spectralquant_calibrate.py`:
  - `_resolve_config_holder(inner, model)` — returns whichever has `.args`.
  - `_resolve_cache_owner(inner, model)` — prefers the top-level model so `make_cache()` is invoked.
  - `_is_attention_cache_state(state)` — skips non-attention cache entries in hybrid models.
- Surface the first forward-pass exception in the empty-collection guard.
- Five unit tests covering both legacy (backbone-has-args) and Qwen3Next paths.

Verified end-to-end: `olmlx spectral prepare mlx-community/Qwen3-Coder-Next-4bit` now completes (12 of 48 layers calibrated — the attention layers), and `olmlx serve` with `kv_cache_quant: spectral:4` runs the model correctly.

## Test plan

- [x] `uv run pytest tests/test_spectralquant.py tests/test_turboquant.py` — 127 passed
- [x] `uv run ruff check && uv run ruff format --check` on the two modified files
- [x] `olmlx spectral prepare mlx-community/Qwen3-Coder-Next-4bit --avg-bits 4 --samples 128` completes successfully
- [x] `olmlx bench run --model mlx-community/Qwen3-Coder-Next-4bit:latest --scenarios baseline` runs to completion under both `spectral:4` and `turboquant:4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)