### PR TITLE
fix(inference): prevent prompt cache invalidation for non-trimmable hybrid caches

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -2008,14 +2008,20 @@ async def _store_prompt_cache_after_generation(
             # next turn; the pre-generation path will discard it if
             # alignment requires a trim.
             #
-            # When None-ID tokens were produced during generation
-            # (eval_count != len(generated_tokens)), the KV cache
-            # offset does not match the full stored_tokens sequence.
-            # In that case store only full_prompt_tokens as metadata
-            # — the generated portion is unreliable and will cause
-            # offset misalignment on the next turn if cached.
+            # If None-ID tokens were produced during generation
+            # (eval_count != len(generated_tokens)), the KV ring buffer
+            # contains stale generation entries at positions we can't
+            # trim out, and the metadata can't faithfully represent
+            # them.  Don't store at all — a stale cache is worse than
+            # no cache.
             if eval_count != len(generated_tokens):
-                stored_tokens = list(full_prompt_tokens)
+                logger.debug(
+                    "Non-trimmable cache with misaligned eval_count "
+                    "(%d != %d); skipping storage",
+                    eval_count,
+                    len(generated_tokens),
+                )
+                return
             logger.warning(
                 "Storing non-trimmable cache at %d tokens "
                 "(would-be trim=%d, exceeds limit of %d); "

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1984,6 +1984,12 @@ async def _store_prompt_cache_after_generation(
 
     Handles trimming to max_cache_tokens, eviction pressure cleanup,
     and cache invalidation on trim failure.
+
+    Non-trimmable hybrid caches (e.g. Gemma 4, Qwen3-Next with
+    RotatingKVCache layers) skip the trim path and are stored as-is
+    even when they exceed max_cache_tokens.  The pre-generation setup
+    path handles their eventual discard when alignment requires a trim;
+    this storage just keeps them alive for strict-extension cache hits.
     """
     prompt_cache = gen_kwargs.get("prompt_cache")
     if prompt_cache is None or full_prompt_tokens is None:
@@ -1993,10 +1999,34 @@ async def _store_prompt_cache_after_generation(
     actual_total = len(full_prompt_tokens) + eval_count
     max_cache_tokens = settings.prompt_cache_max_tokens
     if max_cache_tokens is not None and actual_total > max_cache_tokens:
+        if not lm.supports_cache_trim:
+            # Non-trimmable hybrid cache: trim_prompt_cache would call
+            # can_trim_prompt_cache → RotatingKVCache.is_trimmable()
+            # which returns False once the ring buffer fills, causing
+            # the trim to silently return 0.  Store without trimming
+            # so the cache survives for strict-extension reuse on the
+            # next turn; the pre-generation path will discard it if
+            # alignment requires a trim.
+            logger.debug(
+                "Skipping trim on non-trimmable hybrid cache "
+                "(would-be trim=%d), storing at %d tokens",
+                actual_total - max_cache_tokens,
+                actual_total,
+            )
+            evicted = await lm.prompt_cache_store.async_set(
+                cache_id,
+                CachedPromptState(tokens=stored_tokens, cache=prompt_cache),
+            )
+            if evicted is not None:
+                del evicted
+                if memory_utils.is_memory_pressure_high(settings.memory_limit_fraction):
+                    gc.collect()
+                    mx.clear_cache()
+            return
+
         trim_amount = actual_total - max_cache_tokens
         # cache_invalidated drives the post-trim flow.  Set when:
-        # (a) trim returns the wrong amount (non-trimmable hybrid
-        # cache like Qwen3-Next — expected operating condition), or
+        # (a) trim returns the wrong amount (trimmable cache misreporting), or
         # (b) trim raises an unexpected exception.  In either case
         # the storage block is skipped and the cache reference is
         # released.  Using a flag avoids signalling a normal "this
@@ -2005,10 +2035,9 @@ async def _store_prompt_cache_after_generation(
         try:
             trimmed = trim_prompt_cache(prompt_cache, trim_amount)
             if trimmed != trim_amount:
-                # Hybrid/non-trimmable cache: a partial trim would
-                # leave the stored cache misaligned with stored_tokens
-                # metadata, so invalidate rather than carry a broken
-                # cache forward.
+                # A trimmable cache that under-delivers on trim
+                # (possible with unusual cache implementations).
+                # Invalidate rather than carry a broken cache forward.
                 logger.warning(
                     "Cache trim incomplete (asked for %d, got %d); invalidating cache",
                     trim_amount,

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -2007,11 +2007,22 @@ async def _store_prompt_cache_after_generation(
             # so the cache survives for strict-extension reuse on the
             # next turn; the pre-generation path will discard it if
             # alignment requires a trim.
-            logger.debug(
-                "Skipping trim on non-trimmable hybrid cache "
-                "(would-be trim=%d), storing at %d tokens",
+            #
+            # When None-ID tokens were produced during generation
+            # (eval_count != len(generated_tokens)), the KV cache
+            # offset does not match the full stored_tokens sequence.
+            # In that case store only full_prompt_tokens as metadata
+            # — the generated portion is unreliable and will cause
+            # offset misalignment on the next turn if cached.
+            if eval_count != len(generated_tokens):
+                stored_tokens = list(full_prompt_tokens)
+            logger.warning(
+                "Storing non-trimmable cache at %d tokens "
+                "(would-be trim=%d, exceeds limit of %d); "
+                "max_cache_tokens is advisory for hybrid sliding-window models",
+                len(stored_tokens),
                 actual_total - max_cache_tokens,
-                actual_total,
+                max_cache_tokens,
             )
             evicted = await lm.prompt_cache_store.async_set(
                 cache_id,

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -2037,6 +2037,12 @@ async def _store_prompt_cache_after_generation(
             if memory_utils.is_memory_pressure_high(settings.memory_limit_fraction):
                 gc.collect()
                 mx.clear_cache()
+        logger.debug(
+            "Cache stored (non-trimmable): %d tokens (%d prompt + %d generated)",
+            len(stored_tokens),
+            len(full_prompt_tokens),
+            len(generated_tokens),
+        )
         return
 
     if max_cache_tokens is not None and actual_total > max_cache_tokens:

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1998,30 +1998,28 @@ async def _store_prompt_cache_after_generation(
     stored_tokens = list(full_prompt_tokens) + generated_tokens
     actual_total = len(full_prompt_tokens) + eval_count
     max_cache_tokens = settings.prompt_cache_max_tokens
-    if max_cache_tokens is not None and actual_total > max_cache_tokens:
-        if not lm.supports_cache_trim:
-            # Non-trimmable hybrid cache: trim_prompt_cache would call
-            # can_trim_prompt_cache → RotatingKVCache.is_trimmable()
-            # which returns False once the ring buffer fills, causing
-            # the trim to silently return 0.  Store without trimming
-            # so the cache survives for strict-extension reuse on the
-            # next turn; the pre-generation path will discard it if
-            # alignment requires a trim.
-            #
-            # If None-ID tokens were produced during generation
-            # (eval_count != len(generated_tokens)), the KV ring buffer
-            # contains stale generation entries at positions we can't
-            # trim out, and the metadata can't faithfully represent
-            # them.  Don't store at all — a stale cache is worse than
-            # no cache.
-            if eval_count != len(generated_tokens):
-                logger.debug(
-                    "Non-trimmable cache with misaligned eval_count "
-                    "(%d != %d); skipping storage",
-                    eval_count,
-                    len(generated_tokens),
-                )
-                return
+
+    # Non-trimmable hybrid caches (RotatingKVCache) can never be trimmed
+    # back.  The pre-generation setup path handles cache alignment by
+    # discarding and creating fresh; here we store as-is or skip entirely
+    # when the metadata is known to be unreliable.
+    if not lm.supports_cache_trim:
+        if eval_count != len(generated_tokens):
+            # None-ID tokens: the ring buffer has stale generation entries
+            # at positions we can't trim out, and the metadata can't
+            # faithfully represent them.  Remove any previous entry from
+            # the store (the mutable cache object was shared) and skip
+            # storage — a corrupt cache is worse than no cache.
+            lm.prompt_cache_store.remove(cache_id)
+            logger.debug(
+                "Non-trimmable cache with misaligned eval_count "
+                "(%d != %d); skipping storage",
+                eval_count,
+                len(generated_tokens),
+            )
+            return
+
+        if max_cache_tokens is not None and actual_total > max_cache_tokens:
             logger.warning(
                 "Storing non-trimmable cache at %d tokens "
                 "(would-be trim=%d, exceeds limit of %d); "
@@ -2030,17 +2028,18 @@ async def _store_prompt_cache_after_generation(
                 actual_total - max_cache_tokens,
                 max_cache_tokens,
             )
-            evicted = await lm.prompt_cache_store.async_set(
-                cache_id,
-                CachedPromptState(tokens=stored_tokens, cache=prompt_cache),
-            )
-            if evicted is not None:
-                del evicted
-                if memory_utils.is_memory_pressure_high(settings.memory_limit_fraction):
-                    gc.collect()
-                    mx.clear_cache()
-            return
+        evicted = await lm.prompt_cache_store.async_set(
+            cache_id,
+            CachedPromptState(tokens=stored_tokens, cache=prompt_cache),
+        )
+        if evicted is not None:
+            del evicted
+            if memory_utils.is_memory_pressure_high(settings.memory_limit_fraction):
+                gc.collect()
+                mx.clear_cache()
+        return
 
+    if max_cache_tokens is not None and actual_total > max_cache_tokens:
         trim_amount = actual_total - max_cache_tokens
         # cache_invalidated drives the post-trim flow.  Set when:
         # (a) trim returns the wrong amount (trimmable cache misreporting), or

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -3764,12 +3764,32 @@ class TestStorePromptCacheAfterGeneration:
                 mock_lm, gen_kwargs, [1, 2, 3], [4, 5], 7, "test"
             )
 
-        # Cache must NOT be stored — stale ring-buffer entries would be unsafe
+        # Cache must NOT be stored — stale ring-buffer entries would be unsafe.
+        # The previous entry from a prior turn must be cleaned up since the
+        # mutable ring buffer was shared and is now corrupted.
         mock_lm.prompt_cache_store.async_set.assert_not_awaited()
-        mock_lm.prompt_cache_store.remove.assert_not_called()
+        mock_lm.prompt_cache_store.remove.assert_called_once_with("test")
 
+    @pytest.mark.asyncio
+    async def test_non_trimmable_within_limit_stores_as_is(self, mock_lm):
+        """When supports_cache_trim=False and total <= max, store without trimming."""
+        from olmlx.engine.inference import _store_prompt_cache_after_generation
 
-class TestInferenceTimeout:
+        mock_lm.supports_cache_trim = False
+        cache = MagicMock()
+        gen_kwargs = {"prompt_cache": cache}
+        with patch("olmlx.engine.inference.settings") as mock_settings:
+            mock_settings.prompt_cache_max_tokens = 32768  # well above 5
+            mock_settings.memory_limit_fraction = 0.9
+            await _store_prompt_cache_after_generation(
+                mock_lm, gen_kwargs, [1, 2, 3], [4, 5], 2, "test"
+            )
+
+        mock_lm.prompt_cache_store.async_set.assert_awaited_once()
+        call_args = mock_lm.prompt_cache_store.async_set.call_args
+        assert call_args[0][0] == "test"
+        stored = call_args[0][1]
+        assert stored.tokens == [1, 2, 3, 4, 5]
     @pytest.mark.asyncio
     async def test_streaming_stops_after_inference_timeout(self, mock_manager):
         """Streaming generation should stop and return done_reason=timeout."""

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -3790,6 +3790,9 @@ class TestStorePromptCacheAfterGeneration:
         assert call_args[0][0] == "test"
         stored = call_args[0][1]
         assert stored.tokens == [1, 2, 3, 4, 5]
+
+
+class TestInferenceTimeout:
     @pytest.mark.asyncio
     async def test_streaming_stops_after_inference_timeout(self, mock_manager):
         """Streaming generation should stop and return done_reason=timeout."""

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -3749,7 +3749,8 @@ class TestStorePromptCacheAfterGeneration:
     @pytest.mark.asyncio
     async def test_non_trimmable_misaligned_eval_count(self, mock_lm):
         """When supports_cache_trim=False and eval_count != len(generated_tokens),
-        store only full_prompt_tokens to avoid KV offset misalignment."""
+        skip storage entirely — stale generation entries in the ring buffer
+        can't be trimmed out and would corrupt the next turn."""
         from olmlx.engine.inference import _store_prompt_cache_after_generation
 
         mock_lm.supports_cache_trim = False
@@ -3763,11 +3764,12 @@ class TestStorePromptCacheAfterGeneration:
                 mock_lm, gen_kwargs, [1, 2, 3], [4, 5], 7, "test"
             )
 
-        # Only prompt tokens stored, generated tokens dropped
-        mock_lm.prompt_cache_store.async_set.assert_awaited_once()
-        call_args = mock_lm.prompt_cache_store.async_set.call_args
-        stored = call_args[0][1]
-        assert stored.tokens == [1, 2, 3]
+        # Cache must NOT be stored — stale ring-buffer entries would be unsafe
+        mock_lm.prompt_cache_store.async_set.assert_not_awaited()
+        mock_lm.prompt_cache_store.remove.assert_not_called()
+
+
+class TestInferenceTimeout:
     @pytest.mark.asyncio
     async def test_streaming_stops_after_inference_timeout(self, mock_manager):
         """Streaming generation should stop and return done_reason=timeout."""

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -3724,8 +3724,50 @@ class TestStorePromptCacheAfterGeneration:
         mock_lm.prompt_cache_store.remove.assert_called_with("test")
         mock_lm.prompt_cache_store.async_set.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_non_trimmable_stores_without_trim(self, mock_lm):
+        """When supports_cache_trim=False and total > max, store as-is."""
+        from olmlx.engine.inference import _store_prompt_cache_after_generation
 
-class TestInferenceTimeout:
+        mock_lm.supports_cache_trim = False
+        cache = MagicMock()
+        gen_kwargs = {"prompt_cache": cache}
+        with patch("olmlx.engine.inference.settings") as mock_settings:
+            mock_settings.prompt_cache_max_tokens = 4
+            mock_settings.memory_limit_fraction = 0.9
+            await _store_prompt_cache_after_generation(
+                mock_lm, gen_kwargs, [1, 2, 3], [4, 5], 2, "test"
+            )
+
+        # Cache stored as-is (3 prompt + 2 gen = 5, exceeding limit of 4)
+        mock_lm.prompt_cache_store.async_set.assert_awaited_once()
+        call_args = mock_lm.prompt_cache_store.async_set.call_args
+        assert call_args[0][0] == "test"
+        stored = call_args[0][1]
+        assert stored.tokens == [1, 2, 3, 4, 5]
+
+    @pytest.mark.asyncio
+    async def test_non_trimmable_misaligned_eval_count(self, mock_lm):
+        """When supports_cache_trim=False and eval_count != len(generated_tokens),
+        store only full_prompt_tokens to avoid KV offset misalignment."""
+        from olmlx.engine.inference import _store_prompt_cache_after_generation
+
+        mock_lm.supports_cache_trim = False
+        cache = MagicMock()
+        gen_kwargs = {"prompt_cache": cache}
+        # eval_count=7 != len(generated_tokens)=2: None-ID tokens produced
+        with patch("olmlx.engine.inference.settings") as mock_settings:
+            mock_settings.prompt_cache_max_tokens = 4
+            mock_settings.memory_limit_fraction = 0.9
+            await _store_prompt_cache_after_generation(
+                mock_lm, gen_kwargs, [1, 2, 3], [4, 5], 7, "test"
+            )
+
+        # Only prompt tokens stored, generated tokens dropped
+        mock_lm.prompt_cache_store.async_set.assert_awaited_once()
+        call_args = mock_lm.prompt_cache_store.async_set.call_args
+        stored = call_args[0][1]
+        assert stored.tokens == [1, 2, 3]
     @pytest.mark.asyncio
     async def test_streaming_stops_after_inference_timeout(self, mock_manager):
         """Streaming generation should stop and return done_reason=timeout."""


### PR DESCRIPTION
## Summary
- Fixes a bug where `_store_prompt_cache_after_generation` invalidated the entire prompt cache for models with non-trimmable hybrid caches (Gemma 4, Qwen3-Next with RotatingKVCache layers)
- The storage path now checks `lm.supports_cache_trim` before calling `trim_prompt_cache`, matching the behavior in `_setup_prompt_cache`

## Problem
When a hybrid sliding-window model's RotatingKVCache ring buffer fills, `is_trimmable()` returns `False`. `trim_prompt_cache` → `can_trim_prompt_cache` silently returns 0, which the storage function treated as a trim failure, invalidating the cache entirely. This caused every subsequent chat turn to run a full prefill.

## Fix
Added an `lm.supports_cache_trim` guard before the trim attempt. When `False`, the cache is stored as-is (even if it exceeds `max_cache_tokens`). The pre-generation setup path (`_setup_prompt_cache`) already handles non-trimmable caches correctly by discarding them and creating fresh ones when alignment requires a trim.

## Note
For multi-turn chat with non-trimmable models, each turn still runs a full prefill — this is a fundamental RotatingKVCache limitation. The previous turn's generated tokens remain in the KV cache and can't be trimmed off. Full reuse would require capturing a prefill-time cache snapshot.