### PR TITLE
fix(chat): add max_consecutive_tool_failures, fix deferred crash and None guard

### DIFF
--- a/olmlx/chat/config.py
+++ b/olmlx/chat/config.py
@@ -58,6 +58,7 @@ class ChatConfig:
     local_tool_safety: bool = False
     mcp_connect_retries: int = 3
     tool_result_truncation: int = 2000
+    max_consecutive_tool_failures: int = 3
 
 
 def _load_json_file(path: Path) -> dict[str, Any]:

--- a/olmlx/chat/mcp_client.py
+++ b/olmlx/chat/mcp_client.py
@@ -75,14 +75,14 @@ class MCPClientManager:
             },
         }
 
-    async def connect_all(self, config: dict[str, Any], max_attempts: int = 3) -> None:
+    async def connect_all(self, config: dict[str, Any], max_attempts: int | None = None) -> None:
         """Connect to each configured MCP server and discover tools.
 
         Retries on connection failure with exponential backoff.
         ``max_attempts`` is the total number of connection attempts
-        (minimum 1).
+        (minimum 1). ``None`` defaults to 3.
         """
-        attempts = max(max_attempts, 1)
+        attempts = max(max_attempts or 3, 1)
         for name, server_cfg in config.items():
             for attempt in range(attempts):
                 try:

--- a/olmlx/chat/mcp_client.py
+++ b/olmlx/chat/mcp_client.py
@@ -75,7 +75,9 @@ class MCPClientManager:
             },
         }
 
-    async def connect_all(self, config: dict[str, Any], max_attempts: int | None = None) -> None:
+    async def connect_all(
+        self, config: dict[str, Any], max_attempts: int | None = None
+    ) -> None:
         """Connect to each configured MCP server and discover tools.
 
         Retries on connection failure with exponential backoff.

--- a/olmlx/chat/mcp_client.py
+++ b/olmlx/chat/mcp_client.py
@@ -84,7 +84,7 @@ class MCPClientManager:
         ``max_attempts`` is the total number of connection attempts
         (minimum 1). ``None`` defaults to 3.
         """
-        attempts = max(max_attempts or 3, 1)
+        attempts = max(max_attempts if max_attempts is not None else 3, 1)
         for name, server_cfg in config.items():
             for attempt in range(attempts):
                 try:

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -1051,9 +1051,7 @@ class ChatSession:
             except asyncio.CancelledError:
                 raise
             except Exception:
-                logger.warning(
-                    "Unexpected error during tool execution", exc_info=True
-                )
+                logger.warning("Unexpected error during tool execution", exc_info=True)
                 turn_had_failure = True
 
             if turn_had_success:

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -858,6 +858,7 @@ class ChatSession:
             # Regular exceptions have already been yielded as tool_error
             # events and appended to self.messages. Let the caller
             # (agent loop) handle recovery and track consecutive failures.
+            return
 
     async def send_message(self, user_text: str) -> AsyncGenerator[ChatEvent, None]:
         """Send a user message and run the agent loop.

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -589,7 +589,8 @@ class ChatSession:
         """Classify, confirm, and execute tool calls. Yields event dicts.
 
         Appends tool result messages to self.messages in original call order.
-        Raises the first tool execution exception after all events are yielded.
+        Tool errors are fed back to the model for recovery via tool_error
+        events and error messages appended to the conversation history.
         """
         # Classify tools by safety policy.
         # Local tools (skills, builtins) bypass the safety policy
@@ -852,12 +853,11 @@ class ChatSession:
                 )
 
         if deferred_exc is not None:
-            if isinstance(deferred_exc, (KeyboardInterrupt, SystemExit)):
+            if not isinstance(deferred_exc, Exception):
                 raise deferred_exc
-            # For other exceptions, the error events have already been
-            # yielded and error messages appended to self.messages.
-            # Let the caller (agent loop) handle recovery and track
-            # consecutive failures.
+            # Regular exceptions have already been yielded as tool_error
+            # events and appended to self.messages. Let the caller
+            # (agent loop) handle recovery and track consecutive failures.
 
     async def send_message(self, user_text: str) -> AsyncGenerator[ChatEvent, None]:
         """Send a user message and run the agent loop.
@@ -1050,10 +1050,19 @@ class ChatSession:
                         turn_had_success = True
             except asyncio.CancelledError:
                 raise
