### PR TITLE
fix(speculative): avoid Metal OOM for large-vocab models on long contexts

### DIFF
--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -379,13 +379,6 @@ class DFlashDecoder:
             captured_last = list(self._hidden_capture)
             if any(h is None for h in captured_last):
                 raise RuntimeError(_err_msg)
-            if len(captured_prefix) != len(captured_last):
-                raise RuntimeError(
-                    f"DFlash prefill: pass 1 captured {len(captured_prefix)} "
-                    f"hidden states but pass 2 captured {len(captured_last)} "
-                    f"(expected {len(target_layer_ids)} each). The two passes "
-                    "must hit the same set of target_layer_ids."
-                )
             captured = [
                 mx.concatenate([p, q], axis=1)
                 for p, q in zip(captured_prefix, captured_last)

--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -368,6 +368,10 @@ class DFlashDecoder:
             captured_prefix = list(self._hidden_capture)
             if any(h is None for h in captured_prefix):
                 raise RuntimeError(_err_msg)
+            # Force pass-1 hiddens before dropping slot references, so
+            # correctness does not depend on _eval_cache transitively
+            # materialising the same graph.
+            mx.eval(*captured_prefix)
             # Reset capture slots so the pass-2 None-check is independent.
             self._hidden_capture[:] = [None] * len(self._hidden_capture)
             _eval_cache(self._target_cache)

--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -37,7 +37,7 @@ from olmlx.engine.gdn_rollback import (
     GDNStateCapture,
     get_model_layers as _get_layers,
 )
-from olmlx.engine.speculative import verify_draft_greedy
+from olmlx.engine.speculative import _eval_cache, verify_draft_greedy
 
 
 # ``_trim_recent_cache`` reaches into ``RotatingKVCache._temporal_order`` and
@@ -346,15 +346,45 @@ class DFlashDecoder:
             )
             self._capture.use_buffer(self._capture_buffer)
 
-        target_out = self._target(prompt, cache=self._target_cache)
+        # Two-pass prefill avoids materialising the full [batch, N, vocab] logit
+        # (the OOM path for large-vocab models on long contexts).
+        #
+        # Pass 1 — prefix (positions 0..N-2): fills the KV cache and captures
+        # hidden states for ALL prefix positions. The model output is discarded,
+        # so lm_head on N-1 positions is never evaluated by MLX's lazy scheduler.
+        # Pass 2 — last token: produces a [1, 1, vocab] logit + captures the
+        # last position's hidden state.
+        #
+        # DFlash's draft conditions on self._hidden[1, N, …] (all prompt hiddens),
+        # so we concatenate captured_prefix + captured_last along the time axis.
+        _err_msg = (
+            "Target forward did not populate all configured "
+            "target_layer_ids — check that the layer indices exist on "
+            f"this model (got {target_layer_ids})."
+        )
+        if prompt.shape[1] > 1:
+            prefix, last = prompt[:, :-1], prompt[:, -1:]
+            self._target(prefix, cache=self._target_cache)  # output discarded
+            captured_prefix = list(self._hidden_capture)
+            if any(h is None for h in captured_prefix):
+                raise RuntimeError(_err_msg)
+            # Reset capture slots so the pass-2 None-check is independent.
+            self._hidden_capture[:] = [None] * len(self._hidden_capture)
+            _eval_cache(self._target_cache)
+            target_out = self._target(last, cache=self._target_cache)
+            captured_last = list(self._hidden_capture)
+            if any(h is None for h in captured_last):
+                raise RuntimeError(_err_msg)
+            captured = [
+                mx.concatenate([p, q], axis=1)
+                for p, q in zip(captured_prefix, captured_last)
+            ]
+        else:
+            target_out = self._target(prompt, cache=self._target_cache)
+            captured = list(self._hidden_capture)
+            if any(h is None for h in captured):
+                raise RuntimeError(_err_msg)
         logits = _logits(target_out)
-        captured = list(self._hidden_capture)
-        if any(h is None for h in captured):
-            raise RuntimeError(
-                "Target forward did not populate all configured "
-                "target_layer_ids — check that the layer indices exist on "
-                f"this model (got {target_layer_ids})."
-            )
         self._hidden = mx.concatenate(captured, axis=-1)
         last_logit = logits[:, -1, :]
         mx.eval(last_logit, self._hidden)

--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -379,6 +379,13 @@ class DFlashDecoder:
             captured_last = list(self._hidden_capture)
             if any(h is None for h in captured_last):
                 raise RuntimeError(_err_msg)
