### PR TITLE
perf(chat): robustness, features, and code quality improvements

### DIFF
--- a/olmlx/chat/config.py
+++ b/olmlx/chat/config.py
@@ -49,6 +49,15 @@ class ChatConfig:
     builtin_tools_enabled: bool = True
     plans_dir: Path = field(default_factory=lambda: Path.home() / ".olmlx" / "plans")
     sequential_tool_execution: bool = False
+    temperature: float | None = None
+    top_p: float | None = None
+    top_k: int | None = None
+    tool_timeout: float = 30.0
+    repetition_min_phrase_len: int = 20
+    repetition_min_repeats: int = 4
+    local_tool_safety: bool = False
+    mcp_connect_retries: int = 3
+    tool_result_truncation: int = 2000
 
 
 def _load_json_file(path: Path) -> dict[str, Any]:

--- a/olmlx/chat/mcp_client.py
+++ b/olmlx/chat/mcp_client.py
@@ -75,16 +75,42 @@ class MCPClientManager:
             },
         }
 
-    async def connect_all(self, config: dict[str, Any]) -> None:
-        """Connect to each configured MCP server and discover tools."""
+    async def connect_all(self, config: dict[str, Any], max_attempts: int = 3) -> None:
+        """Connect to each configured MCP server and discover tools.
+
+        Retries on connection failure with exponential backoff.
+        ``max_attempts`` is the total number of connection attempts
+        (minimum 1).
+        """
+        attempts = max(max_attempts, 1)
         for name, server_cfg in config.items():
-            try:
-                if server_cfg["transport"] == "stdio":
-                    await self._connect_stdio(name, server_cfg)
-                elif server_cfg["transport"] == "sse":
-                    await self._connect_sse(name, server_cfg)
-            except Exception as exc:
-                logger.warning("Failed to connect to MCP server %r: %s", name, exc)
+            for attempt in range(attempts):
+                try:
+                    if server_cfg["transport"] == "stdio":
+                        await self._connect_stdio(name, server_cfg)
+                    elif server_cfg["transport"] == "sse":
+                        await self._connect_sse(name, server_cfg)
+                    break
+                except Exception as exc:
+                    if attempt < attempts - 1:
+                        delay = min(2**attempt, 10)
+                        logger.warning(
+                            "Failed to connect to MCP server %r (attempt %d/%d): %s. "
+                            "Retrying in %ds...",
+                            name,
+                            attempt + 1,
+                            attempts,
+                            exc,
+                            delay,
+                        )
+                        await asyncio.sleep(delay)
+                    else:
+                        logger.warning(
+                            "Failed to connect to MCP server %r after %d attempts: %s",
+                            name,
+                            attempts,
+                            exc,
+                        )
 
     async def _connect_stdio(self, name: str, cfg: dict[str, Any]) -> None:
         """Connect to a stdio MCP server."""

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -12,14 +12,177 @@ from olmlx.chat.config import ChatConfig
 from olmlx.chat.mcp_client import MCPClientManager
 from olmlx.chat.skills import SkillManager
 from olmlx.chat.tool_safety import ToolSafetyPolicy
-from olmlx.engine.inference import generate_chat
-from olmlx.engine.model_manager import ModelManager
+from olmlx.config import settings
+from olmlx.engine.inference import (
+    _apply_chat_template_text,
+    _estimate_kv_cache_bytes,
+    _tokenize_for_cache,
+    generate_chat,
+)
+from olmlx.engine.model_manager import LoadedModel, ModelManager
 from olmlx.engine.tool_parser import parse_model_output
+from olmlx.utils import memory as memory_utils
 
 logger = logging.getLogger(__name__)
 
+# Safety multiplier for chat memory estimates (matches inference.py)
+_CHAT_MEMORY_SAFETY_FACTOR = 1.3
+
+# Maximum messages to keep when truncating (system message + N recent pairs)
+_MIN_MESSAGES_AFTER_TRUNCATE = 6
+
 
 class ThinkingTracker:
+    """Tracks <think> tag boundaries during streaming generation.
+
+    Handles both explicit ``<think>...</think>`` tags and implicit
+    thinking (template-injected ``<think>`` at position 0). State
+    mutations are deterministic — callers check ``has_content()``
+    after each ``feed()`` to emit events.
+    """
+
+    def __init__(
+        self,
+        implicit_mode: bool = False,
+        thinking_disabled: bool = False,
+        template_has_thinking: bool = False,
+    ):
+        self._implicit_mode = implicit_mode
+        self._thinking_disabled = thinking_disabled
+        self._template_has_thinking = template_has_thinking
+        self._accumulated = ""
+        self._open_pos = -1
+        self._close_pos = -1
+        self._scan_pos = 0
+        self._think_emitted = 0
+        self._visible_emitted = 0
+        self._in_thinking = False
+        self._just_started = False
+        self._thinking_start_emitted = False
+
+    @property
+    def accumulated(self) -> str:
+        return self._accumulated
+
+    @property
+    def in_thinking(self) -> bool:
+        return self._in_thinking
+
+    @property
+    def just_started(self) -> bool:
+        """True if thinking block just started on this chunk."""
+        return self._just_started
+
+    @property
+    def think_emitted(self) -> int:
+        return self._think_emitted
+
+    @property
+    def visible_emitted(self) -> int:
+        return self._visible_emitted
+
+    def feed(self, text: str) -> tuple[str | None, str | None, bool, bool]:
+        """Ingest a chunk of text.
+
+        Returns ``(think_delta, visible_delta, thinking_ended, thinking_started)`` where
+        each delta is a new substring to emit (or None) and
+        ``thinking_ended`` is True when a visible delta transitions out
+        of thinking mode, ``thinking_started`` on the first thinking chunk.
+        """
+        self._accumulated += text
+
+        # Scan for tag boundaries
+        new_scan = max(0, self._scan_pos - len(_THINK_CLOSE) + 1)
+        self._scan_pos = len(self._accumulated)
+
+        if self._open_pos == -1:
+            pos = self._accumulated.find(_THINK_OPEN, new_scan)
+            if pos != -1:
+                self._open_pos = pos
+                self._implicit_mode = False
+
+        if self._close_pos == -1:
+            search_from = max(
+                (self._open_pos + len(_THINK_OPEN)) if self._open_pos >= 0 else 0,
+                new_scan,
+            )
+            pos = self._accumulated.find(_THINK_CLOSE, search_from)
+            if pos != -1:
+                self._close_pos = pos
+
+        think_content, visible = self._classify()
+        self._just_started = bool(not self._in_thinking and think_content)
+        think_delta = self._emit_think(think_content)
+        visible_delta, thinking_ended = self._emit_visible(visible)
+        return think_delta, visible_delta, thinking_ended, self._just_started
+
+    def flush_disabled(self) -> str | None:
+        """Flush buffered content as visible when thinking is disabled."""
+        if self._implicit_mode and self._close_pos == -1 and self._thinking_disabled:
+            if len(self._accumulated) > self._visible_emitted:
+                text = self._accumulated[self._visible_emitted:]
+                self._visible_emitted = len(self._accumulated)
+                return text
+        return None
+
+    def strip_on_repetition(self) -> int | None:
+        """Truncate accumulated text at the open tag position.
+
+        Cuts before the opening <think> tag to fully remove the incomplete block.
+        """
+        if self._in_thinking and self._open_pos >= 0:
+            self._accumulated = self._accumulated[: self._open_pos]
+            self._visible_emitted = len(self._accumulated)
+            self._in_thinking = False
+            return self._visible_emitted
+        return None
+
+    def _classify(self) -> tuple[str, str]:
+        has_thinking = self._open_pos >= 0 or self._implicit_mode
+        implicit_strip = (
+            self._thinking_disabled
+            and self._template_has_thinking
+            and self._open_pos == -1
+            and self._close_pos >= 0
+        )
+        if has_thinking:
+            cs = (self._open_pos + len(_THINK_OPEN)) if self._open_pos >= 0 else 0
+            if self._close_pos >= 0:
+                think_content = self._accumulated[cs : self._close_pos]
+                visible = self._accumulated[self._close_pos + len(_THINK_CLOSE) :]
+            else:
+                think_content = self._accumulated[cs:]
+                visible = ""
+            if self._thinking_disabled:
+                think_content = ""
+        elif implicit_strip:
+            think_content = ""
+            visible = self._accumulated[self._close_pos + len(_THINK_CLOSE) :]
+        else:
+            think_content = ""
+            visible = self._accumulated
+        return think_content, visible
+
+    def _emit_think(self, think_content: str) -> str | None:
+        if len(think_content) > self._think_emitted:
+            self._in_thinking = True
+            delta = think_content[self._think_emitted:]
+            self._think_emitted = len(think_content)
+            return delta
+        return None
+
+    def _emit_visible(self, visible: str) -> tuple[str | None, bool]:
+        if len(visible) > self._visible_emitted:
+            thinking_ended = self._in_thinking
+            if thinking_ended:
+                self._in_thinking = False
+            delta = visible[self._visible_emitted:]
+            self._visible_emitted = len(visible)
+            return delta, thinking_ended
+        return None, False
+
+
+class ChatSession:
     """Tracks <think> tag boundaries during streaming generation.
 
     Handles both explicit ``<think>...</think>`` tags and implicit
@@ -211,6 +374,84 @@ class ChatSession:
         if system_prompt:
             self.messages.append({"role": "system", "content": system_prompt})
         self.manager.invalidate_prompt_cache(self.config.model_name, "chat")
+
+    async def _estimate_conversation_tokens(self, lm: LoadedModel) -> int:
+        """Estimate total tokens for current conversation history."""
+        try:
+            tokenizer = lm.text_tokenizer
+            # Build a copy of messages for template estimation (without system prompt duplication)
+            msgs = list(self.messages)
+            prompt_text = _apply_chat_template_text(tokenizer, msgs, tools=None, caps=lm.template_caps)
+            tokens = _tokenize_for_cache(tokenizer, prompt_text)
+            return len(tokens)
+        except Exception as exc:
+            logger.debug("Token estimation failed: %s", exc)
+            return 0
+
+    async def _check_memory_and_truncate(self, lm: LoadedModel, max_tokens: int) -> bool:
+        """Check if conversation + generation would exceed memory, truncate if needed.
+
+        Returns True if truncation occurred.
+        """
+        total_physical = memory_utils.get_system_memory_bytes()
+        if total_physical <= 0:
+            return False
+
+        memory_limit = int(total_physical * settings.memory_limit_fraction)
+        current_metal = memory_utils.get_metal_memory()
+
+        # Estimate tokens for current conversation
+        conv_tokens = await self._estimate_conversation_tokens(lm)
+        if conv_tokens <= 0:
+            return False
+
+        # Estimate KV cache for full generation
+        from olmlx.engine.inference import _parse_kv_cache_quant
+
+        kv_bytes = _estimate_kv_cache_bytes(
+            lm.model,
+            conv_tokens + max_tokens,
+            kv_cache_quant=lm.kv_cache_quant,
+        )
+        # Apply safety factor for chat (matches inference.py)
+        kv_bytes = int(kv_bytes * _CHAT_MEMORY_SAFETY_FACTOR)
+
+        if current_metal + kv_bytes <= memory_limit:
+            return False
+
+        # Need to truncate — keep system message + recent message pairs
+        logger.warning(
+            "Chat memory check: %d tokens (%.1f GB KV) would exceed limit. Truncating history.",
+            conv_tokens,
+            kv_bytes / 1024**3,
+        )
+
+        # Find system message index
+        system_idx = 0
+        if self.messages and self.messages[0].get("role") == "system":
+            system_idx = 1
+
+        # Keep system + N most recent (user, assistant) pairs
+        kept = []
+        if system_idx > 0:
+            kept.append(self.messages[0])  # system message
+
+        # Walk backwards from the end, keeping complete user→assistant pairs
+        recent = []
+        idx = len(self.messages) - 1
+        while idx >= system_idx and len(recent) < _MIN_MESSAGES_AFTER_TRUNCATE:
+            msg = self.messages[idx]
+            recent.insert(0, msg)
+            idx -= 1
+
+        kept.extend(recent)
+        self.messages = kept
+
+        # Invalidate prompt cache since history changed
+        self.manager.invalidate_prompt_cache(self.config.model_name, "chat")
+
+        logger.info("Truncated chat history to %d messages", len(self.messages))
+        return True
 
     async def _exec_tool(self, tu: dict) -> dict:
         """Execute a single tool call and return the event + message."""
@@ -581,6 +822,7 @@ class ChatSession:
         - {"type": "tool_call", "name": str, "arguments": dict, "id": str}
         - {"type": "tool_result", "name": str, "result": str, "id": str}
         - {"type": "tool_error", "name": str, "error": str, "id": str}
+        - {"type": "memory_truncated", "message": str} — history was truncated
         - {"type": "max_turns_exceeded"}
         - {"type": "done"}
         """
