### PR TITLE
feat(flash-moe): support classic speculative decoding on Flash-MoE targets

### DIFF
--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -580,17 +580,18 @@ def _apply_serve_overrides(args) -> None:
             "Note: flash-speculative is still experimental.",
             ", ".join(flash_conflicts_actionable),
         )
-    # dflash on Flash-MoE models will raise ValueError at load time;
-    # warn at startup so users see the incompatibility early.
-    dflash_moe_actionable = [m for m in dflash_moe_conflicts if m not in set(bad)]
-    if dflash_moe_actionable:
+    # dflash on Flash-MoE models will raise ValueError at load time once
+    # the Flash-MoE bundle is prepared and loaded; warn at startup so
+    # users see the incompatibility early.
+    if dflash_moe_conflicts:
         logger.warning(
             "The following models combine speculative_strategy='dflash' "
-            "with Flash-MoE, which is unsupported (dflash requires "
+            "with Flash-MoE. Once Flash-MoE is prepared and loads, this "
+            "will raise a ValueError at load time (dflash requires "
             "hidden-state capture that does not generalize to MoE "
             "routing): %s. Use speculative_strategy='classic' or set "
             "speculative=false.",
-            ", ".join(dflash_moe_actionable),
+            ", ".join(dflash_moe_conflicts),
         )
     if bad:
         print(
@@ -717,7 +718,7 @@ def _audit_speculative_config() -> tuple[
     global_draft_used = False
     for name, mc in registry.list_models().items():
         try:
-            enabled, draft, strategy, _ = mc.resolved_speculative()
+            enabled, draft, _, strategy = mc.resolved_speculative()
         except Exception as exc:
             # ``resolved_speculative`` reads ``settings`` and could
             # raise if the runtime ``Settings`` is in an unexpected

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -582,8 +582,11 @@ def _apply_serve_overrides(args) -> None:
         )
     # dflash on Flash-MoE models will raise ValueError at load time once
     # the Flash-MoE bundle is prepared and loaded; warn at startup so
-    # users see the incompatibility early.
-    if dflash_moe_conflicts:
+    # users see the incompatibility early. Filter models also in ``bad``
+    # (missing draft) — the "use classic strategy" suggestion is
+    # misleading when there is no draft model configured at all.
+    dflash_moe_actionable = [m for m in dflash_moe_conflicts if m not in set(bad)]
+    if dflash_moe_actionable:
         logger.warning(
             "The following models combine speculative_strategy='dflash' "
             "with Flash-MoE. Once Flash-MoE is prepared and loads, this "
@@ -591,7 +594,7 @@ def _apply_serve_overrides(args) -> None:
             "hidden-state capture that does not generalize to MoE "
             "routing): %s. Use speculative_strategy='classic' or set "
             "speculative=false.",
-            ", ".join(dflash_moe_conflicts),
+            ", ".join(dflash_moe_actionable),
         )
     if bad:
         print(

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -570,8 +570,8 @@ def _apply_serve_overrides(args) -> None:
         # warning is advisory; the authoritative runtime warning lives
         # in ``_load_model`` for the case where Flash actually wins.
         logger.warning(
-            "The following models combine speculative=true with Flash or "
-            "Flash-MoE: %s. Once Flash is prepared and loads, standalone "
+            "The following models combine speculative=true with Flash: "
+            "%s. Once Flash is prepared and loads, standalone "
             "speculative decoding is dropped — use the per-model "
             "``flash_speculative`` field (or "
             "OLMLX_EXPERIMENTAL_FLASH_SPECULATIVE / "
@@ -651,10 +651,11 @@ def _audit_speculative_config() -> tuple[list[str], list[str], list[str], bool]:
       set but the resolved ``enabled`` flag is False. Triggers a
       warning so users don't silently lose the draft they configured.
     - ``flash_conflicts`` — models that combine ``speculative=True``
-      with Flash or Flash-MoE in the same entry. Standalone speculative
-      decoding is silently dropped on the Flash load path; the model's
-      own ``flash_speculative`` knob is the right one. Triggers a
-      warning so users see the redirect.
+      with Flash in the same entry. Standalone speculative decoding is
+      silently dropped on the Flash load path; the model's own
+      ``flash_speculative`` knob is the right one. Triggers a warning
+      so users see the redirect. Flash-MoE supports standalone speculative
+      (classic strategy only) and is excluded from this check.
     - ``global_draft_used`` — True if at least one model resolves to
       the global ``speculative_draft_model`` (i.e. has ``speculative=True``
       and no per-model draft override). Used to suppress the global
@@ -742,7 +743,7 @@ def _audit_speculative_config() -> tuple[list[str], list[str], list[str], bool]:
                     exc_info=True,
                 )
                 continue
-            if resolved_exp.flash or resolved_exp.flash_moe:
+            if resolved_exp.flash:
                 flash_conflicts.append(name)
     return bad, dormant, flash_conflicts, global_draft_used
 

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -652,7 +652,7 @@ def _models_with_promoted_keys_in_experimental() -> list[str]:
     return bad
 
 
-def _audit_speculative_config() -> tuple[list[str], list[str], list[str], bool]:
+def _audit_speculative_config() -> tuple[list[str], list[str], list[str], list[str], bool]:
     """Walk the registry and audit each model's resolved speculative
     config.
 

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -532,7 +532,7 @@ def _apply_serve_overrides(args) -> None:
         )
         sys.exit(1)
 
-    bad, dormant_drafts, flash_conflicts, global_draft_used = (
+    bad, dormant_drafts, flash_conflicts, dflash_moe_conflicts, global_draft_used = (
         _audit_speculative_config()
     )
     if dormant_drafts:
@@ -579,6 +579,18 @@ def _apply_serve_overrides(args) -> None:
             "OLMLX_EXPERIMENTAL_FLASH_SPECULATIVE_TOKENS) instead. "
             "Note: flash-speculative is still experimental.",
             ", ".join(flash_conflicts_actionable),
+        )
+    # dflash on Flash-MoE models will raise ValueError at load time;
+    # warn at startup so users see the incompatibility early.
+    dflash_moe_actionable = [m for m in dflash_moe_conflicts if m not in set(bad)]
+    if dflash_moe_actionable:
+        logger.warning(
+            "The following models combine speculative_strategy='dflash' "
+            "with Flash-MoE, which is unsupported (dflash requires "
+            "hidden-state capture that does not generalize to MoE "
+            "routing): %s. Use speculative_strategy='classic' or set "
+            "speculative=false.",
+            ", ".join(dflash_moe_actionable),
         )
     if bad:
         print(
@@ -656,6 +668,10 @@ def _audit_speculative_config() -> tuple[list[str], list[str], list[str], bool]:
       ``flash_speculative`` knob is the right one. Triggers a warning
       so users see the redirect. Flash-MoE supports standalone speculative
       (classic strategy only) and is excluded from this check.
+    - ``dflash_moe_conflicts`` — models that combine
+      ``speculative_strategy='dflash'`` with Flash-MoE. Triggers a
+      warning since dflash is unsupported on MoE targets (raises
+      ValueError at load time).
     - ``global_draft_used`` — True if at least one model resolves to
       the global ``speculative_draft_model`` (i.e. has ``speculative=True``
       and no per-model draft override). Used to suppress the global
@@ -682,7 +698,7 @@ def _audit_speculative_config() -> tuple[list[str], list[str], list[str], bool]:
             "Skipping speculative config validation: invalid models.json entry: %s",
             exc,
         )
-        return [], [], [], False
+        return [], [], [], [], False
     except OSError as exc:
         # I/O failures: never block startup. The catch is narrow so
         # programming errors (typos, missing attributes, etc.) inside
@@ -691,14 +707,15 @@ def _audit_speculative_config() -> tuple[list[str], list[str], list[str], bool]:
             "Skipping speculative config validation: could not load registry: %s",
             exc,
         )
-        return [], [], [], False
+        return [], [], [], [], False
     bad: list[str] = []
     dormant: list[str] = []
     flash_conflicts: list[str] = []
+    dflash_moe_conflicts: list[str] = []
     global_draft_used = False
     for name, mc in registry.list_models().items():
         try:
-            enabled, draft, _, _ = mc.resolved_speculative()
+            enabled, draft, strategy, _ = mc.resolved_speculative()
         except Exception as exc:
             # ``resolved_speculative`` reads ``settings`` and could
             # raise if the runtime ``Settings`` is in an unexpected
@@ -745,7 +762,9 @@ def _audit_speculative_config() -> tuple[list[str], list[str], list[str], bool]:
                 continue
             if resolved_exp.flash:
                 flash_conflicts.append(name)
-    return bad, dormant, flash_conflicts, global_draft_used
+            if resolved_exp.flash_moe and strategy == "dflash":
+                dflash_moe_conflicts.append(name)
+    return bad, dormant, flash_conflicts, dflash_moe_conflicts, global_draft_used
 
 
 # Module-level state set by cmd_serve() for the app lifespan to retrieve.

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -652,7 +652,9 @@ def _models_with_promoted_keys_in_experimental() -> list[str]:
     return bad
 
 
-def _audit_speculative_config() -> tuple[list[str], list[str], list[str], list[str], bool]:
+def _audit_speculative_config() -> tuple[
+    list[str], list[str], list[str], list[str], bool
+]:
     """Walk the registry and audit each model's resolved speculative
     config.
 

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2297,7 +2297,7 @@ class ModelManager:
                 )
                 if spec_enabled:
                     decoder = self._load_speculative_decoder(
-                        model, hf_path, spec_config
+                        model, hf_path, spec_config, is_vlm=is_vlm
                     )
                     return model, tokenizer, is_vlm, caps, decoder
                 return model, tokenizer, is_vlm, caps, None

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2292,14 +2292,14 @@ class ModelManager:
                         "Flash-MoE targets. Use speculative_strategy='classic' "
                         "or remove the speculative settings."
                     )
