### PR TITLE
fix(audit): warn on classic speculative + hybrid linear-attention target

### DIFF
--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -532,9 +532,14 @@ def _apply_serve_overrides(args) -> None:
         )
         sys.exit(1)
 
-    bad, dormant_drafts, flash_conflicts, dflash_moe_conflicts, global_draft_used = (
-        _audit_speculative_config()
-    )
+    (
+        bad,
+        dormant_drafts,
+        flash_conflicts,
+        dflash_moe_conflicts,
+        hybrid_classic_conflicts,
+        global_draft_used,
+    ) = _audit_speculative_config()
     if dormant_drafts:
         logger.warning(
             "speculative_draft_model is configured for the following "
@@ -596,6 +601,27 @@ def _apply_serve_overrides(args) -> None:
             "speculative=false.",
             ", ".join(dflash_moe_actionable),
         )
+    # Classic speculative on hybrid linear-attention targets produces
+    # silent output corruption (special vocab tokens leak mid-content;
+    # generation often runs to max_tokens). Suppress for models in
+    # ``bad`` — the missing-draft error is the actionable fix there.
+    hybrid_classic_actionable = [
+        m for m in hybrid_classic_conflicts if m not in set(bad)
+    ]
+    if hybrid_classic_actionable:
+        logger.warning(
+            "The following models combine classic speculative decoding "
+            "with a hybrid linear-attention target (Qwen3.5 / Qwen3.6 / "
+            "Qwen3-Coder-Next family): %s. Classic speculative cannot "
+            "roll back the GatedDeltaNet recurrent state on draft "
+            "rejection (mlx-lm's trim_prompt_cache is a no-op for any "
+            "CacheList containing ArraysCache), so output silently "
+            "corrupts: special vocab tokens leak mid-content and "
+            "generation often runs to max_tokens. Set "
+            "speculative_strategy='dflash' (requires a trained DFlash "
+            "draft; see `olmlx dflash prepare`) or speculative=false.",
+            ", ".join(hybrid_classic_actionable),
+        )
     if bad:
         print(
             "Error: the following models in models.json enable speculative "
@@ -656,13 +682,68 @@ def _models_with_promoted_keys_in_experimental() -> list[str]:
     return bad
 
 
+def _is_hybrid_linear_attention_target(hf_path: str) -> bool:
+    """Detect whether a target model uses hybrid linear-attention layers
+    (mlx-lm ``GatedDeltaNet`` / ``ArraysCache``).
+
+    Classic speculative decoding cannot roll back ``ArraysCache`` recurrent
+    state on draft rejection: ``trim_prompt_cache`` is a no-op for any
+    ``CacheList`` containing an ``ArraysCache`` layer (``is_trimmable()``
+    returns False), so the cache stays desynced from the accepted token
+    sequence after the first rejection. The model then emits special
+    vocab tokens (``<|im_start|>``, ``<|im_end|>``) mid-content and either
+    terminates randomly or runs to ``max_tokens`` producing garbage.
+    DFlash works because ``_GDNStateCapture`` replays
+    ``gated_delta_update`` on the accepted prefix.
+
+    Heuristics, read from the downloaded ``config.json``:
+
+    - ``text_config.layer_types`` contains ``"linear_attention"`` —
+      Qwen3.5 / Qwen3.6 / Qwen3.5_moe family.
+    - Top-level ``model_type == "qwen3_next"`` — Qwen3-Coder-Next, which
+      declares its hybrid layout via ``full_attention_interval`` rather
+      than ``layer_types``.
+    - Top-level ``layer_types`` contains ``"linear_attention"`` —
+      forward-compat for hybrid models that ship without a nested
+      ``text_config``.
+
+    Returns False (rather than raising) when the model has not been
+    downloaded yet — the audit will fire on the first server startup
+    after the model is pulled. Returns False on unparseable config too;
+    a malformed ``config.json`` is an operator error that surfaces at
+    load time.
+    """
+    from olmlx.models.store import _safe_dir_name
+
+    cfg_path = settings.models_dir / _safe_dir_name(hf_path) / "config.json"
+    try:
+        with open(cfg_path) as f:
+            cfg = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return False
+    if not isinstance(cfg, dict):
+        return False
+    if cfg.get("model_type") == "qwen3_next":
+        return True
+    text_cfg = cfg.get("text_config")
+    if isinstance(text_cfg, dict):
+        lt = text_cfg.get("layer_types")
+        if isinstance(lt, list) and "linear_attention" in lt:
+            return True
+    lt_top = cfg.get("layer_types")
+    if isinstance(lt_top, list) and "linear_attention" in lt_top:
+        return True
+    return False
+
+
 def _audit_speculative_config() -> tuple[
-    list[str], list[str], list[str], list[str], bool
+    list[str], list[str], list[str], list[str], list[str], bool
 ]:
     """Walk the registry and audit each model's resolved speculative
     config.
 
-    Returns ``(bad, dormant_drafts, flash_conflicts, global_draft_used)``:
+    Returns ``(bad, dormant_drafts, flash_conflicts, dflash_moe_conflicts,
+    hybrid_classic_conflicts, global_draft_used)``:
     - ``bad`` — models with ``speculative=True`` but no draft model
       anywhere. Triggers a startup error.
     - ``dormant_drafts`` — models with a per-model ``speculative_draft_model``
@@ -678,6 +759,12 @@ def _audit_speculative_config() -> tuple[
       ``speculative_strategy='dflash'`` with Flash-MoE. Triggers a
       warning since dflash is unsupported on MoE targets (raises
       ValueError at load time).
+    - ``hybrid_classic_conflicts`` — models that combine
+      ``speculative_strategy='classic'`` (the default) with a hybrid
+      linear-attention target (Qwen3.5 / Qwen3.6 / Qwen3-Coder-Next).
+      Triggers a warning since the cache cannot be rolled back on draft
+      rejection, producing silent output corruption. See
+      ``_is_hybrid_linear_attention_target`` for the discriminator.
     - ``global_draft_used`` — True if at least one model resolves to
       the global ``speculative_draft_model`` (i.e. has ``speculative=True``
       and no per-model draft override). Used to suppress the global
@@ -704,7 +791,7 @@ def _audit_speculative_config() -> tuple[
             "Skipping speculative config validation: invalid models.json entry: %s",
             exc,
         )
-        return [], [], [], [], False
+        return [], [], [], [], [], False
     except OSError as exc:
         # I/O failures: never block startup. The catch is narrow so
         # programming errors (typos, missing attributes, etc.) inside
@@ -713,11 +800,12 @@ def _audit_speculative_config() -> tuple[
             "Skipping speculative config validation: could not load registry: %s",
             exc,
         )
-        return [], [], [], [], False
+        return [], [], [], [], [], False
     bad: list[str] = []
     dormant: list[str] = []
     flash_conflicts: list[str] = []
     dflash_moe_conflicts: list[str] = []
+    hybrid_classic_conflicts: list[str] = []
     global_draft_used = False
     for name, mc in registry.list_models().items():
         try:
@@ -770,7 +858,28 @@ def _audit_speculative_config() -> tuple[
                 flash_conflicts.append(name)
             if resolved_exp.flash_moe and strategy == "dflash":
                 dflash_moe_conflicts.append(name)
-    return bad, dormant, flash_conflicts, dflash_moe_conflicts, global_draft_used
+            # Classic speculative + hybrid linear-attention target is
+            # silent-corruption territory. Skip when Flash / Flash-MoE
+            # is also configured: Flash dense uses the
+            # ``flash_speculative`` knob (caught above), and Flash-MoE
+            # speculative is classic-only on a separate code path. The
+            # hybrid-trim bug is specific to the standalone speculative
+            # decoder.
+            if (
+                strategy == "classic"
+                and not resolved_exp.flash
+                and not resolved_exp.flash_moe
+                and _is_hybrid_linear_attention_target(mc.hf_path)
+            ):
+                hybrid_classic_conflicts.append(name)
+    return (
+        bad,
+        dormant,
+        flash_conflicts,
+        dflash_moe_conflicts,
+        hybrid_classic_conflicts,
+        global_draft_used,
+    )
 
 
 # Module-level state set by cmd_serve() for the app lifespan to retrieve.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -339,7 +339,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_tokens", None)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], [], [], False),
+            lambda: ([], [], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -375,7 +375,7 @@ class TestBuildParser:
         # Stub out registry-walking helpers so the test is hermetic.
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], [], [], False),
+            lambda: ([], [], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -418,7 +418,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_tokens", None)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], [], [], False),
+            lambda: ([], [], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -445,7 +445,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_tokens", 4)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], [], [], False),
+            lambda: ([], [], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -473,7 +473,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_tokens", 4)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], [], [], False),
+            lambda: ([], [], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -510,7 +510,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_tokens", 4)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], [], [], False),
+            lambda: ([], [], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -540,7 +540,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_tokens", 4)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], [], [], False),
+            lambda: ([], [], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -564,7 +564,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative", False)
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
         monkeypatch.setattr(
-            "olmlx.cli._audit_speculative_config", lambda: ([], [], [], [], False)
+            "olmlx.cli._audit_speculative_config", lambda: ([], [], [], [], [], False)
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -592,7 +592,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: (["bad/model:latest"], [], [], [], False),
+            lambda: (["bad/model:latest"], [], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -648,7 +648,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative", False)
         monkeypatch.setattr(_settings, "speculative_draft_model", "global/draft")
         monkeypatch.setattr(
-            "olmlx.cli._audit_speculative_config", lambda: ([], [], [], [], False)
+            "olmlx.cli._audit_speculative_config", lambda: ([], [], [], [], [], False)
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -693,7 +693,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: (["m:latest"], [], ["m:latest"], [], False),
+            lambda: (["m:latest"], [], ["m:latest"], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -721,7 +721,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], [], ["flash/model:latest"], [], False),
+            lambda: ([], [], ["flash/model:latest"], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -745,7 +745,7 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
         monkeypatch.setattr(
             "olmlx.cli._audit_speculative_config",
-            lambda: ([], ["dormant/model:latest"], [], [], False),
+            lambda: ([], ["dormant/model:latest"], [], [], [], False),
         )
         monkeypatch.setattr(
             "olmlx.cli._models_with_promoted_keys_in_experimental", lambda: []
@@ -916,13 +916,19 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
         monkeypatch.setattr(_exp, "flash", True)
 
-        bad, dormant, flash_conflicts, dflash_moe_conflicts, _global_used = (
-            _audit_speculative_config()
-        )
+        (
+            bad,
+            dormant,
+            flash_conflicts,
+            dflash_moe_conflicts,
+            hybrid_classic_conflicts,
+            _global_used,
+        ) = _audit_speculative_config()
         assert bad == []
         assert dormant == []
         assert flash_conflicts == ["global-flash/m:latest"]
         assert dflash_moe_conflicts == []
+        assert hybrid_classic_conflicts == []
 
     def test_audit_speculative_config_classifies_models(self, monkeypatch, tmp_path):
         """End-to-end: registry walk classifies models into bad / dormant /
@@ -960,15 +966,21 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative", False)
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
 
-        bad, dormant, flash_conflicts, dflash_moe_conflicts, global_used = (
-            _audit_speculative_config()
-        )
+        (
+            bad,
+            dormant,
+            flash_conflicts,
+            dflash_moe_conflicts,
+            hybrid_classic_conflicts,
+            global_used,
+        ) = _audit_speculative_config()
         # Compare as sets so the test isn't coupled to the registry's
         # internal iteration order.
         assert set(bad) == {"bad/no-draft:latest"}
         assert set(dormant) == {"dormant/has-draft:latest"}
         assert set(flash_conflicts) == {"conflict/flash-and-spec:latest"}
         assert dflash_moe_conflicts == []
+        assert hybrid_classic_conflicts == []
         # No model in this fixture uses the global draft (good/a has its own).
         assert global_used is False
 
@@ -995,12 +1007,193 @@ class TestBuildParser:
         monkeypatch.setattr(_settings, "speculative", False)
         monkeypatch.setattr(_settings, "speculative_draft_model", None)
 
-        bad, dormant, flash, dflash_moe, global_used = _audit_speculative_config()
+        (
+            bad,
+            dormant,
+            flash,
+            dflash_moe,
+            hybrid_classic,
+            global_used,
+        ) = _audit_speculative_config()
         assert bad == []
         assert dormant == []
         assert flash == []
         assert dflash_moe == ["moe-dflash/m:latest"]
+        assert hybrid_classic == []
         assert global_used is False
+
+    def test_is_hybrid_linear_attention_target_detects_each_format(
+        self, monkeypatch, tmp_path
+    ):
+        """The helper recognizes all three hybrid layouts seen in the wild."""
+        from olmlx.cli import _is_hybrid_linear_attention_target
+        from olmlx.config import settings as _settings
+        from olmlx.models.store import _safe_dir_name
+
+        monkeypatch.setattr(_settings, "models_dir", tmp_path)
+
+        def write_config(hf_path: str, cfg: dict) -> None:
+            d = tmp_path / _safe_dir_name(hf_path)
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "config.json").write_text(json.dumps(cfg))
+
+        # Qwen3.5 family: text_config.layer_types
+        write_config(
+            "qwen3_5/hybrid",
+            {
+                "model_type": "qwen3_5",
+                "text_config": {
+                    "model_type": "qwen3_5_text",
+                    "layer_types": ["full_attention", "linear_attention"],
+                },
+            },
+        )
+        # Qwen3-Coder-Next: top-level model_type, no layer_types array
+        write_config(
+            "qwen/coder-next",
+            {"model_type": "qwen3_next", "full_attention_interval": 4},
+        )
+        # Forward-compat: top-level layer_types
+        write_config(
+            "hybrid/top-level",
+            {
+                "model_type": "future_hybrid",
+                "layer_types": ["full_attention", "linear_attention"],
+            },
+        )
+        # Non-hybrid (plain qwen3 dense)
+        write_config("plain/qwen3", {"model_type": "qwen3"})
+        # Non-hybrid VLM (vision keys + layer_types without linear_attention)
+        write_config(
+            "vlm/full-attn",
+            {
+                "model_type": "qwen2_5_vl",
+                "text_config": {"layer_types": ["full_attention"]},
+            },
+        )
+
+        assert _is_hybrid_linear_attention_target("qwen3_5/hybrid") is True
+        assert _is_hybrid_linear_attention_target("qwen/coder-next") is True
+        assert _is_hybrid_linear_attention_target("hybrid/top-level") is True
+        assert _is_hybrid_linear_attention_target("plain/qwen3") is False
+        assert _is_hybrid_linear_attention_target("vlm/full-attn") is False
+        # Model not downloaded yet — returns False rather than raising.
+        assert _is_hybrid_linear_attention_target("never/pulled") is False
+
+    def test_audit_flags_classic_speculative_on_hybrid_target(
+        self, monkeypatch, tmp_path
+    ):
+        """Classic speculative (the default strategy) on a hybrid
+        linear-attention target lands in hybrid_classic_conflicts. The
+        rationale: ``trim_prompt_cache`` is a no-op on ``CacheList``
+        containing ``ArraysCache``, so the cache desyncs after the first
+        draft rejection and the model emits garbage."""
+        from olmlx.cli import _audit_speculative_config
+        from olmlx.config import settings as _settings
+        from olmlx.models.store import _safe_dir_name
+
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        # Hybrid target with classic speculative (strategy defaults to
+        # classic when not specified explicitly).
+        hybrid_dir = models_dir / _safe_dir_name("qwen3_5/27b")
+        hybrid_dir.mkdir()
+        (hybrid_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "qwen3_5",
+                    "text_config": {
+                        "layer_types": ["full_attention", "linear_attention"],
+                    },
+                }
+            )
+        )
+        # Non-hybrid target with classic speculative — should NOT be
+        # flagged.
+        dense_dir = models_dir / _safe_dir_name("qwen3/8b")
+        dense_dir.mkdir()
+        (dense_dir / "config.json").write_text(json.dumps({"model_type": "qwen3"}))
+
+        models_json = tmp_path / "models.json"
+        models_json.write_text(
+            json.dumps(
+                {
+                    "qwen3_5/27b:latest": {
+                        "hf_path": "qwen3_5/27b",
+                        "speculative": True,
+                        "speculative_draft_model": "qwen3_5/draft",
+                    },
+                    "qwen3/8b:latest": {
+                        "hf_path": "qwen3/8b",
+                        "speculative": True,
+                        "speculative_draft_model": "qwen3/draft",
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr(_settings, "models_config", models_json)
+        monkeypatch.setattr(_settings, "models_dir", models_dir)
+        monkeypatch.setattr(_settings, "speculative", False)
+        monkeypatch.setattr(_settings, "speculative_draft_model", None)
+
+        (
+            bad,
+            dormant,
+            flash,
+            dflash_moe,
+            hybrid_classic,
+            _global_used,
+        ) = _audit_speculative_config()
+        assert bad == []
+        assert dormant == []
+        assert flash == []
+        assert dflash_moe == []
+        assert hybrid_classic == ["qwen3_5/27b:latest"]
+
+    def test_audit_does_not_flag_dflash_strategy_on_hybrid_target(
+        self, monkeypatch, tmp_path
+    ):
+        """dflash on a hybrid target is the supported combination
+        (``_GDNStateCapture`` rolls back recurrent state). It must NOT
+        land in hybrid_classic_conflicts."""
+        from olmlx.cli import _audit_speculative_config
+        from olmlx.config import settings as _settings
+        from olmlx.models.store import _safe_dir_name
+
+        models_dir = tmp_path / "models"
+        hybrid_dir = models_dir / _safe_dir_name("qwen3_5/27b")
+        hybrid_dir.mkdir(parents=True)
+        (hybrid_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "qwen3_5",
+                    "text_config": {
+                        "layer_types": ["full_attention", "linear_attention"],
+                    },
+                }
+            )
+        )
+
+        models_json = tmp_path / "models.json"
+        models_json.write_text(
+            json.dumps(
+                {
+                    "qwen3_5/27b:latest": {
+                        "hf_path": "qwen3_5/27b",
+                        "speculative": True,
+                        "speculative_strategy": "dflash",
+                        "speculative_draft_model": "qwen3_5/dflash-draft",
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr(_settings, "models_config", models_json)
+        monkeypatch.setattr(_settings, "models_dir", models_dir)
+        monkeypatch.setattr(_settings, "speculative", False)
+        monkeypatch.setattr(_settings, "speculative_draft_model", None)
+
+        (_, _, _, _, hybrid_classic, _) = _audit_speculative_config()
+        assert hybrid_classic == []
 
     def test_service_install(self):
         parser = build_parser()


### PR DESCRIPTION
## Summary

- Adds a startup audit warning for the silent-corruption case of running **classic speculative decoding against a hybrid linear-attention target** (Qwen3.5, Qwen3.6, Qwen3-Coder-Next). Discovered while debugging opencode hanging against `mlx-community/Qwen3.5-27B-4bit` with the global `OLMLX_SPECULATIVE=true` enabled.
- Mirrors the existing `dflash_moe_conflicts` audit pattern: new `hybrid_classic_conflicts` bucket in `_audit_speculative_config`, surfaced as a warning in `_apply_serve_overrides`.

## Why it matters

`mlx_lm.models.cache.trim_prompt_cache` early-returns when any layer in the `CacheList` is non-trimmable, and `ArraysCache` (Qwen3.5's `GatedDeltaNet` state) inherits `_BaseCache.is_trimmable()` which returns False. So on draft rejection, `SpeculativeDecoder.step()` at `engine/speculative.py:240` calls `trim_prompt_cache` and gets a no-op — the recurrent state never rolls back, the cache desyncs from the accepted token sequence, and the model emits special vocab tokens (`<|im_start|>`, `<|im_end|>`) mid-content. Generation either terminates randomly (premature EOS from a leaked stop token) or runs to `max_tokens` producing garbage, holding the inference lock long enough to time out concurrent requests at the 300s queue timeout.

DFlash avoids this through `_GDNStateCapture` replay of `gated_delta_update` on the accepted prefix (`engine/dflash/decoder.py:358`); classic has no equivalent.

## Reproduction (before the fix)

Three probe requests against `mlx-community/Qwen3.5-27B-4bit` with classic speculative enabled, all returned corrupted output:

| Request | Output |
|---|---|
| `"Say hi"` (no tools, 50 tok) | `Thinking Process: 1. **Analyze the Request:** * Task: <\|im_start\|>2. ... <\|im_end\|>` |
| `"What is 2+2?"` (no tools, 200 tok) | `Thinking Process: ... Draft the Response ... 2 equals` |
| 11 tools, 32000 max_tokens | content delta literally containing `<\|im_end\|>`, then spurious `tool_0` call |

The special-token leakage mid-content is the smoking gun — those vocab tokens only appear at message boundaries during training, so their presence inside generated content proves the model's internal state is desynced from its actual history.

## Detection heuristic

`_is_hybrid_linear_attention_target(hf_path)` reads the downloaded `config.json` and returns True for:

- `text_config.layer_types` contains `"linear_attention"` — Qwen3.5 / Qwen3.6 / Qwen3.5_moe family.
- Top-level `model_type == "qwen3_next"` — Qwen3-Coder-Next, which declares hybrid layout via `full_attention_interval` rather than `layer_types`.
- Top-level `layer_types` contains `"linear_attention"` — forward-compat for hybrid models that ship without a nested `text_config`.

Returns False when `config.json` is missing or unparseable — the audit fires on the next startup after the first pull, rather than blocking startup on missing files.

Skipped when Flash or Flash-MoE is configured for the same entry — those paths use the separate `flash_speculative` knob.

## Test plan

- [x] `pytest tests/test_cli.py` — 144/144 pass (3 new tests + 141 pre-existing)
- [x] Full `pytest tests/` sweep — 2455 pass, 0 fails
- [x] `ruff check` + `ruff format --check` — clean
- [x] End-to-end against real local `~/.olmlx/models.json` correctly flags all 4 affected hybrid models (`Qwen3.5-27B-4bit`, `Qwen3.5-35B-A3B-4bit`, `Qwen3.6-35B-A3B-6bit`, `Qwen3.5-0.8B-MLX-4bit`); leaves non-hybrid models alone.

New tests:
- `test_is_hybrid_linear_attention_target_detects_each_format` — unit-tests the helper across all three layouts plus negative cases (plain dense, non-hybrid VLM, missing config).
- `test_audit_flags_classic_speculative_on_hybrid_target` — classic + hybrid is flagged; classic + non-hybrid in the same audit run is not.
- `test_audit_does_not_flag_dflash_strategy_on_hybrid_target` — dflash + hybrid is the supported combination, must not be flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)