### PR TITLE
fix(inference): preserve content key on assistant tool-call messages

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1456,6 +1456,12 @@ def _normalize_tool_calls_in_messages(messages: list[dict]) -> list[dict]:
     for m in messages:
         if m.get("role") == "assistant" and m.get("tool_calls"):
             m = dict(m)
+            # Templates (Qwen3, Llama3, ...) access message.content directly;
+            # OpenAI clients send content=null on tool-call assistant messages
+            # and the router strips None via exclude_none=True, leaving the
+            # key absent. Coerce to "" so the template can render.
+            if m.get("content") is None:
+                m["content"] = ""
             normalised = []
             for tc in m["tool_calls"]:
                 fn = tc.get("function", tc)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1019,6 +1019,62 @@ class TestNormalizeToolCallsInMessages:
         result = _normalize_tool_calls_in_messages(messages)
         assert result[0]["tool_calls"][0]["arguments"] == {}
 
+    def test_assistant_tool_calls_missing_content_coerced_to_empty(self):
+        """Assistant messages with tool_calls but no content key (e.g. from
+        OpenAI router's model_dump(exclude_none=True) when client sends
+        canonical content=null) must get content="" so chat templates that
+        access message.content (Qwen3, Llama3, etc.) don't fail."""
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+        result = _normalize_tool_calls_in_messages(messages)
+        assert result[0]["content"] == ""
+
+    def test_assistant_tool_calls_none_content_coerced_to_empty(self):
+        """Same coercion when content is explicitly None."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+        result = _normalize_tool_calls_in_messages(messages)
+        assert result[0]["content"] == ""
+
+    def test_assistant_tool_calls_existing_content_preserved(self):
+        """Non-empty content on assistant tool-call messages is preserved."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Let me check.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+        result = _normalize_tool_calls_in_messages(messages)
+        assert result[0]["content"] == "Let me check."
+
 
 class TestGemma4TemplateOrdering:
     """Document Gemma 4 template ordering: system prompt before tool declarations.


### PR DESCRIPTION
## Summary
- Multi-turn tool-use through `/v1/chat/completions` returned HTTP 500 (`Chat template failed even without tools: 'dict object' has no attribute 'content'`) whenever the client sent the canonical OpenAI shape `{"role":"assistant","content":null,"tool_calls":[...]}`. The router's `model_dump(exclude_none=True)` strips the `content` key entirely, and Qwen3/Llama3/etc. templates access `message.content` directly.
- Fix coerces missing/`None` content to `""` inside the existing `_normalize_tool_calls_in_messages` step, so every caller funnelling through `generate_chat` (OpenAI, Ollama, Anthropic) gets the fix.

## Test plan
- [x] New unit tests in `TestNormalizeToolCallsInMessages` cover missing key, explicit `None`, and preservation of existing content.
- [x] `pytest tests/test_inference.py tests/test_routers_openai.py tests/test_routers_chat.py tests/test_routers_anthropic.py` — all green (357 tests).
- [x] `ruff check` + `ruff format --check` — clean.
- [x] End-to-end against a running server with `mlx-community/Qwen3-8B-4bit`: two-turn streaming + tools with canonical `content: null` assistant message now returns 200 and streams the final answer cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)