-                model, tokenizer, is_vlm, caps = self._load_flash_moe_model(
-                    hf_path, load_path, flash_moe_dir, model_exp=model_exp
-                )
                 if spec_enabled and model_exp.flash_speculative:
                     raise ValueError(
                         "Only one speculative decoder can be active at a time; "
                         "got both 'speculative' and 'flash_speculative'."
                     )
+                model, tokenizer, is_vlm, caps = self._load_flash_moe_model(
+                    hf_path, load_path, flash_moe_dir, model_exp=model_exp
+                )
                 if spec_enabled:
                     decoder = self._load_speculative_decoder(
                         model, hf_path, spec_config, is_vlm=is_vlm

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2295,6 +2295,11 @@ class ModelManager:
                 model, tokenizer, is_vlm, caps = self._load_flash_moe_model(
                     hf_path, load_path, flash_moe_dir, model_exp=model_exp
                 )
+                if spec_enabled and model_exp.flash_speculative:
+                    raise ValueError(
+                        "Only one speculative decoder can be active at a time; "
+                        "got both 'speculative' and 'flash_speculative'."
+                    )
                 if spec_enabled:
                     decoder = self._load_speculative_decoder(
                         model, hf_path, spec_config, is_vlm=is_vlm

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2304,7 +2304,7 @@ class ModelManager:
                 )
                 if spec_enabled:
                     decoder = self._load_speculative_decoder(
-                        model, hf_path, spec_config, is_vlm=False
+                        model, hf_path, spec_config, is_vlm=is_vlm
                     )
                     return model, tokenizer, is_vlm, caps, decoder
                 return model, tokenizer, is_vlm, caps, None

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2292,17 +2292,19 @@ class ModelManager:
                         "Flash-MoE targets. Use speculative_strategy='classic' "
                         "or remove the speculative settings."
                     )