+            # Defence-in-depth: _execute_tool_calls no longer raises Exception
+            # (errors are fed back as tool_error events), but guard against
+            # future regressions.
             except Exception:
-                logger.warning("Unexpected error during tool execution", exc_info=True)
+                logger.warning(
+                    "Unexpected exception during tool execution", exc_info=True
+                )
                 turn_had_failure = True
 
+            # Any successful tool call in a turn resets the failure counter
+            # so that the agent loop continues as long as the model gets
+            # useful results. Mixed-result turns (parallel success + failure)
+            # also reset — the model has new information to work with.
             if turn_had_success:
                 consecutive_failures = 0
             elif turn_had_failure:

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -853,6 +853,11 @@ class ChatSession:
                 )
 
         if deferred_exc is not None:
+            # Non-Exception BaseException (e.g. KeyboardInterrupt, SystemExit,
+            # GeneratorExit) captured by asyncio.gather in the parallel path —
+            # must be re-raised. Note: the tool error message was already
+            # appended to self.messages above; if the session is reused the
+            # history will contain a dangling tool error.
             if not isinstance(deferred_exc, Exception):
                 raise deferred_exc
             # Regular exceptions have already been yielded as tool_error

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -136,6 +136,12 @@ class _QuestionEvent(TypedDict):
     id: str
 
 
+class _ToolFailuresExceededEvent(TypedDict):
+    type: Literal["tool_failures_exceeded"]
+    message: str
+    consecutive_failures: int
+
+
 # Union type for all events yielded by send_message
 ChatEvent = (
     _TokenEvent
@@ -155,6 +161,7 @@ ChatEvent = (
     | _ToolDeniedEvent
     | _ToolAutoJudgingEvent
     | _QuestionEvent
+    | _ToolFailuresExceededEvent
 )
 
 
@@ -845,7 +852,12 @@ class ChatSession:
                 )
 
         if deferred_exc is not None:
-            raise deferred_exc
+            if isinstance(deferred_exc, (KeyboardInterrupt, SystemExit)):
+                raise deferred_exc
+            # For other exceptions, the error events have already been
+            # yielded and error messages appended to self.messages.
+            # Let the caller (agent loop) handle recovery and track
+            # consecutive failures.
 
     async def send_message(self, user_text: str) -> AsyncGenerator[ChatEvent, None]:
         """Send a user message and run the agent loop.
@@ -867,6 +879,7 @@ class ChatSession:
         - {"type": "repetition_detected"} — repetitive output detected
         - {"type": "model_load_error", "error": str} — model load failed
         - {"type": "max_turns_exceeded"} — agent loop hit turn limit
+        - {"type": "tool_failures_exceeded", "message": str, "consecutive_failures": int}
         - {"type": "done"} — end of response
         """
         self.messages.append({"role": "user", "content": user_text})
@@ -916,6 +929,7 @@ class ChatSession:
         except Exception:
             logger.debug("Memory check failed, proceeding anyway", exc_info=True)
 
+        consecutive_failures = 0
         for turn in range(self.config.max_turns):
             repetition_stopped = False
             token_count = 0
@@ -1025,8 +1039,41 @@ class ChatSession:
             if not tool_uses or repetition_stopped:
                 break
 
-            async for event in self._execute_tool_calls(tool_uses):
-                yield event
+            turn_had_success = False
+            turn_had_failure = False
+            try:
+                async for event in self._execute_tool_calls(tool_uses):
+                    yield event
+                    if event["type"] == "tool_error":
+                        turn_had_failure = True
+                    elif event["type"] == "tool_result":
+                        turn_had_success = True
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "Unexpected error during tool execution", exc_info=True
+                )
+                turn_had_failure = True
+
+            if turn_had_success:
+                consecutive_failures = 0
+            elif turn_had_failure:
+                consecutive_failures += 1
+
+            if (
+                self.config.max_consecutive_tool_failures > 0
+                and consecutive_failures >= self.config.max_consecutive_tool_failures
+            ):
+                yield {
+                    "type": "tool_failures_exceeded",
+                    "message": (
+                        f"Too many consecutive turns with tool failures "
+                        f"({consecutive_failures}). Stopping agent loop."
+                    ),
+                    "consecutive_failures": consecutive_failures,
+                }
+                break
         else:
             # max_turns reached
             yield {"type": "max_turns_exceeded"}

