### PR TITLE
feat(flash-moe): Step-3.5-Flash support

### DIFF
--- a/docs/superpowers/plans/2026-05-04-step3p5-flash-moe-support.md
+++ b/docs/superpowers/plans/2026-05-04-step3p5-flash-moe-support.md
@@ -1,0 +1,371 @@
+# Step-3.5-Flash Flash-MoE Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `olmlx flash prepare mlx-community/Step-3.5-Flash-6bit` succeed and `olmlx serve` produce correct output for the model under Flash-MoE.
+
+**Architecture:** Three small additive changes — recognize `moe_num_experts` as an expert-count alias in MoE detection/prep, parse `moe_layers_enum` for explicit MoE layer indexing in the bundler, and probe `share_expert` (singular) as a shared-expert fallback in the runtime DeepSeek-style replacement. Tests are unit-level against synthetic configs/safetensors; end-to-end is verified manually.
+
+**Tech Stack:** Python, mlx-lm, safetensors, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-step3p5-flash-moe-support-design.md`
+
+---
+
+## File Map
+
+- Modify: `olmlx/engine/flash/moe_prepare.py` — `is_moe_model()` and expert-count read in `prepare_moe_for_flash()`.
+- Modify: `olmlx/engine/flash/moe_bundler.py` — `_detect_moe_layers()` adds `moe_layers_enum` branch.
+- Modify: `olmlx/engine/flash/flash_moe_model.py` — `_FlashMoEDeepSeek.__init__` falls back to `share_expert`.
+- Modify: `tests/test_flash_moe_integration.py` — add `is_moe_model` test for `moe_num_experts`.
+- Modify: `tests/test_flash_moe_bundler.py` — add bundler test for `moe_layers_enum`.
+- Modify: `tests/test_flash_moe_model.py` — add runtime test for `share_expert` (singular) fallback.
+
+---
+
+## Task 1: Recognize `moe_num_experts` in `is_moe_model()`
+
+**Files:**
+- Modify: `olmlx/engine/flash/moe_prepare.py:28-32`
+- Test: `tests/test_flash_moe_integration.py` (new test in `TestIsMoeModel`)
+
+- [ ] **Step 1.1: Write the failing test**
+
+Add to `tests/test_flash_moe_integration.py` inside `class TestIsMoeModel`:
+
+```python
+    def test_step3p5_moe_detected(self, tmp_path):
+        """Step-3.5 uses 'moe_num_experts' instead of the other aliases."""
+        from olmlx.engine.flash.moe_prepare import is_moe_model
+
+        config = {
+            "model_type": "step3p5",
+            "moe_num_experts": 288,
+            "hidden_size": 4096,
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert is_moe_model(tmp_path) is True
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_flash_moe_integration.py::TestIsMoeModel::test_step3p5_moe_detected -v`
+Expected: FAIL — `assert False is True` (the existing OR-chain doesn't see `moe_num_experts`).
+
+- [ ] **Step 1.3: Implement**
+
+In `olmlx/engine/flash/moe_prepare.py`, change `is_moe_model`:
+
+```python
+    return (
+        (config.get("n_routed_experts") or 0) > 1
+        or (config.get("num_local_experts") or 0) > 1
+        or (config.get("num_experts") or 0) > 1
+        or (config.get("moe_num_experts") or 0) > 1
+    )
+```
+
+- [ ] **Step 1.4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_flash_moe_integration.py::TestIsMoeModel -v`
+Expected: PASS (all tests in class, including the new one).
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add olmlx/engine/flash/moe_prepare.py tests/test_flash_moe_integration.py
+git commit -m "feat(flash-moe): recognize moe_num_experts in is_moe_model"
+```
+
+---
+
+## Task 2: Read `moe_num_experts` in `prepare_moe_for_flash()`
+
+**Files:**
+- Modify: `olmlx/engine/flash/moe_prepare.py:78-82`
+- Test: `tests/test_flash_moe_integration.py` (new test in `TestPrepareMoeForFlash`)
+
+- [ ] **Step 2.1: Write the failing test**
+
+Add to `tests/test_flash_moe_integration.py` inside `class TestPrepareMoeForFlash`. Reuse `_make_synthetic_moe_weights` from `test_flash_moe_bundler.py` by importing it:
+
+```python
+    def test_step3p5_moe_num_experts_in_config(self, tmp_path):
+        """Expert count must be read from moe_num_experts when present."""
+        from tests.test_flash_moe_bundler import _make_synthetic_moe_weights
+
+        hidden, inter, experts = 64, 32, 6
+        model_dir = _make_synthetic_moe_weights(hidden, inter, experts, 2, 1, tmp_path)
+
+        # Overwrite config to use moe_num_experts (Step-3.5 style)
+        (model_dir / "config.json").write_text(json.dumps({
+            "model_type": "step3p5",
+            "hidden_size": hidden,
+            "moe_intermediate_size": inter,
+            "moe_num_experts": experts,
+            "num_hidden_layers": 3,
+            "moe_layers_enum": "1,2",
+            "num_experts_per_tok": 2,
+        }))
+
+        from olmlx.engine.flash.moe_prepare import prepare_moe_for_flash
+
+        output_dir = tmp_path / "flash_moe"
+        prepare_moe_for_flash(str(model_dir), output_dir)
+
+        cfg = json.loads((output_dir / "flash_moe_config.json").read_text())
+        assert cfg["num_experts"] == experts
+```
+
+- [ ] **Step 2.2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_flash_moe_integration.py::TestPrepareMoeForFlash::test_step3p5_moe_num_experts_in_config -v`
+Expected: FAIL — either `num_experts` is `None` (the OR-chain returns `None`), or layer detection returns `[]` because `moe_layers_enum` isn't yet handled. Either failure is acceptable; Task 3 fixes the layer detection. Confirm the failure mentions `num_experts` being wrong (`None`/missing) before proceeding.
+
+- [ ] **Step 2.3: Implement**
+
+In `olmlx/engine/flash/moe_prepare.py`:
+
+```python
+    num_experts = (
+        text_config.get("n_routed_experts")
+        or text_config.get("num_local_experts")
+        or text_config.get("num_experts")
+        or text_config.get("moe_num_experts")
+    )
+```
+
+- [ ] **Step 2.4: Run test (still expected to fail)**
+
+Run: `uv run pytest tests/test_flash_moe_integration.py::TestPrepareMoeForFlash::test_step3p5_moe_num_experts_in_config -v`
+Expected: still FAIL, but now with a different error — bundler raises because `_detect_moe_layers` returned `[]`. This confirms Task 2's change works; Task 3 unblocks the test.
+
+- [ ] **Step 2.5: Commit (test stays failing until Task 3)**
+
+```bash
+git add olmlx/engine/flash/moe_prepare.py tests/test_flash_moe_integration.py
+git commit -m "feat(flash-moe): read moe_num_experts in prepare_moe_for_flash"
+```
+
+---
+
+## Task 3: Parse `moe_layers_enum` in `_detect_moe_layers()`
+
+**Files:**
+- Modify: `olmlx/engine/flash/moe_bundler.py:256-291`
+- Test: `tests/test_flash_moe_bundler.py` (new test class)
+
+- [ ] **Step 3.1: Write the failing test**
+
+Add to `tests/test_flash_moe_bundler.py`:
+
+```python
+class TestDetectMoeLayersEnum:
+    """Step-3.5-Flash declares MoE layers via explicit moe_layers_enum string."""
+
+    def test_moe_layers_enum_parsed(self, tmp_path):
+        from olmlx.engine.flash.moe_bundler import _detect_moe_layers
+
+        config = {
+            "num_hidden_layers": 6,
+            "moe_layers_enum": "2,3,5",
+            # Conflicting freq/offset settings should be ignored.
+            "first_k_dense_replace": 0,
+            "moe_layer_freq": 1,
+        }
+        assert _detect_moe_layers(config) == [2, 3, 5]
+
+    def test_moe_layers_enum_empty_string_falls_through(self, tmp_path):
+        """Empty moe_layers_enum falls back to freq-based detection."""
+        from olmlx.engine.flash.moe_bundler import _detect_moe_layers
+
+        config = {
+            "num_hidden_layers": 4,
+            "moe_layers_enum": "",
+            "first_k_dense_replace": 1,
+            "moe_layer_freq": 1,
+        }
+        assert _detect_moe_layers(config) == [1, 2, 3]
+```
+
+- [ ] **Step 3.2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_flash_moe_bundler.py::TestDetectMoeLayersEnum -v`
+Expected: FAIL — `test_moe_layers_enum_parsed` returns `[0,1,2,3,4,5]` (freq path) instead of `[2,3,5]`.
+
+- [ ] **Step 3.3: Implement**
+
+In `olmlx/engine/flash/moe_bundler.py`, edit `_detect_moe_layers` — insert a new branch above the freq/offset logic and below the `hybrid_override_pattern` branch:
+
+```python
+    # Step-3.5: explicit comma-separated MoE layer indices.
+    enum = config.get("moe_layers_enum")
+    if enum:
+        return sorted(int(i) for i in enum.split(","))
+```
+
+Place this immediately after the `hybrid_override_pattern` block. The empty-string check is handled by `if enum:` (falsy).
+
+- [ ] **Step 3.4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_flash_moe_bundler.py::TestDetectMoeLayersEnum -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 3.5: Run the previously-stuck Task-2 test**
+
+Run: `uv run pytest tests/test_flash_moe_integration.py::TestPrepareMoeForFlash::test_step3p5_moe_num_experts_in_config -v`
+Expected: PASS — Task 2's blocker is now resolved.
+
+- [ ] **Step 3.6: Run the full bundler/integration suite for regressions**
+
+Run: `uv run pytest tests/test_flash_moe_bundler.py tests/test_flash_moe_integration.py -v`
+Expected: PASS — no regressions in existing freq-based / `hybrid_override_pattern` tests.
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add olmlx/engine/flash/moe_bundler.py tests/test_flash_moe_bundler.py
+git commit -m "feat(flash-moe): support moe_layers_enum for explicit MoE layer indexing"
+```
+
+---
+
+## Task 4: Probe `share_expert` (singular) in `_FlashMoEDeepSeek`
+
+**Files:**
+- Modify: `olmlx/engine/flash/flash_moe_model.py:53-70`
+- Test: `tests/test_flash_moe_model.py` (new test)
+
+- [ ] **Step 4.1: Inspect existing test patterns**
+
+Run: `head -60 tests/test_flash_moe_model.py`
+
+Note the test fixtures and how `_FlashMoEDeepSeek` is constructed in tests. Match that style.
+
+- [ ] **Step 4.2: Write the failing test**
+
+Add to `tests/test_flash_moe_model.py` (place near other `_FlashMoEDeepSeek` tests; if none exist, create a new class):
+
+```python
+class TestFlashMoEDeepSeekShareExpertSingular:
+    """Step-3.5MoE uses share_expert (singular), not shared_experts (plural)."""
+
+    def test_share_expert_singular_picked_up(self):
+        import mlx.core as mx
+        import mlx.nn as nn
+
+        from olmlx.engine.flash.flash_moe_model import _FlashMoEDeepSeek
+
+        class FakeGate(nn.Module):
+            def __call__(self, x):
+                B = x.shape[0] if x.ndim == 2 else x.shape[0] * x.shape[1]
+                inds = mx.zeros((B, 1), dtype=mx.int32)
+                scores = mx.ones((B, 1))
+                return inds, scores
+
+        class FakeShareExpert(nn.Module):
+            def __call__(self, x):
+                return x * 2.0
+
+        class FakeMoE(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.gate = FakeGate()
+                # singular name — Step-3.5 style
+                self.share_expert = FakeShareExpert()
+
+        original = FakeMoE()
+
+        class StubFlashMoE:
+            def __call__(self, x, inds, scores):
+                return mx.zeros_like(x)
+
+        replacement = _FlashMoEDeepSeek(original, StubFlashMoE())
+
+        x = mx.ones((1, 4))
+        y = replacement(x)
+        # routed output is zeros; share_expert doubles input → expect 2.0
+        assert mx.allclose(y, mx.full((1, 4), 2.0))
+```
+
+- [ ] **Step 4.3: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_flash_moe_model.py::TestFlashMoEDeepSeekShareExpertSingular -v`
+Expected: FAIL — `self.shared_experts` is `None` (it only checks the plural attr), so output is zeros (`0.0` ≠ `2.0`).
+
+- [ ] **Step 4.4: Implement**
+
+In `olmlx/engine/flash/flash_moe_model.py`, change `_FlashMoEDeepSeek.__init__`:
+
+```python
+    def __init__(self, original_moe, flash_moe: FlashMoE):
+        super().__init__(original_moe, flash_moe)
+        self.gate = original_moe.gate
+        # Some models (Step-3.5) use the singular `share_expert` attribute.
+        self.shared_experts = getattr(
+            original_moe, "shared_experts", None
+        ) or getattr(original_moe, "share_expert", None)
+```
+
+The `_combine` method is unchanged — it already handles `None`.
+
+- [ ] **Step 4.5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_flash_moe_model.py::TestFlashMoEDeepSeekShareExpertSingular -v`
+Expected: PASS.
+
+- [ ] **Step 4.6: Run full flash_moe_model tests for regressions**
+
+Run: `uv run pytest tests/test_flash_moe_model.py -v`
+Expected: PASS — DeepSeek-style models (with `shared_experts` plural) still work.
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add olmlx/engine/flash/flash_moe_model.py tests/test_flash_moe_model.py
+git commit -m "feat(flash-moe): probe share_expert (singular) for Step-3.5 compat"
+```
+
+---
+
+## Task 5: Lint, full-suite check, manual smoke
+
+- [ ] **Step 5.1: Run ruff**
+
+Run: `uv run ruff check . && uv run ruff format --check .`
+Expected: clean (or auto-fix and re-run; see memory `feedback_ruff_before_push.md`).
+
+- [ ] **Step 5.2: Run full Flash-MoE test suite**
+
+Run: `uv run pytest tests/test_flash_moe.py tests/test_flash_moe_bundler.py tests/test_flash_moe_integration.py tests/test_flash_moe_model.py tests/test_flash_moe_weight_store.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5.3: Manual prep run**
+
+Run: `uv run olmlx flash prepare mlx-community/Step-3.5-Flash-6bit`
+Expected: completes without error; populates `~/.olmlx/models/mlx-community_Step-3.5-Flash-6bit/flash_moe/` with `flash_moe_config.json`, `flash_moe_layout.json`, and 42 `.flashexperts` files (one per MoE layer 3..44). Verify with: `uv run olmlx flash info mlx-community/Step-3.5-Flash-6bit`.
+
+- [ ] **Step 5.4: Manual serve smoke test**
+
+Run: `uv run olmlx` and in another terminal `curl http://localhost:11434/api/chat -d '{"model":"mlx-community/Step-3.5-Flash-6bit:latest","messages":[{"role":"user","content":"Say hello in one word."}],"stream":false}'`
+Expected: a coherent one-word response. If output is gibberish, the share_expert fallback may not be wiring correctly — debug before proceeding.
+
+- [ ] **Step 5.5: Update CLAUDE.md if needed**
+
+Per memory `feedback_update_claude_md.md`: this change is small and additive (new MoE config keys recognized), so no `# Key Design Decisions` entry is warranted unless something surprising came up during smoke testing. Skip unless smoke test reveals something noteworthy.
+
+- [ ] **Step 5.6: Final commit (if anything left unstaged)**
+
+```bash
+git status
+# only commit if there are leftover formatting fixes or CLAUDE.md edits
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** All four numbered gaps (3 prep + 1 runtime) plus tests are covered by Tasks 1-4. Manual end-to-end is Task 5.
+- **Type / name consistency:** `moe_num_experts` (config key) vs `num_experts` (in-code variable name) — names match between Tasks 1, 2, and the existing `prepare_moe_for_flash` body. `share_expert` (singular, Step-3.5 attr) vs `shared_experts` (plural, internal field) — kept distinct on purpose; documented in the Task 4 comment.
+- **Regression coverage:** Task 3 step 3.6 and Task 4 step 4.6 explicitly run the existing class to catch breakage.
+- **No placeholders / TBDs.**

--- a/docs/superpowers/specs/2026-05-04-step3p5-flash-moe-support-design.md
+++ b/docs/superpowers/specs/2026-05-04-step3p5-flash-moe-support-design.md
@@ -1,0 +1,51 @@
+# Step-3.5-Flash Flash-MoE Support
+
+## Problem
+
+`olmlx flash prepare mlx-community/Step-3.5-Flash-6bit` falls through to dense Flash prep instead of Flash-MoE prep, then dies on `trust_remote_code` for the custom Step3p5 architecture.
+
+Root cause: Step-3.5 declares its MoE topology with non-standard config keys that the Flash-MoE pipeline doesn't recognize.
+
+## Gaps
+
+Compared to existing Flash-MoE-supported models (DeepSeek, Qwen3, gpt-oss, MiniMax, Gemma4, Kimi-K2.5):
+
+1. **Expert count key.** Step-3.5 uses `moe_num_experts: 288`. `is_moe_model()` and `prepare_moe_for_flash()` only check `n_routed_experts` / `num_local_experts` / `num_experts`.
+
+2. **MoE layer set.** Step-3.5 specifies MoE layers via `moe_layers_enum: "3,4,...,44"` (explicit list). `_detect_moe_layers()` only knows `first_k_dense_replace` + `moe_layer_freq` / `decoder_sparse_step` and the Nemotron-H `hybrid_override_pattern`.
+
+3. **Shared expert attribute name.** Step3p5MoE has a `share_expert` (singular) attribute alongside `switch_mlp`. The runtime `_FlashMoEDeepSeek` variant — which is selected for Step-3.5 because the gate is a custom module returning `(inds, scores)` — only probes `shared_experts` (plural). Without a fix, the shared-expert contribution is silently dropped, producing wrong outputs.
+
+## Out of scope
+
+- **MTP layers.** Step-3.5 has `num_nextn_predict_layers: 3`. mlx-lm's `step3p5.sanitize()` (lines 422-428) drops `.mtp.*` weights and any layer index ≥ `num_hidden_layers`, so the bundler never sees them. No change needed.
+- **`moe_layer_offset` / `moe_every_n_layer`.** Step-3.5 also sets these, but `moe_layers_enum` is authoritative and present, so we use it directly. Add fallback only when a future model needs it.
+
+## Changes
+
+### `engine/flash/moe_prepare.py`
+
+`is_moe_model()` and the expert-count read in `prepare_moe_for_flash()`: add `moe_num_experts` to the OR-chain alongside the three existing aliases.
+
+### `engine/flash/moe_bundler.py`
+
+`_detect_moe_layers()`: if `text_config.get("moe_layers_enum")` is a non-empty string, parse it as a comma-separated list of int layer indices, sort, return. This branch sits above the existing freq/offset logic and below the `hybrid_override_pattern` branch.
+
+### `engine/flash/flash_moe_model.py`
+
+`_FlashMoEDeepSeek.__init__`: probe `shared_experts` first, then fall back to `share_expert`. Store under `self.shared_experts` (single attribute name) so `_combine` is unchanged.
+
+## Tests
+
+Unit tests using synthetic config dicts (no model files required):
+
+- `is_moe_model()` returns True for a config with only `moe_num_experts`.
+- `_detect_moe_layers()` returns the parsed list for a config with `moe_layers_enum` and ignores any conflicting `moe_layer_freq` / `first_k_dense_replace` settings on the same dict.
+- `_detect_moe_layers()` still works on existing DeepSeek- and Qwen3-style configs (regression).
+
+Skip an end-to-end prep/serve test for now — the real model is too large for CI. Manual verification: run `olmlx flash prepare mlx-community/Step-3.5-Flash-6bit` then `olmlx serve` and exercise a chat completion.
+
+## Risks
+
+- The serving path may surface additional Step3p5-specific issues not visible from prep alone (e.g., Step3p5MoEGate behavior differences from DeepSeek). Plan: ship the prep + runtime changes, then iterate on serving issues as they appear rather than guessing now.
+- `share_expert` could be named differently in some Step3p5 fork. Acceptable — fix when seen.

--- a/olmlx/engine/flash/flash_moe_model.py
+++ b/olmlx/engine/flash/flash_moe_model.py
@@ -60,9 +60,10 @@ class _FlashMoEDeepSeek(_FlashMoEBase):
         super().__init__(original_moe, flash_moe)
         self.gate = original_moe.gate
         # Some models (Step-3.5) name the shared expert `share_expert` (singular).
-        self.shared_experts = getattr(original_moe, "shared_experts", None) or getattr(
-            original_moe, "share_expert", None
-        )
+        se = getattr(original_moe, "shared_experts", None)
+        if se is None:
+            se = getattr(original_moe, "share_expert", None)
+        self.shared_experts = se
 
     def _route(self, x):
         return self.gate(x)

--- a/olmlx/engine/flash/flash_moe_model.py
+++ b/olmlx/engine/flash/flash_moe_model.py
@@ -59,7 +59,10 @@ class _FlashMoEDeepSeek(_FlashMoEBase):
     def __init__(self, original_moe, flash_moe: FlashMoE):
         super().__init__(original_moe, flash_moe)
         self.gate = original_moe.gate
-        self.shared_experts = getattr(original_moe, "shared_experts", None)
+        # Some models (Step-3.5) name the shared expert `share_expert` (singular).
+        self.shared_experts = getattr(
+            original_moe, "shared_experts", None
+        ) or getattr(original_moe, "share_expert", None)
 
     def _route(self, x):
         return self.gate(x)

--- a/olmlx/engine/flash/flash_moe_model.py
+++ b/olmlx/engine/flash/flash_moe_model.py
@@ -60,9 +60,9 @@ class _FlashMoEDeepSeek(_FlashMoEBase):
         super().__init__(original_moe, flash_moe)
         self.gate = original_moe.gate
         # Some models (Step-3.5) name the shared expert `share_expert` (singular).
-        self.shared_experts = getattr(
-            original_moe, "shared_experts", None
-        ) or getattr(original_moe, "share_expert", None)
+        self.shared_experts = getattr(original_moe, "shared_experts", None) or getattr(
+            original_moe, "share_expert", None
+        )
 
     def _route(self, x):
         return self.gate(x)

--- a/olmlx/engine/flash/moe_bundler.py
+++ b/olmlx/engine/flash/moe_bundler.py
@@ -404,11 +404,13 @@ def bundle_moe_experts(
         config.get("n_routed_experts")
         or config.get("num_local_experts")
         or config.get("num_experts")
+        or config.get("moe_num_experts")
     )
     if num_experts is None:
         raise ValueError(
             f"config.json at {model_dir} is missing "
-            "'n_routed_experts', 'num_local_experts', and 'num_experts'"
+            "'n_routed_experts', 'num_local_experts', 'num_experts', "
+            "and 'moe_num_experts'"
         )
 
     # Check for safetensors index (sharded models)

--- a/olmlx/engine/flash/moe_bundler.py
+++ b/olmlx/engine/flash/moe_bundler.py
@@ -273,7 +273,15 @@ def _detect_moe_layers(config: dict) -> list[int]:
     # Step-3.5: explicit comma-separated MoE layer indices.
     enum = config.get("moe_layers_enum")
     if enum:
-        return sorted(int(i) for i in enum.split(","))
+        num_layers = config.get("num_hidden_layers") or config.get("num_layers", 0)
+        parsed = sorted(int(i) for i in enum.split(","))
+        out_of_bounds = [i for i in parsed if i >= num_layers]
+        if out_of_bounds:
+            raise ValueError(
+                f"moe_layers_enum contains indices {out_of_bounds} "
+                f"beyond num_hidden_layers ({num_layers}); likely MTP-layer leak"
+            )
+        return parsed
 
     num_layers = config.get("num_hidden_layers") or config.get("num_layers", 0)
     first_dense = config.get("first_k_dense_replace", 0)

--- a/olmlx/engine/flash/moe_bundler.py
+++ b/olmlx/engine/flash/moe_bundler.py
@@ -270,6 +270,11 @@ def _detect_moe_layers(config: dict) -> list[int]:
             )
         return [i for i, c in enumerate(pattern) if c == "E"]
 
+    # Step-3.5: explicit comma-separated MoE layer indices.
+    enum = config.get("moe_layers_enum")
+    if enum:
+        return sorted(int(i) for i in enum.split(","))
+
     num_layers = config.get("num_hidden_layers") or config.get("num_layers", 0)
     first_dense = config.get("first_k_dense_replace", 0)
     # Qwen3-MoE uses decoder_sparse_step instead of moe_layer_freq

--- a/olmlx/engine/flash/moe_prepare.py
+++ b/olmlx/engine/flash/moe_prepare.py
@@ -29,6 +29,7 @@ def is_moe_model(model_path: str | Path) -> bool:
         (config.get("n_routed_experts") or 0) > 1
         or (config.get("num_local_experts") or 0) > 1
         or (config.get("num_experts") or 0) > 1
+        or (config.get("moe_num_experts") or 0) > 1
     )
 
 

--- a/olmlx/engine/flash/moe_prepare.py
+++ b/olmlx/engine/flash/moe_prepare.py
@@ -87,7 +87,7 @@ def prepare_moe_for_flash(
     moe_freq_raw = text_config.get("moe_layer_freq")
     if moe_freq_raw is None:
         moe_freq_raw = text_config.get("decoder_sparse_step")
-    if moe_freq_raw == 0:
+    if moe_freq_raw == 0 and not text_config.get("moe_layers_enum"):
         raise ValueError("moe_layer_freq / decoder_sparse_step is 0 — invalid config")
     moe_freq = moe_freq_raw or 1
     num_experts_per_tok = text_config.get("num_experts_per_tok", 8)

--- a/olmlx/engine/flash/moe_prepare.py
+++ b/olmlx/engine/flash/moe_prepare.py
@@ -80,6 +80,7 @@ def prepare_moe_for_flash(
         text_config.get("n_routed_experts")
         or text_config.get("num_local_experts")
         or text_config.get("num_experts")
+        or text_config.get("moe_num_experts")
     )
     num_layers = text_config.get("num_hidden_layers") or text_config.get("num_layers")
     first_dense = text_config.get("first_k_dense_replace", 0)

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -87,7 +87,15 @@ def _sanitize_model_config_in_place(load_path) -> None:
             config_file,
         )
         cfg["layer_types"] = layer_types[:nhl]
-        config_file.write_text(json.dumps(cfg, indent=2, ensure_ascii=False))
+        try:
+            config_file.write_text(json.dumps(cfg, indent=2, ensure_ascii=False))
+        except OSError:
+            logger.warning(
+                "Failed to write sanitized layer_types to %s "
+                "(read-only?); model may fail to load if transformers validates "
+                "the mismatch.",
+                config_file,
+            )
 
 
 def _load_with_model_type_fallback(mlx_lm, load_path, **kwargs):

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -52,6 +52,44 @@ _FALLBACK_EXCEPTIONS = (
 )
 
 
+def _sanitize_model_config_in_place(load_path) -> None:
+    """Fix known on-disk config.json issues that block transformers loading.
+
+    Currently handles: ``layer_types`` longer than ``num_hidden_layers``.
+    Step-3.5 ships with ``num_hidden_layers=45`` but ``len(layer_types)=48``
+    (the trailing 3 entries describe MTP layers whose weights mlx-lm's
+    sanitize() drops). Newer transformers' ``validate_layer_type`` rejects
+    the mismatch. Truncating ``layer_types`` to match is consistent with
+    what mlx-lm does for the weights and is idempotent on subsequent loads.
+    """
+    config_file = Path(load_path) / "config.json"
+    if not config_file.exists():
+        return
+    try:
+        cfg = json.loads(config_file.read_text())
+    except json.JSONDecodeError:
+        return
+
+    nhl = cfg.get("num_hidden_layers")
+    layer_types = cfg.get("layer_types")
+    if (
+        isinstance(layer_types, list)
+        and isinstance(nhl, int)
+        and nhl > 0
+        and len(layer_types) > nhl
+    ):
+        logger.info(
+            "Truncating layer_types from %d to %d entries in %s "
+            "(num_hidden_layers); excess entries describe layers mlx-lm drops "
+            "(e.g. MTP).",
+            len(layer_types),
+            nhl,
+            config_file,
+        )
+        cfg["layer_types"] = layer_types[:nhl]
+        config_file.write_text(json.dumps(cfg, indent=2, ensure_ascii=False))
+
+
 def _load_with_model_type_fallback(mlx_lm, load_path, **kwargs):
     """Load model + tokenizer, remapping unrecognised model_type if needed.
 
@@ -64,6 +102,7 @@ def _load_with_model_type_fallback(mlx_lm, load_path, **kwargs):
     So we load the model first with the real config, then patch config.json
     temporarily to load only the tokenizer.
     """
+    _sanitize_model_config_in_place(load_path)
     kwargs.setdefault("tokenizer_config", {"trust_remote_code": True})
     try:
         return mlx_lm.load(str(load_path), **kwargs)

--- a/tests/test_flash_moe_bundler.py
+++ b/tests/test_flash_moe_bundler.py
@@ -1217,3 +1217,31 @@ class TestShardCacheCleanup:
             f"_shard_cache exceeded max size: {len(_shard_cache)} > {MAX_SHARD_CACHE_SIZE}"
         )
         _clear_shard_cache()
+
+
+class TestDetectMoeLayersEnum:
+    """Step-3.5-Flash declares MoE layers via explicit moe_layers_enum string."""
+
+    def test_moe_layers_enum_parsed(self):
+        from olmlx.engine.flash.moe_bundler import _detect_moe_layers
+
+        config = {
+            "num_hidden_layers": 6,
+            "moe_layers_enum": "2,3,5",
+            # Conflicting freq/offset settings should be ignored.
+            "first_k_dense_replace": 0,
+            "moe_layer_freq": 1,
+        }
+        assert _detect_moe_layers(config) == [2, 3, 5]
+
+    def test_moe_layers_enum_empty_string_falls_through(self):
+        """Empty moe_layers_enum falls back to freq-based detection."""
+        from olmlx.engine.flash.moe_bundler import _detect_moe_layers
+
+        config = {
+            "num_hidden_layers": 4,
+            "moe_layers_enum": "",
+            "first_k_dense_replace": 1,
+            "moe_layer_freq": 1,
+        }
+        assert _detect_moe_layers(config) == [1, 2, 3]

--- a/tests/test_flash_moe_bundler.py
+++ b/tests/test_flash_moe_bundler.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -1245,3 +1246,14 @@ class TestDetectMoeLayersEnum:
             "moe_layer_freq": 1,
         }
         assert _detect_moe_layers(config) == [1, 2, 3]
+
+    def test_moe_layers_enum_out_of_bounds_raises(self):
+        """Indices >= num_hidden_layers should raise clear ValueError."""
+        from olmlx.engine.flash.moe_bundler import _detect_moe_layers
+
+        config = {
+            "num_hidden_layers": 4,
+            "moe_layers_enum": "2,3,7",
+        }
+        with pytest.raises(ValueError, match="beyond num_hidden_layers"):
+            _detect_moe_layers(config)

--- a/tests/test_flash_moe_integration.py
+++ b/tests/test_flash_moe_integration.py
@@ -72,6 +72,18 @@ class TestIsMoeModel:
 
         assert is_moe_model(tmp_path) is False
 
+    def test_step3p5_moe_detected(self, tmp_path):
+        """Step-3.5 uses 'moe_num_experts' instead of the other aliases."""
+        from olmlx.engine.flash.moe_prepare import is_moe_model
+
+        config = {
+            "model_type": "step3p5",
+            "moe_num_experts": 288,
+            "hidden_size": 4096,
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert is_moe_model(tmp_path) is True
+
 
 class TestPrepareMoeForFlash:
     def test_full_preparation(self, tmp_path):

--- a/tests/test_flash_moe_integration.py
+++ b/tests/test_flash_moe_integration.py
@@ -180,3 +180,56 @@ class TestLoadedModelField:
 
         fields = {f.name for f in dataclasses.fields(LoadedModel)}
         assert "is_flash_moe" in fields
+
+
+class TestSanitizeModelConfigInPlace:
+    """Step-3.5 ships layer_types longer than num_hidden_layers; fix in place."""
+
+    def test_truncates_oversized_layer_types(self, tmp_path):
+        from olmlx.engine.model_manager import _sanitize_model_config_in_place
+
+        cfg = {
+            "num_hidden_layers": 3,
+            "layer_types": ["full", "sliding", "full", "extra1", "extra2"],
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+
+        _sanitize_model_config_in_place(tmp_path)
+
+        out = json.loads((tmp_path / "config.json").read_text())
+        assert out["layer_types"] == ["full", "sliding", "full"]
+        assert out["num_hidden_layers"] == 3
+
+    def test_idempotent_when_lengths_match(self, tmp_path):
+        from olmlx.engine.model_manager import _sanitize_model_config_in_place
+
+        cfg = {
+            "num_hidden_layers": 2,
+            "layer_types": ["full", "sliding"],
+        }
+        original = json.dumps(cfg)
+        (tmp_path / "config.json").write_text(original)
+
+        _sanitize_model_config_in_place(tmp_path)
+        _sanitize_model_config_in_place(tmp_path)
+
+        out = json.loads((tmp_path / "config.json").read_text())
+        assert out["layer_types"] == ["full", "sliding"]
+
+    def test_no_op_without_layer_types(self, tmp_path):
+        from olmlx.engine.model_manager import _sanitize_model_config_in_place
+
+        cfg = {"num_hidden_layers": 4, "hidden_size": 64}
+        original = json.dumps(cfg, indent=2)
+        (tmp_path / "config.json").write_text(original)
+
+        _sanitize_model_config_in_place(tmp_path)
+
+        # Untouched.
+        assert (tmp_path / "config.json").read_text() == original
+
+    def test_missing_config_is_silent(self, tmp_path):
+        from olmlx.engine.model_manager import _sanitize_model_config_in_place
+
+        # No config.json present — must not raise.
+        _sanitize_model_config_in_place(tmp_path)

--- a/tests/test_flash_moe_integration.py
+++ b/tests/test_flash_moe_integration.py
@@ -107,6 +107,34 @@ class TestPrepareMoeForFlash:
         assert config["moe_layer_indices"] == [1, 2]
         assert "prepared_at" in config
 
+    def test_step3p5_moe_num_experts_in_config(self, tmp_path):
+        """Expert count must be read from moe_num_experts when present."""
+        hidden, inter, experts = 64, 32, 6
+        model_dir = _make_synthetic_moe_weights(hidden, inter, experts, 2, 1, tmp_path)
+
+        # Overwrite config to use moe_num_experts (Step-3.5 style)
+        (model_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "step3p5",
+                    "hidden_size": hidden,
+                    "moe_intermediate_size": inter,
+                    "moe_num_experts": experts,
+                    "num_hidden_layers": 3,
+                    "moe_layers_enum": "1,2",
+                    "num_experts_per_tok": 2,
+                }
+            )
+        )
+
+        from olmlx.engine.flash.moe_prepare import prepare_moe_for_flash
+
+        output_dir = tmp_path / "flash_moe"
+        prepare_moe_for_flash(str(model_dir), output_dir)
+
+        cfg = json.loads((output_dir / "flash_moe_config.json").read_text())
+        assert cfg["num_experts"] == experts
+
 
 class TestModelManagerFlashMoe:
     def test_flash_moe_dir_detection(self, tmp_path):

--- a/tests/test_flash_moe_integration.py
+++ b/tests/test_flash_moe_integration.py
@@ -233,3 +233,20 @@ class TestSanitizeModelConfigInPlace:
 
         # No config.json present — must not raise.
         _sanitize_model_config_in_place(tmp_path)
+
+    def test_non_writable_config_does_not_crash(self, tmp_path):
+        """Write failure on config.json must not crash model loading."""
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from olmlx.engine.model_manager import _sanitize_model_config_in_place
+
+        cfg = {
+            "num_hidden_layers": 3,
+            "layer_types": ["full", "sliding", "full", "extra1", "extra2"],
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+
+        with patch.object(Path, "write_text", side_effect=OSError("read-only")):
+            # Must not raise.
+            _sanitize_model_config_in_place(tmp_path)

--- a/tests/test_flash_moe_model.py
+++ b/tests/test_flash_moe_model.py
@@ -827,3 +827,39 @@ class TestFlashMoeGemma4Vlm:
 
         assert isinstance(wrapped.layers[0].mlp, _MockMLP)
         assert not hasattr(wrapped.layers[0], "router")
+
+
+class TestFlashMoEDeepSeekShareExpertSingular:
+    """Step-3.5MoE uses share_expert (singular), not shared_experts (plural)."""
+
+    def test_share_expert_singular_picked_up(self):
+        from olmlx.engine.flash.flash_moe_model import _FlashMoEDeepSeek
+
+        class _FakeGate(nn.Module):
+            def __call__(self, x):
+                B, L, _ = x.shape
+                inds = mx.zeros((B, L, 1), dtype=mx.int32)
+                scores = mx.ones((B, L, 1))
+                return inds, scores
+
+        class _FakeShareExpert(nn.Module):
+            def __call__(self, x):
+                return x * 2.0
+
+        class _FakeMoE(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.gate = _FakeGate()
+                # Singular name — Step-3.5 style.
+                self.share_expert = _FakeShareExpert()
+
+        class _StubFlashMoE:
+            def __call__(self, x, inds, scores):
+                return mx.zeros_like(x)
+
+        replacement = _FlashMoEDeepSeek(_FakeMoE(), _StubFlashMoE())
+
+        x = mx.ones((1, 1, 4))
+        y = replacement(x)
+        # Routed output is zeros; share_expert doubles input → expect 2.0.
+        assert mx.allclose(y, mx.full((1, 1, 4), 2.0))


### PR DESCRIPTION
## Summary

Adds Flash-MoE support for `mlx-community/Step-3.5-Flash-6bit` and any other model that uses Step-3.5's MoE config conventions.

- **Prep:** `is_moe_model()` and `prepare_moe_for_flash()` now recognize `moe_num_experts` (Step-3.5's expert-count key, alongside the existing `n_routed_experts` / `num_local_experts` / `num_experts` aliases).
- **Bundler:** `_detect_moe_layers()` parses `moe_layers_enum` (explicit comma-separated MoE layer indices) when present; takes precedence over freq/offset detection.
- **Runtime:** `_FlashMoEDeepSeek` falls back to `share_expert` (singular) when `shared_experts` (plural) is missing — Step-3.5 uses the singular name. Without this, the shared-expert contribution would silently drop and produce wrong outputs.
- **Loader:** New idempotent `_sanitize_model_config_in_place()` truncates oversized `layer_types` to match `num_hidden_layers`. Step-3.5 ships `len(layer_types)=48` vs `num_hidden_layers=45` (the trailing 3 are MTP, whose weights mlx-lm's sanitize already drops); newer transformers' `validate_layer_type` now rejects the mismatch and blocks any load.

Spec: `docs/superpowers/specs/2026-05-04-step3p5-flash-moe-support-design.md`
Plan: `docs/superpowers/plans/2026-05-04-step3p5-flash-moe-support.md`

## Test Plan

- [x] Unit tests: 6 new tests across `is_moe_model`, `prepare_moe_for_flash`, `_detect_moe_layers`, `_FlashMoEDeepSeek`, `_sanitize_model_config_in_place`. All 83 Flash-MoE tests pass; full suite 2272 pass.
- [x] Manual: `olmlx flash prepare mlx-community/Step-3.5-Flash-6bit` → 42 MoE layers bundled (288 experts each), 144 GB output, `flash info` reports prepared.
- [x] Manual: `olmlx serve` + chat completion against `mlx-community/Step-3.5-Flash-6bit:latest` produces coherent output, validating that `share_expert` is wired correctly.
- [x] Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)