-                if spec_enabled and model_exp.flash_speculative:
+                if model_exp.flash_speculative:
                     raise ValueError(
-                        "Only one speculative decoder can be active at a time; "
-                        "got both 'speculative' and 'flash_speculative'."
+                        "flash_speculative is not supported on Flash-MoE "
+                        "targets. Remove flash_speculative from models.json "
+                        "(or unset OLMLX_EXPERIMENTAL_FLASH_SPECULATIVE) and "
+                        "use speculative instead."
                     )
                 model, tokenizer, is_vlm, caps = self._load_flash_moe_model(
                     hf_path, load_path, flash_moe_dir, model_exp=model_exp
                 )
                 if spec_enabled:
                     decoder = self._load_speculative_decoder(
-                        model, hf_path, spec_config, is_vlm=is_vlm
+                        model, hf_path, spec_config, is_vlm=False
                     )
                     return model, tokenizer, is_vlm, caps, decoder
                 return model, tokenizer, is_vlm, caps, None

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2286,19 +2286,21 @@ class ModelManager:
         if self._is_flash_moe_enabled(model_exp):
             flash_moe_dir = self._flash_moe_dir(hf_path)
             if flash_moe_dir is not None:
-                if spec_enabled:
-                    logger.warning(
-                        "OLMLX_SPECULATIVE is enabled but %s is loaded via "
-                        "Flash-MoE, which does not support standalone "
-                        "speculative decoding; the setting will be ignored.",
-                        hf_path,
+                if spec_enabled and spec_config.strategy == "dflash":
+                    raise ValueError(
+                        "speculative_strategy='dflash' is not supported on "
+                        "Flash-MoE targets. Use speculative_strategy='classic' "
+                        "or remove the speculative settings."
                     )
-                return (
-                    *self._load_flash_moe_model(
-                        hf_path, load_path, flash_moe_dir, model_exp=model_exp
-                    ),
-                    None,
+                model, tokenizer, is_vlm, caps = self._load_flash_moe_model(
+                    hf_path, load_path, flash_moe_dir, model_exp=model_exp
                 )
+                if spec_enabled:
+                    decoder = self._load_speculative_decoder(
+                        model, hf_path, spec_config
+                    )
+                    return model, tokenizer, is_vlm, caps, decoder
+                return model, tokenizer, is_vlm, caps, None
 
         # Check for flash-prepared model
         if self._is_flash_enabled(model_exp):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -592,7 +592,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: (["bad/model:latest"], [], [], False),
+            lambda: (["bad/model:latest"], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -693,7 +693,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: (["m:latest"], [], ["m:latest"], False),
+            lambda: (["m:latest"], [], ["m:latest"], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -721,7 +721,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], ["flash/model:latest"], False),
+            lambda: ([], [], ["flash/model:latest"], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -745,7 +745,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], ["dormant/model:latest"], [], False),
+            lambda: ([], ["dormant/model:latest"], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -972,6 +972,36 @@ class TestBuildParser:
         # No model in this fixture uses the global draft (good/a has its own).
         assert global_used is False
 
+    def test_audit_dflags_flash_moe_conflicts(self, monkeypatch, tmp_path):
+        """dflash + Flash-MoE populates the dflash_moe_conflicts bucket."""
+        from olmlx.cli import _audit_speculative_config
+        from olmlx.config import settings as _settings
+
+        models_json = tmp_path / "models.json"
+        models_json.write_text(
+            json.dumps(
+                {
+                    "moe-dflash/m:latest": {
+                        "hf_path": "moe-dflash/m",
+                        "speculative": True,
+                        "speculative_strategy": "dflash",
+                        "speculative_draft_model": "moe-dflash/draft",
+                        "experimental": {"flash_moe": True},
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr(_settings, "models_config", models_json)
+        monkeypatch.setattr(_settings, "speculative", False)
+        monkeypatch.setattr(_settings, "speculative_draft_model", None)
+
+        bad, dormant, flash, dflash_moe, global_used = _audit_speculative_config()
+        assert bad == []
+        assert dormant == []
+        assert flash == []
+        assert dflash_moe == ["moe-dflash/m:latest"]
+        assert global_used is False
+
     def test_service_install(self):
         parser = build_parser()
         args = parser.parse_args(["service", "install"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -339,7 +339,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_tokens", None)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], [], False),
+            lambda: ([], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -375,7 +375,7 @@ class TestBuildParser:
         # Stub out registry-walking helpers so the test is hermetic.
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], [], False),
+            lambda: ([], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -418,7 +418,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_tokens", None)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], [], False),
+            lambda: ([], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -445,7 +445,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_tokens", 4)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], [], False),
+            lambda: ([], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -473,7 +473,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_tokens", 4)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], [], False),
+            lambda: ([], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -510,7 +510,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_tokens", 4)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], [], False),
+            lambda: ([], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -540,7 +540,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_tokens", 4)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], [], False),
+            lambda: ([], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -564,7 +564,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative", False)
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
         monkeypatch.setattr(
-            "olmlx.cli._audit_speculative_config", lambda: ([], [], [], False)
+            "olmlx.cli._audit_speculative_config", lambda: ([], [], [], [], False)
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -648,7 +648,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative", False)
         monkeypatch.setattr(_settings, "speculative_draft_model", "global/draft")
         monkeypatch.setattr(
-            "olmlx.cli._audit_speculative_config", lambda: ([], [], [], False)
+            "olmlx.cli._audit_speculative_config", lambda: ([], [], [], [], False)
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -916,10 +916,13 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
         monkeypatch.setattr(_exp, "flash", True)
 
-        bad, dormant, flash_conflicts, _global_used = _audit_speculative_config()
+        bad, dormant, flash_conflicts, dflash_moe_conflicts, _global_used = (
+            _audit_speculative_config()
+        )
         assert bad == []
         assert dormant == []
         assert flash_conflicts == ["global-flash/m:latest"]
+        assert dflash_moe_conflicts == []
 
     def test_audit_speculative_config_classifies_models(self, monkeypatch, tmp_path):
         """End-to-end: registry walk classifies models into bad / dormant /
@@ -957,12 +960,15 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative", False)
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
 
-        bad, dormant, flash_conflicts, global_used = _audit_speculative_config()
+        bad, dormant, flash_conflicts, dflash_moe_conflicts, global_used = (
+            _audit_speculative_config()
+        )
         # Compare as sets so the test isn't coupled to the registry's
         # internal iteration order.
         assert set(bad) == {"bad/no-draft:latest"}
         assert set(dormant) == {"dormant/has-draft:latest"}
         assert set(flash_conflicts) == {"conflict/flash-and-spec:latest"}
+        assert dflash_moe_conflicts == []
         # No model in this fixture uses the global draft (good/a has its own).
         assert global_used is False
 

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -2767,9 +2767,7 @@ class TestSpeculativeLoading:
         assert "OLMLX_SPECULATIVE" in caplog.text
         assert "Flash" in caplog.text
 
-    def test_flash_moe_path_supports_classic_speculative(
-        self, monkeypatch, caplog
-    ):
+    def test_flash_moe_path_supports_classic_speculative(self, monkeypatch, caplog):
         """Flash-MoE + classic speculative should load the decoder (not drop it)."""
         import logging
 
@@ -2825,9 +2823,7 @@ class TestSpeculativeLoading:
         model_exp = ExperimentalSettings(_env_file=None)
         spec_config = SpeculativeConfig(True, "test/draft", 4, strategy="dflash")
 
-        with pytest.raises(
-            ValueError, match="dflash.*not supported on Flash-MoE"
-        ):
+        with pytest.raises(ValueError, match="dflash.*not supported on Flash-MoE"):
             manager._load_model(
                 "test/moe-model", model_exp=model_exp, spec_config=spec_config
             )

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -2767,11 +2767,10 @@ class TestSpeculativeLoading:
         assert "OLMLX_SPECULATIVE" in caplog.text
         assert "Flash" in caplog.text
 
-    def test_flash_moe_path_warns_when_standalone_speculative_set(
+    def test_flash_moe_path_supports_classic_speculative(
         self, monkeypatch, caplog
     ):
-        """Symmetric to the Flash test: a Flash-MoE model with the
-        standalone speculative flag must log a warning."""
+        """Flash-MoE + classic speculative should load the decoder (not drop it)."""
         import logging
 
         from olmlx.config import ExperimentalSettings
@@ -2791,6 +2790,12 @@ class TestSpeculativeLoading:
             "_load_flash_moe_model",
             lambda hf_path, load_path, flash_moe_dir, *, model_exp: sentinel_load,
         )
+        sentinel_decoder = object()
+        monkeypatch.setattr(
+            manager,
+            "_load_speculative_decoder",
+            lambda model, hf_path, spec_config, *, is_vlm=False: sentinel_decoder,
+        )
 
         model_exp = ExperimentalSettings(_env_file=None)
         spec_config = SpeculativeConfig(True, "test/draft", 4)
@@ -2799,11 +2804,33 @@ class TestSpeculativeLoading:
             model, tokenizer, is_vlm, caps, decoder = manager._load_model(
                 "test/moe-model", model_exp=model_exp, spec_config=spec_config
             )
-        # Flash-MoE path returns the sentinel followed by None.
+        # Flash-MoE now supports classic speculative; decoder is loaded.
         assert (model, tokenizer, is_vlm, caps) == sentinel_load
-        assert decoder is None
-        assert "OLMLX_SPECULATIVE" in caplog.text
-        assert "Flash-MoE" in caplog.text
+        assert decoder is sentinel_decoder
+
+    def test_flash_moe_path_rejects_dflash(self, monkeypatch):
+        """Flash-MoE + dflash should raise ValueError."""
+        from olmlx.config import ExperimentalSettings
+
+        registry = MagicMock()
+        store = MagicMock()
+        store.ensure_downloaded.return_value = Path("/tmp/test-moe")
+
+        manager = ModelManager(registry, store)
+        monkeypatch.setattr(manager, "_is_flash_moe_enabled", lambda *a: True)
+        monkeypatch.setattr(
+            manager, "_flash_moe_dir", lambda hf_path: Path("/tmp/test-moe/flash_moe")
+        )
+
+        model_exp = ExperimentalSettings(_env_file=None)
+        spec_config = SpeculativeConfig(True, "test/draft", 4, strategy="dflash")
+
+        with pytest.raises(
+            ValueError, match="dflash.*not supported on Flash-MoE"
+        ):
+            manager._load_model(
+                "test/moe-model", model_exp=model_exp, spec_config=spec_config
+            )
 
 
 class TestDFlashLoading:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -2805,6 +2805,7 @@ class TestSpeculativeLoading:
         # Flash-MoE now supports classic speculative; decoder is loaded.
         assert (model, tokenizer, is_vlm, caps) == sentinel_load
         assert decoder is sentinel_decoder
+        assert "OLMLX_SPECULATIVE" not in caplog.text
 
     def test_flash_moe_path_rejects_dflash(self, monkeypatch):
         """Flash-MoE + dflash should raise ValueError."""

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -2829,6 +2829,30 @@ class TestSpeculativeLoading:
                 "test/moe-model", model_exp=model_exp, spec_config=spec_config
             )
 
+    def test_flash_moe_path_rejects_flash_speculative(self, monkeypatch):
+        """Flash-MoE + flash_speculative should raise ValueError."""
+        from olmlx.config import ExperimentalSettings
+
+        registry = MagicMock()
+        store = MagicMock()
+        store.ensure_downloaded.return_value = Path("/tmp/test-moe")
+
+        manager = ModelManager(registry, store)
+        monkeypatch.setattr(manager, "_is_flash_moe_enabled", lambda *a: True)
+        monkeypatch.setattr(
+            manager, "_flash_moe_dir", lambda hf_path: Path("/tmp/test-moe/flash_moe")
+        )
+
+        model_exp = ExperimentalSettings(_env_file=None, flash_speculative=True)
+        spec_config = SpeculativeConfig(False, None, 4)
+
+        with pytest.raises(
+            ValueError, match="flash_speculative.*not supported on Flash-MoE"
+        ):
+            manager._load_model(
+                "test/moe-model", model_exp=model_exp, spec_config=spec_config
+            )
+
 
 class TestDFlashLoading:
     """Tests for dflash decoder loading in _load_model."""


### PR DESCRIPTION
## Summary

- Enables standalone speculative decoding (classic strategy) on Flash-MoE models, which was previously silently dropped with a warning.
- Explicitly rejects `dflash` strategy on Flash-MoE with a clear `ValueError`, since dflash requires hidden-state capture that doesn't generalize to MoE routing.
- Updates the speculative config auditor to exclude Flash-MoE from flash conflict warnings.
- Adds test coverage for both the supported classic path and the rejected dflash path.

**Changes**: 3 files, +55/-25 lines.