### PR TITLE
fix(dflash): derive num_target_layers from target_layer_ids, default version to 2

### DIFF
--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -747,16 +747,18 @@ def _resolve_attention_causal(dflash_cfg: dict) -> bool:
     bidirectional; version 1 or missing defaults to causal with a warning
     so operators know to re-train.
     """
-    version = dflash_cfg.get("dflash_attention_version", 1)
+    version = dflash_cfg.get("dflash_attention_version", 2)
     # Accept int, float, and string: JSON doesn't distinguish ``2``
     # from ``2.0`` at the wire level, and a hand-edited config might
     # store ``\"2\"``.  Convert to int so fractional values like
     # ``1.5`` are treated as v1 rather than silently misclassified —
     # version bumps are integers; fractional values are misconfigs.
+    # Default to 2 (bidirectional) when the key is absent — matches
+    # both z-lab pre-trained drafts and current training output.
     try:
         version_int = int(float(version))
     except (TypeError, ValueError):
-        version_int = 1
+        version_int = 2
     if version_int >= 2:
         return False
     logger.warning(
@@ -1831,7 +1833,6 @@ class ModelManager:
             "rope_theta",
             "max_position_embeddings",
             "block_size",
-            "num_target_layers",
         ]
         missing = [k for k in _required_top if k not in draft_cfg_dict]
         _required_dflash = ["target_layer_ids", "mask_token_id"]
@@ -1861,7 +1862,7 @@ class ModelManager:
             rope_theta=draft_cfg_dict["rope_theta"],
             max_position_embeddings=draft_cfg_dict["max_position_embeddings"],
             block_size=draft_cfg_dict["block_size"],
-            num_target_layers=draft_cfg_dict["num_target_layers"],
+            num_target_layers=len(dflash_cfg["target_layer_ids"]),
             target_layer_ids=list(dflash_cfg["target_layer_ids"]),
             mask_token_id=int(dflash_cfg["mask_token_id"]),
             rope_scaling=draft_cfg_dict.get("rope_scaling"),


### PR DESCRIPTION
Two loader fixes for z-lab pre-trained DFlash draft compatibility:

- **num_target_layers**: z-lab configs use this for the TARGET model's total layer count (e.g. 40 for Qwen3.5-35B-A3B), but the fc projection needs `len(target_layer_ids)=5`. Derive from `len(target_layer_ids)` instead of reading the config field.

- **dflash_attention_version**: Default to 2 (bidirectional) when the key is absent. z-lab pre-trained drafts use bidirectional attention and don't carry the version key. Version 1 (causal) only fires when explicitly set in the config.