@@ -593,10 +835,7 @@ class ChatSession:
             "repeat_last_n": self.config.repeat_last_n,
         }
 
-        # Check template caps for implicit thinking detection.
-        # generate_chat() calls ensure_loaded too; the model stays cached.
-        # Only has_thinking_tags implies implicit thinking (template injects
-        # <think>); supports_enable_thinking alone means explicit tags.
+        # Load model once and extract template caps + do memory check
         try:
             lm = await self.manager.ensure_loaded(self.config.model_name)
             template_has_thinking = lm.template_caps.has_thinking_tags
@@ -606,12 +845,24 @@ class ChatSession:
                 exc_info=True,
             )
             template_has_thinking = False
+            lm = None
 
         # Implicit thinking: model injects <think> into the template prompt,
         # so generated text starts with thinking content (no <think> prefix).
         # Buffer content before </think> regardless of the thinking display
         # flag — when disabled, we still need to strip thinking from output.
         assume_implicit_thinking = template_has_thinking
+
+        # Pre-check memory before starting agent loop
+        if lm is not None:
+            try:
+                truncated = await self._check_memory_and_truncate(
+                    lm, self.config.max_tokens
+                )
+                if truncated:
+                    yield {"type": "memory_truncated", "message": "History truncated to fit memory"}
+            except Exception:
+                logger.debug("Memory check failed, proceeding anyway", exc_info=True)
 
         for turn in range(self.config.max_turns):
             repetition_stopped = False

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -5,7 +5,7 @@ import json
 import logging
 import re
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import Any, Literal, TypedDict
 
 from olmlx.chat.builtin_tools import BuiltinToolManager
 from olmlx.chat.config import ChatConfig
@@ -14,9 +14,9 @@ from olmlx.chat.skills import SkillManager
 from olmlx.chat.tool_safety import ToolSafetyPolicy
 from olmlx.config import settings
 from olmlx.engine.inference import (
-    _apply_chat_template_text,
-    _estimate_kv_cache_bytes,
-    _tokenize_for_cache,
+    apply_chat_template_text,
+    estimate_kv_cache_bytes,
+    tokenize_for_cache,
     generate_chat,
 )
 from olmlx.engine.model_manager import LoadedModel, ModelManager
@@ -25,164 +25,140 @@ from olmlx.utils import memory as memory_utils
 
 logger = logging.getLogger(__name__)
 
-# Safety multiplier for chat memory estimates (matches inference.py)
-_CHAT_MEMORY_SAFETY_FACTOR = 1.3
-
 # Maximum messages to keep when truncating (system message + N recent pairs)
 _MIN_MESSAGES_AFTER_TRUNCATE = 6
 
+# Emergency truncation target when first pass still exceeds memory
+_MIN_MESSAGES_EMERGENCY_TRUNCATE = 2
+
+# Thinking tag constants
+_THINK_OPEN = "<think>"
+_THINK_CLOSE = "</think>"
+_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", re.DOTALL)
+_THINK_CONTENT_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+
+
+class _TokenEvent(TypedDict):
+    type: Literal["token"]
+    text: str
+
+
+class _ThinkingTokenEvent(TypedDict):
+    type: Literal["thinking_token"]
+    text: str
+
+
+class _ToolCallEvent(TypedDict):
+    type: Literal["tool_call"]
+    name: str
+    arguments: dict[str, Any]
+    id: str
+
+
+class _ToolResultEvent(TypedDict):
+    type: Literal["tool_result"]
+    name: str
+    result: str
+    id: str
+
+
+class _ToolErrorEvent(TypedDict):
+    type: Literal["tool_error"]
+    name: str
+    error: str
+    id: str
+
+
+class _RepetitionDetectedEvent(TypedDict):
+    type: Literal["repetition_detected"]
+
+
+class _MemoryTruncatedEvent(TypedDict):
+    type: Literal["memory_truncated"]
+    message: str
+
+
+class _ModelLoadErrorEvent(TypedDict):
+    type: Literal["model_load_error"]
+    error: str
+
+
+class _ThinkingStartEvent(TypedDict):
+    type: Literal["thinking_start"]
+
+
+class _ThinkingEndEvent(TypedDict):
+    type: Literal["thinking_end"]
+
+
+class _DoneEvent(TypedDict):
+    type: Literal["done"]
+
+
+class _MaxTurnsExceededEvent(TypedDict):
+    type: Literal["max_turns_exceeded"]
+
+
+class _ToolConfirmationNeededEvent(TypedDict):
+    type: Literal["tool_confirmation_needed"]
+    name: str
+    arguments: dict[str, Any]
+    id: str
+
+
+class _ToolApprovedEvent(TypedDict):
+    type: Literal["tool_approved"]
+    name: str
+    id: str
+
+
+class _ToolDeniedEvent(TypedDict):
+    type: Literal["tool_denied"]
+    name: str
+    arguments: dict[str, Any]
+    id: str
+    reason: str
+
+
+class _ToolAutoJudgingEvent(TypedDict):
+    type: Literal["tool_auto_judging"]
+    name: str
+    arguments: dict[str, Any]
+    id: str
+
+
+class _QuestionEvent(TypedDict):
+    type: Literal["question"]
+    header: str
+    question: str
+    options: list[str] | None
+    multiple: bool
+    id: str
+
+
+# Union type for all events yielded by send_message
+ChatEvent = (
+    _TokenEvent
+    | _ThinkingTokenEvent
+    | _ToolCallEvent
+    | _ToolResultEvent
+    | _ToolErrorEvent
+    | _RepetitionDetectedEvent
+    | _MemoryTruncatedEvent
+    | _ModelLoadErrorEvent
+    | _ThinkingStartEvent
+    | _ThinkingEndEvent
+    | _DoneEvent
+    | _MaxTurnsExceededEvent
+    | _ToolConfirmationNeededEvent
+    | _ToolApprovedEvent
+    | _ToolDeniedEvent
+    | _ToolAutoJudgingEvent
+    | _QuestionEvent
+)
+
 
 class ThinkingTracker:
