### PR TITLE
refactor(flash): single-source SSD weight-store infrastructure (#246)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,8 @@ olmlx/
 │       ├── prefetch.py      # Prefetcher: background neuron prefetch with thread pool + stats
 │       ├── prepare.py       # prepare_model_for_flash pipeline, predictor training
 │       ├── speculative.py   # SpeculativeFlashDecoder: extends SpeculativeDecoder with prefetch
-│       ├── weight_store.py  # FlashWeightStore: SSD I/O, NeuronCache, preallocated buffers
+│       ├── _ssd_base.py     # LayerLruCache, HeaderSpec codec, full_pread — shared by dense + MoE stores
+│       ├── weight_store.py  # FlashWeightStore: SSD I/O + LayerLruCache + preallocated buffers
 │       ├── flash_moe.py     # Flash-MoE sparse expert loading
 │       ├── flash_moe_model.py # Flash-MoE model wrapper
 │       ├── moe_bundler.py   # Bundle MoE expert weights

--- a/olmlx/engine/flash/_ssd_base.py
+++ b/olmlx/engine/flash/_ssd_base.py
@@ -25,7 +25,7 @@ import sys
 import threading
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Generic, Hashable, Sequence, TypeVar
+from typing import Any, Generic, Hashable, Sequence, TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,11 @@ def open_fds(
 
 
 def close_fds(fds: dict[int, int]) -> None:
-    """Close all file descriptors in the mapping, ignoring close errors."""
+    """Close all file descriptors in the mapping and clear it.
+
+    Clearing the mapping prevents a second close attempt when ``close()`` is
+    followed by ``__del__`` on the same store.
+    """
     for fd in fds.values():
         try:
             os.close(fd)
@@ -114,16 +118,20 @@ class HeaderSpec:
     size: int
     body_format: str
 
+    def __post_init__(self) -> None:
+        # struct.Struct(fmt) is not internally cached — compile once per spec.
+        object.__setattr__(self, "_body_struct", struct.Struct(self.body_format))
+
     @property
     def body_struct(self) -> struct.Struct:
-        return struct.Struct(self.body_format)
+        return self._body_struct  # type: ignore[attr-defined]
 
 
 # Magic + version are always little-endian uint32s at the head of the buffer.
 _PREFIX = struct.Struct("<II")
 
 
-def encode_header(spec: HeaderSpec, *values: object) -> bytes:
+def encode_header(spec: HeaderSpec, *values: Any) -> bytes:
     """Pack magic + version + *values*, then zero-pad to ``spec.size``."""
     body = spec.body_struct.pack(*values)
     head = _PREFIX.pack(spec.magic, spec.version) + body
@@ -134,7 +142,7 @@ def encode_header(spec: HeaderSpec, *values: object) -> bytes:
     return head + b"\x00" * (spec.size - len(head))
 
 
-def parse_header(spec: HeaderSpec, data: bytes) -> tuple[object, ...]:
+def parse_header(spec: HeaderSpec, data: bytes) -> tuple[Any, ...]:
     """Verify magic + version and unpack the body. Returns the body tuple."""
     if len(data) < spec.size:
         raise ValueError(

--- a/olmlx/engine/flash/_ssd_base.py
+++ b/olmlx/engine/flash/_ssd_base.py
@@ -1,0 +1,221 @@
+"""Shared infrastructure for Flash SSD-streamed weight stores.
+
+This module is internal to the ``olmlx.engine.flash`` package. It exposes
+three reusable pieces:
+
+* ``full_pread`` — a pread helper that retries on short reads.
+* ``HeaderSpec`` + ``encode_header`` / ``parse_header`` — a magic/version
+  header codec parameterised by struct format; concrete bundler modules
+  hold module-level HeaderSpec constants.
+* ``LayerLruCache[K, V]`` — a thread-safe per-layer LRU cache used by both
+  the dense (``FlashWeightStore``) and MoE (``FlashMoeWeightStore``)
+  paths.
+
+The two weight stores share enough I/O plumbing that a single point of
+failure is worth maintaining; the bundle bodies and cached value types
+differ and are *not* abstracted here.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import struct
+import sys
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Generic, Hashable, Sequence, TypeVar
+
+logger = logging.getLogger(__name__)
+
+# macOS fcntl command to bypass OS page cache (for accurate flash benchmarks).
+F_NOCACHE = 48
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def full_pread(fd: int, size: int, offset: int) -> bytes:
+    """Read exactly *size* bytes from *fd* at *offset*, retrying on short reads."""
+    buf = bytearray()
+    pos = offset
+    remaining = size
+    while remaining > 0:
+        chunk = os.pread(fd, remaining, pos)
+        if not chunk:
+            raise OSError(f"Unexpected EOF: wanted {size} bytes at offset {offset}")
+        buf.extend(chunk)
+        pos += len(chunk)
+        remaining -= len(chunk)
+    return bytes(buf)
+
+
+def open_fds(
+    layer_paths: dict[int, os.PathLike | str], *, bypass_cache: bool
+) -> dict[int, int]:
+    """Open read-only fds for each layer file, optionally with F_NOCACHE on macOS.
+
+    On error, any fds already opened are closed before the exception propagates.
+    """
+    if bypass_cache and sys.platform != "darwin":
+        logger.warning(
+            "bypass_cache is only supported on macOS (F_NOCACHE); "
+            "OS page cache will not be bypassed on %s",
+            sys.platform,
+        )
+    fds: dict[int, int] = {}
+    try:
+        for layer_idx, path in layer_paths.items():
+            fd = os.open(str(path), os.O_RDONLY)
+            if bypass_cache and sys.platform == "darwin":
+                import fcntl
+
+                fcntl.fcntl(fd, F_NOCACHE, 1)
+            fds[layer_idx] = fd
+    except Exception:
+        for fd in fds.values():
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        raise
+    return fds
+
+
+def close_fds(fds: dict[int, int]) -> None:
+    """Close all file descriptors in the mapping, ignoring close errors."""
+    for fd in fds.values():
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+    fds.clear()
+
+
+# ---------------------------------------------------------------------------
+# Header codec
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HeaderSpec:
+    """Describes the wire format of a bundle file header.
+
+    ``body_format`` is the struct format for the payload fields *after* the
+    fixed ``magic (I)`` and ``version (I)`` prefix. The encoder zero-pads
+    the remainder of the buffer out to ``size`` bytes.
+    """
+
+    magic: int
+    version: int
+    size: int
+    body_format: str
+
+    @property
+    def body_struct(self) -> struct.Struct:
+        return struct.Struct(self.body_format)
+
+
+# Magic + version are always little-endian uint32s at the head of the buffer.
+_PREFIX = struct.Struct("<II")
+
+
+def encode_header(spec: HeaderSpec, *values: object) -> bytes:
+    """Pack magic + version + *values*, then zero-pad to ``spec.size``."""
+    body = spec.body_struct.pack(*values)
+    head = _PREFIX.pack(spec.magic, spec.version) + body
+    if len(head) > spec.size:
+        raise ValueError(
+            f"Header payload ({len(head)} bytes) exceeds spec.size ({spec.size})"
+        )
+    return head + b"\x00" * (spec.size - len(head))
+
+
+def parse_header(spec: HeaderSpec, data: bytes) -> tuple[object, ...]:
+    """Verify magic + version and unpack the body. Returns the body tuple."""
+    if len(data) < spec.size:
+        raise ValueError(
+            f"Header buffer too short: got {len(data)} bytes, need {spec.size}"
+        )
+    magic, version = _PREFIX.unpack_from(data, 0)
+    if magic != spec.magic:
+        raise ValueError(
+            f"Invalid bundle magic: expected {spec.magic:#010x}, got {magic:#010x}"
+        )
+    if version != spec.version:
+        raise ValueError(
+            f"Unsupported bundle version: expected {spec.version}, got {version}"
+        )
+    body_size = spec.body_struct.size
+    body_end = _PREFIX.size + body_size
+    return spec.body_struct.unpack(data[_PREFIX.size : body_end])
+
+
+# ---------------------------------------------------------------------------
+# Layer LRU cache
+# ---------------------------------------------------------------------------
+
+
+K = TypeVar("K", bound=Hashable)
+V = TypeVar("V")
+
+
+class LayerLruCache(Generic[K, V]):
+    """Thread-safe per-layer LRU cache.
+
+    Backs both ``FlashWeightStore`` (K=neuron index, V=(gate, up, down))
+    and ``FlashMoeWeightStore`` (K=expert index, V=component dict).
+    """
+
+    def __init__(self, max_per_layer: int):
+        self._max = max_per_layer
+        self._lock = threading.Lock()
+        self._cache: dict[int, OrderedDict[K, V]] = {}
+
+    def get(self, layer_idx: int, key: K) -> V | None:
+        with self._lock:
+            layer_cache = self._cache.get(layer_idx)
+            if layer_cache is None or key not in layer_cache:
+                return None
+            layer_cache.move_to_end(key)
+            return layer_cache[key]
+
+    def put(self, layer_idx: int, key: K, value: V) -> None:
+        if self._max <= 0:
+            return
+        with self._lock:
+            layer_cache = self._cache.setdefault(layer_idx, OrderedDict())
+            layer_cache[key] = value
+            layer_cache.move_to_end(key)
+            while len(layer_cache) > self._max:
+                layer_cache.popitem(last=False)
+
+    def get_batch(self, layer_idx: int, keys: Sequence[K]) -> dict[K, V]:
+        """Return a dict with cached entries for *keys* (refreshes their LRU order)."""
+        with self._lock:
+            result: dict[K, V] = {}
+            layer_cache = self._cache.get(layer_idx)
+            if layer_cache is None:
+                return result
+            for k in keys:
+                if k in layer_cache:
+                    layer_cache.move_to_end(k)
+                    result[k] = layer_cache[k]
+            return result
+
+    def get_cached_indices(
+        self, layer_idx: int, keys: Sequence[K]
+    ) -> tuple[list[K], list[K]]:
+        """Return ``(cached, missing)`` — does not update LRU order."""
+        with self._lock:
+            layer_cache = self._cache.get(layer_idx)
+            if layer_cache is None:
+                return [], list(keys)
+            cached: list[K] = []
+            missing: list[K] = []
+            for k in keys:
+                (cached if k in layer_cache else missing).append(k)
+            return cached, missing

--- a/olmlx/engine/flash/_ssd_base.py
+++ b/olmlx/engine/flash/_ssd_base.py
@@ -40,9 +40,14 @@ F_NOCACHE = 48
 
 def full_pread(fd: int, size: int, offset: int) -> bytes:
     """Read exactly *size* bytes from *fd* at *offset*, retrying on short reads."""
-    buf = bytearray()
-    pos = offset
-    remaining = size
+    chunk = os.pread(fd, size, offset)
+    if len(chunk) == size:
+        return chunk
+    if not chunk:
+        raise OSError(f"Unexpected EOF: wanted {size} bytes at offset {offset}")
+    buf = bytearray(chunk)
+    pos = offset + len(chunk)
+    remaining = size - len(chunk)
     while remaining > 0:
         chunk = os.pread(fd, remaining, pos)
         if not chunk:
@@ -78,7 +83,8 @@ def open_fds(
             # except-block cleanup below is guaranteed to close it.
             fds[layer_idx] = fd
             if apply_nocache:
-                fcntl.fcntl(fd, F_NOCACHE, 1)
+                # fcntl is imported above when apply_nocache is True
+                fcntl.fcntl(fd, F_NOCACHE, 1)  # pyright: ignore[reportPossiblyUnboundVariable]
     except Exception:
         for fd in fds.values():
             try:

--- a/olmlx/engine/flash/_ssd_base.py
+++ b/olmlx/engine/flash/_ssd_base.py
@@ -60,21 +60,25 @@ def open_fds(
 
     On error, any fds already opened are closed before the exception propagates.
     """
-    if bypass_cache and sys.platform != "darwin":
+    apply_nocache = bypass_cache and sys.platform == "darwin"
+    if bypass_cache and not apply_nocache:
         logger.warning(
             "bypass_cache is only supported on macOS (F_NOCACHE); "
             "OS page cache will not be bypassed on %s",
             sys.platform,
         )
+    if apply_nocache:
+        import fcntl
+
     fds: dict[int, int] = {}
     try:
         for layer_idx, path in layer_paths.items():
             fd = os.open(str(path), os.O_RDONLY)
-            if bypass_cache and sys.platform == "darwin":
-                import fcntl
-
-                fcntl.fcntl(fd, F_NOCACHE, 1)
+            # Register the fd before any further call that might raise, so the
+            # except-block cleanup below is guaranteed to close it.
             fds[layer_idx] = fd
+            if apply_nocache:
+                fcntl.fcntl(fd, F_NOCACHE, 1)
     except Exception:
         for fd in fds.values():
             try:
@@ -119,7 +123,7 @@ class HeaderSpec:
     body_format: str
 
     def __post_init__(self) -> None:
-        # struct.Struct(fmt) is not internally cached — compile once per spec.
+        # Compile once; HeaderSpec is frozen, so body_struct is a constant property.
         object.__setattr__(self, "_body_struct", struct.Struct(self.body_format))
 
     @property

--- a/olmlx/engine/flash/bundler.py
+++ b/olmlx/engine/flash/bundler.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 import json
 import logging
 import re
-import struct
 from dataclasses import dataclass
 from pathlib import Path
 
 import mlx.core as mx
 import numpy as np
+
+from olmlx.engine.flash import _ssd_base
+from olmlx.engine.flash._ssd_base import HeaderSpec
 
 logger = logging.getLogger(__name__)
 
@@ -33,33 +35,35 @@ _DTYPE_BYTES = {
     "bfloat16": 2,
 }
 
-# Header format: magic(4) version(4) num_neurons(4) hidden_size(4)
-# dtype_len(4) dtype(16) padding(28) = 64 bytes
-_HEADER_STRUCT = struct.Struct("<IIII4s16s28s")
+# Body: num_neurons(4) hidden_size(4) dtype_len(4) dtype(16) = 28 bytes.
+# Prefix (magic+version) is 8 bytes; padding to 64 bytes is handled by the codec.
+_HEADER_SPEC = HeaderSpec(
+    magic=HEADER_MAGIC,
+    version=HEADER_VERSION,
+    size=HEADER_SIZE,
+    body_format="<III16s",
+)
 
 
 def _encode_header(num_neurons: int, hidden_size: int, dtype: str) -> bytes:
     dtype_bytes = dtype.encode("ascii")
-    return _HEADER_STRUCT.pack(
-        HEADER_MAGIC,
-        HEADER_VERSION,
+    return _ssd_base.encode_header(
+        _HEADER_SPEC,
         num_neurons,
         hidden_size,
-        struct.pack("<I", len(dtype_bytes)),
+        len(dtype_bytes),
         dtype_bytes.ljust(16, b"\x00"),
-        b"\x00" * 28,
     )
 
 
 def parse_header(data: bytes) -> dict:
-    magic, version, num_neurons, hidden_size, dtype_len_bytes, dtype_raw, _ = (
-        _HEADER_STRUCT.unpack(data[:HEADER_SIZE])
+    num_neurons, hidden_size, dtype_len, dtype_raw = _ssd_base.parse_header(
+        _HEADER_SPEC, data
     )
-    dtype_len = struct.unpack("<I", dtype_len_bytes)[0]
     dtype = dtype_raw[:dtype_len].decode("ascii")
     return {
-        "magic": magic,
-        "version": version,
+        "magic": HEADER_MAGIC,
+        "version": HEADER_VERSION,
         "num_neurons": num_neurons,
         "hidden_size": hidden_size,
         "dtype": dtype,

--- a/olmlx/engine/flash/bundler.py
+++ b/olmlx/engine/flash/bundler.py
@@ -57,6 +57,7 @@ def _encode_header(num_neurons: int, hidden_size: int, dtype: str) -> bytes:
 
 
 def parse_header(data: bytes) -> dict:
+    """Parse a .flashweights header. Raises ValueError on bad magic or version."""
     num_neurons, hidden_size, dtype_len, dtype_raw = _ssd_base.parse_header(
         _HEADER_SPEC, data
     )

--- a/olmlx/engine/flash/moe_bundler.py
+++ b/olmlx/engine/flash/moe_bundler.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 
 import json
 import logging
-import struct
 from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
+
+from olmlx.engine.flash import _ssd_base
+from olmlx.engine.flash._ssd_base import HeaderSpec
 
 logger = logging.getLogger(__name__)
 
@@ -23,11 +25,15 @@ MOE_HEADER_MAGIC = 0x464C4D45  # "FLME"
 MOE_HEADER_VERSION = 1
 MOE_HEADER_SIZE = 128  # bytes
 
-# Header format:
-# magic(4) version(4) num_experts(4) hidden_size(4) intermediate_size(4)
-# is_quantized(4) bits(4) group_size(4) expert_byte_size(8)
-# padding(88) = 128 bytes
-_MOE_HEADER_STRUCT = struct.Struct("<IIIIIIII Q 88s")
+# Body: num_experts(4) hidden(4) intermediate(4) is_quantized(4) bits(4)
+# group_size(4) expert_byte_size(8) = 32 bytes. Prefix (magic+version) is 8;
+# padding to 128 bytes is handled by the codec.
+_MOE_HEADER_SPEC = HeaderSpec(
+    magic=MOE_HEADER_MAGIC,
+    version=MOE_HEADER_VERSION,
+    size=MOE_HEADER_SIZE,
+    body_format="<IIIIIIQ",
+)
 
 # Map numpy dtype to string for manifest
 _DTYPE_TO_STR = {
@@ -48,9 +54,8 @@ def _encode_moe_header(
     group_size: int,
     expert_byte_size: int,
 ) -> bytes:
-    return _MOE_HEADER_STRUCT.pack(
-        MOE_HEADER_MAGIC,
-        MOE_HEADER_VERSION,
+    return _ssd_base.encode_header(
+        _MOE_HEADER_SPEC,
         num_experts,
         hidden_size,
         intermediate_size,
@@ -58,14 +63,11 @@ def _encode_moe_header(
         bits,
         group_size,
         expert_byte_size,
-        b"\x00" * 88,
     )
 
 
 def parse_moe_header(data: bytes) -> dict:
     (
-        magic,
-        version,
         num_experts,
         hidden_size,
         intermediate_size,
@@ -73,15 +75,10 @@ def parse_moe_header(data: bytes) -> dict:
         bits,
         group_size,
         expert_byte_size,
-        _,
-    ) = _MOE_HEADER_STRUCT.unpack(data[:MOE_HEADER_SIZE])
-    if magic != MOE_HEADER_MAGIC:
-        raise ValueError(
-            f"Invalid .flashexperts magic: expected {MOE_HEADER_MAGIC:#010x}, got {magic:#010x}"
-        )
+    ) = _ssd_base.parse_header(_MOE_HEADER_SPEC, data)
     return {
-        "magic": magic,
-        "version": version,
+        "magic": MOE_HEADER_MAGIC,
+        "version": MOE_HEADER_VERSION,
         "num_experts": num_experts,
         "hidden_size": hidden_size,
         "intermediate_size": intermediate_size,

--- a/olmlx/engine/flash/moe_bundler.py
+++ b/olmlx/engine/flash/moe_bundler.py
@@ -67,6 +67,7 @@ def _encode_moe_header(
 
 
 def parse_moe_header(data: bytes) -> dict:
+    """Parse a .flashexperts header. Raises ValueError on bad magic or version."""
     (
         num_experts,
         hidden_size,

--- a/olmlx/engine/flash/moe_weight_store.py
+++ b/olmlx/engine/flash/moe_weight_store.py
@@ -3,9 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
-import threading
-from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -13,6 +10,12 @@ from pathlib import Path
 import mlx.core as mx
 import numpy as np
 
+from olmlx.engine.flash._ssd_base import (
+    LayerLruCache,
+    close_fds,
+    full_pread,
+    open_fds,
+)
 from olmlx.engine.flash.moe_bundler import (
     MOE_HEADER_SIZE,
     MoeExpertLayout,
@@ -65,45 +68,7 @@ class LoadedExperts:
     remap_lut: mx.array | None = None
 
 
-class ExpertCache:
-    """Thread-safe per-layer LRU cache for loaded expert data."""
-
-    def __init__(self, max_experts_per_layer: int):
-        self._max = max_experts_per_layer
-        self._lock = threading.Lock()
-        self._cache: dict[int, OrderedDict[int, dict]] = {}
-
-    def get(self, layer_idx: int, expert_idx: int) -> dict | None:
-        with self._lock:
-            layer_cache = self._cache.get(layer_idx)
-            if layer_cache is None or expert_idx not in layer_cache:
-                return None
-            layer_cache.move_to_end(expert_idx)
-            return layer_cache[expert_idx]
-
-    def put(self, layer_idx: int, expert_idx: int, data: dict) -> None:
-        if self._max <= 0:
-            return
-        with self._lock:
-            if layer_idx not in self._cache:
-                self._cache[layer_idx] = OrderedDict()
-            layer_cache = self._cache[layer_idx]
-            layer_cache[expert_idx] = data
-            layer_cache.move_to_end(expert_idx)
-            while len(layer_cache) > self._max:
-                layer_cache.popitem(last=False)
-
-    def get_batch(self, layer_idx: int, indices: list[int]) -> dict[int, dict]:
-        with self._lock:
-            result = {}
-            layer_cache = self._cache.get(layer_idx)
-            if layer_cache is None:
-                return result
-            for idx in indices:
-                if idx in layer_cache:
-                    layer_cache.move_to_end(idx)
-                    result[idx] = layer_cache[idx]
-            return result
+_ExpertCache = LayerLruCache[int, dict]
 
 
 class FlashMoeWeightStore:
@@ -117,7 +82,7 @@ class FlashMoeWeightStore:
     ):
         self._flash_dir = flash_dir
         self._executor = ThreadPoolExecutor(max_workers=num_io_threads)
-        self._cache = ExpertCache(max_experts_per_layer=cache_budget_experts)
+        self._cache: _ExpertCache = LayerLruCache(max_per_layer=cache_budget_experts)
         self._layout_config = json.loads(
             (flash_dir / "flash_moe_layout.json").read_text()
         )
@@ -126,8 +91,10 @@ class FlashMoeWeightStore:
         self._layouts = self._load_layouts()
         self._fds: dict[int, int] = {}
         try:
-            for layer_idx, layout in self._layouts.items():
-                self._fds[layer_idx] = os.open(str(layout.file_path), os.O_RDONLY)
+            self._fds = open_fds(
+                {idx: layout.file_path for idx, layout in self._layouts.items()},
+                bypass_cache=False,
+            )
         except Exception:
             self.close()
             raise
@@ -163,27 +130,12 @@ class FlashMoeWeightStore:
 
         return layouts
 
-    @staticmethod
-    def _full_pread(fd: int, size: int, offset: int) -> bytes:
-        """Read exactly *size* bytes via pread, retrying on short reads."""
-        buf = bytearray()
-        pos = offset
-        remaining = size
-        while remaining > 0:
-            chunk = os.pread(fd, remaining, pos)
-            if not chunk:
-                raise OSError(f"Unexpected EOF: wanted {size} bytes at offset {offset}")
-            buf.extend(chunk)
-            pos += len(chunk)
-            remaining -= len(chunk)
-        return bytes(buf)
-
     def _read_expert(self, layer_idx: int, expert_idx: int) -> dict:
         """Read a single expert's weights from SSD."""
         layout = self._layouts[layer_idx]
         fd = self._fds[layer_idx]
         offset = int(layout.offsets[expert_idx])
-        raw = self._full_pread(fd, layout.expert_byte_size, offset)
+        raw = full_pread(fd, layout.expert_byte_size, offset)
 
         if self._manifest:
             return self._parse_expert_with_manifest(raw, self._manifest)
@@ -419,22 +371,12 @@ class FlashMoeWeightStore:
     def close(self) -> None:
         """Release file descriptors and shut down the I/O thread pool."""
         self._executor.shutdown(wait=True)
-        for fd in self._fds.values():
-            try:
-                os.close(fd)
-            except OSError:
-                pass
-        self._fds.clear()
+        close_fds(self._fds)
 
     def __del__(self) -> None:
         # Use wait=False to avoid deadlock during interpreter shutdown
         self._executor.shutdown(wait=False)
-        for fd in self._fds.values():
-            try:
-                os.close(fd)
-            except OSError:
-                pass
-        self._fds.clear()
+        close_fds(self._fds)
 
     def __enter__(self):
         return self

--- a/olmlx/engine/flash/moe_weight_store.py
+++ b/olmlx/engine/flash/moe_weight_store.py
@@ -6,6 +6,7 @@ import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import mlx.core as mx
 import numpy as np
@@ -68,7 +69,7 @@ class LoadedExperts:
     remap_lut: mx.array | None = None
 
 
-_ExpertCache = LayerLruCache[int, dict]
+_ExpertCache = LayerLruCache[int, dict[str, Any]]
 
 
 class FlashMoeWeightStore:

--- a/olmlx/engine/flash/weight_store.py
+++ b/olmlx/engine/flash/weight_store.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import sys
 import threading
 from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -14,6 +12,12 @@ from pathlib import Path
 import mlx.core as mx
 import numpy as np
 
+from olmlx.engine.flash._ssd_base import (
+    LayerLruCache,
+    close_fds,
+    full_pread,
+    open_fds,
+)
 from olmlx.engine.flash.bundler import (
     HEADER_SIZE,
     BundledLayerLayout,
@@ -28,76 +32,10 @@ _NP_DTYPE = {"float16": np.float16, "float32": np.float32, "bfloat16": np.uint16
 # MLX dtype for reinterpreting uint16 storage back to bfloat16
 _MX_DTYPE = {"float16": mx.float16, "float32": mx.float32, "bfloat16": mx.bfloat16}
 
-# macOS fcntl command to bypass OS page cache for accurate flash benchmarks
-_F_NOCACHE = 48
 
-
-class NeuronCache:
-    """Thread-safe per-layer LRU cache for loaded neuron weight chunks."""
-
-    def __init__(self, max_neurons_per_layer: int):
-        self._max = max_neurons_per_layer
-        self._lock = threading.Lock()
-        # layer_idx -> OrderedDict[neuron_idx -> (gate, up, down)]
-        self._cache: dict[
-            int, OrderedDict[int, tuple[mx.array, mx.array, mx.array]]
-        ] = {}
-
-    def get(
-        self, layer_idx: int, neuron_idx: int
-    ) -> tuple[mx.array, mx.array, mx.array] | None:
-        with self._lock:
-            layer_cache = self._cache.get(layer_idx)
-            if layer_cache is None:
-                return None
-            if neuron_idx not in layer_cache:
-                return None
-            layer_cache.move_to_end(neuron_idx)
-            return layer_cache[neuron_idx]
-
-    def put(
-        self,
-        layer_idx: int,
-        neuron_idx: int,
-        data: tuple[mx.array, mx.array, mx.array],
-    ) -> None:
-        if self._max <= 0:
-            return
-        with self._lock:
-            if layer_idx not in self._cache:
-                self._cache[layer_idx] = OrderedDict()
-            layer_cache = self._cache[layer_idx]
-            layer_cache[neuron_idx] = data
-            layer_cache.move_to_end(neuron_idx)
-            while len(layer_cache) > self._max:
-                layer_cache.popitem(last=False)
-
-    def get_batch(
-        self, layer_idx: int, indices: list[int]
-    ) -> dict[int, tuple[mx.array, mx.array, mx.array]]:
-        """Return dict mapping neuron_idx -> data for cached neurons."""
-        with self._lock:
-            result = {}
-            layer_cache = self._cache.get(layer_idx)
-            if layer_cache is None:
-                return result
-            for idx in indices:
-                if idx in layer_cache:
-                    layer_cache.move_to_end(idx)
-                    result[idx] = layer_cache[idx]
-            return result
-
-    def get_cached_indices(
-        self, layer_idx: int, neuron_indices: list[int]
-    ) -> tuple[list[int], list[int]]:
-        """Return (cached_indices, missing_indices)."""
-        with self._lock:
-            layer_cache = self._cache.get(layer_idx)
-            if layer_cache is None:
-                return [], list(neuron_indices)
-            cached = [idx for idx in neuron_indices if idx in layer_cache]
-            missing = [idx for idx in neuron_indices if idx not in layer_cache]
-            return cached, missing
+# NeuronCache[int, tuple[mx.array, mx.array, mx.array]] — kept as a named alias
+# so the cache's value type is obvious at call sites.
+_NeuronCache = LayerLruCache[int, tuple[mx.array, mx.array, mx.array]]
 
 
 class PreallocatedNeuronBuffer:
@@ -220,11 +158,11 @@ class FlashWeightStore:
         use_preallocated_buffer: bool = False,
     ):
         self._flash_dir = flash_dir
-        self._bypass_cache = bypass_cache
         self._use_preallocated = use_preallocated_buffer
         self._executor = ThreadPoolExecutor(max_workers=num_io_threads)
-        self._cache: NeuronCache | None = None
+        self._cache: _NeuronCache | None = None
         self._buffers: dict[int, PreallocatedNeuronBuffer] = {}
+        self._fds: dict[int, int] = {}
         self._layouts = self._load_layouts()
 
         if use_preallocated_buffer:
@@ -240,22 +178,13 @@ class FlashWeightStore:
                     mx_dtype=_MX_DTYPE[layout.dtype] if needs_reinterpret else None,
                 )
         else:
-            self._cache = NeuronCache(max_neurons_per_layer=cache_budget_neurons)
-        if bypass_cache and sys.platform != "darwin":
-            logger.warning(
-                "bypass_cache is only supported on macOS (F_NOCACHE); "
-                "OS page cache will not be bypassed on %s",
-                sys.platform,
-            )
-        self._fds: dict[int, int] = {}
-        try:
-            for layer_idx, layout in self._layouts.items():
-                fd = os.open(str(layout.file_path), os.O_RDONLY)
-                if bypass_cache and sys.platform == "darwin":
-                    import fcntl
+            self._cache = LayerLruCache(max_per_layer=cache_budget_neurons)
 
-                    fcntl.fcntl(fd, _F_NOCACHE, 1)
-                self._fds[layer_idx] = fd
+        try:
+            self._fds = open_fds(
+                {idx: layout.file_path for idx, layout in self._layouts.items()},
+                bypass_cache=bypass_cache,
+            )
         except Exception:
             self.close()
             raise
@@ -295,21 +224,6 @@ class FlashWeightStore:
 
         return layouts
 
-    @staticmethod
-    def _full_pread(fd: int, size: int, offset: int) -> bytes:
-        """Read exactly *size* bytes via pread, retrying on short reads."""
-        buf = bytearray()
-        pos = offset
-        remaining = size
-        while remaining > 0:
-            chunk = os.pread(fd, remaining, pos)
-            if not chunk:
-                raise OSError(f"Unexpected EOF: wanted {size} bytes at offset {offset}")
-            buf.extend(chunk)
-            pos += len(chunk)
-            remaining -= len(chunk)
-        return bytes(buf)
-
     def _read_neuron_raw(
         self, layer_idx: int, neuron_idx: int
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -317,7 +231,7 @@ class FlashWeightStore:
         layout = self._layouts[layer_idx]
         fd = self._fds[layer_idx]
         offset = int(layout.offsets[neuron_idx])
-        raw = self._full_pread(fd, layout.neuron_byte_size, offset)
+        raw = full_pread(fd, layout.neuron_byte_size, offset)
 
         hidden = layout.hidden_size
         np_dtype = _NP_DTYPE[layout.dtype]
@@ -401,7 +315,8 @@ class FlashWeightStore:
     def _load_neurons_cache(
         self, layer_idx: int, neuron_indices: list[int]
     ) -> tuple[mx.array, mx.array, mx.array]:
-        """Load neurons using the NeuronCache path (original)."""
+        """Load neurons via the per-layer LRU cache, fetching missing from SSD."""
+        assert self._cache is not None
         cached = self._cache.get_batch(layer_idx, neuron_indices)
         missing = [idx for idx in neuron_indices if idx not in cached]
 
@@ -489,12 +404,7 @@ class FlashWeightStore:
     def close(self) -> None:
         """Release file descriptors and shut down the I/O thread pool."""
         self._executor.shutdown(wait=True)
-        for fd in self._fds.values():
-            try:
-                os.close(fd)
-            except OSError:
-                pass
-        self._fds.clear()
+        close_fds(self._fds)
 
     def __enter__(self):
         return self

--- a/olmlx/engine/flash/weight_store.py
+++ b/olmlx/engine/flash/weight_store.py
@@ -312,12 +312,24 @@ class FlashWeightStore:
                 buf.insert(idx, gate, up, down)
             return buf.get_matrices(neuron_indices)
 
+    def _require_cache(self) -> _NeuronCache:
+        """Return the LRU cache, raising if the store is in preallocated-buffer mode.
+
+        Asserts are stripped under ``python -O``, so we use an explicit raise.
+        """
+        if self._cache is None:
+            raise RuntimeError(
+                "FlashWeightStore cache is None; "
+                "this path must not be reached when use_preallocated_buffer=True"
+            )
+        return self._cache
+
     def _load_neurons_cache(
         self, layer_idx: int, neuron_indices: list[int]
     ) -> tuple[mx.array, mx.array, mx.array]:
         """Load neurons via the per-layer LRU cache, fetching missing from SSD."""
-        assert self._cache is not None
-        cached = self._cache.get_batch(layer_idx, neuron_indices)
+        cache = self._require_cache()
+        cached = cache.get_batch(layer_idx, neuron_indices)
         missing = [idx for idx in neuron_indices if idx not in cached]
 
         if missing:
@@ -328,7 +340,7 @@ class FlashWeightStore:
             for idx, future in futures.items():
                 data = future.result()
                 cached[idx] = data
-                self._cache.put(layer_idx, idx, data)
+                cache.put(layer_idx, idx, data)
 
         gate_cols = []
         up_cols = []
@@ -357,8 +369,7 @@ class FlashWeightStore:
             buf = self._buffers[layer_idx]
             with buf.lock:
                 return buf.get_cached_indices(neuron_indices)
-        assert self._cache is not None
-        return self._cache.get_cached_indices(layer_idx, neuron_indices)
+        return self._require_cache().get_cached_indices(layer_idx, neuron_indices)
 
     def prefetch_neurons(
         self,
@@ -391,15 +402,15 @@ class FlashWeightStore:
                 for idx, (gate, up, down) in results.items():
                     buf.insert(idx, gate, up, down)
         else:
-            assert self._cache is not None
-            _, missing = self._cache.get_cached_indices(layer_idx, neuron_indices)
+            cache = self._require_cache()
+            _, missing = cache.get_cached_indices(layer_idx, neuron_indices)
             if not missing:
                 return
             futures = {
                 pool.submit(self._read_neuron, layer_idx, idx): idx for idx in missing
             }
             for fut in as_completed(futures):
-                self._cache.put(layer_idx, futures[fut], fut.result())
+                cache.put(layer_idx, futures[fut], fut.result())
 
     def close(self) -> None:
         """Release file descriptors and shut down the I/O thread pool."""

--- a/tests/test_flash_moe_weight_store.py
+++ b/tests/test_flash_moe_weight_store.py
@@ -11,65 +11,6 @@ from tests.test_flash_moe_bundler import (
 
 
 # ---------------------------------------------------------------------------
-# ExpertCache tests
-# ---------------------------------------------------------------------------
-
-
-class TestExpertCache:
-    def test_put_and_get(self):
-        from olmlx.engine.flash.moe_weight_store import ExpertCache
-
-        cache = ExpertCache(max_experts_per_layer=10)
-        data = {"gate_proj": mx.ones((4, 8)), "up_proj": mx.ones((4, 8))}
-        cache.put(0, 5, data)
-        result = cache.get(0, 5)
-        assert result is not None
-        assert mx.array_equal(result["gate_proj"], data["gate_proj"])
-
-    def test_get_missing_returns_none(self):
-        from olmlx.engine.flash.moe_weight_store import ExpertCache
-
-        cache = ExpertCache(max_experts_per_layer=10)
-        assert cache.get(0, 99) is None
-
-    def test_lru_eviction(self):
-        from olmlx.engine.flash.moe_weight_store import ExpertCache
-
-        cache = ExpertCache(max_experts_per_layer=3)
-        for i in range(4):
-            cache.put(0, i, {"w": mx.array([float(i)])})
-
-        # Expert 0 should have been evicted (oldest)
-        assert cache.get(0, 0) is None
-        assert cache.get(0, 1) is not None
-        assert cache.get(0, 2) is not None
-        assert cache.get(0, 3) is not None
-
-    def test_get_batch(self):
-        from olmlx.engine.flash.moe_weight_store import ExpertCache
-
-        cache = ExpertCache(max_experts_per_layer=10)
-        cache.put(0, 1, {"w": mx.array([1.0])})
-        cache.put(0, 3, {"w": mx.array([3.0])})
-
-        cached = cache.get_batch(0, [1, 2, 3, 4])
-        assert 1 in cached and 3 in cached
-        assert 2 not in cached and 4 not in cached
-
-    def test_layers_are_independent(self):
-        from olmlx.engine.flash.moe_weight_store import ExpertCache
-
-        cache = ExpertCache(max_experts_per_layer=5)
-        cache.put(0, 1, {"w": mx.array([0.0])})
-        cache.put(1, 1, {"w": mx.array([1.0])})
-
-        r0 = cache.get(0, 1)
-        r1 = cache.get(1, 1)
-        assert r0 is not None and r1 is not None
-        assert not mx.array_equal(r0["w"], r1["w"])
-
-
-# ---------------------------------------------------------------------------
 # FlashMoeWeightStore tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_flash_prefetch.py
+++ b/tests/test_flash_prefetch.py
@@ -15,7 +15,7 @@ from olmlx.engine.flash.predictor import (
     PredictorBank,
     SparsityPredictor,
 )
-from olmlx.engine.flash.weight_store import FlashWeightStore, NeuronCache
+from olmlx.engine.flash.weight_store import FlashWeightStore
 
 
 # ---------------------------------------------------------------------------
@@ -49,42 +49,6 @@ def _make_bundled_model(tmp_path, hidden=16, inter=8, num_layers=2):
     flash_dir = tmp_path / "flash"
     bundle_ffn_weights(model_dir, flash_dir)
     return flash_dir, model_dir, tensors
-
-
-# ---------------------------------------------------------------------------
-# NeuronCache.get_cached_indices tests
-# ---------------------------------------------------------------------------
-
-
-class TestNeuronCacheGetCachedIndices:
-    def test_empty_cache(self):
-        cache = NeuronCache(max_neurons_per_layer=64)
-        cached, missing = cache.get_cached_indices(0, [0, 1, 2])
-        assert cached == []
-        assert missing == [0, 1, 2]
-
-    def test_all_cached(self):
-        cache = NeuronCache(max_neurons_per_layer=64)
-        for i in range(3):
-            cache.put(0, i, (mx.zeros(4), mx.zeros(4), mx.zeros(4)))
-        cached, missing = cache.get_cached_indices(0, [0, 1, 2])
-        assert cached == [0, 1, 2]
-        assert missing == []
-
-    def test_partial_cache(self):
-        cache = NeuronCache(max_neurons_per_layer=64)
-        cache.put(0, 0, (mx.zeros(4), mx.zeros(4), mx.zeros(4)))
-        cache.put(0, 2, (mx.zeros(4), mx.zeros(4), mx.zeros(4)))
-        cached, missing = cache.get_cached_indices(0, [0, 1, 2])
-        assert cached == [0, 2]
-        assert missing == [1]
-
-    def test_wrong_layer(self):
-        cache = NeuronCache(max_neurons_per_layer=64)
-        cache.put(0, 0, (mx.zeros(4), mx.zeros(4), mx.zeros(4)))
-        cached, missing = cache.get_cached_indices(1, [0])
-        assert cached == []
-        assert missing == [0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_flash_ssd_base.py
+++ b/tests/test_flash_ssd_base.py
@@ -16,6 +16,7 @@ from olmlx.engine.flash._ssd_base import (
     LayerLruCache,
     encode_header,
     full_pread,
+    open_fds,
     parse_header,
 )
 
@@ -283,3 +284,51 @@ class TestFullPread:
             assert call_count[0] > 1
         finally:
             os.close(fd)
+
+
+class TestOpenFds:
+    def test_closes_already_opened_fds_when_fcntl_fails(self, tmp_path):
+        """If F_NOCACHE setup fails mid-loop, every fd opened so far must be closed."""
+        import os
+        import sys
+        from unittest.mock import patch
+
+        paths = {}
+        for i in range(3):
+            p = tmp_path / f"layer_{i}.bin"
+            p.write_bytes(b"x")
+            paths[i] = p
+
+        opened: list[int] = []
+        closed: list[int] = []
+        real_open = os.open
+        real_close = os.close
+
+        def tracking_open(path, flags):
+            fd = real_open(path, flags)
+            opened.append(fd)
+            return fd
+
+        def tracking_close(fd):
+            closed.append(fd)
+            real_close(fd)
+
+        # Force the darwin branch and make fcntl.fcntl raise on the second file.
+        def fail_fcntl(fd, cmd, arg):
+            if len(opened) >= 2:
+                raise OSError("simulated F_NOCACHE failure")
+
+        fake_fcntl = type("FakeFcntl", (), {"fcntl": staticmethod(fail_fcntl)})
+
+        with (
+            patch.object(sys, "platform", "darwin"),
+            patch.dict("sys.modules", {"fcntl": fake_fcntl}),
+            patch("os.open", side_effect=tracking_open),
+            patch("os.close", side_effect=tracking_close),
+        ):
+            with pytest.raises(OSError, match="simulated F_NOCACHE"):
+                open_fds(paths, bypass_cache=True)
+
+        # Every fd handed out by os.open must have been closed by the cleanup path.
+        assert opened, "test setup should have opened at least one fd"
+        assert set(closed) == set(opened), f"fd leak: opened={opened}, closed={closed}"

--- a/tests/test_flash_ssd_base.py
+++ b/tests/test_flash_ssd_base.py
@@ -1,0 +1,285 @@
+"""Tests for shared SSD weight-store infrastructure.
+
+Covers the generic LayerLruCache and HeaderSpec codec helpers that back
+FlashWeightStore and FlashMoeWeightStore.
+"""
+
+from __future__ import annotations
+
+import struct
+import threading
+
+import pytest
+
+from olmlx.engine.flash._ssd_base import (
+    HeaderSpec,
+    LayerLruCache,
+    encode_header,
+    full_pread,
+    parse_header,
+)
+
+
+# ---------------------------------------------------------------------------
+# LayerLruCache
+# ---------------------------------------------------------------------------
+
+
+class TestLayerLruCache:
+    def test_put_then_get_returns_value(self):
+        cache: LayerLruCache[int, str] = LayerLruCache(max_per_layer=4)
+        cache.put(0, 7, "seven")
+        assert cache.get(0, 7) == "seven"
+
+    def test_get_missing_returns_none(self):
+        cache: LayerLruCache[int, str] = LayerLruCache(max_per_layer=4)
+        assert cache.get(0, 7) is None
+
+    def test_get_missing_layer_returns_none(self):
+        cache: LayerLruCache[int, str] = LayerLruCache(max_per_layer=4)
+        cache.put(1, 0, "x")
+        assert cache.get(0, 0) is None
+
+    def test_eviction_drops_oldest_when_full(self):
+        cache: LayerLruCache[int, str] = LayerLruCache(max_per_layer=3)
+        for i in range(4):
+            cache.put(0, i, f"v{i}")
+        # Key 0 is oldest; expect it evicted
+        assert cache.get(0, 0) is None
+        for i in range(1, 4):
+            assert cache.get(0, i) == f"v{i}"
+
+    def test_get_refreshes_lru_order(self):
+        cache: LayerLruCache[int, str] = LayerLruCache(max_per_layer=3)
+        for i in range(3):
+            cache.put(0, i, f"v{i}")
+        # Touch key 0 so key 1 becomes the oldest
+        assert cache.get(0, 0) == "v0"
+        cache.put(0, 3, "v3")
+        assert cache.get(0, 1) is None
+        assert cache.get(0, 0) == "v0"
+        assert cache.get(0, 2) == "v2"
+        assert cache.get(0, 3) == "v3"
+
+    def test_put_updates_existing_entry_without_eviction(self):
+        cache: LayerLruCache[int, str] = LayerLruCache(max_per_layer=2)
+        cache.put(0, 0, "a")
+        cache.put(0, 1, "b")
+        cache.put(0, 0, "a2")  # update
+        cache.put(0, 2, "c")  # evicts LRU, which is now 1
+        assert cache.get(0, 0) == "a2"
+        assert cache.get(0, 1) is None
+        assert cache.get(0, 2) == "c"
+
+    def test_put_with_zero_budget_is_noop(self):
+        cache: LayerLruCache[int, str] = LayerLruCache(max_per_layer=0)
+        cache.put(0, 0, "a")
+        assert cache.get(0, 0) is None
+
+    def test_layers_are_independent(self):
+        cache: LayerLruCache[int, str] = LayerLruCache(max_per_layer=2)
+        cache.put(0, 0, "a")
+        cache.put(1, 0, "b")
+        assert cache.get(0, 0) == "a"
+        assert cache.get(1, 0) == "b"
+
+    def test_get_batch_returns_only_cached(self):
+        cache: LayerLruCache[int, str] = LayerLruCache(max_per_layer=4)
+        cache.put(0, 0, "a")
+        cache.put(0, 2, "c")
+        got = cache.get_batch(0, [0, 1, 2, 3])
+        assert got == {0: "a", 2: "c"}
+
+    def test_get_batch_missing_layer_returns_empty(self):
+        cache: LayerLruCache[int, str] = LayerLruCache(max_per_layer=4)
+        assert cache.get_batch(99, [0, 1]) == {}
+
+    def test_get_cached_indices_splits_hits_and_misses(self):
+        cache: LayerLruCache[int, str] = LayerLruCache(max_per_layer=4)
+        cache.put(0, 0, "a")
+        cache.put(0, 2, "c")
+        cached, missing = cache.get_cached_indices(0, [0, 1, 2, 3])
+        assert cached == [0, 2]
+        assert missing == [1, 3]
+
+    def test_get_cached_indices_missing_layer_all_miss(self):
+        cache: LayerLruCache[int, str] = LayerLruCache(max_per_layer=4)
+        cached, missing = cache.get_cached_indices(0, [0, 1])
+        assert cached == []
+        assert missing == [0, 1]
+
+    def test_thread_safety_under_concurrent_put(self):
+        """Concurrent puts from many threads must not corrupt internal state."""
+        cache: LayerLruCache[int, int] = LayerLruCache(max_per_layer=512)
+        num_threads = 8
+        per_thread = 64
+
+        def worker(tid: int) -> None:
+            for i in range(per_thread):
+                cache.put(0, tid * per_thread + i, tid * per_thread + i)
+
+        threads = [
+            threading.Thread(target=worker, args=(t,)) for t in range(num_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All entries fit (max 512 > 8 * 64 = 512); every value must be readable
+        for tid in range(num_threads):
+            for i in range(per_thread):
+                key = tid * per_thread + i
+                assert cache.get(0, key) == key
+
+
+# ---------------------------------------------------------------------------
+# HeaderSpec codec
+# ---------------------------------------------------------------------------
+
+
+DENSE_SPEC = HeaderSpec(
+    magic=0x464C5348,
+    version=1,
+    size=64,
+    body_format="<III16s",
+)
+
+MOE_SPEC = HeaderSpec(
+    magic=0x464C4D45,
+    version=1,
+    size=128,
+    body_format="<IIIIIIQ",
+)
+
+
+class TestHeaderCodec:
+    def test_dense_round_trip(self):
+        num_neurons = 11008
+        hidden = 4096
+        dtype = b"float16"
+
+        raw = encode_header(
+            DENSE_SPEC,
+            num_neurons,
+            hidden,
+            len(dtype),
+            dtype.ljust(16, b"\x00"),
+        )
+        assert len(raw) == DENSE_SPEC.size
+
+        nn, h, dlen, draw = parse_header(DENSE_SPEC, raw)
+        assert nn == num_neurons
+        assert h == hidden
+        assert dlen == len(dtype)
+        assert draw.rstrip(b"\x00") == dtype
+
+    def test_moe_round_trip(self):
+        raw = encode_header(
+            MOE_SPEC,
+            64,  # num_experts
+            2048,  # hidden
+            5632,  # intermediate
+            1,  # is_quantized
+            4,  # bits
+            64,  # group_size
+            123456,  # expert_byte_size
+        )
+        assert len(raw) == MOE_SPEC.size
+
+        num_experts, hidden, inter, is_q, bits, gs, byte_size = parse_header(
+            MOE_SPEC, raw
+        )
+        assert num_experts == 64
+        assert hidden == 2048
+        assert inter == 5632
+        assert is_q == 1
+        assert bits == 4
+        assert gs == 64
+        assert byte_size == 123456
+
+    def test_pads_to_full_size(self):
+        raw = encode_header(
+            DENSE_SPEC,
+            1,
+            2,
+            0,
+            b"x".ljust(16, b"\x00"),
+        )
+        # Trailing bytes past body must be zeros (padding region)
+        body_size = struct.calcsize(DENSE_SPEC.body_format) + 8  # + magic + version
+        assert raw[body_size:] == b"\x00" * (DENSE_SPEC.size - body_size)
+
+    def test_rejects_bad_magic(self):
+        # Build a byte buffer that has the right size but wrong magic
+        bogus = b"\xff\xff\xff\xff" + b"\x00" * (DENSE_SPEC.size - 4)
+        with pytest.raises(ValueError, match="magic"):
+            parse_header(DENSE_SPEC, bogus)
+
+    def test_rejects_bad_version(self):
+        bogus = struct.pack("<II", DENSE_SPEC.magic, 99) + b"\x00" * (
+            DENSE_SPEC.size - 8
+        )
+        with pytest.raises(ValueError, match="version"):
+            parse_header(DENSE_SPEC, bogus)
+
+
+# ---------------------------------------------------------------------------
+# full_pread
+# ---------------------------------------------------------------------------
+
+
+class TestFullPread:
+    def test_reads_exact_bytes_at_offset(self, tmp_path):
+        import os
+
+        path = tmp_path / "blob.bin"
+        payload = bytes(range(256)) * 4  # 1024 bytes
+        path.write_bytes(payload)
+
+        fd = os.open(str(path), os.O_RDONLY)
+        try:
+            assert full_pread(fd, 10, 0) == payload[:10]
+            assert full_pread(fd, 10, 100) == payload[100:110]
+            assert full_pread(fd, 256, 0) == payload[:256]
+        finally:
+            os.close(fd)
+
+    def test_raises_on_eof(self, tmp_path):
+        import os
+
+        path = tmp_path / "blob.bin"
+        path.write_bytes(b"abc")
+
+        fd = os.open(str(path), os.O_RDONLY)
+        try:
+            with pytest.raises(OSError, match="EOF"):
+                full_pread(fd, 100, 0)
+        finally:
+            os.close(fd)
+
+    def test_reassembles_short_reads(self, tmp_path):
+        """When os.pread returns partial chunks, full_pread must retry and stitch."""
+        import os
+        from unittest.mock import patch
+
+        data = b"abcdefghijklmnopqrstuvwxyz"
+        path = tmp_path / "blob.bin"
+        path.write_bytes(data)
+
+        fd = os.open(str(path), os.O_RDONLY)
+        try:
+            real_pread = os.pread
+            call_count = [0]
+
+            def short_pread(fd_, size_, offset_):
+                call_count[0] += 1
+                return real_pread(fd_, min(size_, 5), offset_)
+
+            with patch("os.pread", side_effect=short_pread):
+                result = full_pread(fd, len(data), 0)
+
+            assert result == data
+            assert call_count[0] > 1
+        finally:
+            os.close(fd)

--- a/tests/test_flash_ssd_base.py
+++ b/tests/test_flash_ssd_base.py
@@ -126,7 +126,7 @@ class TestLayerLruCache:
         for t in threads:
             t.join()
 
-        # All entries fit (max 512 > 8 * 64 = 512); every value must be readable
+        # All entries fit (max_per_layer=512 == 8×64); no eviction, every key must be readable.
         for tid in range(num_threads):
             for i in range(per_thread):
                 key = tid * per_thread + i

--- a/tests/test_flash_weight_store.py
+++ b/tests/test_flash_weight_store.py
@@ -12,7 +12,7 @@ from olmlx.engine.flash.bundler import (
     bundle_ffn_weights,
     parse_header,
 )
-from olmlx.engine.flash.weight_store import FlashWeightStore, NeuronCache
+from olmlx.engine.flash.weight_store import FlashWeightStore
 
 
 # ---------------------------------------------------------------------------
@@ -216,57 +216,6 @@ class TestBundleVLModelWeights:
 
 
 # ---------------------------------------------------------------------------
-# NeuronCache tests
-# ---------------------------------------------------------------------------
-
-
-class TestNeuronCache:
-    def test_put_and_get(self):
-        cache = NeuronCache(max_neurons_per_layer=10)
-        data = (mx.ones((4,)), mx.ones((4,)), mx.ones((4,)))
-        cache.put(0, 5, data)
-        result = cache.get(0, 5)
-        assert result is not None
-        assert mx.array_equal(result[0], data[0])
-
-    def test_get_missing_returns_none(self):
-        cache = NeuronCache(max_neurons_per_layer=10)
-        assert cache.get(0, 99) is None
-
-    def test_lru_eviction(self):
-        cache = NeuronCache(max_neurons_per_layer=3)
-        for i in range(4):
-            cache.put(0, i, (mx.array([i]),) * 3)
-
-        # Neuron 0 should have been evicted (oldest)
-        assert cache.get(0, 0) is None
-        # Neurons 1, 2, 3 should still be present
-        assert cache.get(0, 1) is not None
-        assert cache.get(0, 2) is not None
-        assert cache.get(0, 3) is not None
-
-    def test_get_batch_returns_hits_and_misses(self):
-        cache = NeuronCache(max_neurons_per_layer=10)
-        cache.put(0, 1, (mx.array([1.0]),) * 3)
-        cache.put(0, 3, (mx.array([3.0]),) * 3)
-
-        cached = cache.get_batch(0, [1, 2, 3, 4])
-        assert 1 in cached and 3 in cached
-        assert 2 not in cached and 4 not in cached
-        assert len(cached) == 2
-
-    def test_layers_are_independent(self):
-        cache = NeuronCache(max_neurons_per_layer=5)
-        cache.put(0, 1, (mx.array([0.0]),) * 3)
-        cache.put(1, 1, (mx.array([1.0]),) * 3)
-
-        r0 = cache.get(0, 1)
-        r1 = cache.get(1, 1)
-        assert r0 is not None and r1 is not None
-        assert not mx.array_equal(r0[0], r1[0])
-
-
-# ---------------------------------------------------------------------------
 # FlashWeightStore tests
 # ---------------------------------------------------------------------------
 
@@ -371,21 +320,6 @@ class TestFlashWeightStore:
         # Different layers should have different weights (extremely unlikely to match)
         assert not mx.array_equal(g0, g1)
 
-    def test_bypass_cache_flag_stored(self, tmp_path):
-        """FlashWeightStore stores the bypass_cache flag."""
-        hidden, inter, num_layers = 16, 8, 1
-        model_dir = _make_synthetic_mlp_weights(hidden, inter, num_layers, tmp_path)
-        output_dir = tmp_path / "flash"
-        bundle_ffn_weights(model_dir, output_dir)
-
-        store = FlashWeightStore(output_dir, bypass_cache=True)
-        assert store._bypass_cache is True
-        store.close()
-
-        store2 = FlashWeightStore(output_dir, bypass_cache=False)
-        assert store2._bypass_cache is False
-        store2.close()
-
     def test_bypass_cache_reads_correctly(self, tmp_path):
         """With bypass_cache=True, reads still return correct data."""
         from safetensors.numpy import load_file
@@ -405,51 +339,3 @@ class TestFlashWeightStore:
         expected = mx.array(gate_w[indices].T)
         assert mx.allclose(gate_cols, expected, atol=1e-6)
         store.close()
-
-
-class TestFullPread:
-    """Tests for FlashWeightStore._full_pread handling short reads."""
-
-    def test_single_complete_read(self, tmp_path):
-        """Normal case: pread returns all bytes in one call."""
-        data = b"hello world, this is test data!"
-        p = tmp_path / "test.bin"
-        p.write_bytes(data)
-
-        import os
-
-        fd = os.open(str(p), os.O_RDONLY)
-        try:
-            result = FlashWeightStore._full_pread(fd, len(data), 0)
-            assert result == data
-        finally:
-            os.close(fd)
-
-    def test_short_reads_reassembled(self, tmp_path):
-        """When pread returns partial data, _full_pread retries and assembles."""
-        data = b"abcdefghijklmnopqrstuvwxyz"
-        p = tmp_path / "test.bin"
-        p.write_bytes(data)
-
-        import os
-        from unittest.mock import patch
-
-        fd = os.open(str(p), os.O_RDONLY)
-        try:
-            # Simulate short reads by returning small chunks
-            real_pread = os.pread
-            call_count = [0]
-
-            def short_pread(fd, size, offset):
-                call_count[0] += 1
-                # Return at most 5 bytes per call
-                return real_pread(fd, min(size, 5), offset)
-
-            with patch("os.pread", side_effect=short_pread):
-                result = FlashWeightStore._full_pread(fd, len(data), 0)
-
-            assert result == data
-            # Should have needed multiple calls
-            assert call_count[0] > 1
-        finally:
-            os.close(fd)


### PR DESCRIPTION
## Summary

- Extracts the shared I/O layer between `FlashWeightStore` (dense FFN) and `FlashMoeWeightStore` (MoE experts) into a new internal `olmlx.engine.flash._ssd_base` module: `LayerLruCache[K, V]`, `full_pread` / `open_fds` / `close_fds`, and a `HeaderSpec` + `encode_header` / `parse_header` codec.
- Drops duplicated `NeuronCache` / `ExpertCache` classes and duplicate `_full_pread` / fd-management code from both weight stores.
- Bundle wire format (magic, version, header size, body, offset table, padding) is byte-for-byte unchanged — existing `.flashweights` and `.flashexperts` files still load.

## Behavior changes (small, deliberate)

- `bundler.parse_header` and `moe_bundler.parse_moe_header` now raise `ValueError` on bad magic or version. Previously the dense `parse_header` performed no validation and `parse_moe_header` validated only magic. All existing files are at version 1 so there is no real-world breakage; synthetic test buffers that set only `magic` will now need to set `version=1` too.
- `parse_header` / `parse_moe_header` return dicts with `"magic"` and `"version"` set to the expected constants (since validation already rejected anything else). Callers never relied on these dict entries for diagnostics — the exception is the signal now.

## Scope notes

Explicitly **not** unified: bundle body layouts (dense is fixed 3-component gate/up/down rows; MoE is manifest-driven variable components with quantization metadata), `prepare.py` vs `moe_prepare.py` (dense is 90% predictor/calibration training, MoE is config-only), and `PreallocatedNeuronBuffer` (dense-only numpy swap buffer with slot mapping).

Closes #246.

## Test plan

- [x] `uv run pytest -k flash` — 303 passed
- [x] Full non-integration suite — 2,162 passed
- [x] `uv run ruff check` + `uv run ruff format --check` clean
- [x] `uv run pyright` — 0 errors on the touched files (5 pre-existing warnings in untouched regions)
- [x] Round-trip tests for both dense and MoE `HeaderSpec` (`tests/test_flash_ssd_base.py`)
- [x] Thread-safety test for `LayerLruCache` under concurrent puts
- [x] `full_pread` short-read reassembly test (patches `os.pread` to return 5 bytes at a time)
- [x] Regression test for fd-leak-on-F_NOCACHE-failure in `open_fds` (patches `sys.platform`, `os.open`/`os.close`, fake `fcntl`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)