--- a/olmlx/chat/tui.py
+++ b/olmlx/chat/tui.py
@@ -124,6 +124,16 @@ class ChatTUI:
             )
         )
 
+    def display_tool_failures_exceeded(self, message: str) -> None:
+        """Show error when too many consecutive tool failures occurred."""
+        self.console.print(
+            Panel(
+                f"[red]{message}[/red]",
+                title="tool failures exceeded",
+                border_style="red",
+            )
+        )
+
     def display_model_load_error(self, error: str) -> None:
         """Show model load error."""
         self.console.print(

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -819,8 +819,8 @@ def cmd_chat(args):
     # ChatConfig's default wins — if the default ever flips to True, the CLI
     # won't silently override it back to False.
     for _key in ("local_tool_safety",):
-        if not chat_kwargs.get(_key):
-            del chat_kwargs[_key]
+        if not chat_kwargs.pop(_key, None):
+            pass  # key already absent; ChatConfig default wins
     if args.mcp_config:
         chat_kwargs["mcp_config_path"] = Path(args.mcp_config)
     if args.skills_dir:

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -819,8 +819,8 @@ def cmd_chat(args):
     # ChatConfig's default wins — if the default ever flips to True, the CLI
     # won't silently override it back to False.
     for _key in ("local_tool_safety",):
-        if not chat_kwargs.pop(_key, None):
-            pass  # key already absent; ChatConfig default wins
+        if not chat_kwargs.get(_key):
+            chat_kwargs.pop(_key, None)  # ChatConfig default wins
     if args.mcp_config:
         chat_kwargs["mcp_config_path"] = Path(args.mcp_config)
     if args.skills_dir:

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -800,6 +800,7 @@ def cmd_chat(args):
         mcp_connect_retries=args.mcp_connect_retries,
         local_tool_safety=args.local_tool_safety,
         tool_result_truncation=args.tool_result_truncation,
+        max_consecutive_tool_failures=args.max_consecutive_tool_failures,
     )
     # Filter out None for nullable args so ChatConfig defaults apply.
     # Boolean flags (store_true) are never None — only filter numeric args.
@@ -810,8 +811,15 @@ def cmd_chat(args):
         "tool_timeout",
         "mcp_connect_retries",
         "tool_result_truncation",
+        "max_consecutive_tool_failures",
     ):
         if chat_kwargs[_key] is None:
+            del chat_kwargs[_key]
+    # Boolean store_true flags default to False. Drop them when False so
+    # ChatConfig's default wins — if the default ever flips to True, the CLI
+    # won't silently override it back to False.
+    for _key in ("local_tool_safety",):
+        if not chat_kwargs.get(_key):
             del chat_kwargs[_key]
     if args.mcp_config:
         chat_kwargs["mcp_config_path"] = Path(args.mcp_config)
@@ -1087,6 +1095,8 @@ def cmd_chat(args):
                         pass  # handled inline by decider callback
                     elif event["type"] == "max_turns_exceeded":
                         tui.display_error("Max tool turns reached")
+                    elif event["type"] == "tool_failures_exceeded":
+                        tui.display_tool_failures_exceeded(event["message"])
                     elif event["type"] == "memory_truncated":
                         tui.display_memory_truncated(event["message"])
                     elif event["type"] == "repetition_detected":
@@ -1540,6 +1550,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=None,
         help="Max chars for tool result display (default: 2000)",
+    )
+    chat_p.add_argument(
+        "--max-consecutive-tool-failures",
+        type=int,
+        default=None,
+        help="Max consecutive tool failure turns before stopping (default: 3, 0=unlimited)",
     )
 
     # Flash inference

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -1703,16 +1703,17 @@ class TestConsecutiveToolFailures:
             async for event in session.send_message("Use the tool"):
                 events.append(event)
 
-        # Failures should be: fail1 (turn1), then success (turn2, resets),
-        # then fail2 (turn3), then fail from call4 (turn4),
-        # and continue failing -> should hit limit after 2 more failures
-        # So at least 4 turns should have run before the exceeded event
+        # Turn 1: fail → counter=1
+        # Turn 2: success → counter=0 (reset)
+        # Turn 3: fail → counter=1
+        # Turn 4: fail → counter=2 → exceeded
         exceeded = [e for e in events if e["type"] == "tool_failures_exceeded"]
         assert len(exceeded) == 1