-    """Tracks <think> tag boundaries during streaming generation.
-
-    Handles both explicit ``<think>...</think>`` tags and implicit
-    thinking (template-injected ``<think>`` at position 0). State
-    mutations are deterministic — callers check ``has_content()``
-    after each ``feed()`` to emit events.
-    """
-
-    def __init__(
-        self,
-        implicit_mode: bool = False,
-        thinking_disabled: bool = False,
-        template_has_thinking: bool = False,
-    ):
-        self._implicit_mode = implicit_mode
-        self._thinking_disabled = thinking_disabled
-        self._template_has_thinking = template_has_thinking
-        self._accumulated = ""
-        self._open_pos = -1
-        self._close_pos = -1
-        self._scan_pos = 0
-        self._think_emitted = 0
-        self._visible_emitted = 0
-        self._in_thinking = False
-        self._just_started = False
-        self._thinking_start_emitted = False
-
-    @property
-    def accumulated(self) -> str:
-        return self._accumulated
-
-    @property
-    def in_thinking(self) -> bool:
-        return self._in_thinking
-
-    @property
-    def just_started(self) -> bool:
-        """True if thinking block just started on this chunk."""
-        return self._just_started
-
-    @property
-    def think_emitted(self) -> int:
-        return self._think_emitted
-
-    @property
-    def visible_emitted(self) -> int:
-        return self._visible_emitted
-
-    def feed(self, text: str) -> tuple[str | None, str | None, bool, bool]:
-        """Ingest a chunk of text.
-
-        Returns ``(think_delta, visible_delta, thinking_ended, thinking_started)`` where
-        each delta is a new substring to emit (or None) and
-        ``thinking_ended`` is True when a visible delta transitions out
-        of thinking mode, ``thinking_started`` on the first thinking chunk.
-        """
-        self._accumulated += text
-
-        # Scan for tag boundaries
-        new_scan = max(0, self._scan_pos - len(_THINK_CLOSE) + 1)
-        self._scan_pos = len(self._accumulated)
-
-        if self._open_pos == -1:
-            pos = self._accumulated.find(_THINK_OPEN, new_scan)
-            if pos != -1:
-                self._open_pos = pos
-                self._implicit_mode = False
-
-        if self._close_pos == -1:
-            search_from = max(
-                (self._open_pos + len(_THINK_OPEN)) if self._open_pos >= 0 else 0,
-                new_scan,
-            )
-            pos = self._accumulated.find(_THINK_CLOSE, search_from)
-            if pos != -1:
-                self._close_pos = pos
-
-        think_content, visible = self._classify()
-        self._just_started = bool(not self._in_thinking and think_content)
-        think_delta = self._emit_think(think_content)
-        visible_delta, thinking_ended = self._emit_visible(visible)
-        return think_delta, visible_delta, thinking_ended, self._just_started
-
-    def flush_disabled(self) -> str | None:
-        """Flush buffered content as visible when thinking is disabled."""
-        if self._implicit_mode and self._close_pos == -1 and self._thinking_disabled:
-            if len(self._accumulated) > self._visible_emitted:
-                text = self._accumulated[self._visible_emitted:]
-                self._visible_emitted = len(self._accumulated)
-                return text
-        return None
-
-    def strip_on_repetition(self) -> int | None:
-        """Truncate accumulated text at the open tag position.
-
-        Cuts before the opening <think> tag to fully remove the incomplete block.
-        """
-        if self._in_thinking and self._open_pos >= 0:
-            self._accumulated = self._accumulated[: self._open_pos]
-            self._visible_emitted = len(self._accumulated)
-            self._in_thinking = False
-            return self._visible_emitted
-        return None
-
-    def _classify(self) -> tuple[str, str]:
-        has_thinking = self._open_pos >= 0 or self._implicit_mode
-        implicit_strip = (
-            self._thinking_disabled
-            and self._template_has_thinking
-            and self._open_pos == -1
-            and self._close_pos >= 0
-        )
-        if has_thinking:
-            cs = (self._open_pos + len(_THINK_OPEN)) if self._open_pos >= 0 else 0
-            if self._close_pos >= 0:
-                think_content = self._accumulated[cs : self._close_pos]
-                visible = self._accumulated[self._close_pos + len(_THINK_CLOSE) :]
-            else:
-                think_content = self._accumulated[cs:]
-                visible = ""
-            if self._thinking_disabled:
-                think_content = ""
-        elif implicit_strip:
-            think_content = ""
-            visible = self._accumulated[self._close_pos + len(_THINK_CLOSE) :]
-        else:
-            think_content = ""
-            visible = self._accumulated
-        return think_content, visible
-
-    def _emit_think(self, think_content: str) -> str | None:
-        if len(think_content) > self._think_emitted:
-            self._in_thinking = True
-            delta = think_content[self._think_emitted:]
-            self._think_emitted = len(think_content)
-            return delta
-        return None
-
-    def _emit_visible(self, visible: str) -> tuple[str | None, bool]:
-        if len(visible) > self._visible_emitted:
-            thinking_ended = self._in_thinking
-            if thinking_ended:
-                self._in_thinking = False
-            delta = visible[self._visible_emitted:]
-            self._visible_emitted = len(visible)
-            return delta, thinking_ended
-        return None, False
-
-
-class ChatSession:
     """Tracks <think> tag boundaries during streaming generation.
 
     Handles both explicit ``<think>...</think>`` tags and implicit
@@ -379,16 +355,23 @@ class ChatSession:
         """Estimate total tokens for current conversation history."""
         try:
             tokenizer = lm.text_tokenizer
-            # Build a copy of messages for template estimation (without system prompt duplication)
             msgs = list(self.messages)
-            prompt_text = _apply_chat_template_text(tokenizer, msgs, tools=None, caps=lm.template_caps)
-            tokens = _tokenize_for_cache(tokenizer, prompt_text)
-            return len(tokens)
+            caps = lm.template_caps
+
+            def _estimate() -> int:
+                prompt_text = apply_chat_template_text(
+                    tokenizer, msgs, tools=None, caps=caps
+                )
+                return len(tokenize_for_cache(tokenizer, prompt_text))
+
+            return await asyncio.to_thread(_estimate)
         except Exception as exc:
             logger.debug("Token estimation failed: %s", exc)
             return 0
 
-    async def _check_memory_and_truncate(self, lm: LoadedModel, max_tokens: int) -> bool:
+    async def _check_memory_and_truncate(
+        self, lm: LoadedModel, max_tokens: int
+    ) -> bool:
         """Check if conversation + generation would exceed memory, truncate if needed.
 
         Returns True if truncation occurred.
@@ -406,15 +389,11 @@ class ChatSession:
             return False
 
         # Estimate KV cache for full generation