+            if len(captured_prefix) != len(captured_last):
+                raise RuntimeError(
+                    f"DFlash prefill: pass 1 captured {len(captured_prefix)} "
+                    f"hidden states but pass 2 captured {len(captured_last)} "
+                    f"(expected {len(target_layer_ids)} each). The two passes "
+                    "must hit the same set of target_layer_ids."
+                )
             captured = [
                 mx.concatenate([p, q], axis=1)
                 for p, q in zip(captured_prefix, captured_last)

--- a/olmlx/engine/eagle/decoder.py
+++ b/olmlx/engine/eagle/decoder.py
@@ -328,6 +328,9 @@ class EagleDecoder:
             # produces a [1, 1, vocab] logit and refreshes the capture slot.
             if prompt.shape[1] > 1:
                 self._target(prompt[:, :-1], cache=self._target_cache)
+                # Discard pass-1 capture so the pass-2 None-check below is
+                # an active guard rather than dead code.
+                self._hidden_storage[0] = None
                 _eval_cache(self._target_cache)
                 target_out = self._target(prompt[:, -1:], cache=self._target_cache)
             else:

--- a/olmlx/engine/eagle/decoder.py
+++ b/olmlx/engine/eagle/decoder.py
@@ -50,7 +50,7 @@ from olmlx.engine.gdn_rollback import (
     get_model_layers as _get_layers,
 )
 from olmlx.engine.eagle.draft_model import EagleDraftModel
-from olmlx.engine.speculative import verify_draft_greedy
+from olmlx.engine.speculative import _eval_cache, verify_draft_greedy
 
 try:
     from mlx_lm.models.cache import (
@@ -323,7 +323,15 @@ class EagleDecoder:
                 self._capture = _GDNStateCapture(self._target)
 
             # Run the target on the prompt and capture its last-layer hidden.
-            target_out = self._target(prompt, cache=self._target_cache)
+            # Two-pass: prefix fills the KV cache without materialising the
+            # full [batch, seq_len, vocab] logit; final single-token pass
+            # produces a [1, 1, vocab] logit and refreshes the capture slot.
+            if prompt.shape[1] > 1:
+                self._target(prompt[:, :-1], cache=self._target_cache)
+                _eval_cache(self._target_cache)
+                target_out = self._target(prompt[:, -1:], cache=self._target_cache)
+            else:
+                target_out = self._target(prompt, cache=self._target_cache)
             target_logits = _logits(target_out)
             captured = self._hidden_storage[0]
             if captured is None:

--- a/olmlx/engine/eagle/decoder.py
+++ b/olmlx/engine/eagle/decoder.py
@@ -328,6 +328,14 @@ class EagleDecoder:
             # produces a [1, 1, vocab] logit and refreshes the capture slot.
             if prompt.shape[1] > 1:
                 self._target(prompt[:, :-1], cache=self._target_cache)
+                # Force the pass-1 hidden (if captured) before dropping the
+                # slot reference, mirroring DFlash. Correctness does not
+                # require it today — _eval_cache transitively materialises
+                # the same graph — but the explicit eval makes the ordering
+                # robust to future narrowing of _eval_cache's scope.
+                _hidden_p1 = self._hidden_storage[0]
+                if _hidden_p1 is not None:
+                    mx.eval(_hidden_p1)
                 # Discard pass-1 capture so the pass-2 None-check below is
                 # an active guard rather than dead code.
                 self._hidden_storage[0] = None

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -557,6 +557,14 @@ class SpeculativeDecoder:
                 f"{type(self._draft).__name__!r}: {exc}. The draft model may "
                 "not be compatible with mlx-lm's KV-cache API."
             ) from exc
+        # Same reset prefill()/generate_step apply to the target: VLM drafts
+        # (mlx-vlm 0.4.4 Qwen3_5 etc.) cache _position_ids/_rope_deltas on
+        # the module instance across calls, and pass 1 of _prefill_last_logit
+        # below has cache_offset==0, which would consume a stale slice of
+        # _position_ids from a previous request.
+        for attr in ("_position_ids", "_rope_deltas"):
+            if hasattr(self._draft, attr):
+                setattr(self._draft, attr, None)
         tokens: list[int] = []
 
         # Same OOM path as the target: a large-vocab draft (e.g. same model

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -61,10 +61,12 @@ def _eval_cache(cache: list) -> None:
             state = getattr(c, "state", None)
             if isinstance(state, (list, tuple)):
                 arrs.extend(a for a in state if isinstance(a, mx.array))
-        # TurboQuantKVCache / SpectralQuantKVCache return values from
-        # update_and_fetch are views over a separately maintained dequant
-        # side buffer that is not surfaced via .state. Probe explicitly so
-        # the dequant graph is forced here instead of fusing into pass 2.
+        # TurboQuantKVCache maintains a dequantized side buffer in
+        # _key_dequant / _value_dequant that update_and_fetch returns
+        # views over. The buffer is not part of .state, so probe it
+        # explicitly to force the dequant graph here instead of letting
+        # it fuse into pass 2. (SpectralQuantKVCache dequantizes fresh on
+        # each call and is already covered by the .state branch above.)
         for attr in ("_key_dequant", "_value_dequant"):
             buf = getattr(c, attr, None)
             if isinstance(buf, mx.array):
@@ -545,6 +547,8 @@ class SpeculativeDecoder:
                 "mlx_lm.models.cache.make_prompt_cache is not available; "
                 "upgrade mlx-lm to a version that exports it."
             )
+        if n <= 0:
+            return []
         try:
             cache = make_prompt_cache(self._draft)
         except (TypeError, AttributeError) as exc:
@@ -555,10 +559,14 @@ class SpeculativeDecoder:
             ) from exc
         tokens: list[int] = []
 
-        logits = _logits(self._draft(prompt, cache=cache))
-        next_logits = logits[:, -1, :]
-        mx.eval(next_logits)
-        next_token = int(mx.argmax(next_logits, axis=-1).item())
+        # Same OOM path as the target: a large-vocab draft (e.g. same model
+        # family as target, 262k vocab) on a long prompt would materialise
+        # [1, seq_len, vocab] inside lm_head before the [:, -1, :] slice.
+        # Route through _prefill_last_logit to keep the prefix lm_head out
+        # of the eval graph.
+        first_logit = _prefill_last_logit(self._draft, prompt, cache)
+        mx.eval(first_logit)
+        next_token = int(mx.argmax(first_logit).item())
         tokens.append(next_token)
 
         for _ in range(n - 1):

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -80,7 +80,7 @@ def _eval_cache(cache: list) -> None:
         # the gap is visible; do not raise, since hard-failing here would
         # break speculative decoding for every new mlx-lm cache type
         # before its probe lands in this function.
