### PR TITLE
fix(flash-moe): support heterogeneous per-layer quantization in MoE bundler

### DIFF
--- a/olmlx/engine/flash/moe_bundler.py
+++ b/olmlx/engine/flash/moe_bundler.py
@@ -105,6 +105,7 @@ class MoeExpertLayout:
     bits: int
     group_size: int
     quant_mode: str = "affine"
+    manifest: list[dict] | None = None
 
 
 # Cache for loaded shard files to avoid re-reading the same shard.
@@ -382,6 +383,31 @@ def _collect_all_projections(
     return all_components, manifest
 
 
+def _quant_params_from_manifest(
+    manifest: list[dict], hidden_size: int
+) -> tuple[bool, int, int]:
+    """Detect (is_quantized, bits, group_size) from a per-layer expert manifest.
+
+    Uses the first gate/fc1 projection weight shape to infer bit-width, and the
+    corresponding scales shape to infer group_size. Works for any projection that
+    maps hidden_size → intermediate_size (gate_proj, up_proj, fc1).
+    """
+    weight_entry = next(
+        (e for e in manifest if e["name"] in ("gate_proj.weight", "fc1.weight")),
+        None,
+    )
+    if weight_entry is None or weight_entry["dtype"] != "uint32":
+        return False, 0, 0
+    packed_in = weight_entry["shape"][1]
+    bits = round(32 * packed_in / hidden_size)
+    scales_key = weight_entry["name"].replace(".weight", ".scales")
+    scales_entry = next((e for e in manifest if e["name"] == scales_key), None)
+    group_size = 64
+    if scales_entry is not None:
+        group_size = round(hidden_size / scales_entry["shape"][1])
+    return True, bits, group_size
+
+
 def bundle_moe_experts(
     model_dir: Path,
     output_dir: Path,
@@ -453,40 +479,31 @@ def bundle_moe_experts(
         fmt = _detect_expert_format(model_dir, moe_layers[0], index)
         expert_prefix = fmt.expert_prefix
 
-        # Process first MoE layer to determine component manifest
+        # Process first MoE layer to get the expert prefix format and quant_mode.
         first_prefix = fmt.full_prefix(moe_layers[0])
-        _, manifest = _collect_all_projections(
+        _, first_manifest = _collect_all_projections(
             model_dir, first_prefix, index, fmt.projections
         )
-        expert_byte_size = sum(entry["nbytes"] for entry in manifest)
+        quant_mode = quant_config.get("mode", "affine") if quant_config else "affine"
 
-        bits = 0
-        group_size = 0
-        quant_mode = "affine"
-        is_quantized = any(
-            e["dtype"] == "uint32" for e in manifest if "weight" in e["name"]
-        )
-        if is_quantized and quant_config:
-            bits = quant_config.get("bits", 4)
-            group_size = quant_config.get("group_size", 32)
-            quant_mode = quant_config.get("mode", "affine")
         for layer_idx in moe_layers:
             prefix = fmt.full_prefix(layer_idx)
 
             all_components, layer_manifest = _collect_all_projections(
                 model_dir, prefix, index, fmt.projections
             )
-            if layer_manifest != manifest:
-                raise ValueError(
-                    f"MoE layer {layer_idx} has different component layout than "
-                    f"layer {moe_layers[0]}. Heterogeneous MoE layers are not supported."
-                )
+
+            # Compute per-layer layout params from actual tensor shapes/dtypes.
+            layer_expert_byte_size = sum(entry["nbytes"] for entry in layer_manifest)
+            layer_is_quantized, layer_bits, layer_group_size = (
+                _quant_params_from_manifest(layer_manifest, hidden_size)
+            )
 
             # Build offset table
             offset_table_size = num_experts * 8
             data_start = MOE_HEADER_SIZE + offset_table_size
             offsets = np.array(
-                [data_start + i * expert_byte_size for i in range(num_experts)],
+                [data_start + i * layer_expert_byte_size for i in range(num_experts)],
                 dtype=np.uint64,
             )
 
@@ -497,10 +514,10 @@ def bundle_moe_experts(
                         num_experts,
                         hidden_size,
                         intermediate_size,
-                        is_quantized,
-                        bits,
-                        group_size,
-                        expert_byte_size,
+                        layer_is_quantized,
+                        layer_bits,
+                        layer_group_size,
+                        layer_expert_byte_size,
                     )
                 )
                 f.write(offsets.tobytes())
@@ -519,12 +536,13 @@ def bundle_moe_experts(
                 num_experts=num_experts,
                 hidden_size=hidden_size,
                 intermediate_size=intermediate_size,
-                expert_byte_size=expert_byte_size,
+                expert_byte_size=layer_expert_byte_size,
                 file_path=file_path,
                 offsets=offsets,
-                is_quantized=is_quantized,
-                bits=bits,
-                group_size=group_size,
+                is_quantized=layer_is_quantized,
+                bits=layer_bits,
+                group_size=layer_group_size,
+                manifest=layer_manifest,
             )
 
             logger.info("Bundled MoE layer %d: %d experts", layer_idx, num_experts)
@@ -535,16 +553,19 @@ def bundle_moe_experts(
     finally:
         _clear_shard_cache()
 
-    # Write layout JSON with component manifest
+    # Write layout JSON. Per-layer manifests are stored under each layer entry so
+    # the weight store can parse heterogeneous (mixed-precision) experts correctly.
+    # The top-level component_manifest is kept for backward compat with existing bundles.
+    first_layout = layouts[moe_layers[0]]
     layout_config = {
         "num_moe_layers": len(layouts),
         "num_experts": num_experts,
         "hidden_size": hidden_size,
         "intermediate_size": intermediate_size,
-        "is_quantized": is_quantized,
+        "is_quantized": first_layout.is_quantized,
         "quant_mode": quant_mode,
         "expert_prefix": expert_prefix,
-        "component_manifest": manifest,
+        "component_manifest": first_manifest,
         "layers": {
             str(idx): {
                 "file": layout.file_path.name,
@@ -553,6 +574,7 @@ def bundle_moe_experts(
                 "is_quantized": layout.is_quantized,
                 "bits": layout.bits,
                 "group_size": layout.group_size,
+                "component_manifest": layout.manifest,
             }
             for idx, layout in layouts.items()
         },

--- a/olmlx/engine/flash/moe_bundler.py
+++ b/olmlx/engine/flash/moe_bundler.py
@@ -383,6 +383,10 @@ def _collect_all_projections(
     return all_components, manifest
 
 
+# MLX affine quantization supports these bit widths (see mx.quantize docs).
+_VALID_QUANT_BITS = {2, 3, 4, 5, 6, 8}
+
+
 def _quant_params_from_manifest(
     manifest: list[dict], hidden_size: int
 ) -> tuple[bool, int, int]:
@@ -400,11 +404,21 @@ def _quant_params_from_manifest(
         return False, 0, 0
     packed_in = weight_entry["shape"][1]
     bits = round(32 * packed_in / hidden_size)
+    if bits not in _VALID_QUANT_BITS:
+        raise ValueError(
+            f"Inferred bit-width {bits} is not a supported MLX quantization value "
+            f"{_VALID_QUANT_BITS}. packed_in={packed_in}, hidden_size={hidden_size}. "
+            "The checkpoint may be corrupt or use an unsupported quantization format."
+        )
     scales_key = weight_entry["name"].replace(".weight", ".scales")
     scales_entry = next((e for e in manifest if e["name"] == scales_key), None)
-    group_size = 64
-    if scales_entry is not None:
-        group_size = round(hidden_size / scales_entry["shape"][1])
+    if scales_entry is None:
+        raise ValueError(
+            f"Expert manifest has quantized weights (dtype=uint32) for "
+            f"'{weight_entry['name']}' but no corresponding scales entry "
+            f"'{scales_key}'. The checkpoint may be corrupt."
+        )
+    group_size = round(hidden_size / scales_entry["shape"][1])
     return True, bits, group_size
 
 
@@ -484,6 +498,9 @@ def bundle_moe_experts(
         _, first_manifest = _collect_all_projections(
             model_dir, first_prefix, index, fmt.projections
         )
+        # quant_mode is treated as layer-invariant: OptiQ varies bits per layer but
+        # always uses "affine" mode. A checkpoint mixing affine and non-affine modes
+        # per layer would need a per-layer quant_mode field added here.
         quant_mode = quant_config.get("mode", "affine") if quant_config else "affine"
 
         for layer_idx in moe_layers:
@@ -555,7 +572,11 @@ def bundle_moe_experts(
 
     # Write layout JSON. Per-layer manifests are stored under each layer entry so
     # the weight store can parse heterogeneous (mixed-precision) experts correctly.
-    # The top-level component_manifest is kept for backward compat with existing bundles.
+    # The top-level component_manifest is layer 0's manifest, kept so that an updated
+    # reader loading an old (homogeneous) bundle still finds the global manifest.
+    # NOTE: an old reader loading a new heterogeneous bundle will use layer 0's manifest
+    # for every layer and silently misparse layers with different bit-widths. There is
+    # no version gate — rolling back the reader on a heterogeneous bundle is unsupported.
     first_layout = layouts[moe_layers[0]]
     layout_config = {
         "num_moe_layers": len(layouts),

--- a/olmlx/engine/flash/moe_weight_store.py
+++ b/olmlx/engine/flash/moe_weight_store.py
@@ -127,6 +127,7 @@ class FlashMoeWeightStore:
                 bits=header["bits"],
                 group_size=header["group_size"],
                 quant_mode=self._quant_mode,
+                manifest=layer_info.get("component_manifest"),
             )
 
         return layouts
@@ -138,8 +139,9 @@ class FlashMoeWeightStore:
         offset = int(layout.offsets[expert_idx])
         raw = full_pread(fd, layout.expert_byte_size, offset)
 
-        if self._manifest:
-            return self._parse_expert_with_manifest(raw, self._manifest)
+        manifest = layout.manifest if layout.manifest is not None else self._manifest
+        if manifest:
+            return self._parse_expert_with_manifest(raw, manifest)
         elif layout.is_quantized:
             return self._parse_quantized_expert(raw, layout)
         else:

--- a/tests/test_flash_moe_bundler.py
+++ b/tests/test_flash_moe_bundler.py
@@ -1321,6 +1321,111 @@ class TestBundleHeterogeneousMoeExperts:
         ][expert_idx]
         np.testing.assert_array_equal(gate_read, gate_orig)
 
+    def test_invalid_bits_raises(self, tmp_path):
+        """_quant_params_from_manifest should raise on an unsupported bit-width."""
+        from safetensors.numpy import save_file
+
+        from olmlx.engine.flash.moe_bundler import bundle_moe_experts
+
+        # Craft a weight where packed_in doesn't correspond to any valid bit-width.
+        # hidden=64, packed_in=7 → bits = round(32*7/64) = round(3.5) = 4 — that's valid,
+        # so use hidden=64, packed_in=3 → bits = round(32*3/64) = round(1.5) = 2 — valid.
+        # Use packed_in=5 → bits = round(32*5/64) = round(2.5) = 2 — rounds to valid.
+        # Use hidden=60 (not divisible cleanly), packed_in=7 → round(32*7/60)=round(3.73)=4 valid.
+        # Actually craft hidden=64, packed_in=9 → round(32*9/64) = round(4.5) = 4 — valid.
+        # Use hidden=64, packed_in=11 → round(32*11/64) = round(5.5) = 6 — valid.
+        # Use hidden=100, packed_in=9 → round(32*9/100) = round(2.88) = 3 — valid.
+        # Safest: hidden=64, packed_in=13 → round(32*13/64) = round(6.5) = 6 — valid.
+        # We need something that rounds outside {2,3,4,5,6,8}.
+        # hidden=64, packed_in=20 → round(32*20/64) = round(10) = 10 — INVALID ✓
+        rng = np.random.RandomState(0)
+        hidden, inter, experts = 64, 32, 4
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        tensors = {
+            "language_model.model.layers.0.router.proj.weight": rng.randn(
+                experts, hidden
+            ).astype(np.float16),
+            # packed_in=20 → inferred bits = round(32*20/64) = 10, not in valid set
+            "language_model.model.layers.0.experts.switch_glu.gate_proj.weight": rng.randint(
+                0, 2**31, (experts, inter, 20)
+            ).astype(np.uint32),
+            "language_model.model.layers.0.experts.switch_glu.up_proj.weight": rng.randint(
+                0, 2**31, (experts, inter, 20)
+            ).astype(np.uint32),
+            "language_model.model.layers.0.experts.switch_glu.down_proj.weight": rng.randint(
+                0, 2**31, (experts, hidden, 10)
+            ).astype(np.uint32),
+            "language_model.model.embed_tokens.weight": rng.randn(100, hidden).astype(
+                np.float16
+            ),
+        }
+        save_file(tensors, str(model_dir / "model.safetensors"))
+        config = {
+            "model_type": "gemma4",
+            "text_config": {
+                "model_type": "gemma4_text",
+                "hidden_size": hidden,
+                "intermediate_size": inter,
+                "moe_intermediate_size": inter,
+                "num_hidden_layers": 1,
+                "num_experts": experts,
+                "top_k_experts": 2,
+                "enable_moe_block": True,
+            },
+        }
+        (model_dir / "config.json").write_text(json.dumps(config))
+
+        with pytest.raises(ValueError, match="not a supported MLX quantization"):
+            bundle_moe_experts(model_dir, tmp_path / "flash_moe")
+
+    def test_missing_scales_raises(self, tmp_path):
+        """_quant_params_from_manifest should raise when scales are absent for quantized weights."""
+        from safetensors.numpy import save_file
+
+        from olmlx.engine.flash.moe_bundler import bundle_moe_experts
+
+        rng = np.random.RandomState(0)
+        hidden, inter, experts = 64, 32, 4
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        # 4-bit weights (packed_in=8) but NO scales tensors
+        tensors = {
+            "language_model.model.layers.0.router.proj.weight": rng.randn(
+                experts, hidden
+            ).astype(np.float16),
+            "language_model.model.layers.0.experts.switch_glu.gate_proj.weight": rng.randint(
+                0, 2**31, (experts, inter, 8)
+            ).astype(np.uint32),
+            "language_model.model.layers.0.experts.switch_glu.up_proj.weight": rng.randint(
+                0, 2**31, (experts, inter, 8)
+            ).astype(np.uint32),
+            "language_model.model.layers.0.experts.switch_glu.down_proj.weight": rng.randint(
+                0, 2**31, (experts, hidden, 4)
+            ).astype(np.uint32),
+            "language_model.model.embed_tokens.weight": rng.randn(100, hidden).astype(
+                np.float16
+            ),
+        }
+        save_file(tensors, str(model_dir / "model.safetensors"))
+        config = {
+            "model_type": "gemma4",
+            "text_config": {
+                "model_type": "gemma4_text",
+                "hidden_size": hidden,
+                "intermediate_size": inter,
+                "moe_intermediate_size": inter,
+                "num_hidden_layers": 1,
+                "num_experts": experts,
+                "top_k_experts": 2,
+                "enable_moe_block": True,
+            },
+        }
+        (model_dir / "config.json").write_text(json.dumps(config))
+
+        with pytest.raises(ValueError, match="no corresponding scales"):
+            bundle_moe_experts(model_dir, tmp_path / "flash_moe")
+
 
 class TestShardCacheCleanup:
     """Tests for _shard_cache lifecycle — issue #171."""

--- a/tests/test_flash_moe_bundler.py
+++ b/tests/test_flash_moe_bundler.py
@@ -1149,6 +1149,179 @@ class TestBundleGemma4MoeExperts:
         assert header["bits"] == 4
 
 
+def _make_synthetic_heterogeneous_moe_weights(
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    tmp_path: Path,
+) -> Path:
+    """Create Gemma-4 style MoE model with heterogeneous per-layer quantization.
+
+    Mimics OptiQ mixed-precision: layer 0 at 4-bit, layer 1 at 8-bit, layer 2 bf16.
+    No global quantization key in config — each layer's format is encoded in its weights.
+    """
+    from safetensors.numpy import save_file
+
+    rng = np.random.RandomState(42)
+    tensors = {}
+
+    layer_configs = [(4, 32), (8, 64), (None, None)]
+
+    for layer_idx, (bits, group_size) in enumerate(layer_configs):
+        prefix = f"language_model.model.layers.{layer_idx}.experts.switch_glu"
+        tensors[f"language_model.model.layers.{layer_idx}.router.proj.weight"] = (
+            rng.randn(num_experts, hidden_size).astype(np.float16)
+        )
+        if bits is None:
+            for proj, out_dim, in_dim in [
+                ("gate_proj", intermediate_size, hidden_size),
+                ("up_proj", intermediate_size, hidden_size),
+                ("down_proj", hidden_size, intermediate_size),
+            ]:
+                tensors[f"{prefix}.{proj}.weight"] = rng.randn(
+                    num_experts, out_dim, in_dim
+                ).astype(np.float16)
+        else:
+            for proj, out_dim, in_dim in [
+                ("gate_proj", intermediate_size, hidden_size),
+                ("up_proj", intermediate_size, hidden_size),
+                ("down_proj", hidden_size, intermediate_size),
+            ]:
+                packed = in_dim * bits // 32
+                tensors[f"{prefix}.{proj}.weight"] = rng.randint(
+                    0, 2**31, (num_experts, out_dim, packed)
+                ).astype(np.uint32)
+                tensors[f"{prefix}.{proj}.scales"] = rng.randn(
+                    num_experts, out_dim, in_dim // group_size
+                ).astype(np.float16)
+                tensors[f"{prefix}.{proj}.biases"] = rng.randn(
+                    num_experts, out_dim, in_dim // group_size
+                ).astype(np.float16)
+
+    tensors["language_model.model.embed_tokens.weight"] = rng.randn(
+        100, hidden_size
+    ).astype(np.float16)
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    save_file(tensors, str(model_dir / "model.safetensors"))
+
+    config = {
+        "model_type": "gemma4",
+        "text_config": {
+            "model_type": "gemma4_text",
+            "hidden_size": hidden_size,
+            "intermediate_size": intermediate_size,
+            "moe_intermediate_size": intermediate_size,
+            "num_hidden_layers": 3,
+            "num_experts": num_experts,
+            "top_k_experts": 2,
+            "enable_moe_block": True,
+        },
+    }
+    (model_dir / "config.json").write_text(json.dumps(config))
+    return model_dir
+
+
+class TestBundleHeterogeneousMoeExperts:
+    """Heterogeneous per-layer quantization (e.g. OptiQ mixed-precision)."""
+
+    def test_heterogeneous_bundle_succeeds(self, tmp_path):
+        """Bundling should succeed when MoE layers have different bit-widths."""
+        hidden, inter, experts = 64, 32, 4
+        model_dir = _make_synthetic_heterogeneous_moe_weights(
+            hidden, inter, experts, tmp_path
+        )
+        from olmlx.engine.flash.moe_bundler import bundle_moe_experts
+
+        layouts = bundle_moe_experts(model_dir, tmp_path / "flash_moe")
+
+        assert len(layouts) == 3
+        for layer_idx in [0, 1, 2]:
+            assert (
+                tmp_path / "flash_moe" / f"layer_{layer_idx:02d}.flashexperts"
+            ).exists()
+
+    def test_heterogeneous_per_layer_bits(self, tmp_path):
+        """Each layer should record its own bit-width in the .flashexperts header."""
+        hidden, inter, experts = 64, 32, 4
+        model_dir = _make_synthetic_heterogeneous_moe_weights(
+            hidden, inter, experts, tmp_path
+        )
+        output_dir = tmp_path / "flash_moe"
+        from olmlx.engine.flash.moe_bundler import (
+            MOE_HEADER_SIZE,
+            bundle_moe_experts,
+            parse_moe_header,
+        )
+
+        bundle_moe_experts(model_dir, output_dir)
+
+        for layer_idx, expected_bits, expected_quant in [
+            (0, 4, True),
+            (1, 8, True),
+            (2, 0, False),
+        ]:
+            with open(output_dir / f"layer_{layer_idx:02d}.flashexperts", "rb") as f:
+                header = parse_moe_header(f.read(MOE_HEADER_SIZE))
+            assert header["is_quantized"] == expected_quant, f"layer {layer_idx}"
+            if expected_quant:
+                assert header["bits"] == expected_bits, f"layer {layer_idx}"
+
+    def test_heterogeneous_layout_json_per_layer_manifest(self, tmp_path):
+        """Layout JSON should have a component_manifest per layer entry."""
+        hidden, inter, experts = 64, 32, 4
+        model_dir = _make_synthetic_heterogeneous_moe_weights(
+            hidden, inter, experts, tmp_path
+        )
+        output_dir = tmp_path / "flash_moe"
+        from olmlx.engine.flash.moe_bundler import bundle_moe_experts
+
+        bundle_moe_experts(model_dir, output_dir)
+
+        cfg = json.loads((output_dir / "flash_moe_layout.json").read_text())
+        for layer_str in ["0", "1", "2"]:
+            assert "component_manifest" in cfg["layers"][layer_str], layer_str
+
+        assert any(
+            e["dtype"] == "uint32" for e in cfg["layers"]["0"]["component_manifest"]
+        )
+        assert all(
+            e["dtype"] == "float16"
+            for e in cfg["layers"]["2"]["component_manifest"]
+            if "weight" in e["name"]
+        )
+
+    def test_heterogeneous_data_roundtrip(self, tmp_path):
+        """Each layer's expert data must round-trip through the bundle."""
+        hidden, inter, experts = 64, 32, 4
+        model_dir = _make_synthetic_heterogeneous_moe_weights(
+            hidden, inter, experts, tmp_path
+        )
+        output_dir = tmp_path / "flash_moe"
+        from safetensors.numpy import load_file
+
+        from olmlx.engine.flash.moe_bundler import bundle_moe_experts
+
+        original = load_file(str(model_dir / "model.safetensors"))
+        layouts = bundle_moe_experts(model_dir, output_dir)
+
+        layout = layouts[2]
+        expert_idx = 0
+        with open(layout.file_path, "rb") as f:
+            f.seek(int(layout.offsets[expert_idx]))
+            raw = f.read(layout.expert_byte_size)
+
+        gate_size = inter * hidden * 2
+        gate_read = np.frombuffer(raw[:gate_size], dtype=np.float16).reshape(
+            inter, hidden
+        )
+        gate_orig = original[
+            "language_model.model.layers.2.experts.switch_glu.gate_proj.weight"
+        ][expert_idx]
+        np.testing.assert_array_equal(gate_read, gate_orig)
+
+
 class TestShardCacheCleanup:
     """Tests for _shard_cache lifecycle — issue #171."""
 

--- a/tests/test_flash_moe_weight_store.py
+++ b/tests/test_flash_moe_weight_store.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from tests.test_flash_moe_bundler import (
+    _make_synthetic_heterogeneous_moe_weights,
     _make_synthetic_moe_weights,
     _make_synthetic_nemotron_moe_weights,
 )
@@ -306,3 +307,60 @@ class TestFlashMoeWeightStoreNemotron:
 
         np.testing.assert_array_equal(np.array(loaded.up_weight[0]), fc1_w[3])
         np.testing.assert_array_equal(np.array(loaded.down_weight[0]), fc2_w[3])
+
+
+class TestFlashMoeWeightStoreHeterogeneous:
+    """Weight store with heterogeneous per-layer quantization (OptiQ-style)."""
+
+    @pytest.fixture()
+    def hetero_store(self, tmp_path):
+        hidden, inter, experts = 64, 32, 4
+        model_dir = _make_synthetic_heterogeneous_moe_weights(
+            hidden, inter, experts, tmp_path
+        )
+        output_dir = tmp_path / "flash_moe"
+
+        from olmlx.engine.flash.moe_bundler import bundle_moe_experts
+
+        bundle_moe_experts(model_dir, output_dir)
+
+        from olmlx.engine.flash.moe_weight_store import FlashMoeWeightStore
+
+        store = FlashMoeWeightStore(
+            output_dir, num_io_threads=2, cache_budget_experts=8
+        )
+        return store, model_dir, hidden, inter, experts
+
+    def test_load_quantized_layer(self, hetero_store):
+        """4-bit layer should load with is_quantized=True."""
+        store, _, hidden, inter, experts = hetero_store
+        loaded = store.load_experts(0, [0])
+        assert loaded.is_quantized is True
+        assert loaded.bits == 4
+
+    def test_load_higher_bit_layer(self, hetero_store):
+        """8-bit layer should load with correct bit-width."""
+        store, _, hidden, inter, experts = hetero_store
+        loaded = store.load_experts(1, [0])
+        assert loaded.is_quantized is True
+        assert loaded.bits == 8
+
+    def test_load_unquantized_layer(self, hetero_store):
+        """bf16 layer should load with is_quantized=False."""
+        store, _, hidden, inter, experts = hetero_store
+        loaded = store.load_experts(2, [0])
+        assert loaded.is_quantized is False
+
+    def test_bf16_data_matches_original(self, hetero_store):
+        """bf16 layer (layer 2) expert data must match original safetensors."""
+        from safetensors.numpy import load_file
+
+        store, model_dir, hidden, inter, experts = hetero_store
+        original = load_file(str(model_dir / "model.safetensors"))
+
+        loaded = store.load_experts(2, [1])
+
+        gate_orig = original[
+            "language_model.model.layers.2.experts.switch_glu.gate_proj.weight"
+        ][1]
+        np.testing.assert_array_equal(np.array(loaded.gate_weight[0]), gate_orig)

--- a/tests/test_flash_moe_weight_store.py
+++ b/tests/test_flash_moe_weight_store.py
@@ -332,18 +332,36 @@ class TestFlashMoeWeightStoreHeterogeneous:
         return store, model_dir, hidden, inter, experts
 
     def test_load_quantized_layer(self, hetero_store):
-        """4-bit layer should load with is_quantized=True."""
-        store, _, hidden, inter, experts = hetero_store
-        loaded = store.load_experts(0, [0])
+        """4-bit layer: metadata correct and packed weights match original."""
+        from safetensors.numpy import load_file
+
+        store, model_dir, hidden, inter, experts = hetero_store
+        original = load_file(str(model_dir / "model.safetensors"))
+
+        loaded = store.load_experts(0, [2])
         assert loaded.is_quantized is True
         assert loaded.bits == 4
 
+        gate_orig = original[
+            "language_model.model.layers.0.experts.switch_glu.gate_proj.weight"
+        ][2]
+        np.testing.assert_array_equal(np.array(loaded.gate_weight[0]), gate_orig)
+
     def test_load_higher_bit_layer(self, hetero_store):
-        """8-bit layer should load with correct bit-width."""
-        store, _, hidden, inter, experts = hetero_store
-        loaded = store.load_experts(1, [0])
+        """8-bit layer: metadata correct and packed weights match original."""
+        from safetensors.numpy import load_file
+
+        store, model_dir, hidden, inter, experts = hetero_store
+        original = load_file(str(model_dir / "model.safetensors"))
+
+        loaded = store.load_experts(1, [3])
         assert loaded.is_quantized is True
         assert loaded.bits == 8
+
+        gate_orig = original[
+            "language_model.model.layers.1.experts.switch_glu.gate_proj.weight"
+        ][3]
+        np.testing.assert_array_equal(np.array(loaded.gate_weight[0]), gate_orig)
 
     def test_load_unquantized_layer(self, hetero_store):
         """bf16 layer should load with is_quantized=False."""


### PR DESCRIPTION
## Summary

- Remove the homogeneity check that required all MoE layers to have identical component layouts — OptiQ mixed-precision models assign different bit-widths per layer and were failing with `ValueError: Heterogeneous MoE layers are not supported`
- Add `_quant_params_from_manifest(manifest, hidden_size)` to detect `is_quantized`, `bits`, and `group_size` per layer from actual tensor shapes, rather than from a global `quant_config`
- Store per-layer `component_manifest` in the layout JSON; weight store uses it when present, falling back to the top-level manifest for backward compat with existing bundles

## Motivation

`gemma-4-26B-A4B-it-OptiQ-4bit` (and any future OptiQ MoE checkpoint) failed `olmlx flash prepare` because its 30 MoE layers use mixed precision — some at 4-bit, some at 8-bit — which the bundler interpreted as incompatible layouts.

## Test Plan

- [x] `TestBundleHeterogeneousMoeExperts` — bundling succeeds, per-layer bits are correct in headers, layout JSON has per-layer manifests, data round-trips correctly
- [x] `TestFlashMoeWeightStoreHeterogeneous` — store loads 4-bit, 8-bit, and bf16 layers correctly; bf16 expert data matches original
- [x] All existing MoE bundler and weight store tests (51 total) pass