-        from olmlx.engine.inference import _parse_kv_cache_quant
-
-        kv_bytes = _estimate_kv_cache_bytes(
+        kv_bytes = estimate_kv_cache_bytes(
             lm.model,
             conv_tokens + max_tokens,
             kv_cache_quant=lm.kv_cache_quant,
         )
-        # Apply safety factor for chat (matches inference.py)
-        kv_bytes = int(kv_bytes * _CHAT_MEMORY_SAFETY_FACTOR)
 
         if current_metal + kv_bytes <= memory_limit:
             return False
@@ -431,27 +410,81 @@ class ChatSession:
         if self.messages and self.messages[0].get("role") == "system":
             system_idx = 1
 
+        # Capture original length so we only report truncation if
+        # messages were actually removed (not just memory pressure).
+        original_len = len(self.messages)
+
         # Keep system + N most recent (user, assistant) pairs
         kept = []
         if system_idx > 0:
             kept.append(self.messages[0])  # system message
 
-        # Walk backwards from the end, keeping complete user→assistant pairs
+        # Walk backwards from the end, collecting messages. After hitting
+        # the target count, continue walking back until we reach a clean
+        # turn boundary (a user message) so we never split tool_call /
+        # tool_result pairs or leave orphan tool results.
         recent = []
         idx = len(self.messages) - 1
-        while idx >= system_idx and len(recent) < _MIN_MESSAGES_AFTER_TRUNCATE:
+        while idx >= system_idx:
             msg = self.messages[idx]
             recent.insert(0, msg)
             idx -= 1
+            if len(recent) >= _MIN_MESSAGES_AFTER_TRUNCATE:
+                # Walk back to next user message to avoid splitting a turn
+                while idx >= system_idx:
+                    msg = self.messages[idx]
+                    if msg.get("role") == "user":
+                        recent.insert(0, msg)
+                        idx -= 1
+                        break
+                    recent.insert(0, msg)
+                    idx -= 1
+                break
 
         kept.extend(recent)
         self.messages = kept
 
-        # Invalidate prompt cache since history changed
-        self.manager.invalidate_prompt_cache(self.config.model_name, "chat")
+        # Re-verify the truncated history still fits; if not, truncate again
+        # but with a shallower target — keep only the last 2 messages.
+        conv_tokens_after = await self._estimate_conversation_tokens(lm)
+        if conv_tokens_after > 0:
+            kv_bytes_after = estimate_kv_cache_bytes(
+                lm.model,
+                conv_tokens_after + max_tokens,
+                kv_cache_quant=lm.kv_cache_quant,
+            )
+            if current_metal + kv_bytes_after > memory_limit:
+                logger.warning(
+                    "Truncated history still exceeds memory limit; reducing further"
+                )
+                kept = []
+                if system_idx > 0:
+                    kept.append(self.messages[0])
+                recent = []
+                idx = len(self.messages) - 1
+                while idx >= system_idx:
+                    msg = self.messages[idx]
+                    recent.insert(0, msg)
+                    idx -= 1
+                    if len(recent) >= _MIN_MESSAGES_EMERGENCY_TRUNCATE:
+                        while idx >= system_idx:
+                            msg = self.messages[idx]
+                            if msg.get("role") == "user":
+                                recent.insert(0, msg)
+                                idx -= 1
+                                break
+                            recent.insert(0, msg)
+                            idx -= 1
+                        break
+                kept.extend(recent)
+                self.messages = kept
 
-        logger.info("Truncated chat history to %d messages", len(self.messages))
-        return True
+        if len(self.messages) < original_len:
+            self.manager.invalidate_prompt_cache(self.config.model_name, "chat")
+            logger.info("Truncated chat history to %d messages", len(self.messages))
+            return True
+
+        return False
 
     async def _exec_tool(self, tu: dict) -> dict:
         """Execute a single tool call and return the event + message."""
@@ -464,7 +497,9 @@ class ChatSession:
             elif self.builtin and tool_name in self.builtin.tool_names:
                 result = await self.builtin.call_tool(tool_name, tool_input)
             elif self.mcp is not None:
-                result = await self.mcp.call_tool(tool_name, tool_input)
+                result = await self.mcp.call_tool(
+                    tool_name, tool_input, timeout=self.config.tool_timeout
+                )
             else:
                 raise ValueError(f"No handler for tool: {tool_name!r}")
             return {
@@ -543,7 +578,7 @@ class ChatSession:
 
     async def _execute_tool_calls(
         self, tool_uses: list[dict]
-    ) -> AsyncGenerator[dict, None]:
+    ) -> AsyncGenerator[ChatEvent, None]:
         """Classify, confirm, and execute tool calls. Yields event dicts.
 
         Appends tool result messages to self.messages in original call order.
@@ -551,18 +586,19 @@ class ChatSession:
         """
         # Classify tools by safety policy.
         # Local tools (skills, builtins) bypass the safety policy
-        # because they run in-process and were already trusted by
-        # the user when configured. Note: tool names come from model
-        # output (not MCP directly), so a prompt injection could
-        # cause the model to emit a local tool name — but local
-        # tools are no more dangerous than the model calling them
-        # without the safety layer.
+        # by default (local_tool_safety=False) because they run
+        # in-process and were already trusted by the user when
+        # configured. Set local_tool_safety=True to apply the
+        # safety policy to local tools as well.
         local_tools = []
         remote_tools = []
         for tu in tool_uses:
-            if tu["name"] == "use_skill" and self.skills:
-                local_tools.append(tu)
-            elif self.builtin and tu["name"] in self.builtin.tool_names:
+            is_local = (tu["name"] == "use_skill" and self.skills) or (
+                self.builtin and tu["name"] in self.builtin.tool_names
+            )
+            if is_local and self.config.local_tool_safety:
+                remote_tools.append(tu)
+            elif is_local:
                 local_tools.append(tu)
             else:
                 remote_tools.append(tu)
@@ -811,7 +847,7 @@ class ChatSession:
         if deferred_exc is not None:
             raise deferred_exc
 
-    async def send_message(self, user_text: str) -> AsyncGenerator[dict, None]:
+    async def send_message(self, user_text: str) -> AsyncGenerator[ChatEvent, None]:
         """Send a user message and run the agent loop.
 
         Yields event dicts:
@@ -822,30 +858,44 @@ class ChatSession:
         - {"type": "tool_call", "name": str, "arguments": dict, "id": str}
         - {"type": "tool_result", "name": str, "result": str, "id": str}
         - {"type": "tool_error", "name": str, "error": str, "id": str}
+        - {"type": "tool_confirmation_needed", "name": str, "arguments": dict, "id": str}
+        - {"type": "tool_approved", "name": str, "id": str}
+        - {"type": "tool_denied", "name": str, "arguments": dict, "id": str, "reason": str}
+        - {"type": "tool_auto_judging", "name": str, "arguments": dict, "id": str}
+        - {"type": "question", "header": str, "question": str, "options": list|None, "multiple": bool, "id": str}
         - {"type": "memory_truncated", "message": str} — history was truncated
-        - {"type": "max_turns_exceeded"}
-        - {"type": "done"}
+        - {"type": "repetition_detected"} — repetitive output detected
+        - {"type": "model_load_error", "error": str} — model load failed
+        - {"type": "max_turns_exceeded"} — agent loop hit turn limit
+        - {"type": "done"} — end of response
         """
         self.messages.append({"role": "user", "content": user_text})
 
         mcp_tools = self._prepare_tools()
 
-        options = {
+        options: dict[str, Any] = {
             "repeat_penalty": self.config.repeat_penalty,
             "repeat_last_n": self.config.repeat_last_n,
         }
+        if self.config.temperature is not None:
+            options["temperature"] = self.config.temperature
+        if self.config.top_p is not None:
+            options["top_p"] = self.config.top_p
+        if self.config.top_k is not None:
+            options["top_k"] = self.config.top_k
 
         # Load model once and extract template caps + do memory check
         try:
             lm = await self.manager.ensure_loaded(self.config.model_name)
             template_has_thinking = lm.template_caps.has_thinking_tags
-        except Exception:
-            logger.debug(
-                "Could not detect template caps, assuming no implicit thinking",
-                exc_info=True,
-            )
-            template_has_thinking = False
-            lm = None
+        except Exception as exc:
+            logger.error("Failed to load model %r: %s", self.config.model_name, exc)
+            # Roll back the user message already appended at the top of send_message
+            self.messages.pop()
+            error_msg = f"Failed to load model: {exc}"
+            yield {"type": "model_load_error", "error": error_msg}
+            yield {"type": "done"}
+            return
 
         # Implicit thinking: model injects <think> into the template prompt,
         # so generated text starts with thinking content (no <think> prefix).
@@ -854,15 +904,17 @@ class ChatSession:
         assume_implicit_thinking = template_has_thinking
 
         # Pre-check memory before starting agent loop
-        if lm is not None:
-            try:
-                truncated = await self._check_memory_and_truncate(
-                    lm, self.config.max_tokens
-                )
-                if truncated:
-                    yield {"type": "memory_truncated", "message": "History truncated to fit memory"}
-            except Exception:
-                logger.debug("Memory check failed, proceeding anyway", exc_info=True)
+        try:
+            truncated = await self._check_memory_and_truncate(
+                lm, self.config.max_tokens
+            )
+            if truncated:
+                yield {
+                    "type": "memory_truncated",
+                    "message": f"History truncated to {len(self.messages)} messages to fit memory",
+                }
+        except Exception:
+            logger.debug("Memory check failed, proceeding anyway", exc_info=True)
 
         for turn in range(self.config.max_turns):
             repetition_stopped = False
@@ -906,12 +958,15 @@ class ChatSession:
                         yield {"type": "token", "text": visible_delta}
 
                     if token_count % 10 == 0 and _detect_repetition(
-                        tracker.accumulated
+                        tracker.accumulated,
+                        min_phrase_len=self.config.repetition_min_phrase_len,
+                        min_repeats=self.config.repetition_min_repeats,
                     ):
                         logger.warning(
                             "Repetitive output detected, stopping generation"
                         )
                         repetition_stopped = True
+                        yield {"type": "repetition_detected"}
                         break
 
             # Flush disabled-thinking content
@@ -929,9 +984,24 @@ class ChatSession:
 
             full_text = tracker.accumulated
 
-            thinking, visible_text, tool_uses = parse_model_output(
-                full_text, has_tools=(mcp_tools is not None)
-            )
+            try:
+                _, visible_text, tool_uses = parse_model_output(
+                    full_text, has_tools=(mcp_tools is not None)
+                )
+            except Exception as exc:
+                logger.error(
+                    "Failed to parse model output: %s\ntext: %.200s",
+                    exc,
+                    full_text,
+                )
+                visible_text = _strip_thinking(full_text)
+                tool_uses = []
+                yield {
+                    "type": "tool_error",
+                    "name": "(parse error)",
+                    "error": f"Failed to parse model output; tools were dropped: {exc}",
+                    "id": "",
+                }
 
             # Build assistant message
             assistant_msg: dict[str, Any] = {
@@ -964,12 +1034,6 @@ class ChatSession:
         yield {"type": "done"}
 
 
-_THINK_OPEN = "<think>"
-_THINK_CLOSE = "</think>"
-_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", re.DOTALL)
-_THINK_CONTENT_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
-
-
 def _strip_thinking(text: str) -> str:
     """Remove complete and in-progress <think> blocks from text.
 
@@ -978,14 +1042,11 @@ def _strip_thinking(text: str) -> str:
     Also handles implicit thinking where the template injects ``<think>``
     so only ``</think>`` appears in the output.
     """
-    # Remove complete blocks
     result = _THINK_BLOCK_RE.sub("", text)
-    # Handle implicit thinking: </think> without matching <think>
     if _THINK_OPEN not in result:
         close_idx = result.find(_THINK_CLOSE)
         if close_idx != -1:
             return result[close_idx + len(_THINK_CLOSE) :]
-    # Truncate at any unclosed <think>
     idx = result.find(_THINK_OPEN)
     if idx != -1:
         result = result[:idx]
@@ -1001,15 +1062,12 @@ def _extract_thinking_content(text: str) -> str:
     and only ``</think>`` appears in the output.
     """
     parts = []
-    # Closed blocks
     for m in _THINK_CONTENT_RE.finditer(text):
         parts.append(m.group(1))
-    # Check for unclosed trailing <think> after removing closed blocks
     cleaned = _THINK_BLOCK_RE.sub("", text)
     idx = cleaned.find(_THINK_OPEN)
     if idx != -1:
         parts.append(cleaned[idx + len(_THINK_OPEN) :])
-    # Implicit thinking: no <think> tag but </think> present
     elif not parts:
         close_idx = cleaned.find(_THINK_CLOSE)
         if close_idx != -1:
@@ -1022,22 +1080,28 @@ def _detect_repetition(
 ) -> bool:
     """Detect if the accumulated text contains a repeating phrase.
 
-    Checks if any substring of length >= min_phrase_len repeats
-    min_repeats or more times consecutively in the recent text.
+    Searches the tail (last 1000 chars) of the text for any short
+    substring that repeats consecutively at least min_repeats times.
+    The phrase length is capped at 100 chars for performance; this
+    is a deliberate trade-off — very long repetitive blocks (e.g.
+    repeated function bodies >100 chars) won't be detected at the
+    default config values.  Lowering ``repetition_min_phrase_len``
+    or ``repetition_min_repeats`` increases detection surface at
+    the cost of more checks per step.
     """
     if len(text) < min_phrase_len * min_repeats:
         return False
 
-    # Only check the tail to keep it fast
-    tail = text[-1000:] if len(text) > 1000 else text
+    if min_repeats < 1 or min_phrase_len < 1:
+        return False
 
-    # Try different phrase lengths from short to long
-    for phrase_len in range(min_phrase_len, len(tail) // min_repeats + 1):
-        # Take the last phrase_len chars as candidate
+    tail = text[-1000:] if len(text) > 1000 else text
+    max_phrase_len = max(min_phrase_len, min(100, len(tail) // min_repeats))
+
+    for phrase_len in range(min_phrase_len, max_phrase_len + 1):
         candidate = tail[-phrase_len:]
         if not candidate.strip():
             continue
-        # Count consecutive occurrences from the end
         count = 0
         pos = len(tail)
         while pos >= phrase_len:

--- a/olmlx/chat/tui.py
+++ b/olmlx/chat/tui.py
@@ -19,8 +19,12 @@ logger = logging.getLogger(__name__)
 class ChatTUI:
     """Terminal UI using Rich for markdown rendering and panels."""
 
-    def __init__(self):
+    def __init__(self, tool_result_truncation: int | None = None):
         self.console = Console()
+        self._always_allow: set[str] = set()
+        self._tool_result_truncation = (
+            tool_result_truncation if tool_result_truncation is not None else 2000
+        )
 
     def display_welcome(self, model_name: str, tools: list[dict]) -> None:
         """Show welcome panel with model and tool info."""
@@ -80,8 +84,10 @@ class ChatTUI:
 
     def display_tool_result(self, name: str, result: str) -> None:
         """Show tool response panel."""
-        # Truncate long results
-        display = result if len(result) <= 2000 else result[:2000] + "\n... (truncated)"
+        limit = self._tool_result_truncation
+        display = (
+            result if len(result) <= limit else result[:limit] + "\n... (truncated)"
+        )
         self.console.print(
             Panel(display, title=f"tool result: {name}", border_style="green")
         )
@@ -108,12 +114,37 @@ class ChatTUI:
             Panel(f"[yellow]{message}[/yellow]", title="memory", border_style="yellow")
         )
 
+    def display_repetition_detected(self) -> None:
+        """Show warning that repetition was detected and generation stopped."""
+        self.console.print(
+            Panel(
+                "[yellow]Repetitive output detected, generation stopped[/yellow]",
+                title="warning",
+                border_style="yellow",
+            )
+        )
+
+    def display_model_load_error(self, error: str) -> None:
+        """Show model load error."""
+        self.console.print(
+            Panel(f"[red]{error}[/red]", title="error", border_style="red")
+        )
+
     def confirm_tool_call(self, name: str, arguments: dict) -> bool:
-        """Prompt user to approve a tool call. Returns True if approved."""
+        """Prompt user to approve a tool call. Returns True if approved.
+
+        Supports "always allow" (a) to auto-approve the tool for the session.
+        """
+        if name in self._always_allow:
+            return True
         self.display_tool_call(name, arguments)
         try:
-            answer = self.console.input("[yellow]Allow? [y/N] [/yellow]")
-            return answer.strip().lower() in ("y", "yes")
+            answer = self.console.input("[yellow]Allow? [y/N/a(always)] [/yellow]")
+            answer = answer.strip().lower()
+            if answer in ("a", "always"):
+                self._always_allow.add(name)
+                return True
+            return answer in ("y", "yes")
         except (EOFError, KeyboardInterrupt):
             return False
 

--- a/olmlx/chat/tui.py
+++ b/olmlx/chat/tui.py
@@ -102,6 +102,12 @@ class ChatTUI:
             Panel(f"[red]{message}[/red]", title="error", border_style="red")
         )
 
+    def display_memory_truncated(self, message: str) -> None:
+        """Show warning that chat history was truncated due to memory."""
+        self.console.print(
+            Panel(f"[yellow]{message}[/yellow]", title="memory", border_style="yellow")
+        )
+
     def confirm_tool_call(self, name: str, arguments: dict) -> bool:
         """Prompt user to approve a tool call. Returns True if approved."""
         self.display_tool_call(name, arguments)

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -793,7 +793,26 @@ def cmd_chat(args):
         repeat_last_n=args.repeat_last_n,
         skills_enabled=not args.no_skills,
         builtin_tools_enabled=not args.no_builtin_tools,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        top_k=args.top_k,
+        tool_timeout=args.tool_timeout,
+        mcp_connect_retries=args.mcp_connect_retries,
+        local_tool_safety=args.local_tool_safety,
+        tool_result_truncation=args.tool_result_truncation,
     )
+    # Filter out None for nullable args so ChatConfig defaults apply.
+    # Boolean flags (store_true) are never None — only filter numeric args.
+    for _key in (
+        "temperature",
+        "top_p",
+        "top_k",
+        "tool_timeout",
+        "mcp_connect_retries",
+        "tool_result_truncation",
+    ):
+        if chat_kwargs[_key] is None:
+            del chat_kwargs[_key]
     if args.mcp_config:
         chat_kwargs["mcp_config_path"] = Path(args.mcp_config)
     if args.skills_dir:
@@ -807,7 +826,7 @@ def cmd_chat(args):
         store = _create_store()
         manager = ModelManager(store.registry, store)
 
-        tui = ChatTUI()
+        tui = ChatTUI(tool_result_truncation=config.tool_result_truncation)
         mcp = None
         skills = None
         builtin = None
@@ -820,7 +839,9 @@ def cmd_chat(args):
                 mcp_cfg = load_mcp_config(config.mcp_config_path)
                 if mcp_cfg:
                     mcp = MCPClientManager()
-                    await mcp.connect_all(mcp_cfg)
+                    await mcp.connect_all(
+                        mcp_cfg, max_attempts=config.mcp_connect_retries
+                    )
 
             if config.skills_enabled:
                 skills = SkillManager(config.skills_dir)
@@ -1068,6 +1089,11 @@ def cmd_chat(args):
                         tui.display_error("Max tool turns reached")
                     elif event["type"] == "memory_truncated":
                         tui.display_memory_truncated(event["message"])
+                    elif event["type"] == "repetition_detected":
+                        tui.display_repetition_detected()
+                    elif event["type"] == "model_load_error":
+                        tui.display_model_load_error(event["error"])
+                        break
 
         except MemoryError as exc:
             tui.display_error(str(exc))
@@ -1472,6 +1498,48 @@ def build_parser() -> argparse.ArgumentParser:
     )
     chat_p.add_argument(
         "--skills-dir", help="Skills directory (default: ~/.olmlx/skills)"
+    )
+    chat_p.add_argument(
+        "--temperature",
+        type=float,
+        default=None,
+        help="Sampling temperature (default: model default)",
+    )
+    chat_p.add_argument(
+        "--top-p",
+        type=float,
+        default=None,
+        help="Top-p sampling (default: model default)",
+    )
+    chat_p.add_argument(
+        "--top-k",
+        type=int,
+        default=None,
+        help="Top-k sampling (default: model default)",
+    )
+    chat_p.add_argument(
+        "--tool-timeout",
+        type=float,
+        default=None,
+        help="Timeout for MCP tool calls in seconds (default: 30)",
+    )
+    chat_p.add_argument(
+        "--mcp-connect-retries",
+        type=int,
+        default=None,
+        help="MCP server connection retry attempts (default: 3)",
+    )
+    chat_p.add_argument(
+        "--local-tool-safety",
+        action="store_true",
+        default=False,
+        help="Apply tool safety policy to local tools (builtins, skills)",
+    )
+    chat_p.add_argument(
+        "--tool-result-truncation",
+        type=int,
+        default=None,
+        help="Max chars for tool result display (default: 2000)",
     )
 
     # Flash inference

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -1066,6 +1066,8 @@ def cmd_chat(args):
                         pass  # handled inline by decider callback
                     elif event["type"] == "max_turns_exceeded":
                         tui.display_error("Max tool turns reached")
+                    elif event["type"] == "memory_truncated":
+                        tui.display_memory_truncated(event["message"])
 
         except MemoryError as exc:
             tui.display_error(str(exc))

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -659,7 +659,7 @@ memory usage to exceed the raw 2-bytes-per-element calculation by 20-30%.
 """
 
 
-def _estimate_kv_cache_bytes(
+def estimate_kv_cache_bytes(
     model: Any, num_tokens: int, *, kv_cache_quant: str | None = None
 ) -> int:
     """Estimate KV cache memory for a given number of tokens.
@@ -851,7 +851,7 @@ def _estimate_kv_cache_bytes(
     return int(raw * _tq_ratio * MEMORY_SAFETY_FACTOR)
 
 
-def _tokenize_for_cache(tokenizer: Any, prompt_text: str) -> list[int]:
+def tokenize_for_cache(tokenizer: Any, prompt_text: str) -> list[int]:
     """Tokenize prompt text matching stream_generate's tokenization logic.
 
     Must exactly replicate the BOS heuristic in mlx_lm.generate.stream_generate
@@ -1286,7 +1286,7 @@ def _apply_chat_template(
         raise RuntimeError(f"Chat template failed: {exc}") from exc
 
 
-def _apply_chat_template_text(
+def apply_chat_template_text(
     tokenizer: Any,
     messages: list[dict],
     tools: list[dict] | None = None,
@@ -1613,7 +1613,7 @@ async def generate_completion(
             messages.append({"role": "system", "content": system})
         messages.append({"role": "user", "content": prompt})
         try:
-            prompt = _apply_chat_template_text(
+            prompt = apply_chat_template_text(
                 lm.text_tokenizer,
                 messages,
                 caps=lm.template_caps,
@@ -1914,7 +1914,7 @@ async def _kv_cache_preflight_check(
         return result
 
     try:
-        kv_bytes = _estimate_kv_cache_bytes(
+        kv_bytes = estimate_kv_cache_bytes(
             lm.model,
             num_prefill_tokens + max_tokens,
             kv_cache_quant=lm.kv_cache_quant,
@@ -1946,7 +1946,7 @@ async def _kv_cache_preflight_check(
                 if full_prompt_tokens is not None and not lm.is_vlm:
                     result.prompt = full_prompt_tokens
             estimate_total = estimate_tokens + max_tokens
-            kv_bytes = _estimate_kv_cache_bytes(
+            kv_bytes = estimate_kv_cache_bytes(
                 lm.model,
                 estimate_total,
                 kv_cache_quant=lm.kv_cache_quant,
@@ -2197,7 +2197,7 @@ async def _stream_completion(
             tokens = (
                 prompt_tokens
                 if prompt_tokens is not None
-                else _tokenize_for_cache(lm.text_tokenizer, original_prompt)
+                else tokenize_for_cache(lm.text_tokenizer, original_prompt)
             )
             broadcast_kwargs = {
                 k: v
@@ -2449,7 +2449,7 @@ async def _full_completion_inner(
         # computation at the same time (avoids all_sum timeout).
         # Must happen before _apply_seed which pops seed from gen_kwargs.
         if lm.is_distributed:
-            tokens = _tokenize_for_cache(lm.text_tokenizer, prompt)
+            tokens = tokenize_for_cache(lm.text_tokenizer, prompt)
             _maybe_broadcast_distributed(lm, tokens, prompt, max_tokens, gen_kwargs)
 
         _apply_seed(gen_kwargs, consume=not lm.is_vlm)
@@ -2742,7 +2742,7 @@ async def generate_chat(
                 enable_thinking,
             )
     else:
-        prompt = _apply_chat_template_text(
+        prompt = apply_chat_template_text(
             lm.text_tokenizer,
             messages,
             tools,
@@ -2776,7 +2776,7 @@ async def generate_chat(
     )
     prompt_tokens = None
     if use_prompt_cache:
-        prompt_tokens = _tokenize_for_cache(lm.text_tokenizer, prompt)
+        prompt_tokens = tokenize_for_cache(lm.text_tokenizer, prompt)
         # Memory-only peek for debug logging; the authoritative lookup happens
         # inside _stream_completion under the inference lock.
         cached_state = lm.prompt_cache_store.peek(cache_id)

--- a/tests/test_builtin_tools.py
+++ b/tests/test_builtin_tools.py
@@ -464,11 +464,16 @@ class TestSessionIntegration:
     @pytest.mark.asyncio
     async def test_builtin_tools_in_tool_list(self, tmp_path):
         """Built-in tools should be included in tools passed to generate_chat."""
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import AsyncMock, MagicMock, patch
+
         from olmlx.chat.session import ChatSession
+        from olmlx.engine.template_caps import TemplateCaps
 
         config = ChatConfig(model_name="test:latest", plans_dir=tmp_path / "plans")
         mgr = MagicMock()
+        loaded_model = MagicMock()
+        loaded_model.template_caps = TemplateCaps()
+        mgr.ensure_loaded = AsyncMock(return_value=loaded_model)
         builtin = BuiltinToolManager(config)
         session = ChatSession(config=config, manager=mgr, builtin=builtin)
 
@@ -496,14 +501,19 @@ class TestSessionIntegration:
     @pytest.mark.asyncio
     async def test_builtin_tool_routed_correctly(self, tmp_path):
         """Built-in tool calls should be routed to BuiltinToolManager, not MCP."""
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import AsyncMock, MagicMock, patch
+
         from olmlx.chat.session import ChatSession
+        from olmlx.engine.template_caps import TemplateCaps
 
         test_file = tmp_path / "test.txt"
         test_file.write_text("hello from file\n")
 
         config = ChatConfig(model_name="test:latest", plans_dir=tmp_path / "plans")
         mgr = MagicMock()
+        loaded_model = MagicMock()
+        loaded_model.template_caps = TemplateCaps()
+        mgr.ensure_loaded = AsyncMock(return_value=loaded_model)
         builtin = BuiltinToolManager(config)
         session = ChatSession(config=config, manager=mgr, builtin=builtin)
         call_count = 0

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -382,7 +382,9 @@ class TestAgentLoop:
         assert "file contents here" in tool_result_events[0]["result"]
 
         # MCP should have been called
-        mcp.call_tool.assert_awaited_once_with("read_file", {"path": "/tmp/test.txt"})
+        mcp.call_tool.assert_awaited_once_with(
+            "read_file", {"path": "/tmp/test.txt"}, timeout=30.0
+        )
 
         # Should have two generate_chat calls
         assert call_count == 2
@@ -660,6 +662,9 @@ class TestRepetitionOptions:
             repeat_last_n=128,
         )
         manager = MagicMock()
+        loaded_model = MagicMock()
+        loaded_model.template_caps = TemplateCaps()
+        manager.ensure_loaded = AsyncMock(return_value=loaded_model)
         session = ChatSession(config=config, manager=manager)
 
         captured_kwargs = {}
@@ -1107,10 +1112,10 @@ class TestToolSafetyIntegration:
 
         original_call_tool = mcp.call_tool
 
-        async def call_tool_with_cancel(name, args):
+        async def call_tool_with_cancel(name, args, timeout=30.0):
             if name == "write_file":
                 raise _asyncio.CancelledError("simulated")
-            return await original_call_tool(name, args)
+            return await original_call_tool(name, args, timeout=timeout)
 
         mcp.call_tool = AsyncMock(side_effect=call_tool_with_cancel)
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -11,13 +11,13 @@ from olmlx.engine.inference import (
     _acquire_inference_lock,
     _apply_seed,
     _build_generate_kwargs,
-    _estimate_kv_cache_bytes,
+    estimate_kv_cache_bytes,
     _extract_images,
     _inference_lock,
     _inference_locked,
     _inject_tools_into_system,
     _normalize_tool_calls_in_messages,
-    _apply_chat_template_text,
+    apply_chat_template_text,
     _lock_boundary_sync,
     _safe_sync,
     _schedule_deferred_inference_cleanup,
@@ -587,7 +587,7 @@ class TestApplyChatTemplateText:
         tokenizer = MagicMock()
         tokenizer.apply_chat_template = MagicMock(return_value="formatted prompt")
         messages = [{"role": "user", "content": "hi"}]
-        result = _apply_chat_template_text(tokenizer, messages)
+        result = apply_chat_template_text(tokenizer, messages)
         assert result == "formatted prompt"
         tokenizer.apply_chat_template.assert_called_once_with(
             messages,
@@ -602,7 +602,7 @@ class TestApplyChatTemplateText:
         messages = [{"role": "user", "content": "hi"}]
         tools = [{"type": "function", "function": {"name": "f"}}]
         caps = TemplateCaps(supports_tools=True, supports_enable_thinking=True)
-        _apply_chat_template_text(tokenizer, messages, tools, caps)
+        apply_chat_template_text(tokenizer, messages, tools, caps)
         call_kwargs = tokenizer.apply_chat_template.call_args[1]
         assert call_kwargs["tools"] == tools
         assert call_kwargs["enable_thinking"] is False
@@ -618,7 +618,7 @@ class TestApplyChatTemplateText:
             }
         ]
         caps = TemplateCaps(supports_tools=False)
-        _apply_chat_template_text(tokenizer, messages, tools, caps)
+        apply_chat_template_text(tokenizer, messages, tools, caps)
         # Should inject tools into system message instead
         call_args = tokenizer.apply_chat_template.call_args[0][0]
         assert call_args[0]["role"] == "system"
@@ -643,7 +643,7 @@ class TestApplyChatTemplateText:
             }
         ]
         caps = TemplateCaps(supports_tools=True)
-        result = _apply_chat_template_text(tokenizer, messages, tools, caps)
+        result = apply_chat_template_text(tokenizer, messages, tools, caps)
         assert result == "fallback prompt"
         assert call_count[0] == 2
 
@@ -669,7 +669,7 @@ class TestApplyChatTemplateText:
             }
         ]
         caps = TemplateCaps(supports_tools=True, supports_enable_thinking=True)
-        result = _apply_chat_template_text(
+        result = apply_chat_template_text(
             tokenizer, messages, tools, caps, enable_thinking=False
         )
         assert result == "fallback prompt"
@@ -682,7 +682,7 @@ class TestApplyChatTemplateText:
         tokenizer.apply_chat_template = MagicMock(return_value="prompt")
         messages = [{"role": "user", "content": "hi"}]
         caps = TemplateCaps(supports_tools=False, supports_enable_thinking=True)
-        _apply_chat_template_text(tokenizer, messages, caps=caps, enable_thinking=True)
+        apply_chat_template_text(tokenizer, messages, caps=caps, enable_thinking=True)
         call_kwargs = tokenizer.apply_chat_template.call_args[1]
         assert call_kwargs["enable_thinking"] is True
 
@@ -692,7 +692,7 @@ class TestApplyChatTemplateText:
         tokenizer.apply_chat_template = MagicMock(return_value="prompt")
         messages = [{"role": "user", "content": "hi"}]
         caps = TemplateCaps(supports_tools=False, supports_enable_thinking=True)
-        _apply_chat_template_text(tokenizer, messages, caps=caps, enable_thinking=False)
+        apply_chat_template_text(tokenizer, messages, caps=caps, enable_thinking=False)
         call_kwargs = tokenizer.apply_chat_template.call_args[1]
         assert call_kwargs["enable_thinking"] is False
 
@@ -702,7 +702,7 @@ class TestApplyChatTemplateText:
         tokenizer.apply_chat_template = MagicMock(return_value="prompt")
         messages = [{"role": "user", "content": "hi"}]
         caps = TemplateCaps(supports_tools=False, supports_enable_thinking=True)
-        _apply_chat_template_text(tokenizer, messages, caps=caps)
+        apply_chat_template_text(tokenizer, messages, caps=caps)
         call_kwargs = tokenizer.apply_chat_template.call_args[1]
         assert call_kwargs["enable_thinking"] is True
 
@@ -713,9 +713,7 @@ class TestApplyChatTemplateText:
         messages = [{"role": "user", "content": "hi"}]
         tools = [{"type": "function", "function": {"name": "f"}}]
         caps = TemplateCaps(supports_tools=True, supports_enable_thinking=True)
-        _apply_chat_template_text(
-            tokenizer, messages, tools, caps, enable_thinking=True
-        )
+        apply_chat_template_text(tokenizer, messages, tools, caps, enable_thinking=True)
         call_kwargs = tokenizer.apply_chat_template.call_args[1]
         assert call_kwargs["tools"] == tools
         assert call_kwargs["enable_thinking"] is True
@@ -726,21 +724,21 @@ class TestApplyChatTemplateText:
         tokenizer.apply_chat_template = MagicMock(return_value="prompt")
         messages = [{"role": "user", "content": "hi"}]
         caps = TemplateCaps(supports_tools=False, supports_enable_thinking=False)
-        _apply_chat_template_text(tokenizer, messages, caps=caps, enable_thinking=True)
+        apply_chat_template_text(tokenizer, messages, caps=caps, enable_thinking=True)
         call_kwargs = tokenizer.apply_chat_template.call_args[1]
         assert "enable_thinking" not in call_kwargs
 
     def test_no_caps_defaults(self):
         tokenizer = MagicMock()
         tokenizer.apply_chat_template = MagicMock(return_value="result")
-        _apply_chat_template_text(tokenizer, [], None, caps=None)
+        apply_chat_template_text(tokenizer, [], None, caps=None)
         tokenizer.apply_chat_template.assert_called_once()
 
     def test_template_fails_completely(self):
         tokenizer = MagicMock()
         tokenizer.apply_chat_template = MagicMock(side_effect=RuntimeError("broken"))
         with pytest.raises(RuntimeError, match="Chat template failed"):
-            _apply_chat_template_text(tokenizer, [], None)
+            apply_chat_template_text(tokenizer, [], None)
 
     def test_tools_kwarg_fails_then_injection_fails(self):
         tokenizer = MagicMock()
@@ -757,7 +755,7 @@ class TestApplyChatTemplateText:
         with pytest.raises(
             RuntimeError, match="Chat template failed even without tools"
         ):
-            _apply_chat_template_text(tokenizer, [], tools, caps)
+            apply_chat_template_text(tokenizer, [], tools, caps)
 
 
 class TestApplyChatTemplateVlm:
@@ -1541,7 +1539,7 @@ class TestGenerateChatVlm:
         with patch("olmlx.engine.inference.mx", mock_mx):
             with patch.dict("sys.modules", {"mlx_vlm": mock_mlx_vlm}):
                 with patch(
-                    "olmlx.engine.inference._apply_chat_template_text",
+                    "olmlx.engine.inference.apply_chat_template_text",
                 ) as mock_text_tpl:
                     with patch(
                         "olmlx.engine.inference.asyncio.to_thread",
@@ -2583,7 +2581,7 @@ class TestAwaitDeferredCleanup:
 
 
 class TestEstimateKvCacheBytes:
-    """Tests for _estimate_kv_cache_bytes()."""
+    """Tests for estimate_kv_cache_bytes()."""
 
     def _make_model_args(
         self,
@@ -2618,12 +2616,12 @@ class TestEstimateKvCacheBytes:
         # head_dim = 4096 / 32 = 128
         # raw = 32 * 2 * 8 * 128 * 1000 * 2 = 131_072_000
         # expected = int(131_072_000 * 1.3) = 170_393_600
-        result = _estimate_kv_cache_bytes(model, 1000)
+        result = estimate_kv_cache_bytes(model, 1000)
         assert result == int(131_072_000 * _inf_mod.MEMORY_SAFETY_FACTOR)
 
     def test_zero_tokens(self):
         model = self._make_model()
-        assert _estimate_kv_cache_bytes(model, 0) == 0
+        assert estimate_kv_cache_bytes(model, 0) == 0
 
     def test_gqa_fallback_to_mha(self):
         """When num_key_value_heads is missing, fall back to num_attention_heads."""
@@ -2636,7 +2634,7 @@ class TestEstimateKvCacheBytes:
         del model.args.num_key_value_heads
         # head_dim = 128, kv_heads = 32 (fallback)
         # raw = 32 * 2 * 32 * 128 * 100 * 2 = 52_428_800
-        result = _estimate_kv_cache_bytes(model, 100)
+        result = estimate_kv_cache_bytes(model, 100)
         assert result == int(52_428_800 * _inf_mod.MEMORY_SAFETY_FACTOR)
 
     def test_large_prompt(self):
@@ -2649,7 +2647,7 @@ class TestEstimateKvCacheBytes:
         )
         # head_dim = 3584 / 28 = 128
         # raw = 28 * 2 * 4 * 128 * 22000 * 2 = 1_261_568_000 (~1.2 GB)
-        result = _estimate_kv_cache_bytes(model, 22000)
+        result = estimate_kv_cache_bytes(model, 22000)
         assert result == int(1_261_568_000 * _inf_mod.MEMORY_SAFETY_FACTOR)
 
     def test_explicit_head_dim(self):
@@ -2662,7 +2660,7 @@ class TestEstimateKvCacheBytes:
             head_dim=256,
         )
         # raw = 32 * 2 * 8 * 256 * 100 * 2 = 26_214_400
-        result = _estimate_kv_cache_bytes(model, 100)
+        result = estimate_kv_cache_bytes(model, 100)
         assert result == int(26_214_400 * _inf_mod.MEMORY_SAFETY_FACTOR)
 
     def test_vlm_fallback_to_language_model_args(self):
@@ -2675,7 +2673,7 @@ class TestEstimateKvCacheBytes:
             num_key_value_heads=8,
             hidden_size=4096,
         )
-        result = _estimate_kv_cache_bytes(model, 1000)
+        result = estimate_kv_cache_bytes(model, 1000)
         assert result == int(131_072_000 * _inf_mod.MEMORY_SAFETY_FACTOR)
 
     def test_vlm_introspects_language_model_layers(self):
@@ -2701,7 +2699,7 @@ class TestEstimateKvCacheBytes:
         model.language_model.model.layers = layers
 
         # Should use introspected kv_heads=4, not fallback to num_attention_heads=32
-        result = _estimate_kv_cache_bytes(model, 1000)
+        result = estimate_kv_cache_bytes(model, 1000)
         expected_raw = 32 * 2 * 4 * 128 * 1000 * 2
         assert result == int(expected_raw * _inf_mod.MEMORY_SAFETY_FACTOR)
 
@@ -2715,7 +2713,7 @@ class TestEstimateKvCacheBytes:
             num_key_value_heads=8,
             hidden_size=4096,
         )
-        result = _estimate_kv_cache_bytes(model, 1000)
+        result = estimate_kv_cache_bytes(model, 1000)
         assert result == int(131_072_000 * _inf_mod.MEMORY_SAFETY_FACTOR)
 
     def test_vlm_text_config_wrapper_prefers_language_model_args(self):
@@ -2742,14 +2740,14 @@ class TestEstimateKvCacheBytes:
             head_dim=256,
         )
         # raw = 64 * 2 * 4 * 256 * 1000 * 2 = 262_144_000
-        result = _estimate_kv_cache_bytes(model, 1000)
+        result = estimate_kv_cache_bytes(model, 1000)
         assert result == int(262_144_000 * _inf_mod.MEMORY_SAFETY_FACTOR)
 
     def test_raises_when_no_args_found(self):
         """Raises AttributeError when model has no discoverable args or config."""
         model = MagicMock(spec=[])
         with pytest.raises(AttributeError, match="no 'args'"):
-            _estimate_kv_cache_bytes(model, 1000)
+            estimate_kv_cache_bytes(model, 1000)
 
     def test_wrapper_without_language_model_raises(self):
         """Wrapper args + no language_model → explicit error (not opaque later crash)."""
@@ -2758,7 +2756,7 @@ class TestEstimateKvCacheBytes:
         wrapper.text_config = {"num_hidden_layers": 64}
         model.args = wrapper
         with pytest.raises(AttributeError, match="text_config wrapper"):
-            _estimate_kv_cache_bytes(model, 1000)
+            estimate_kv_cache_bytes(model, 1000)
 
     def test_wrapper_with_empty_language_model_raises(self):
         """Wrapper args + language_model without args/config → explicit error."""
@@ -2768,7 +2766,7 @@ class TestEstimateKvCacheBytes:
         model.args = wrapper
         model.language_model = MagicMock(spec=[])
         with pytest.raises(AttributeError, match="text_config wrapper"):
-            _estimate_kv_cache_bytes(model, 1000)
+            estimate_kv_cache_bytes(model, 1000)
 
     def test_nas_model_with_per_layer_variable_attention(self):
         """NAS models (nemotron-nas) have per-layer variable attention.
@@ -2806,7 +2804,7 @@ class TestEstimateKvCacheBytes:
         # head_dim = 8192 / 64 = 128
         # Correct: 49 layers * 2 * 8 kv_heads * 128 head_dim * 1000 tokens * 2 bytes
         # = 49 * 2 * 8 * 128 * 1000 * 2 = 200_704_000
-        result = _estimate_kv_cache_bytes(model, 1000)
+        result = estimate_kv_cache_bytes(model, 1000)
         expected_raw = 49 * 2 * 8 * 128 * 1000 * 2
         assert result == int(expected_raw * _inf_mod.MEMORY_SAFETY_FACTOR)
 
@@ -2825,7 +2823,7 @@ class TestEstimateKvCacheBytes:
         del model.model
 
         # Falls back to: 80 * 2 * 64 * 128 * 1000 * 2
-        result = _estimate_kv_cache_bytes(model, 1000)
+        result = estimate_kv_cache_bytes(model, 1000)
         expected_raw = 80 * 2 * 64 * 128 * 1000 * 2
         assert result == int(expected_raw * _inf_mod.MEMORY_SAFETY_FACTOR)
 
@@ -2850,7 +2848,7 @@ class TestEstimateKvCacheBytes:
         model.model.layers = layers
 
         # Should fall back to args-based estimate, not return 0
-        result = _estimate_kv_cache_bytes(model, 1000)
+        result = estimate_kv_cache_bytes(model, 1000)
         expected_raw = 32 * 2 * 8 * 128 * 1000 * 2
         assert result == int(expected_raw * _inf_mod.MEMORY_SAFETY_FACTOR)
 
@@ -2870,7 +2868,7 @@ class TestEstimateKvCacheBytes:
         model = MagicMock(spec=[])
         model.args = args
 
-        result = _estimate_kv_cache_bytes(model, 1000)
+        result = estimate_kv_cache_bytes(model, 1000)
 
         # MLA cache per layer per token: (kv_lora_rank + qk_rope_head_dim) * 2 bytes
         # = (512 + 64) * 2 = 1152 bytes  (keys=compressed_kv, values=k_pe, 1 "head" each)
@@ -2937,7 +2935,7 @@ class TestEstimateKvCacheBytes:
         full_per_layer = 2 * 4 * 512 * num_tokens * 2
         expected_raw = 50 * sliding_per_layer + 10 * full_per_layer
 
-        result = _estimate_kv_cache_bytes(model, num_tokens)
+        result = estimate_kv_cache_bytes(model, num_tokens)
         assert result == int(expected_raw * _inf_mod.MEMORY_SAFETY_FACTOR)
 
         # Sanity check: result should fit in 16 GB.  The naive uniform-layer
@@ -2977,7 +2975,7 @@ class TestEstimateKvCacheBytes:
         model.model.layers = layers
 
         # 8000 tokens, but per-layer window is 512 (not 4096)
-        result = _estimate_kv_cache_bytes(model, 8000)
+        result = estimate_kv_cache_bytes(model, 8000)
         expected_raw = 4 * 2 * 8 * 128 * 512 * 2
         assert result == int(expected_raw * _inf_mod.MEMORY_SAFETY_FACTOR)
 
@@ -3007,7 +3005,7 @@ class TestEstimateKvCacheBytes:
         model.model.layers = layers
 
         # 500 < 1024, so sliding layers use full prompt length
-        result = _estimate_kv_cache_bytes(model, 500)
+        result = estimate_kv_cache_bytes(model, 500)
         expected_raw = 4 * 2 * 8 * 128 * 500 * 2
         assert result == int(expected_raw * _inf_mod.MEMORY_SAFETY_FACTOR)
 
@@ -3025,8 +3023,8 @@ class TestEstimateKvCacheBytes:
             head_dim=128,
             hidden_size=8192,
         )
-        fp16_result = _estimate_kv_cache_bytes(model, 37000)
-        tq4_result = _estimate_kv_cache_bytes(
+        fp16_result = estimate_kv_cache_bytes(model, 37000)
+        tq4_result = estimate_kv_cache_bytes(
             model, 37000, kv_cache_quant="turboquant:4"
         )
         # TurboQuant 4-bit should be significantly smaller
@@ -3043,8 +3041,8 @@ class TestEstimateKvCacheBytes:
             head_dim=128,
             hidden_size=8192,
         )
-        fp16_result = _estimate_kv_cache_bytes(model, 37000)
-        tq2_result = _estimate_kv_cache_bytes(
+        fp16_result = estimate_kv_cache_bytes(model, 37000)
+        tq2_result = estimate_kv_cache_bytes(
             model, 37000, kv_cache_quant="turboquant:2"
         )
         # Per-element: fp16 = 256 bytes, tq2 = 36 bytes → ratio ≈ 7.1x
@@ -3054,7 +3052,7 @@ class TestEstimateKvCacheBytes:
     def test_turboquant_none_unchanged(self):
         """Passing kv_cache_quant=None should give the same result as no arg."""
         model = self._make_model()
-        assert _estimate_kv_cache_bytes(model, 1000) == _estimate_kv_cache_bytes(
+        assert estimate_kv_cache_bytes(model, 1000) == estimate_kv_cache_bytes(
             model, 1000, kv_cache_quant=None
         )
 
@@ -3099,7 +3097,7 @@ class TestEstimateKvCacheBytes:
         num_tokens = 86245
         # Only 12 full-attention layers contribute to growing KV cache
         expected_raw = 12 * 2 * 2 * 256 * num_tokens * 2
-        result = _estimate_kv_cache_bytes(model, num_tokens)
+        result = estimate_kv_cache_bytes(model, num_tokens)
         assert result == int(expected_raw * _inf_mod.MEMORY_SAFETY_FACTOR)
 
         # Verify: ~2.6 GB, NOT ~10.3 GB
@@ -3169,7 +3167,7 @@ class TestKvCachePreflightCheck:
                 patch("olmlx.engine.inference.settings") as mock_settings,
                 patch("olmlx.engine.inference.mx"),
                 patch(
-                    "olmlx.engine.inference._estimate_kv_cache_bytes",
+                    "olmlx.engine.inference.estimate_kv_cache_bytes",
                     return_value=kv_estimate,
                 ),
                 patch("olmlx.engine.inference._safe_sync"),
@@ -3236,7 +3234,7 @@ class TestKvCachePreflightCheck:
                 patch("olmlx.engine.inference.settings") as mock_settings,
                 patch("olmlx.engine.inference.mx"),
                 patch(
-                    "olmlx.engine.inference._estimate_kv_cache_bytes",
+                    "olmlx.engine.inference.estimate_kv_cache_bytes",
                     return_value=kv_estimate,
                 ),
                 patch("olmlx.engine.inference._safe_sync"),
@@ -3514,7 +3512,7 @@ class TestKvCachePreflightCheckHelper:
             ),
             patch("olmlx.engine.inference.settings") as mock_settings,
             patch(
-                "olmlx.engine.inference._estimate_kv_cache_bytes",
+                "olmlx.engine.inference.estimate_kv_cache_bytes",
                 return_value=1 * 1024**3,
             ),
         ):
@@ -3549,7 +3547,7 @@ class TestKvCachePreflightCheckHelper:
             ),
             patch("olmlx.engine.inference.settings") as mock_settings,
             patch(
-                "olmlx.engine.inference._estimate_kv_cache_bytes",
+                "olmlx.engine.inference.estimate_kv_cache_bytes",
                 return_value=3 * 1024**3,
             ),
             patch("olmlx.engine.inference._safe_sync"),
@@ -3607,7 +3605,7 @@ class TestKvCachePreflightCheckHelper:
             ),
             patch("olmlx.engine.inference.settings") as mock_settings,
             patch(
-                "olmlx.engine.inference._estimate_kv_cache_bytes",
+                "olmlx.engine.inference.estimate_kv_cache_bytes",
                 side_effect=ValueError("bad model"),
             ),
         ):

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -8,7 +8,7 @@ import pytest
 
 import olmlx.engine.inference as _inf_mod
 from olmlx.engine.inference import (
-    _estimate_kv_cache_bytes,
+    estimate_kv_cache_bytes,
     _inference_ref,
 )
 from olmlx.engine.model_manager import LoadedModel
@@ -703,7 +703,7 @@ class TestKVCacheMemorySafetyFactor:
         )
 
     def test_estimate_includes_safety_margin(self):
-        """_estimate_kv_cache_bytes should include MEMORY_SAFETY_FACTOR multiplier."""
+        """estimate_kv_cache_bytes should include MEMORY_SAFETY_FACTOR multiplier."""
         model = MagicMock()
         model.args.num_hidden_layers = 32
         model.args.num_attention_heads = 32
@@ -711,7 +711,7 @@ class TestKVCacheMemorySafetyFactor:
         model.args.head_dim = 128
         model.args.hidden_size = 4096
 
-        result = _estimate_kv_cache_bytes(model, 1000)
+        result = estimate_kv_cache_bytes(model, 1000)
         # Raw estimate: 32 layers * 2 * 8 heads * 128 dim * 1000 tokens * 2 bytes
         raw = 32 * 2 * 8 * 128 * 1000 * 2
         expected = int(raw * _inf_mod.MEMORY_SAFETY_FACTOR)
@@ -722,4 +722,4 @@ class TestKVCacheMemorySafetyFactor:
     def test_estimate_zero_tokens_unchanged(self):
         """Zero tokens should still return 0."""
         model = MagicMock()
-        assert _estimate_kv_cache_bytes(model, 0) == 0
+        assert estimate_kv_cache_bytes(model, 0) == 0

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -63,41 +63,41 @@ class TestFindCommonPrefix:
 
 class TestTokenizeForCache:
     def test_with_bos_in_prompt(self):
-        from olmlx.engine.inference import _tokenize_for_cache
+        from olmlx.engine.inference import tokenize_for_cache
 
         tokenizer = MagicMock()
         tokenizer.bos_token = "<s>"
         tokenizer.encode = MagicMock(return_value=[1, 2, 3])
-        result = _tokenize_for_cache(tokenizer, "<s>hello")
+        result = tokenize_for_cache(tokenizer, "<s>hello")
         tokenizer.encode.assert_called_once_with("<s>hello", add_special_tokens=False)
         assert result == [1, 2, 3]
 
     def test_without_bos_in_prompt(self):
-        from olmlx.engine.inference import _tokenize_for_cache
+        from olmlx.engine.inference import tokenize_for_cache
 
         tokenizer = MagicMock()
         tokenizer.bos_token = "<s>"
         tokenizer.encode = MagicMock(return_value=[1, 2, 3])
-        result = _tokenize_for_cache(tokenizer, "hello")
+        result = tokenize_for_cache(tokenizer, "hello")
         tokenizer.encode.assert_called_once_with("hello", add_special_tokens=True)
         assert result == [1, 2, 3]
 
     def test_no_bos_token(self):
-        from olmlx.engine.inference import _tokenize_for_cache
+        from olmlx.engine.inference import tokenize_for_cache
 
         tokenizer = MagicMock(spec=[])  # no bos_token attribute
         tokenizer.encode = MagicMock(return_value=[1, 2, 3])
-        result = _tokenize_for_cache(tokenizer, "hello")
+        result = tokenize_for_cache(tokenizer, "hello")
         tokenizer.encode.assert_called_once_with("hello", add_special_tokens=True)
         assert result == [1, 2, 3]
 
     def test_bos_token_is_none(self):
-        from olmlx.engine.inference import _tokenize_for_cache
+        from olmlx.engine.inference import tokenize_for_cache
 
         tokenizer = MagicMock()
         tokenizer.bos_token = None
         tokenizer.encode = MagicMock(return_value=[1, 2, 3])
-        result = _tokenize_for_cache(tokenizer, "hello")
+        result = tokenize_for_cache(tokenizer, "hello")
         tokenizer.encode.assert_called_once_with("hello", add_special_tokens=True)
         assert result == [1, 2, 3]
 
@@ -1038,12 +1038,12 @@ class TestTokenizeForCacheEmptyBos:
         string falls through to `not prompt.startswith("")` which is always False.
         We must match exactly to avoid token sequence divergence and cache misses.
         """
-        from olmlx.engine.inference import _tokenize_for_cache
+        from olmlx.engine.inference import tokenize_for_cache
 
         tokenizer = MagicMock()
         tokenizer.bos_token = ""
         tokenizer.encode = MagicMock(return_value=[1, 2, 3])
-        result = _tokenize_for_cache(tokenizer, "hello")
+        result = tokenize_for_cache(tokenizer, "hello")
         tokenizer.encode.assert_called_once_with("hello", add_special_tokens=False)
         assert result == [1, 2, 3]
 


### PR DESCRIPTION
## Summary
- Fixes model load failure handling (yields error event instead of crashing)
- Removes ~150 lines of dead code (duplicate ChatSession class)
- Wraps parse_model_output in try-except for robustness
- Adds missing generation parameters (temperature, top_p, top_k)
- Adds configurable repetition detection with user feedback event
- Adds configurable MCP tool timeout and connection retry
- Adds local_tool_safety flag for optional safety checks on local tools
- TUI improvements: always-allow tool confirmations, configurable truncation
- Code quality: TypedDict event types, constant centralization, repetition detection optimization

## Files Changed
- `olmlx/chat/session.py` — core fixes + new features
- `olmlx/chat/config.py` — 7 new ChatConfig fields
- `olmlx/chat/tui.py` — always-allow, configurable truncation, new display methods
- `olmlx/chat/mcp_client.py` — connection retry with exponential backoff
- `olmlx/cli.py` — 4 new CLI args + new event handlers
- `tests/test_chat_session.py` — updated for new ChatConfig fields
- `tests/test_builtin_tools.py` — AsyncMock setup for model load