-        logger.warning(
+        logger.error(
             "_eval_cache: no mx.array entries found in %d cache objects "
             "(types: %s); the OOM-avoidance graph break is a no-op for "
             "this cache type — add an explicit probe here if Metal OOMs "
@@ -112,7 +112,10 @@ def _prefill_last_logit(model: Any, prompt: mx.array, cache: list) -> mx.array:
     prefix, last = prompt[:, :-1], prompt[:, -1:]
     model(prefix, cache=cache)  # output discarded; lm_head never materialised
     _eval_cache(cache)  # materialise KV state before the single-token pass
-    return _logits(model(last, cache=cache))[0, 0, :]
+    result = _logits(model(last, cache=cache))[0, 0, :]
+    # Uniform postcondition: cache materialised on return for either branch.
+    _eval_cache(cache)
+    return result
 
 
 def verify_draft_greedy(

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -63,6 +63,18 @@ def _eval_cache(cache: list) -> None:
                 arrs.extend(a for a in state if isinstance(a, mx.array))
     if arrs:
         mx.eval(*arrs)
+    elif cache:
+        # Defensive: a non-empty cache produced no arrays to evaluate. The
+        # caller relies on pass 1's KV state being materialised before pass
+        # 2; a silent no-op here would let pass 2 see lazily-unevaluated
+        # state and produce wrong logits. Warn so unrecognised cache types
+        # surface instead of failing silently.
+        logger.warning(
+            "_eval_cache: no mx.array entries found in %d cache objects "
+            "(types: %s); pass-2 correctness may be compromised",
+            len(cache),
+            sorted({type(c).__name__ for c in cache}),
+        )
 
 
 def _prefill_last_logit(model: Any, prompt: mx.array, cache: list) -> mx.array:

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -599,8 +599,12 @@ class SpeculativeDecoder:
         """
         if make_prompt_cache is None:
             raise RuntimeError(
-                "mlx_lm.models.cache not available; cannot use stateless "
-                "speculative decoding"
+                "mlx_lm.models.cache.make_prompt_cache is not available "
+                "(import failed at module load). Upgrade mlx-lm to a "
+                "version that exports it (or use the cached prefill+step "
+                "API instead, which has the same requirement). The "
+                "previous cache-less path was removed because it OOMed "
+                "on Metal for large-vocab models on long prompts."
             )
 
         draft_tokens = self._draft_generate(prompt, self._lambda)

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -37,6 +37,49 @@ def _logits(out: Any) -> mx.array:
     return cast(mx.array, getattr(out, "logits", out))
 
 
+def _eval_cache(cache: list) -> None:
+    """Materialise KV cache state without evaluating logits.
+
+    Handles KVCache (.keys/.values) and ArraysCache-style caches (.state
+    returning a list of tensors).
+    """
+    arrs = []
+    for c in cache:
+        k = getattr(c, "keys", None)
+        if isinstance(k, mx.array):
+            arrs.append(k)
+        v = getattr(c, "values", None)
+        if isinstance(v, mx.array):
+            arrs.append(v)
+        if k is None and v is None:
+            # ArraysCache and similar: state is a list/tuple of arrays
+            state = getattr(c, "state", None)
+            if isinstance(state, (list, tuple)):
+                arrs.extend(a for a in state if isinstance(a, mx.array))
+    if arrs:
+        mx.eval(*arrs)
+
+
+def _prefill_last_logit(model: Any, prompt: mx.array, cache: list) -> mx.array:
+    """Return the logit for the last prompt position without materialising
+    the full [batch, seq_len, vocab] tensor.
+
+    For prompts longer than 1 token, runs two passes:
+    - Pass 1: prefix[:-1] fills the KV cache; the model output is discarded
+      so MLX's lazy evaluation never computes lm_head on seq_len-1 positions.
+    - Pass 2: last token produces a [1, 1, vocab] logit; safe to evaluate.
+
+    This avoids the Metal OOM that occurs when seq_len × vocab_size exceeds
+    the ~41 GB Metal buffer limit (e.g. Gemma 4 31B, vocab=262 144, long ctx).
+    """
+    if prompt.shape[1] <= 1:
+        return _logits(model(prompt, cache=cache))[0, -1, :]
+    prefix, last = prompt[:, :-1], prompt[:, -1:]
+    model(prefix, cache=cache)  # output discarded; lm_head never materialised
+    _eval_cache(cache)  # materialise KV state before the single-token pass
+    return _logits(model(last, cache=cache))[0, 0, :]
+
+
 def verify_draft_greedy(
     draft_tokens: list[int],
     target_logits: mx.array,
@@ -283,13 +326,14 @@ class SpeculativeDecoder:
         if self._gdn_capture is not None:
             self._gdn_capture.use_buffer(None)
 
-        target_out = _logits(self._target(prompt, cache=self._target_cache))
-        self._last_target_logit = target_out[0, -1, :]
+        self._last_target_logit = _prefill_last_logit(
+            self._target, prompt, self._target_cache
+        )
         mx.eval(self._last_target_logit)
 
-        # Populate draft cache (logits discarded — only cache state needed).
-        draft_logits = _logits(self._draft(prompt, cache=self._draft_cache))
-        mx.eval(draft_logits)
+        # Populate draft cache; logits not needed.
+        self._draft(prompt, cache=self._draft_cache)
+        _eval_cache(self._draft_cache)
 
         self._cache_seq_len = prompt.shape[1]
 

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -540,6 +540,8 @@ class SpeculativeDecoder:
 
     def _draft_generate(self, prompt: mx.array, n: int) -> list[int]:
         """Generate n candidate tokens with fresh KV cache (stateless)."""
+        if n <= 0:
+            return []
         if make_prompt_cache is None:
             # Caller (generate_step) already raises with the same wording;
             # this guard exists because asserts are stripped under -O.
@@ -547,8 +549,6 @@ class SpeculativeDecoder:
                 "mlx_lm.models.cache.make_prompt_cache is not available; "
                 "upgrade mlx-lm to a version that exports it."
             )
-        if n <= 0:
-            return []
         try:
             cache = make_prompt_cache(self._draft)
         except (TypeError, AttributeError) as exc:

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -72,16 +72,15 @@ def _eval_cache(cache: list) -> None:
     if arrs:
         mx.eval(*arrs)
     elif cache:
-        # Defensive: a non-empty cache produced no arrays to evaluate. The
-        # caller relies on pass 1's KV state being materialised before pass
-        # 2; a silent no-op here would let pass 2 see lazily-unevaluated
-        # state and produce wrong logits. Warn so unrecognised cache types
-        # surface instead of failing silently.
-        logger.warning(
-            "_eval_cache: no mx.array entries found in %d cache objects "
-            "(types: %s); pass-2 correctness may be compromised",
-            len(cache),
-            sorted({type(c).__name__ for c in cache}),
+        # A non-empty cache produced no arrays to evaluate. The caller's
+        # contract is that pass-2 logits are only meaningful if pass-1's
+        # KV state has been materialised. Continuing would produce silently
+        # wrong tokens for any unrecognised cache type, so fail loudly.
+        raise RuntimeError(
+            f"_eval_cache: no mx.array entries found in {len(cache)} cache "
+            f"objects (types: {sorted({type(c).__name__ for c in cache})}). "
+            "Pass-2 KV state cannot be guaranteed. Add explicit handling "
+            "for this cache type in _eval_cache."
         )
 
 

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -72,15 +72,21 @@ def _eval_cache(cache: list) -> None:
     if arrs:
         mx.eval(*arrs)
     elif cache:
-        # A non-empty cache produced no arrays to evaluate. The caller's
-        # contract is that pass-2 logits are only meaningful if pass-1's
-        # KV state has been materialised. Continuing would produce silently
-        # wrong tokens for any unrecognised cache type, so fail loudly.
-        raise RuntimeError(
-            f"_eval_cache: no mx.array entries found in {len(cache)} cache "
-            f"objects (types: {sorted({type(c).__name__ for c in cache})}). "
-            "Pass-2 KV state cannot be guaranteed. Add explicit handling "
-            "for this cache type in _eval_cache."
+        # A non-empty cache produced no arrays to evaluate (unrecognised
+        # cache type). MLX's lazy graph chains pass-1's cache mutations
+        # into pass-2's forward regardless, so tokens stay correct — but
+        # the OOM this helper was designed to prevent will resurface
+        # (pass-2's eval pulls pass-1's lm_head graph through). Warn so
+        # the gap is visible; do not raise, since hard-failing here would
+        # break speculative decoding for every new mlx-lm cache type
+        # before its probe lands in this function.
+        logger.warning(
+            "_eval_cache: no mx.array entries found in %d cache objects "
+            "(types: %s); the OOM-avoidance graph break is a no-op for "
+            "this cache type — add an explicit probe here if Metal OOMs "
+            "during prefill on long prompts.",
+            len(cache),
+            sorted({type(c).__name__ for c in cache}),
         )
 
 
@@ -97,7 +103,12 @@ def _prefill_last_logit(model: Any, prompt: mx.array, cache: list) -> mx.array:
     the ~41 GB Metal buffer limit (e.g. Gemma 4 31B, vocab=262 144, long ctx).
     """
     if prompt.shape[1] <= 1:
-        return _logits(model(prompt, cache=cache))[0, -1, :]
+        result = _logits(model(prompt, cache=cache))[0, -1, :]
+        # Uniform postcondition with the two-pass branch: callers can rely
+        # on the cache being materialised on return regardless of prompt
+        # length. Cheap here because the prompt is a single token.
+        _eval_cache(cache)
+        return result
     prefix, last = prompt[:, :-1], prompt[:, -1:]
     model(prefix, cache=cache)  # output discarded; lm_head never materialised
     _eval_cache(cache)  # materialise KV state before the single-token pass

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -537,15 +537,23 @@ class SpeculativeDecoder:
     # ------------------------------------------------------------------
 
     def _draft_generate(self, prompt: mx.array, n: int) -> list[int]:
-        """Generate n candidate tokens with fresh KV cache (stateless).
-
-        Only invoked from ``generate_step``, which guards on
-        ``make_prompt_cache is None`` before calling, so ``cache`` here is
-        always usable.
-        """
-        assert make_prompt_cache is not None
+        """Generate n candidate tokens with fresh KV cache (stateless)."""
+        if make_prompt_cache is None:
+            # Caller (generate_step) already raises with the same wording;
+            # this guard exists because asserts are stripped under -O.
+            raise RuntimeError(
+                "mlx_lm.models.cache.make_prompt_cache is not available; "
+                "upgrade mlx-lm to a version that exports it."
+            )
+        try:
+            cache = make_prompt_cache(self._draft)
+        except (TypeError, AttributeError) as exc:
+            raise RuntimeError(
+                f"make_prompt_cache failed for draft model "
+                f"{type(self._draft).__name__!r}: {exc}. The draft model may "
+                "not be compatible with mlx-lm's KV-cache API."
+            ) from exc
         tokens: list[int] = []
-        cache = make_prompt_cache(self._draft)
 
         logits = _logits(self._draft(prompt, cache=cache))
         next_logits = logits[:, -1, :]

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -61,6 +61,14 @@ def _eval_cache(cache: list) -> None:
             state = getattr(c, "state", None)
             if isinstance(state, (list, tuple)):
                 arrs.extend(a for a in state if isinstance(a, mx.array))
+        # TurboQuantKVCache / SpectralQuantKVCache return values from
+        # update_and_fetch are views over a separately maintained dequant
+        # side buffer that is not surfaced via .state. Probe explicitly so
+        # the dequant graph is forced here instead of fusing into pass 2.
+        for attr in ("_key_dequant", "_value_dequant"):
+            buf = getattr(c, attr, None)
+            if isinstance(buf, mx.array):
+                arrs.append(buf)
     if arrs:
         mx.eval(*arrs)
     elif cache:
@@ -570,20 +578,35 @@ class SpeculativeDecoder:
         self,
         prompt: mx.array,
     ) -> tuple[list[int], int]:
-        """One speculative decoding step (stateless, no cross-step caching)."""
+        """One speculative decoding step (stateless, no cross-step caching).
+
+        Uses a temporary KV cache internally so the target forward over the
+        long prompt does not materialise the full [batch, seq_len, vocab]
+        logit matrix (same Metal OOM that ``_prefill_last_logit`` avoids).
+        """
+        if make_prompt_cache is None:
+            raise RuntimeError(
+                "mlx_lm.models.cache not available; cannot use stateless "
+                "speculative decoding"
+            )
+
         draft_tokens = self._draft_generate(prompt, self._lambda)
 
-        draft_ids = mx.array([draft_tokens])
-        combined = mx.concatenate([prompt, draft_ids], axis=1)
         # See prefill() for why this reset is needed (mlx-vlm 0.4.4 VLMs).
         for attr in ("_position_ids", "_rope_deltas"):
             if hasattr(self._target, attr):
                 setattr(self._target, attr, None)
-        target_out = _logits(self._target(combined))
-        mx.eval(target_out)
 
-        seq_len = prompt.shape[1]
-        target_logits = target_out[0, seq_len - 1 : seq_len + self._lambda, :]
+        # Two-pass split: prefill the prompt into a temporary cache (yields
+        # the first verification logit), then feed [pending, D1..D_lambda]
+        # for the remaining lambda logits. Total materialised logit shape is
+        # [1, lambda+1, vocab] instead of [1, seq_len+lambda, vocab].
+        target_cache = make_prompt_cache(self._target)
+        first_logit = _prefill_last_logit(self._target, prompt, target_cache)
+        draft_ids = mx.array([draft_tokens])
+        draft_out = _logits(self._target(draft_ids, cache=target_cache))
+        target_logits = mx.concatenate([first_logit[None, :], draft_out[0]], axis=0)
+        mx.eval(target_logits)
 
         accepted = self._verify(draft_tokens, target_logits)
 

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -40,17 +40,22 @@ def _logits(out: Any) -> mx.array:
 def _eval_cache(cache: list) -> None:
     """Materialise KV cache state without evaluating logits.
 
-    Handles KVCache (.keys/.values) and ArraysCache-style caches (.state
+    Handles KVCache (.keys/.values as mx.array), quantised caches that wrap
+    packed data in a list/tuple, and ArraysCache-style caches (.state
     returning a list of tensors).
     """
     arrs = []
     for c in cache:
         k = getattr(c, "keys", None)
+        v = getattr(c, "values", None)
         if isinstance(k, mx.array):
             arrs.append(k)
-        v = getattr(c, "values", None)
+        elif isinstance(k, (list, tuple)):
+            arrs.extend(a for a in k if isinstance(a, mx.array))
         if isinstance(v, mx.array):
             arrs.append(v)
+        elif isinstance(v, (list, tuple)):
+            arrs.extend(a for a in v if isinstance(a, mx.array))
         if k is None and v is None:
             # ArraysCache and similar: state is a list/tuple of arrays
             state = getattr(c, "state", None)

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -101,21 +101,17 @@ def _prefill_last_logit(model: Any, prompt: mx.array, cache: list) -> mx.array:
 
     This avoids the Metal OOM that occurs when seq_len × vocab_size exceeds
     the ~41 GB Metal buffer limit (e.g. Gemma 4 31B, vocab=262 144, long ctx).
+
+    The returned logit is lazy. Cache state is materialised between passes
+    (graph-break for OOM avoidance) but the caller is expected to evaluate
+    the returned logit, which transitively forces pass-2's cache state.
     """
     if prompt.shape[1] <= 1:
-        result = _logits(model(prompt, cache=cache))[0, -1, :]
-        # Uniform postcondition with the two-pass branch: callers can rely
-        # on the cache being materialised on return regardless of prompt
-        # length. Cheap here because the prompt is a single token.
-        _eval_cache(cache)
-        return result
+        return _logits(model(prompt, cache=cache))[0, -1, :]
     prefix, last = prompt[:, :-1], prompt[:, -1:]
     model(prefix, cache=cache)  # output discarded; lm_head never materialised
     _eval_cache(cache)  # materialise KV state before the single-token pass
-    result = _logits(model(last, cache=cache))[0, 0, :]
-    # Uniform postcondition: cache materialised on return for either branch.
-    _eval_cache(cache)
-    return result
+    return _logits(model(last, cache=cache))[0, 0, :]
 
 
 def verify_draft_greedy(
@@ -541,41 +537,29 @@ class SpeculativeDecoder:
     # ------------------------------------------------------------------
 
     def _draft_generate(self, prompt: mx.array, n: int) -> list[int]:
-        """Generate n candidate tokens with fresh KV cache (stateless)."""
+        """Generate n candidate tokens with fresh KV cache (stateless).
+
+        Only invoked from ``generate_step``, which guards on
+        ``make_prompt_cache is None`` before calling, so ``cache`` here is
+        always usable.
+        """
+        assert make_prompt_cache is not None
         tokens: list[int] = []
+        cache = make_prompt_cache(self._draft)
 
-        cache = None
-        if make_prompt_cache is not None:
-            try:
-                cache = make_prompt_cache(self._draft)
-            except (TypeError, AttributeError):
-                pass
+        logits = _logits(self._draft(prompt, cache=cache))
+        next_logits = logits[:, -1, :]
+        mx.eval(next_logits)
+        next_token = int(mx.argmax(next_logits, axis=-1).item())
+        tokens.append(next_token)
 
-        if cache is not None:
-            logits = _logits(self._draft(prompt, cache=cache))
+        for _ in range(n - 1):
+            inp = mx.array([[next_token]])
+            logits = _logits(self._draft(inp, cache=cache))
             next_logits = logits[:, -1, :]
             mx.eval(next_logits)
             next_token = int(mx.argmax(next_logits, axis=-1).item())
             tokens.append(next_token)
-
-            for _ in range(n - 1):
-                inp = mx.array([[next_token]])
-                logits = _logits(self._draft(inp, cache=cache))
-                next_logits = logits[:, -1, :]
-                mx.eval(next_logits)
-                next_token = int(mx.argmax(next_logits, axis=-1).item())
-                tokens.append(next_token)
-        else:
-            for _ in range(n):
-                if tokens:
-                    current = mx.concatenate([prompt, mx.array([tokens])], axis=1)
-                else:
-                    current = prompt
-                logits = _logits(self._draft(current))
-                next_logits = logits[:, -1, :]
-                mx.eval(next_logits)
-                next_token = int(mx.argmax(next_logits, axis=-1).item())
-                tokens.append(next_token)
 
         return tokens
 

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -155,3 +155,87 @@ class TestSpeculativeDecoder:
         prompt = mx.array([[1, 2, 3]])
         decoder.generate_step(prompt)
         assert 0 <= decoder._alpha <= 1.0
+
+    def test_prefill_long_prompt_gives_valid_token(self, shared_decoder):
+        """prefill() with a long prompt must return a valid token and populate caches."""
+        prompt = mx.array([list(range(20))])
+        first_token = shared_decoder.prefill(prompt)
+
+        assert 0 <= first_token < 32
+        assert shared_decoder._cache_seq_len == 20
+        assert shared_decoder._target_cache is not None
+
+
+class TestPrefillLastLogit:
+    """Tests for _prefill_last_logit: two-pass prefill to avoid materialising
+    the full [batch, seq_len, vocab] logit matrix."""
+
+    @pytest.fixture()
+    def model(self):
+        return MockModel(32, 16)
+
+    def test_single_token_returns_vocab_shaped_logit(self, model):
+        from mlx_lm.models.cache import make_prompt_cache
+
+        from olmlx.engine.speculative import _prefill_last_logit
+
+        cache = make_prompt_cache(model)
+        result = _prefill_last_logit(model, mx.array([[7]]), cache)
+        assert result.shape == (32,)
+
+    def test_multi_token_returns_vocab_shaped_logit(self, model):
+        from mlx_lm.models.cache import make_prompt_cache
+
+        from olmlx.engine.speculative import _prefill_last_logit
+
+        cache = make_prompt_cache(model)
+        result = _prefill_last_logit(model, mx.array([[1, 2, 3, 4, 5]]), cache)
+        assert result.shape == (32,)
+
+    def test_matches_naive_single_token(self, model):
+        """Single-token result must match naive forward."""
+        from mlx_lm.models.cache import make_prompt_cache
+
+        from olmlx.engine.speculative import _logits, _prefill_last_logit
+
+        prompt = mx.array([[7]])
+        cache_naive = make_prompt_cache(model)
+        naive = _logits(model(prompt, cache=cache_naive))[0, -1, :]
+        mx.eval(naive)
+
+        cache_2p = make_prompt_cache(model)
+        result = _prefill_last_logit(model, prompt, cache_2p)
+        mx.eval(result)
+
+        assert mx.allclose(result, naive, atol=1e-5)
+
+    def test_matches_naive_multi_token(self, model):
+        """Two-pass result for a multi-token prompt must match naive full-sequence forward."""
+        from mlx_lm.models.cache import make_prompt_cache
+
+        from olmlx.engine.speculative import _logits, _prefill_last_logit
+
+        prompt = mx.array([[1, 2, 3, 4, 5]])
+        cache_naive = make_prompt_cache(model)
+        naive = _logits(model(prompt, cache=cache_naive))[0, -1, :]
+        mx.eval(naive)
+
+        cache_2p = make_prompt_cache(model)
+        result = _prefill_last_logit(model, prompt, cache_2p)
+        mx.eval(result)
+
+        assert mx.allclose(result, naive, atol=1e-5)
+
+    def test_cache_offset_equals_prompt_length(self, model):
+        """After _prefill_last_logit, KV cache offset must equal prompt length."""
+        from mlx_lm.models.cache import make_prompt_cache
+
+        from olmlx.engine.speculative import _prefill_last_logit
+
+        prompt = mx.array([[1, 2, 3, 4, 5]])
+        cache = make_prompt_cache(model)
+        _prefill_last_logit(model, prompt, cache)
+        # Force evaluation so offset is committed.
+        mx.eval(cache[0].keys, cache[0].values)
+
+        assert cache[0].offset == prompt.shape[1]

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -209,28 +209,24 @@ class TestPrefillLastLogit:
 
         assert mx.allclose(result, naive, atol=1e-5)
 
-    def test_matches_naive_multi_token(self, model):
-        """Smoke test: two-pass result shape matches naive forward on MockModel.
+    def test_multi_token_smoke(self, model):
+        """Smoke test: ``_prefill_last_logit`` runs end-to-end on a multi-token
+        prompt and returns a vocab-shaped logit.
 
-        Note: MockModel is cache-agnostic, so this does not verify numerical
-        correctness of the KV-cache split for real causal transformers. It
-        validates that ``_prefill_last_logit`` runs end-to-end and returns
-        the expected shape, not that pass 2 sees the correct cached state.
+        MockModel is cache-agnostic (``MockAttention`` discards the
+        ``update_and_fetch`` return), so this only exercises the code path.
+        Numerical correctness of the two-pass split is covered by
+        ``TestPrefillLastLogitCausal``.
         """
         from mlx_lm.models.cache import make_prompt_cache
 
-        from olmlx.engine.speculative import _logits, _prefill_last_logit
-
-        prompt = mx.array([[1, 2, 3, 4, 5]])
-        cache_naive = make_prompt_cache(model)
-        naive = _logits(model(prompt, cache=cache_naive))[0, -1, :]
-        mx.eval(naive)
+        from olmlx.engine.speculative import _prefill_last_logit
 
         cache_2p = make_prompt_cache(model)
-        result = _prefill_last_logit(model, prompt, cache_2p)
+        result = _prefill_last_logit(model, mx.array([[1, 2, 3, 4, 5]]), cache_2p)
         mx.eval(result)
 
-        assert mx.allclose(result, naive, atol=1e-5)
+        assert result.shape == (32,)
 
     def test_cache_offset_equals_prompt_length(self, model):
         """After _prefill_last_logit, KV cache offset must equal prompt length."""

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -176,6 +176,11 @@ class TestSpeculativeDecoder:
         assert num_draft == 3
         assert all(0 <= t < 32 for t in accepted)
 
+    def test_draft_generate_n_zero_returns_empty(self, decoder):
+        """_draft_generate(prompt, n=0) must return [] (no tokens)."""
+        prompt = mx.array([[1, 2, 3]])
+        assert decoder._draft_generate(prompt, n=0) == []
+
 
 class TestPrefillLastLogit:
     """Tests for _prefill_last_logit: two-pass prefill to avoid materialising
@@ -373,6 +378,62 @@ class TestEvalCacheCacheTypes:
         # Sanity: values are still those we set.
         assert mx.allclose(kd, mx.full((2, 4, 4), 0.5))
         assert mx.allclose(vd, mx.full((2, 4, 4), 0.25))
+
+    def test_real_spectralquant_cache_does_not_log_error(self, caplog):
+        """Regression: a real ``SpectralQuantKVCache`` must hit the ``.state``
+        probe branch. If ``.state`` is removed or restructured on the cache
+        class, the helper would silently fall through to the unrecognised
+        cache error path and the OOM protection would degrade to a no-op."""
+        import logging
+
+        import numpy as np
+
+        from olmlx.engine.spectralquant import (
+            SpectralRotation,
+            fit_codebook,
+        )
+        from olmlx.engine.spectralquant_cache import SpectralQuantKVCache
+        from olmlx.engine.speculative import _eval_cache
+
+        head_dim = 8
+        d_eff = 4
+        bits_high = 4
+        bits_low = 2
+        rng = np.random.RandomState(42)
+        q, _ = np.linalg.qr(rng.randn(head_dim, head_dim).astype(np.float32))
+        rot_k = SpectralRotation(mx.array(q))
+        q2, _ = np.linalg.qr(rng.randn(head_dim, head_dim).astype(np.float32))
+        rot_v = SpectralRotation(mx.array(q2))
+        data = mx.random.normal((500, head_dim))
+        norms = mx.linalg.norm(data, axis=-1, keepdims=True)
+        data_n = data / mx.maximum(norms, mx.array(1e-8))
+        rotated = rot_k.rotate(data_n)
+        cb_sem = fit_codebook(rotated[..., :d_eff].reshape(-1), bits=bits_high)
+        cb_tail = fit_codebook(rotated[..., d_eff:].reshape(-1), bits=bits_low)
+        cache = SpectralQuantKVCache(
+            rotation_key=rot_k,
+            rotation_value=rot_v,
+            codebook_sem_key=cb_sem,
+            codebook_tail_key=cb_tail,
+            codebook_sem_value=cb_sem,
+            codebook_tail_value=cb_tail,
+            d_eff=d_eff,
+            bits_high=bits_high,
+            bits_low=bits_low,
+        )
+        k = mx.random.normal((1, 2, 4, head_dim))
+        v = mx.random.normal((1, 2, 4, head_dim))
+        cache.update_and_fetch(k, v)
+
+        with caplog.at_level(logging.ERROR, logger="olmlx.engine.speculative"):
+            _eval_cache([cache])
+        assert not any(
+            "no mx.array entries found" in r.message for r in caplog.records
+        ), (
+            "_eval_cache hit the unrecognised-cache branch for a real "
+            "SpectralQuantKVCache. Check that .state still returns the "
+            "packed-storage arrays."
+        )
 
     def test_real_turboquant_cache_does_not_log_error(self, caplog):
         """Regression: a real ``TurboQuantKVCache`` must hit a known probe

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -374,6 +374,36 @@ class TestEvalCacheCacheTypes:
         assert mx.allclose(kd, mx.full((2, 4, 4), 0.5))
         assert mx.allclose(vd, mx.full((2, 4, 4), 0.25))
 
+    def test_real_turboquant_cache_does_not_log_error(self, caplog):
+        """Regression: a real ``TurboQuantKVCache`` must hit a known probe
+        branch in ``_eval_cache``. If anyone renames ``_key_dequant`` /
+        ``_value_dequant`` on the cache class, the helper would silently
+        fall through to the unrecognised-cache error path and the OOM
+        protection would degrade to a no-op without test failure. This
+        test pins the contract by instantiating the real cache."""
+        import logging
+
+        from olmlx.engine.speculative import _eval_cache
+        from olmlx.engine.turboquant import TurboQuantRotation
+        from olmlx.engine.turboquant_cache import TurboQuantKVCache
+
+        rk = TurboQuantRotation(head_dim=64, seed=0)
+        rv = TurboQuantRotation(head_dim=64, seed=1)
+        cache = TurboQuantKVCache(bits=4, rotation_key=rk, rotation_value=rv)
+        k = mx.random.normal((1, 8, 4, 64))
+        v = mx.random.normal((1, 8, 4, 64))
+        cache.update_and_fetch(k, v)
+
+        with caplog.at_level(logging.ERROR, logger="olmlx.engine.speculative"):
+            _eval_cache([cache])
+        assert not any(
+            "no mx.array entries found" in r.message for r in caplog.records
+        ), (
+            "_eval_cache hit the unrecognised-cache branch for a real "
+            "TurboQuantKVCache. Check that _key_dequant / _value_dequant "
+            "(or any replacement attributes) are probed in _eval_cache."
+        )
+
     def test_unrecognised_cache_logs_error(self, caplog):
         """A cache with no probed arrays must log at ERROR level so the
         OOM-avoidance no-op surfaces on first encounter."""

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -240,7 +240,12 @@ class TestPrefillLastLogit:
         assert result.shape == (32,)
 
     def test_cache_offset_equals_prompt_length(self, model):
-        """After _prefill_last_logit, KV cache offset must equal prompt length."""
+        """After _prefill_last_logit, KV cache offset must equal prompt length.
+
+        ``offset`` is a Python int incremented by ``update_and_fetch``
+        regardless of lazy evaluation, so reading it directly is enough —
+        no explicit ``mx.eval`` to mask whether the two passes ran.
+        """
         from mlx_lm.models.cache import make_prompt_cache
 
         from olmlx.engine.speculative import _prefill_last_logit
@@ -248,8 +253,6 @@ class TestPrefillLastLogit:
         prompt = mx.array([[1, 2, 3, 4, 5]])
         cache = make_prompt_cache(model)
         _prefill_last_logit(model, prompt, cache)
-        # Force evaluation so offset is committed.
-        mx.eval(cache[0].keys, cache[0].values)
 
         assert cache[0].offset == prompt.shape[1]
 
@@ -347,6 +350,29 @@ class TestEvalCacheCacheTypes:
         # Sanity: arrays are still valid and have their expected values.
         assert mx.allclose(a, mx.ones((4, 4)))
         assert mx.allclose(b, mx.full((4, 4), 2.0))
+
+    def test_turboquant_dequant_buffer_probe(self):
+        """TurboQuantKVCache exposes _key_dequant / _value_dequant rather
+        than .keys/.values. _eval_cache must probe those attributes so the
+        dequant chain is forced as a separate graph (otherwise pass-2 would
+        fuse pass-1's dequant into one Metal command buffer)."""
+
+        from olmlx.engine.speculative import _eval_cache
+
+        class _TurboQuantStub:
+            """No .keys/.values/.state, but exposes dequant side buffers."""
+
+            def __init__(self, kd, vd):
+                self._key_dequant = kd
+                self._value_dequant = vd
+
+        kd = mx.zeros((2, 4, 4)) + 0.5
+        vd = mx.zeros((2, 4, 4)) + 0.25
+        # Should reach the dequant-probe branch and NOT log an error.
+        _eval_cache([_TurboQuantStub(kd, vd)])
+        # Sanity: values are still those we set.
+        assert mx.allclose(kd, mx.full((2, 4, 4), 0.5))
+        assert mx.allclose(vd, mx.full((2, 4, 4), 0.25))
 
     def test_unrecognised_cache_logs_error(self, caplog):
         """A cache with no probed arrays must log at ERROR level so the

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -334,3 +334,75 @@ class TestPrefillLastLogitCausal:
         mx.eval(result)
 
         assert mx.allclose(result, naive, atol=1e-4)
+
+
+class _Qwen3_5StyleModel(_CausalMockModel):
+    """Mock model that mimics mlx-vlm 0.4.4 Qwen3_5/Qwen2-VL position-id
+    caching. Pass 1 (cache_offset==0, _rope_deltas is None) computes positions
+    from scratch and stores _position_ids / _rope_deltas on the instance.
+    Subsequent calls with cache_offset > 0 take the cache-extension code path
+    that builds positions on the fly from cache_offset + _rope_deltas, without
+    consulting (or updating) _position_ids. Resetting _rope_deltas between
+    those calls would force the model back onto the from-scratch code path
+    with the wrong starting position.
+    """
+
+    def __init__(self, vocab_size: int, hidden_size: int):
+        super().__init__(vocab_size, hidden_size)
+        self._position_ids: mx.array | None = None
+        self._rope_deltas: mx.array | None = None
+
+    def __call__(self, input_ids, cache=None):
+        cache_offset = (
+            cache[0].offset if cache is not None and cache[0] is not None else 0
+        )
+        if cache_offset == 0 or self._rope_deltas is None or cache is None:
+            # "Inner" branch (Qwen3_5 language.py:619): compute fresh, cache.
+            seq_length = input_ids.shape[1]
+            self._position_ids = mx.arange(seq_length).reshape(1, -1)
+            self._rope_deltas = mx.array(0)
+        else:
+            # "Else" branch (Qwen3_5 language.py:631): cache-extension. Does
+            # NOT update _position_ids or _rope_deltas — they persist from
+            # the first call. This is the path pass-2 and the draft forward
+            # take.
+            pass
+        return super().__call__(input_ids, cache=cache)
+
+
+class TestVLMStateAcrossPasses:
+    """Regression: the two-pass split must not require resetting cached
+    VLM position state between passes, because Qwen3_5/Qwen2-VL only update
+    that state on the cache_offset==0 call and use it as a delta thereafter.
+    Resetting between passes forces the model onto the wrong code path."""
+
+    def test_two_pass_does_not_overwrite_position_state_at_pass2(self):
+        from mlx_lm.models.cache import KVCache
+
+        from olmlx.engine.speculative import _prefill_last_logit
+
+        model = _Qwen3_5StyleModel(vocab_size=32, hidden_size=16)
+        prompt = mx.array([[1, 2, 3, 4, 5, 6, 7]])
+
+        # Naive single-pass: pass 1 sets _position_ids with prompt length.
+        naive_cache = [KVCache()]
+        naive = model(prompt, cache=naive_cache)[0, -1, :]
+        mx.eval(naive)
+
+        # Reset model and run the two-pass split: pass 1 is on prompt[:, :-1]
+        # (N-1 tokens, cache_offset=0), pass 2 is on prompt[:, -1:] (1 token,
+        # cache_offset=N-1). Pass 2 must take the cache-extension else branch.
+        model._position_ids = None
+        model._rope_deltas = None
+        two_pass_cache = [KVCache()]
+        result = _prefill_last_logit(model, prompt, two_pass_cache)
+        mx.eval(result)
+
+        # Output matches naive (numerical correctness).
+        assert mx.allclose(result, naive, atol=1e-4)
+        # _position_ids retains its pass-1 shape (N-1 = 6), confirming pass 2
+        # did NOT enter the inner branch (which would have overwritten it
+        # with a 1-element tensor). A reset between passes — as suggested by
+        # reviewers — would force pass 2 into the inner branch and break this.
+        assert model._position_ids is not None
+        assert model._position_ids.shape == (1, prompt.shape[1] - 1)

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -165,6 +165,17 @@ class TestSpeculativeDecoder:
         assert shared_decoder._cache_seq_len == 20
         assert shared_decoder._target_cache is not None
 
+    def test_generate_step_long_prompt_two_pass(self, shared_decoder):
+        """generate_step() with a long prompt exercises the two-pass split
+        (temporary KV cache + _prefill_last_logit) added to avoid the
+        [batch, seq_len+lambda, vocab] materialisation OOM."""
+        prompt = mx.array([list(range(20))])
+        accepted, num_draft = shared_decoder.generate_step(prompt)
+
+        assert len(accepted) >= 1
+        assert num_draft == 3
+        assert all(0 <= t < 32 for t in accepted)
+
 
 class TestPrefillLastLogit:
     """Tests for _prefill_last_logit: two-pass prefill to avoid materialising

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -245,3 +245,85 @@ class TestPrefillLastLogit:
         mx.eval(cache[0].keys, cache[0].values)
 
         assert cache[0].offset == prompt.shape[1]
+
+
+class _CausalAttention:
+    """Minimal scaled-dot-product attention over a real KV cache.
+
+    The pass-2 output for the last position depends on K/V from positions
+    0..N-2 via the attention mechanism, so a broken cache split (e.g. pass 1
+    not materialised before pass 2) produces numerically different logits
+    than a single-pass forward.
+    """
+
+    def __init__(self, hidden_size: int):
+        rng = mx.random.key(0)
+        self.wqkv = mx.random.normal((hidden_size, hidden_size * 3), key=rng) * 0.1
+        self.n_heads = 1
+
+    def __call__(self, x, cache=None):
+        B, T, D = x.shape
+        qkv = x @ self.wqkv
+        q, k, v = mx.split(qkv, 3, axis=-1)
+        # (B, n_heads=1, T, D)
+        q = q.reshape(B, 1, T, D)
+        k = k.reshape(B, 1, T, D)
+        v = v.reshape(B, 1, T, D)
+        if cache is not None:
+            k, v = cache.update_and_fetch(k, v)
+        scale = 1.0 / (D**0.5)
+        scores = (q @ mx.swapaxes(k, -1, -2)) * scale
+        # Causal mask over the appended-to history.
+        S = k.shape[2]
+        offset = S - T
+        i = mx.arange(T).reshape(T, 1) + offset
+        j = mx.arange(S).reshape(1, S)
+        mask = mx.where(j <= i, 0.0, -1e9)
+        scores = scores + mask
+        attn = mx.softmax(scores, axis=-1)
+        out = (attn @ v).reshape(B, T, D)
+        return out
+
+
+class _CausalMockModel:
+    """Model with real causal attention so KV cache state matters for output."""
+
+    def __init__(self, vocab_size: int, hidden_size: int):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        rng = mx.random.key(1)
+        self.embed_w = mx.random.normal((vocab_size, hidden_size), key=rng) * 0.1
+        self.attn = _CausalAttention(hidden_size)
+        self.lm_head_w = mx.random.normal((hidden_size, vocab_size), key=rng) * 0.1
+        # KV cache protocol expects model.layers iterable for make_prompt_cache
+        self.layers = [self.attn]
+
+    def __call__(self, input_ids, cache=None):
+        h = self.embed_w[input_ids]
+        layer_cache = cache[0] if cache is not None else None
+        h = self.attn(h, cache=layer_cache)
+        return h @ self.lm_head_w
+
+
+class TestPrefillLastLogitCausal:
+    """Validates that _prefill_last_logit's two-pass split produces the same
+    last-position logit as a single-pass forward on a model where attention
+    actually consults the KV cache."""
+
+    def test_two_pass_matches_naive_with_causal_attention(self):
+        from mlx_lm.models.cache import KVCache
+
+        from olmlx.engine.speculative import _prefill_last_logit
+
+        model = _CausalMockModel(vocab_size=32, hidden_size=16)
+        prompt = mx.array([[1, 2, 3, 4, 5, 6, 7]])
+
+        naive_cache = [KVCache()]
+        naive = model(prompt, cache=naive_cache)[0, -1, :]
+        mx.eval(naive)
+
+        two_pass_cache = [KVCache()]
+        result = _prefill_last_logit(model, prompt, two_pass_cache)
+        mx.eval(result)
+
+        assert mx.allclose(result, naive, atol=1e-4)

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -210,7 +210,13 @@ class TestPrefillLastLogit:
         assert mx.allclose(result, naive, atol=1e-5)
 
     def test_matches_naive_multi_token(self, model):
-        """Two-pass result for a multi-token prompt must match naive full-sequence forward."""
+        """Smoke test: two-pass result shape matches naive forward on MockModel.
+
+        Note: MockModel is cache-agnostic, so this does not verify numerical
+        correctness of the KV-cache split for real causal transformers. It
+        validates that ``_prefill_last_logit`` runs end-to-end and returns
+        the expected shape, not that pass 2 sees the correct cached state.
+        """
         from mlx_lm.models.cache import make_prompt_cache
 
         from olmlx.engine.speculative import _logits, _prefill_last_logit

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -298,10 +298,13 @@ class _CausalMockModel:
     def __init__(self, vocab_size: int, hidden_size: int):
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size
-        rng = mx.random.key(1)
-        self.embed_w = mx.random.normal((vocab_size, hidden_size), key=rng) * 0.1
+        # Separate PRNG keys so embed_w and lm_head_w are independent.
+        # Reusing one key would tie them (MLX PRNGs are deterministic per key).
+        rng_embed = mx.random.key(1)
+        rng_head = mx.random.key(2)
+        self.embed_w = mx.random.normal((vocab_size, hidden_size), key=rng_embed) * 0.1
         self.attn = _CausalAttention(hidden_size)
-        self.lm_head_w = mx.random.normal((hidden_size, vocab_size), key=rng) * 0.1
+        self.lm_head_w = mx.random.normal((hidden_size, vocab_size), key=rng_head) * 0.1
         # KV cache protocol expects model.layers iterable for make_prompt_cache
         self.layers = [self.attn]
 
@@ -310,6 +313,54 @@ class _CausalMockModel:
         layer_cache = cache[0] if cache is not None else None
         h = self.attn(h, cache=layer_cache)
         return h @ self.lm_head_w
+
+
+class TestEvalCacheCacheTypes:
+    """Coverage for the cache-type dispatch in _eval_cache. The function must
+    surface arrays from each supported cache shape (KVCache via .keys/.values,
+    ArraysCache-style via .state, TurboQuantKVCache via _key_dequant /
+    _value_dequant) so pass-1 state is forced before pass-2 runs."""
+
+    def test_arrays_cache_state_branch(self):
+        """ArraysCache-style cache (no .keys/.values; .state returns a list of
+        arrays) must reach the .state branch and be eval'd."""
+
+        from olmlx.engine.speculative import _eval_cache
+
+        class _ArraysCacheStub:
+            """Minimal stand-in for mlx-lm's ArraysCache: no .keys/.values,
+            exposes .state as a list of mx.arrays. Mirrors what hybrid
+            linear-attention layers (e.g. Qwen3.5 GatedDeltaNet) use."""
+
+            def __init__(self, arrs):
+                self._arrs = arrs
+
+            @property
+            def state(self):
+                return self._arrs
+
+        a = mx.zeros((4, 4)) + 1.0
+        b = mx.zeros((4, 4)) + 2.0
+        cache = [_ArraysCacheStub([a, b])]
+        # Should not raise and should not log an error (arrays were found).
+        _eval_cache(cache)
+        # Sanity: arrays are still valid and have their expected values.
+        assert mx.allclose(a, mx.ones((4, 4)))
+        assert mx.allclose(b, mx.full((4, 4), 2.0))
+
+    def test_unrecognised_cache_logs_error(self, caplog):
+        """A cache with no probed arrays must log at ERROR level so the
+        OOM-avoidance no-op surfaces on first encounter."""
+        import logging
+
+        from olmlx.engine.speculative import _eval_cache
+
+        class _OpaqueCache:
+            pass
+
+        with caplog.at_level(logging.ERROR, logger="olmlx.engine.speculative"):
+            _eval_cache([_OpaqueCache()])
+        assert any("no mx.array entries found" in r.message for r in caplog.records)
 
 
 class TestPrefillLastLogitCausal:


### PR DESCRIPTION
## Summary

- `prefill()` in all three speculative decoder strategies previously materialised a `[batch, seq_len, vocab_size]` logit matrix for the entire prompt. For Gemma 4 31B (vocab=262 144) with a ~300 k-token context this exceeds Metal's ~41.7 GB single-buffer limit.
- Adds `_prefill_last_logit()` and `_eval_cache()` helpers and applies a two-pass prefill across classic, Eagle, and DFlash decoders.

**Classic** (`speculative.py`): prefix pass fills KV cache with output discarded → MLX lazy eval skips lm_head; single-token final pass yields `[1, 1, vocab]`.

**Eagle** (`eagle/decoder.py`): same two-pass structure; the hook-captured hidden for the last position (used as `seed_hidden`) comes from the single-token pass.

**DFlash** (`dflash/decoder.py`): DFlash's draft conditions on ALL prompt hidden states, so `captured_prefix` is saved from pass 1 and concatenated with `captured_last` from pass 2 along the time axis — preserving `self._hidden` shape `[1, N, total_hidden]` and keeping the draft-cache offset invariant.

## Test plan

- [ ] `TestPrefillLastLogit` — 5 new unit tests: shape, single-token, multi-token correctness (matches naive), and cache-offset invariant
- [ ] `TestSpeculativeDecoder::test_prefill_long_prompt_gives_valid_token` — regression test with 20-token prompt
- [ ] All existing speculative / dflash / eagle / hybrid tests pass (101 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)