+        assert exceeded[0]["consecutive_failures"] == 2
         result_events = [e for e in events if e["type"] == "tool_result"]
         assert len(result_events) == 1  # one success
         error_events = [e for e in events if e["type"] == "tool_error"]
-        assert len(error_events) >= 2  # at least the 2 failures in the final run
+        assert len(error_events) == 3  # fail1, fail2(turn3), fail2(turn4)
 
     @pytest.mark.asyncio
     async def test_deferred_exception_does_not_crash_session(self):

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -1595,3 +1595,172 @@ class TestExecuteToolCalls:
         assert len(session.messages) == 2
         assert session.messages[0]["tool_call_id"] == "tc_a"
         assert session.messages[1]["tool_call_id"] == "tc_b"
+
+
+class TestConsecutiveToolFailures:
+    """Tests for max_consecutive_tool_failures config option."""
+
+    @pytest.mark.asyncio
+    async def test_stops_after_consecutive_failures(self):
+        """Agent loop stops after exceeding max_consecutive_tool_failures."""
+        mcp = MagicMock()
+        mcp.get_tools_for_chat.return_value = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "fail_tool",
+                    "description": "A tool that fails",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        mcp.call_tool = AsyncMock(side_effect=RuntimeError("Connection refused"))
+
+        config = ChatConfig(
+            model_name="test:latest",
+            max_turns=10,
+            max_consecutive_tool_failures=2,
+        )
+        manager = MagicMock()
+        loaded_model = MagicMock()
+        loaded_model.template_caps = TemplateCaps()
+        manager.ensure_loaded = AsyncMock(return_value=loaded_model)
+        session = ChatSession(config=config, manager=manager, mcp=mcp)
+
+        async def fake_generate(*args, **kwargs):
+            yield {
+                "text": '<tool_call>{"name": "fail_tool", "arguments": {}}</tool_call>',
+                "done": False,
+            }
+            yield {"text": "", "done": True, "stats": MagicMock()}
+
+        with patch(
+            "olmlx.chat.session.generate_chat",
+            side_effect=lambda *a, **kw: fake_generate(),
+        ):
+            events = []
+            async for event in session.send_message("Use the tool"):
+                events.append(event)
+
+        exceeded = [e for e in events if e["type"] == "tool_failures_exceeded"]
+        assert len(exceeded) == 1
+        assert exceeded[0]["consecutive_failures"] == 2
+
+        error_events = [e for e in events if e["type"] == "tool_error"]
+        assert len(error_events) == 2  # one per turn
+
+        # Should have stopped before max_turns (10)
+        max_turns_events = [e for e in events if e["type"] == "max_turns_exceeded"]
+        assert len(max_turns_events) == 0
+
+    @pytest.mark.asyncio
+    async def test_success_resets_failure_counter(self):
+        """A successful tool call resets the consecutive failure counter."""
+        mcp = MagicMock()
+        mcp.get_tools_for_chat.return_value = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "maybe_fail",
+                    "description": "Might fail",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+        session = _make_session(mcp=mcp, max_turns=10)
+        session.config.max_consecutive_tool_failures = 2
+
+        call_num = 0
+
+        async def call_tool(name, args, timeout=30.0):
+            nonlocal call_num
+            call_num += 1
+            if call_num == 1:
+                raise RuntimeError("fail1")
+            elif call_num == 2:
+                return "success"
+            else:
+                raise RuntimeError("fail2")
+
+        mcp.call_tool = AsyncMock(side_effect=call_tool)
+        gen_count = 0
+
+        async def fake_generate(*args, **kwargs):
+            nonlocal gen_count
+            gen_count += 1
+            yield {
+                "text": '<tool_call>{"name": "maybe_fail", "arguments": {}}</tool_call>',
+                "done": False,
+            }
+            yield {"text": "", "done": True, "stats": MagicMock()}
+
+        with patch(
+            "olmlx.chat.session.generate_chat",
+            side_effect=lambda *a, **kw: fake_generate(),
+        ):
+            events = []
+            async for event in session.send_message("Use the tool"):
+                events.append(event)
+
+        # Failures should be: fail1 (turn1), then success (turn2, resets),
+        # then fail2 (turn3), then fail from call4 (turn4),
+        # and continue failing -> should hit limit after 2 more failures
+        # So at least 4 turns should have run before the exceeded event
+        exceeded = [e for e in events if e["type"] == "tool_failures_exceeded"]
+        assert len(exceeded) == 1
+        result_events = [e for e in events if e["type"] == "tool_result"]
+        assert len(result_events) == 1  # one success
+        error_events = [e for e in events if e["type"] == "tool_error"]
+        assert len(error_events) >= 2  # at least the 2 failures in the final run
+
+    @pytest.mark.asyncio
+    async def test_deferred_exception_does_not_crash_session(self):
+        """BaseException from parallel tool execution does not crash session."""
+        mcp = MagicMock()
+        mcp.get_tools_for_chat.return_value = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "crash_tool",
+                    "description": "A tool that raises BaseException",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        mcp.call_tool = AsyncMock(side_effect=BaseException("unexpected"))
+
+        session = _make_session(mcp=mcp)
+        session.config.max_consecutive_tool_failures = 3
+
+        call_count = 0
+        async def fake_generate(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                yield {
+                    "text": '<tool_call>{"name": "crash_tool", "arguments": {}}</tool_call>',
+                    "done": False,
+                }
+                yield {"text": "", "done": True, "stats": MagicMock()}
+            else:
+                yield {"text": "The tool crashed, sorry.", "done": False}
+                yield {"text": "", "done": True, "stats": MagicMock()}
+
+        with patch(
+            "olmlx.chat.session.generate_chat",
+            side_effect=lambda *a, **kw: fake_generate(),
+        ):
+            events = []
+            async for event in session.send_message("Use the tool"):
+                events.append(event)
+
+        # Should not crash — the old code raised deferred_exc and crashed
+        # With max_consecutive_tool_failures=3, a single error is fine
+        error_events = [e for e in events if e["type"] == "tool_error"]
+        assert len(error_events) == 1
+        exceeded = [e for e in events if e["type"] == "tool_failures_exceeded"]
+        assert len(exceeded) == 0
+
+        # Model should have seen the error and responded
+        assert session.messages[-1]["content"] == "The tool crashed, sorry."

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -1716,19 +1716,19 @@ class TestConsecutiveToolFailures:
 
     @pytest.mark.asyncio
     async def test_deferred_exception_does_not_crash_session(self):
-        """BaseException from parallel tool execution does not crash session."""
+        """Exception from parallel tool execution does not crash session."""
         mcp = MagicMock()
         mcp.get_tools_for_chat.return_value = [
             {
                 "type": "function",
                 "function": {
                     "name": "crash_tool",
-                    "description": "A tool that raises BaseException",
+                    "description": "A tool that raises an Exception",
                     "parameters": {"type": "object", "properties": {}},
                 },
             }
         ]
-        mcp.call_tool = AsyncMock(side_effect=BaseException("unexpected"))
+        mcp.call_tool = AsyncMock(side_effect=RuntimeError("unexpected"))
 
         session = _make_session(mcp=mcp)
         session.config.max_consecutive_tool_failures = 3

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -1734,6 +1734,7 @@ class TestConsecutiveToolFailures:
         session.config.max_consecutive_tool_failures = 3
 
         call_count = 0
+
         async def fake_generate(*args, **kwargs):
             nonlocal call_count
             call_count += 1


### PR DESCRIPTION
## Summary
- Add `max_consecutive_tool_failures` config (default 3) to stop agent loop gracefully when tools fail too many times in a row
- Fix `_execute_tool_calls` deferred exception crash — errors are now fed back to the model for recovery instead of killing the session
- Fix `connect_all` None crash on `max(max_attempts, 1)` 
- Fix `local_tool_safety` store_true filter to not override ChatConfig default

## Details
- `ChatConfig.max_consecutive_tool_failures = 3` (CLI `--max-consecutive-tool-failures`, 0 = unlimited)
- New `tool_failures_exceeded` event type with TypedDict and ChatEvent union
- Failure counter resets on any successful tool call in a turn
- Parse errors and denied tools don't affect the counter
- CancelledError still propagates correctly