### PR TITLE
fix(flash): close prefetcher + weight_store on eviction and keep-alive expiry

### DIFF
--- a/olmlx/engine/eagle/decoder.py
+++ b/olmlx/engine/eagle/decoder.py
@@ -172,6 +172,15 @@ class EagleDecoder:
 
     # ----- lifecycle -------------------------------------------------------
 
+    def close(self) -> None:
+        """Alias for :meth:`reset` so callers can use the same
+        ``close()`` lifecycle name as :class:`SpeculativeDecoder` and
+        :class:`DFlashDecoder` — ``ModelManager`` holds whichever
+        decoder type the strategy resolved to and treats them uniformly
+        on unload, eviction, and keep-alive expiry.
+        """
+        self.reset()
+
     def reset(self) -> None:
         # Close the GDN capture *first* — it holds ``_GDN_PATCH_LOCK``,
         # and if any of the steps below raises we still want the lock

--- a/olmlx/engine/flash/flash_model.py
+++ b/olmlx/engine/flash/flash_model.py
@@ -66,6 +66,12 @@ class FlashModelWrapper(nn.Module):
         # for _-prefixed names).
         object.__setattr__(self, "_model", model)
         object.__setattr__(self, "_sharded", False)
+        # Surface the weight store so ModelManager can close it on
+        # eviction / keep-alive expiry. Without this attribute, the
+        # FlashWeightStore's 32-thread ThreadPoolExecutor and per-layer
+        # file descriptors leak when a dense Flash model rolls out.
+        # Mirrors FlashMoeModelWrapper._weight_store.
+        object.__setattr__(self, "_weight_store", weight_store)
         self.window_manager = WindowManager(
             flash_config.num_layers,
             flash_config.window_size,

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -289,6 +289,16 @@ class SpectralCalibrationMissingError(FileNotFoundError):
     """Raised when SpectralQuant is configured but calibration data is absent."""
 
 
+class ActiveRequestsError(RuntimeError):
+    """Raised by ``ModelManager.unload`` when a model has in-flight requests.
+
+    Subclasses ``RuntimeError`` so legacy ``except RuntimeError:`` keeps
+    working, but the dedicated type lets HTTP routers narrow the 409 path
+    to exactly this condition. Without it, an unrelated ``RuntimeError``
+    from ``_close_loaded_model`` would be misreported as 409.
+    """
+
+
 @dataclass
 class CachedPromptState:
     """KV cache state from a previous generation, for prompt cache reuse."""
@@ -890,6 +900,12 @@ class ModelManager:
             except Exception as exc:
                 logger.exception("Error closing speculative decoder for %s", lm.name)
                 errors.append(exc)
+        # Null every direct field on the LoadedModel that we just closed, so
+        # later code can't accidentally observe (or double-close) a closed
+        # resource. ``lm.model.prefetcher`` is not nulled because that lives
+        # on the model wrapper itself, not on the LM — the model is dropped
+        # along with the LM and shouldn't be mutated here.
+        lm.weight_store = None
         lm.speculative_decoder = None
         if errors:
             raise ExceptionGroup(f"Errors closing resources for {lm.name}", errors)
@@ -1278,7 +1294,7 @@ class ModelManager:
         if lm is None:
             return False
         if lm.active_refs > 0:
-            raise RuntimeError(
+            raise ActiveRequestsError(
                 f"Model '{normalized}' has {lm.active_refs} active request(s)"
             )
         lm = self._loaded.pop(normalized)

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -860,24 +860,36 @@ class ModelManager:
         the capture instance via its closure, so ``__del__`` never fires and
         the patch lock stays held until ``close()`` is called explicitly.
 
-        Each close() is wrapped in its own try/finally so a failure in one
-        resource doesn't skip the others — without this, a single raising
-        prefetcher.close() would leak the weight store's file descriptors and
-        leave the GDN monkey-patch installed indefinitely.
+        Each close() is attempted independently and logged at point of
+        failure. If exactly one raises, that exception is re-raised; if
+        multiple do, an ``ExceptionGroup`` surfaces all of them — Python's
+        nested-try/finally semantics would otherwise silently discard
+        earlier exceptions when a later finally also raised.
         """
-        try:
-            if getattr(lm.model, "prefetcher", None) is not None:
-                lm.model.prefetcher.close()
-        finally:
+        errors: list[BaseException] = []
+        if getattr(lm.model, "prefetcher", None) is not None:
             try:
-                if lm.weight_store is not None:
-                    lm.weight_store.close()
-            finally:
-                try:
-                    if lm.speculative_decoder is not None:
-                        lm.speculative_decoder.close()
-                finally:
-                    lm.speculative_decoder = None
+                lm.model.prefetcher.close()
+            except Exception as exc:
+                logger.exception("Error closing prefetcher for %s", lm.name)
+                errors.append(exc)
+        if lm.weight_store is not None:
+            try:
+                lm.weight_store.close()
+            except Exception as exc:
+                logger.exception("Error closing weight store for %s", lm.name)
+                errors.append(exc)
+        if lm.speculative_decoder is not None:
+            try:
+                lm.speculative_decoder.close()
+            except Exception as exc:
+                logger.exception("Error closing speculative decoder for %s", lm.name)
+                errors.append(exc)
+        lm.speculative_decoder = None
+        if len(errors) == 1:
+            raise errors[0]
+        if errors:
+            raise ExceptionGroup(f"Errors closing resources for {lm.name}", errors)
 
     def _evict_lru_if_needed(self) -> None:
         """Evict least-recently-used models until below max_loaded_models.
@@ -894,7 +906,17 @@ class ModelManager:
             oldest_name = min(evictable, key=lambda k: evictable[k].loaded_at)
             logger.info("Evicting model %s", oldest_name)
             evicted = self._loaded.pop(oldest_name)
-            self._close_loaded_model(evicted)
+            # Absorb cleanup failures so a stuck prefetcher on the evicted
+            # model can't permanently block subsequent model loads. The model
+            # is already removed from ``_loaded``; the new load will proceed
+            # with leaked threads/fds rather than failing.
+            # Mirrors the per-model guard in ``_expire_stale``.
+            try:
+                self._close_loaded_model(evicted)
+            except Exception:
+                logger.exception(
+                    "Error closing resources for evicted model %s", oldest_name
+                )
             del evicted
 
         # Flush Metal allocator cache so that buffers from evicted models
@@ -1100,7 +1122,6 @@ class ModelManager:
                     # Detect if flash mode was used
                     is_flash = False
                     is_flash_moe = False
-                    _weight_store = None
                     try:
                         from olmlx.engine.flash.flash_model import (
                             FlashModelWrapper,
@@ -1114,11 +1135,13 @@ class ModelManager:
                             FlashMoeModelWrapper,
                         )
 
-                        if isinstance(model, FlashMoeModelWrapper):
-                            is_flash_moe = True
-                            _weight_store = getattr(model, "_weight_store", None)
+                        is_flash_moe = isinstance(model, FlashMoeModelWrapper)
                     except ImportError:
                         pass
+                    # Both Flash wrappers store the underlying weight store as
+                    # ``_weight_store`` so eviction / keep-alive expiry can
+                    # close it. Non-Flash models leave this at None.
+                    _weight_store = getattr(model, "_weight_store", None)
 
                     lm = LoadedModel(
                         name=normalized,

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -910,13 +910,12 @@ class ModelManager:
             # model can't permanently block subsequent model loads. The model
             # is already removed from ``_loaded``; the new load will proceed
             # with leaked threads/fds rather than failing.
-            # Mirrors the per-model guard in ``_expire_stale``.
+            # _close_loaded_model logs per-resource on failure, so no extra
+            # logging here — mirrors the absorb pattern in _expire_stale.
             try:
                 self._close_loaded_model(evicted)
             except Exception:
-                logger.exception(
-                    "Error closing resources for evicted model %s", oldest_name
-                )
+                pass  # already logged inside _close_loaded_model
             del evicted
 
         # Flush Metal allocator cache so that buffers from evicted models
@@ -1263,6 +1262,13 @@ class ModelManager:
         """Unload a model. Returns True if unloaded, False if not loaded.
 
         Raises RuntimeError if model has active requests.
+
+        Note: if ``_close_loaded_model`` raises, the model has already been
+        removed from ``_loaded`` (so a subsequent ``unload`` would return
+        ``False``) but the caller still sees the exception. Each resource
+        is attempted independently and logged before the raise — strictly
+        better than the pre-refactor inline code, which would abort on
+        the first failure and leak the remaining resources silently.
         """
         normalized = self.registry.normalize_name(name)
         lm = self._loaded.get(normalized)
@@ -2775,39 +2781,42 @@ class ModelManager:
     async def _expire_stale(self):
         """Unload models whose keep-alive has expired (active_refs == 0)."""
         now = time.time()
+        # Pop expired entries under the lock, then close them after releasing
+        # it. _close_loaded_model calls executor.shutdown(wait=True) which
+        # blocks the event loop until the pool drains; holding self._lock
+        # during that would stall every concurrent ensure_loaded() caller.
+        # Models with active_refs > 0 are skipped — they are currently
+        # serving requests. Even if a model slips through with
+        # active_refs == 0 between ensure_loaded() and _inference_ref(),
+        # the caller still holds a Python reference, so the model/
+        # tokenizer stay alive; only the _loaded dict entry is removed.
         async with self._lock:
-            # Models with active_refs > 0 are skipped — they are currently
-            # serving requests.  Even if a model slips through with
-            # active_refs == 0 between ensure_loaded() and _inference_ref(),
-            # the caller still holds a Python reference, so the model/
-            # tokenizer stay alive; only the _loaded dict entry is removed.
-            expired = [
-                name
-                for name, lm in self._loaded.items()
-                if lm.expires_at is not None
-                and lm.expires_at <= now
-                and lm.active_refs == 0
-            ]
-            had_expired = False
-            for name in expired:
-                logger.info("Unloading expired model %s", name)
-                lm = self._loaded.pop(name)
-                # Per-model isolation: one failing close() must not skip the
-                # remaining expired models. ``_close_loaded_model`` already
-                # try/finally-chains its own three resources; this guard
-                # protects sibling models in the same expiry cycle.
-                try:
-                    self._close_loaded_model(lm)
-                except Exception:
-                    logger.exception("Error closing resources for model %s", name)
-                had_expired = True
-            # Flush Metal allocator cache so freed buffers don't inflate the
-            # next ensure_loaded() memory check. Mirrors _evict_lru_if_needed.
-            # Skip when any deferred cleanup is pending — a background thread
-            # for a different model may still be allocating Metal memory.
-            if had_expired and not self._pending_cleanups:
-                gc.collect()
-                mx.clear_cache()
+            expired_lms: list[LoadedModel] = []
+            for name, lm in list(self._loaded.items()):
+                if (
+                    lm.expires_at is not None
+                    and lm.expires_at <= now
+                    and lm.active_refs == 0
+                ):
+                    logger.info("Unloading expired model %s", name)
+                    expired_lms.append(self._loaded.pop(name))
+
+        # Close outside the lock. Per-model isolation: one failing close()
+        # must not skip the remaining expired models. _close_loaded_model
+        # already logs per-resource on failure, so callers absorb silently.
+        for lm in expired_lms:
+            try:
+                self._close_loaded_model(lm)
+            except Exception:
+                pass  # already logged inside _close_loaded_model
+
+        # Flush Metal allocator cache so freed buffers don't inflate the
+        # next ensure_loaded() memory check. Mirrors _evict_lru_if_needed.
+        # Skip when any deferred cleanup is pending — a background thread
+        # for a different model may still be allocating Metal memory.
+        if expired_lms and not self._pending_cleanups:
+            gc.collect()
+            mx.clear_cache()
 
     async def _check_expiry_loop(self):
         while True:

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -844,6 +844,30 @@ class ModelManager:
             keep_alive if keep_alive is not None else settings.default_keep_alive
         )
 
+    @staticmethod
+    def _close_loaded_model(lm: "LoadedModel") -> None:
+        """Release resources held by a LoadedModel.
+
+        Used by every lifecycle exit (explicit unload, LRU eviction, keep-alive
+        expiry). Without this, Flash models leak ThreadPoolExecutor workers and
+        per-layer file descriptors on eviction/expiry — issue #178.
+
+        Order matters: prefetcher tasks submit into the weight store's pool, so
+        the prefetcher must shut down before the weight store. Closing the
+        speculative decoder (not just dropping the reference) is required when
+        it owns a ``GDNStateCapture`` for a hybrid linear-attention
+        target/draft: the class-level monkey-patch holds a strong reference to
+        the capture instance via its closure, so ``__del__`` never fires and
+        the patch lock stays held until ``close()`` is called explicitly.
+        """
+        if getattr(lm.model, "prefetcher", None) is not None:
+            lm.model.prefetcher.close()
+        if lm.weight_store is not None:
+            lm.weight_store.close()
+        if lm.speculative_decoder is not None:
+            lm.speculative_decoder.close()
+        lm.speculative_decoder = None
+
     def _evict_lru_if_needed(self) -> None:
         """Evict least-recently-used models until below max_loaded_models.
 
@@ -859,16 +883,7 @@ class ModelManager:
             oldest_name = min(evictable, key=lambda k: evictable[k].loaded_at)
             logger.info("Evicting model %s", oldest_name)
             evicted = self._loaded.pop(oldest_name)
-            # Release draft model Metal memory promptly. Closing the
-            # decoder (not just dropping the reference) is required when
-            # the decoder owns a ``GDNStateCapture`` for a hybrid
-            # linear-attention target/draft: the class-level monkey-patch
-            # holds a strong reference to the capture instance via its
-            # closure, so ``__del__`` never fires and the patch lock
-            # stays held until ``close()`` is called explicitly.
-            if evicted.speculative_decoder is not None:
-                evicted.speculative_decoder.close()
-            evicted.speculative_decoder = None
+            self._close_loaded_model(evicted)
             del evicted
 
         # Flush Metal allocator cache so that buffers from evicted models
@@ -1224,19 +1239,7 @@ class ModelManager:
                 f"Model '{normalized}' has {lm.active_refs} active request(s)"
             )
         lm = self._loaded.pop(normalized)
-        # Close prefetcher *before* weight store: prefetcher tasks submit into
-        # the weight store's pool, so weight store must outlive the prefetcher.
-        if hasattr(lm.model, "prefetcher") and lm.model.prefetcher is not None:
-            lm.model.prefetcher.close()
-        if lm.weight_store is not None:
-            lm.weight_store.close()
-        # Release draft model Metal memory promptly and unhook the
-        # class-level GatedDeltaNet patch if one is installed (hybrid
-        # target/draft). See the eviction site above for why ``close()``
-        # is required — ``__del__`` cannot break the closure cycle.
-        if lm.speculative_decoder is not None:
-            lm.speculative_decoder.close()
-        lm.speculative_decoder = None
+        self._close_loaded_model(lm)
         return True
 
     # Config keys that indicate a vision-language model
@@ -2753,7 +2756,8 @@ class ModelManager:
             ]
             for name in expired:
                 logger.info("Unloading expired model %s", name)
-                del self._loaded[name]
+                lm = self._loaded.pop(name)
+                self._close_loaded_model(lm)
 
     async def _check_expiry_loop(self):
         while True:

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -891,22 +891,25 @@ class ModelManager:
         if lm.weight_store is not None:
             try:
                 lm.weight_store.close()
+                # Null only on success — if close() raised, the store may
+                # be partially closed (executor mid-drain). Preserving the
+                # reference lets a future cleanup path (or test) inspect
+                # the failed object instead of orphaning it. Same reasoning
+                # for speculative_decoder below.
+                lm.weight_store = None
             except Exception as exc:
                 logger.exception("Error closing weight store for %s", lm.name)
                 errors.append(exc)
         if lm.speculative_decoder is not None:
             try:
                 lm.speculative_decoder.close()
+                lm.speculative_decoder = None
             except Exception as exc:
                 logger.exception("Error closing speculative decoder for %s", lm.name)
                 errors.append(exc)
-        # Null every direct field on the LoadedModel that we just closed, so
-        # later code can't accidentally observe (or double-close) a closed
-        # resource. ``lm.model.prefetcher`` is not nulled because that lives
-        # on the model wrapper itself, not on the LM — the model is dropped
-        # along with the LM and shouldn't be mutated here.
-        lm.weight_store = None
-        lm.speculative_decoder = None
+        # ``lm.model.prefetcher`` is intentionally not nulled — it lives on
+        # the FlashModelWrapper, not on the LM bookkeeping, and the wrapper
+        # goes away with the LM.
         if errors:
             raise ExceptionGroup(f"Errors closing resources for {lm.name}", errors)
 
@@ -1280,14 +1283,16 @@ class ModelManager:
     def unload(self, name: str) -> bool:
         """Unload a model. Returns True if unloaded, False if not loaded.
 
-        Raises RuntimeError if model has active requests.
+        Raises ActiveRequestsError if model has in-flight requests.
 
-        Note: if ``_close_loaded_model`` raises, the model has already been
-        removed from ``_loaded`` (so a subsequent ``unload`` would return
-        ``False``) but the caller still sees the exception. Each resource
-        is attempted independently and logged before the raise — strictly
-        better than the pre-refactor inline code, which would abort on
-        the first failure and leak the remaining resources silently.
+        Close failures from ``_close_loaded_model`` are absorbed: the
+        model is already gone from ``_loaded`` (won't accept new
+        requests), so the user-visible unload semantics are satisfied
+        even if some background threads leaked. The per-resource log
+        lines inside ``_close_loaded_model`` record what failed.
+        Surfacing the ExceptionGroup as a 500 instead would leave the
+        client unable to distinguish "close failed, model is gone" from
+        an unrelated 500 — and either way, the model is gone.
         """
         normalized = self.registry.normalize_name(name)
         lm = self._loaded.get(normalized)
@@ -1298,7 +1303,10 @@ class ModelManager:
                 f"Model '{normalized}' has {lm.active_refs} active request(s)"
             )
         lm = self._loaded.pop(normalized)
-        self._close_loaded_model(lm)
+        try:
+            self._close_loaded_model(lm)
+        except ExceptionGroup:
+            pass  # already logged per-resource inside _close_loaded_model
         return True
 
     # Config keys that indicate a vision-language model
@@ -2820,19 +2828,24 @@ class ModelManager:
                     logger.info("Unloading expired model %s", name)
                     expired_lms.append(self._loaded.pop(name))
 
-        # Close outside the lock. Per-model isolation: one failing close()
-        # must not skip the remaining expired models. _close_loaded_model
-        # already logs per-resource on failure, so callers absorb silently.
+        # Close outside the lock AND off the event loop thread.
+        # ``_close_loaded_model`` calls ``executor.shutdown(wait=True)`` on
+        # the prefetcher (16 threads) and weight store (32 threads); that
+        # join is synchronous, so running it on the event loop would stall
+        # every concurrent coroutine until the pools drained. ``to_thread``
+        # offloads the join. Per-model isolation: one failing close() must
+        # not skip the remaining expired models — _close_loaded_model
+        # already logs per-resource, so callers absorb silently.
         # Pop from the list so no live reference (including the loop
         # variable) survives into the gc.collect() below — otherwise the
-        # Metal buffers attached to the LoadedModel can't be reclaimed
-        # and mx.clear_cache() runs against nothing. Same reason
+        # Metal buffers attached to the LoadedModel can't be reclaimed and
+        # mx.clear_cache() runs against nothing. Same reason
         # _evict_lru_if_needed calls ``del evicted``.
         flush = bool(expired_lms) and not self._pending_cleanups
         while expired_lms:
             lm = expired_lms.pop()
             try:
-                self._close_loaded_model(lm)
+                await asyncio.to_thread(self._close_loaded_model, lm)
             except Exception:
                 pass  # already logged inside _close_loaded_model
             del lm

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -859,14 +859,25 @@ class ModelManager:
         target/draft: the class-level monkey-patch holds a strong reference to
         the capture instance via its closure, so ``__del__`` never fires and
         the patch lock stays held until ``close()`` is called explicitly.
+
+        Each close() is wrapped in its own try/finally so a failure in one
+        resource doesn't skip the others — without this, a single raising
+        prefetcher.close() would leak the weight store's file descriptors and
+        leave the GDN monkey-patch installed indefinitely.
         """
-        if getattr(lm.model, "prefetcher", None) is not None:
-            lm.model.prefetcher.close()
-        if lm.weight_store is not None:
-            lm.weight_store.close()
-        if lm.speculative_decoder is not None:
-            lm.speculative_decoder.close()
-        lm.speculative_decoder = None
+        try:
+            if getattr(lm.model, "prefetcher", None) is not None:
+                lm.model.prefetcher.close()
+        finally:
+            try:
+                if lm.weight_store is not None:
+                    lm.weight_store.close()
+            finally:
+                try:
+                    if lm.speculative_decoder is not None:
+                        lm.speculative_decoder.close()
+                finally:
+                    lm.speculative_decoder = None
 
     def _evict_lru_if_needed(self) -> None:
         """Evict least-recently-used models until below max_loaded_models.

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -861,9 +861,14 @@ class ModelManager:
         the patch lock stays held until ``close()`` is called explicitly.
 
         Each close() is attempted independently and logged at point of
-        failure. If exactly one raises, that exception is re-raised; if
-        multiple do, an ``ExceptionGroup`` surfaces all of them — Python's
-        nested-try/finally semantics would otherwise silently discard
+        failure. On any error, always raises an ``ExceptionGroup`` carrying
+        every failure — even when only one resource failed — so callers see
+        a stable exception type. Without this, code writing
+        ``except RuntimeError:`` around the single-failure case would
+        silently miss a two-failure case. Use ``except*`` (PEP 654) to
+        handle individual member types.
+
+        Python's nested-try/finally would otherwise silently discard
         earlier exceptions when a later finally also raised.
         """
         errors: list[BaseException] = []
@@ -886,8 +891,6 @@ class ModelManager:
                 logger.exception("Error closing speculative decoder for %s", lm.name)
                 errors.append(exc)
         lm.speculative_decoder = None
-        if len(errors) == 1:
-            raise errors[0]
         if errors:
             raise ExceptionGroup(f"Errors closing resources for {lm.name}", errors)
 

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -932,12 +932,14 @@ class ModelManager:
             # model can't permanently block subsequent model loads. The model
             # is already removed from ``_loaded``; the new load will proceed
             # with leaked threads/fds rather than failing.
-            # _close_loaded_model logs per-resource on failure, so no extra
-            # logging here — mirrors the absorb pattern in _expire_stale.
+            # Narrowed to ExceptionGroup to match _close_loaded_model's
+            # documented contract (always raises ExceptionGroup on any
+            # error) — same shape as the catch in unload(). An unexpected
+            # non-ExceptionGroup exception would propagate as a bug.
             try:
                 self._close_loaded_model(evicted)
-            except Exception:
-                pass  # already logged inside _close_loaded_model
+            except ExceptionGroup:
+                pass  # already logged per-resource inside _close_loaded_model
             del evicted
 
         # Flush Metal allocator cache so that buffers from evicted models
@@ -2846,8 +2848,8 @@ class ModelManager:
             lm = expired_lms.pop()
             try:
                 await asyncio.to_thread(self._close_loaded_model, lm)
-            except Exception:
-                pass  # already logged inside _close_loaded_model
+            except ExceptionGroup:
+                pass  # already logged per-resource inside _close_loaded_model
             del lm
 
         # Flush Metal allocator cache so freed buffers don't inflate the

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2807,17 +2807,25 @@ class ModelManager:
         # Close outside the lock. Per-model isolation: one failing close()
         # must not skip the remaining expired models. _close_loaded_model
         # already logs per-resource on failure, so callers absorb silently.
-        for lm in expired_lms:
+        # Pop from the list so no live reference (including the loop
+        # variable) survives into the gc.collect() below — otherwise the
+        # Metal buffers attached to the LoadedModel can't be reclaimed
+        # and mx.clear_cache() runs against nothing. Same reason
+        # _evict_lru_if_needed calls ``del evicted``.
+        flush = bool(expired_lms) and not self._pending_cleanups
+        while expired_lms:
+            lm = expired_lms.pop()
             try:
                 self._close_loaded_model(lm)
             except Exception:
                 pass  # already logged inside _close_loaded_model
+            del lm
 
         # Flush Metal allocator cache so freed buffers don't inflate the
         # next ensure_loaded() memory check. Mirrors _evict_lru_if_needed.
         # Skip when any deferred cleanup is pending — a background thread
         # for a different model may still be allocating Metal memory.
-        if expired_lms and not self._pending_cleanups:
+        if flush:
             gc.collect()
             mx.clear_cache()
 

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2765,12 +2765,38 @@ class ModelManager:
                 and lm.expires_at <= now
                 and lm.active_refs == 0
             ]
+            had_expired = False
             for name in expired:
                 logger.info("Unloading expired model %s", name)
                 lm = self._loaded.pop(name)
-                self._close_loaded_model(lm)
+                # Per-model isolation: one failing close() must not skip the
+                # remaining expired models. ``_close_loaded_model`` already
+                # try/finally-chains its own three resources; this guard
+                # protects sibling models in the same expiry cycle.
+                try:
+                    self._close_loaded_model(lm)
+                except Exception:
+                    logger.exception("Error closing resources for model %s", name)
+                had_expired = True
+            # Flush Metal allocator cache so freed buffers don't inflate the
+            # next ensure_loaded() memory check. Mirrors _evict_lru_if_needed.
+            # Skip when any deferred cleanup is pending — a background thread
+            # for a different model may still be allocating Metal memory.
+            if had_expired and not self._pending_cleanups:
+                gc.collect()
+                mx.clear_cache()
 
     async def _check_expiry_loop(self):
         while True:
             await asyncio.sleep(30)
-            await self._expire_stale()
+            # Guard the while True: any unhandled exception here would
+            # permanently kill the background expiry task and leak models
+            # indefinitely. Per-model errors are already absorbed inside
+            # ``_expire_stale``; this catch is a belt-and-braces for the
+            # surrounding async machinery (CancelledError still propagates).
+            try:
+                await self._expire_stale()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Expiry check failed")

--- a/olmlx/routers/manage.py
+++ b/olmlx/routers/manage.py
@@ -161,10 +161,15 @@ async def abort_generation(req: AbortRequest, request: Request):
 @router.post("/api/unload")
 async def unload_model(req: UnloadRequest, request: Request):
     """Manually unload a model from VRAM."""
+    from olmlx.engine.model_manager import ActiveRequestsError
+
     manager = request.app.state.model_manager
     try:
         unloaded = manager.unload(req.model)
-    except RuntimeError as e:
+    except ActiveRequestsError as e:
+        # 409 is narrow on purpose: only "model has active requests".
+        # Resource-close failures from _close_loaded_model surface as
+        # ExceptionGroup and fall through to FastAPI's 500 handler.
         return JSONResponse({"error": str(e)}, status_code=409)
     if not unloaded:
         return JSONResponse(

--- a/olmlx/routers/manage.py
+++ b/olmlx/routers/manage.py
@@ -168,8 +168,11 @@ async def unload_model(req: UnloadRequest, request: Request):
         unloaded = manager.unload(req.model)
     except ActiveRequestsError as e:
         # 409 is narrow on purpose: only "model has active requests".
-        # Resource-close failures from _close_loaded_model surface as
-        # ExceptionGroup and fall through to FastAPI's 500 handler.
+        # Resource-close failures inside ``_close_loaded_model`` are
+        # absorbed by ``ModelManager.unload`` itself (the model is gone
+        # from ``_loaded`` regardless), so the router never sees them —
+        # they show up only in the per-resource log lines inside the
+        # helper.
         return JSONResponse({"error": str(e)}, status_code=409)
     if not unloaded:
         return JSONResponse(

--- a/tests/test_eagle.py
+++ b/tests/test_eagle.py
@@ -420,6 +420,21 @@ class TestEagleDecoderLifecycle:
         assert not decoder._patched
         assert not decoder._bound
 
+    def test_close_is_alias_for_reset(self):
+        """ModelManager._close_loaded_model calls .close() on whichever decoder
+        type the strategy resolved to. Eagle must expose the same lifecycle
+        name as SpeculativeDecoder and DFlashDecoder, otherwise eviction and
+        keep-alive expiry raise AttributeError for eagle users.
+        """
+        decoder, _, _ = _make_decoder()
+        prompt = mx.array([[1, 2, 3]], dtype=mx.int32)
+        decoder.prefill(prompt)
+        decoder.close()
+        assert decoder._target_cache is None
+        assert decoder._draft_cache is None
+        assert not decoder._patched
+        assert not decoder._bound
+
 
 class TestEagleDecoderPrefillStep:
     """End-to-end protocol: prefill, then step produces accepted tokens."""

--- a/tests/test_flash_mlp.py
+++ b/tests/test_flash_mlp.py
@@ -351,6 +351,22 @@ class TestFlashModelWrapperShard:
         wrapper = FlashModelWrapper(model, predictor_bank, store, config)
         return wrapper, model, dim, n_heads, n_kv_heads, num_layers
 
+    def test_wrapper_exposes_weight_store_attribute(self, wrapper_setup):
+        """FlashModelWrapper must surface its weight store as ``_weight_store``.
+
+        ``ModelManager._close_loaded_model`` closes ``lm.weight_store`` on
+        eviction and keep-alive expiry; the value comes from
+        ``getattr(model, "_weight_store", None)`` in the LoadedModel
+        construction block. Without this attribute on the dense wrapper,
+        every non-MoE Flash model leaks its FlashWeightStore's
+        ThreadPoolExecutor and per-layer file descriptors on rollover.
+        """
+        wrapper, *_ = wrapper_setup
+        assert wrapper._weight_store is not None
+        from olmlx.engine.flash.weight_store import FlashWeightStore
+
+        assert isinstance(wrapper._weight_store, FlashWeightStore)
+
     def test_shard_divides_attention_heads(self, wrapper_setup):
         """shard() should divide n_heads and n_kv_heads by world size."""
         from olmlx.engine.pre_shard import FakeGroup

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1979,9 +1979,43 @@ class TestExpiryChecker:
         ws_a.close.assert_called_once()
         ws_b.close.assert_called_once()
         ws_c.close.assert_called_once()
+        # _close_loaded_model logs per-resource; A's prefetcher failure
+        # surfaces as "Error closing prefetcher for a".
         assert any(
-            "Error closing resources for model a" in r.message for r in caplog.records
+            "Error closing prefetcher for a" in r.message for r in caplog.records
         )
+
+    @pytest.mark.asyncio
+    async def test_expire_stale_releases_lock_before_closing(
+        self, registry, mock_store
+    ):
+        """_close_loaded_model must run outside self._lock.
+
+        ``executor.shutdown(wait=True)`` is synchronous and can take long
+        enough to be noticeable. Holding ``self._lock`` during that would
+        stall every concurrent ``ensure_loaded()`` caller until the pool
+        drained — a latency spike on a server doing real inference when
+        a keep-alive happens to expire.
+        """
+        manager = ModelManager(registry, mock_store)
+        lock_held_during_close: list[bool] = []
+
+        def _record_lock_state(_lm):
+            lock_held_during_close.append(manager._lock.locked())
+
+        manager._close_loaded_model = _record_lock_state  # type: ignore[assignment]
+        lm = LoadedModel(
+            name="expired:latest",
+            hf_path="test/model",
+            model=MagicMock(),
+            tokenizer=MagicMock(),
+            expires_at=time.time() - 10,
+        )
+        manager._loaded["expired:latest"] = lm
+
+        await manager._expire_stale()
+
+        assert lock_held_during_close == [False]
 
     @pytest.mark.asyncio
     async def test_check_expiry_loop_survives_unhandled_error(
@@ -2827,9 +2861,9 @@ class TestEvictLruIfNeeded:
             manager._evict_lru_if_needed()  # must not raise
 
         assert "old" not in manager._loaded
+        # _close_loaded_model logs per-resource; eviction site absorbs silently.
         assert any(
-            "Error closing resources for evicted model old" in r.message
-            for r in caplog.records
+            "Error closing prefetcher for old" in r.message for r in caplog.records
         )
 
     def test_closes_flash_resources_on_evict(self, registry, mock_store, monkeypatch):

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1957,6 +1957,66 @@ class TestExpiryChecker:
         assert "busy:latest" in manager._loaded
 
     @pytest.mark.asyncio
+    async def test_expire_stale_closes_flash_resources(self, registry, mock_store):
+        """_expire_stale must close prefetcher + weight_store on a Flash model.
+
+        Otherwise the keep-alive timer leaks ThreadPoolExecutor workers and
+        per-layer file descriptors for every expired Flash model (issue #178).
+        """
+        manager = ModelManager(registry, mock_store)
+        parent = MagicMock()
+        prefetcher = parent.prefetcher
+        weight_store = parent.weight_store
+        flash_model = MagicMock()
+        flash_model.prefetcher = prefetcher
+        lm = LoadedModel(
+            name="expired:latest",
+            hf_path="test/model",
+            model=flash_model,
+            tokenizer=MagicMock(),
+            weight_store=weight_store,
+            is_flash=True,
+            expires_at=time.time() - 10,
+        )
+        manager._loaded["expired:latest"] = lm
+
+        await manager._expire_stale()
+
+        assert "expired:latest" not in manager._loaded
+        prefetcher.close.assert_called_once()
+        weight_store.close.assert_called_once()
+        call_names = [c[0] for c in parent.mock_calls]
+        assert call_names.index("prefetcher.close") < call_names.index(
+            "weight_store.close"
+        )
+
+    @pytest.mark.asyncio
+    async def test_expire_stale_skips_active(self, registry, mock_store):
+        """Models with active_refs > 0 must not be expired or closed."""
+        manager = ModelManager(registry, mock_store)
+        prefetcher = MagicMock()
+        weight_store = MagicMock()
+        flash_model = MagicMock()
+        flash_model.prefetcher = prefetcher
+        lm = LoadedModel(
+            name="busy:latest",
+            hf_path="test/model",
+            model=flash_model,
+            tokenizer=MagicMock(),
+            weight_store=weight_store,
+            is_flash=True,
+            expires_at=time.time() - 10,
+            active_refs=1,
+        )
+        manager._loaded["busy:latest"] = lm
+
+        await manager._expire_stale()
+
+        assert "busy:latest" in manager._loaded
+        prefetcher.close.assert_not_called()
+        weight_store.close.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_expired_model_object_still_usable(self, registry, mock_store):
         """Even if a model is removed from _loaded, the object remains usable."""
         manager = ModelManager(registry, mock_store)
@@ -2609,6 +2669,39 @@ class TestEvictLruIfNeeded:
         manager._loaded["old"] = old
         manager._evict_lru_if_needed()
         assert "old" not in manager._loaded
+
+    def test_closes_flash_resources_on_evict(self, registry, mock_store, monkeypatch):
+        """LRU eviction of a Flash model must close prefetcher + weight_store.
+
+        Otherwise ThreadPoolExecutor workers and per-layer file descriptors
+        leak for every evicted Flash model (issue #178).
+        """
+        monkeypatch.setattr("olmlx.engine.model_manager.settings.max_loaded_models", 1)
+        manager = ModelManager(registry, mock_store)
+        parent = MagicMock()
+        prefetcher = parent.prefetcher
+        weight_store = parent.weight_store
+        flash_model = MagicMock()
+        flash_model.prefetcher = prefetcher
+        old = LoadedModel(
+            name="old",
+            hf_path="o/o",
+            model=flash_model,
+            tokenizer=MagicMock(),
+            weight_store=weight_store,
+            is_flash=True,
+            loaded_at=time.time() - 100,
+        )
+        manager._loaded["old"] = old
+        manager._evict_lru_if_needed()
+        prefetcher.close.assert_called_once()
+        weight_store.close.assert_called_once()
+        # Order matters: prefetcher tasks submit into the weight store's pool,
+        # so the prefetcher must shut down before the weight store.
+        call_names = [c[0] for c in parent.mock_calls]
+        assert call_names.index("prefetcher.close") < call_names.index(
+            "weight_store.close"
+        )
 
 
 class TestSpeculativeLoading:

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1934,6 +1934,91 @@ class TestExpiryChecker:
         assert "busy:latest" in manager._loaded
 
     @pytest.mark.asyncio
+    async def test_expire_stale_isolates_per_model_failures(
+        self, registry, mock_store, caplog
+    ):
+        """A failing close() on model A must not skip models B and C.
+
+        Without per-model isolation, a single broken prefetcher would block
+        every other expired model in the same cycle from being cleaned up.
+        """
+        manager = ModelManager(registry, mock_store)
+
+        def _flash_lm(name: str, *, raises: bool = False):
+            prefetcher = MagicMock()
+            if raises:
+                prefetcher.close.side_effect = RuntimeError(f"{name} boom")
+            weight_store = MagicMock()
+            model = MagicMock()
+            model.prefetcher = prefetcher
+            lm = LoadedModel(
+                name=name,
+                hf_path=f"x/{name}",
+                model=model,
+                tokenizer=MagicMock(),
+                weight_store=weight_store,
+                is_flash=True,
+                expires_at=time.time() - 10,
+            )
+            return lm, prefetcher, weight_store
+
+        a, _, ws_a = _flash_lm("a", raises=True)
+        b, _, ws_b = _flash_lm("b")
+        c, _, ws_c = _flash_lm("c")
+        manager._loaded["a"] = a
+        manager._loaded["b"] = b
+        manager._loaded["c"] = c
+
+        with caplog.at_level(logging.ERROR, logger="olmlx.engine.model_manager"):
+            await manager._expire_stale()  # must not raise
+
+        assert "a" not in manager._loaded
+        assert "b" not in manager._loaded
+        assert "c" not in manager._loaded
+        # Sibling weight stores must have been closed despite A's failure.
+        ws_a.close.assert_called_once()
+        ws_b.close.assert_called_once()
+        ws_c.close.assert_called_once()
+        assert any(
+            "Error closing resources for model a" in r.message for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_check_expiry_loop_survives_unhandled_error(
+        self, registry, mock_store, caplog, monkeypatch
+    ):
+        """The background expiry task must survive a raising _expire_stale.
+
+        If _expire_stale ever propagates, the unguarded `while True` in
+        _check_expiry_loop exits permanently — no log, no restart, models
+        accumulate forever. Defense in depth on top of per-model isolation.
+        """
+        manager = ModelManager(registry, mock_store)
+        sleep_calls = {"n": 0}
+
+        async def _fake_sleep(_seconds):
+            sleep_calls["n"] += 1
+            if sleep_calls["n"] >= 2:
+                raise asyncio.CancelledError()
+
+        monkeypatch.setattr("olmlx.engine.model_manager.asyncio.sleep", _fake_sleep)
+        call_count = {"n": 0}
+
+        async def _raising_expire():
+            call_count["n"] += 1
+            raise RuntimeError("simulated failure")
+
+        manager._expire_stale = _raising_expire  # type: ignore[method-assign]
+
+        with caplog.at_level(logging.ERROR, logger="olmlx.engine.model_manager"):
+            with pytest.raises(asyncio.CancelledError):
+                await manager._check_expiry_loop()
+
+        # First iteration raised → loop continued → second iteration cancelled.
+        assert call_count["n"] == 1
+        assert any("Expiry check failed" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
     async def test_expire_stale_closes_flash_resources(self, registry, mock_store):
         """_expire_stale must close prefetcher + weight_store on a Flash model.
 

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1986,6 +1986,50 @@ class TestExpiryChecker:
         )
 
     @pytest.mark.asyncio
+    async def test_expire_stale_drops_refs_before_gc(
+        self, registry, mock_store, monkeypatch
+    ):
+        """The expired-models list must be dropped before gc.collect().
+
+        Otherwise gc.collect() can't reclaim the Metal buffers referenced
+        by the LoadedModel objects, and the mx.clear_cache() that was
+        specifically added to flush expired-model memory is effectively
+        a no-op. Mirrors the ``del evicted`` pattern in
+        _evict_lru_if_needed.
+
+        Uses a weakref to assert the LoadedModel is unreachable at the
+        moment gc.collect() runs — proving expired_lms was dropped.
+        """
+        import weakref
+
+        manager = ModelManager(registry, mock_store)
+        weakref_alive_at_gc: list[bool] = []
+        ref_holder: dict[str, Any] = {}
+
+        def _fake_gc():
+            weakref_alive_at_gc.append(ref_holder["wr"]() is not None)
+
+        monkeypatch.setattr("olmlx.engine.model_manager.gc.collect", _fake_gc)
+        monkeypatch.setattr("olmlx.engine.model_manager.mx.clear_cache", lambda: None)
+
+        lm = LoadedModel(
+            name="expired:latest",
+            hf_path="test/model",
+            model=MagicMock(),
+            tokenizer=MagicMock(),
+            expires_at=time.time() - 10,
+        )
+        manager._loaded["expired:latest"] = lm
+        ref_holder["wr"] = weakref.ref(lm)
+        del lm  # only manager._loaded holds it now
+
+        await manager._expire_stale()
+
+        # If expired_lms was still alive at gc time, the weakref would
+        # resolve to a live object. The fix asserts it's dead.
+        assert weakref_alive_at_gc == [False]
+
+    @pytest.mark.asyncio
     async def test_expire_stale_releases_lock_before_closing(
         self, registry, mock_store
     ):

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -2772,6 +2772,9 @@ class TestEvictLruIfNeeded:
         Without try/finally chaining, a single resource failure during eviction
         or expiry would leak the weight store's file descriptors and leave the
         speculative decoder's GDN monkey-patch installed indefinitely.
+
+        _close_loaded_model always raises ExceptionGroup on any error
+        (single or multiple) so callers see a stable exception type.
         """
         manager = ModelManager(registry, mock_store)
         prefetcher = MagicMock()
@@ -2790,9 +2793,14 @@ class TestEvictLruIfNeeded:
             is_flash=True,
         )
 
-        with pytest.raises(RuntimeError, match="boom"):
+        with pytest.raises(ExceptionGroup) as exc_info:
             manager._close_loaded_model(lm)
 
+        # Single-failure case is still wrapped in ExceptionGroup for a
+        # stable contract — see docstring on _close_loaded_model.
+        assert len(exc_info.value.exceptions) == 1
+        assert isinstance(exc_info.value.exceptions[0], RuntimeError)
+        assert "boom" in str(exc_info.value.exceptions[0])
         # Both subsequent resources must still be released.
         weight_store.close.assert_called_once()
         decoder.close.assert_called_once()

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -113,6 +113,26 @@ class TestModelManager:
         assert len(mock_manager.get_loaded()) == 1  # still loaded
         lm.active_refs = 0
 
+    def test_unload_absorbs_close_failure(self, mock_manager):
+        """unload() returns True even when _close_loaded_model raises.
+
+        The model is already popped from ``_loaded`` before close is
+        attempted, so the user-visible semantics are satisfied: the
+        model is gone. Surfacing the ExceptionGroup as a 500 would
+        leave the HTTP client unable to distinguish "close failed,
+        model is gone" from an unrelated 500.
+        """
+        from unittest.mock import MagicMock
+
+        # Replace _close_loaded_model with one that raises like the
+        # real helper does when a resource close fails.
+        mock_manager._close_loaded_model = MagicMock(
+            side_effect=ExceptionGroup("simulated", [RuntimeError("prefetcher boom")])
+        )
+        result = mock_manager.unload("qwen3")
+        assert result is True
+        assert "qwen3:latest" not in mock_manager._loaded
+
     @pytest.mark.asyncio
     async def test_ensure_loaded_cached(self, mock_manager):
         lm = await mock_manager.ensure_loaded("qwen3")
@@ -2045,6 +2065,44 @@ class TestExpiryChecker:
         assert weakref_alive_at_gc == [False]
 
     @pytest.mark.asyncio
+    async def test_expire_stale_offloads_close_to_thread(
+        self, registry, mock_store, monkeypatch
+    ):
+        """Close runs off the event loop.
+
+        ``executor.shutdown(wait=True)`` is synchronous. Running it on
+        the event loop thread would stall every concurrent coroutine
+        until the pools drained, even with the lock released. The fix
+        is ``await asyncio.to_thread(self._close_loaded_model, lm)``.
+        This test asserts the call went through ``asyncio.to_thread``.
+        """
+        manager = ModelManager(registry, mock_store)
+        original_to_thread = asyncio.to_thread
+        to_thread_calls: list[Any] = []
+
+        async def _tracking_to_thread(fn, *args, **kwargs):
+            to_thread_calls.append(fn)
+            return await original_to_thread(fn, *args, **kwargs)
+
+        monkeypatch.setattr(
+            "olmlx.engine.model_manager.asyncio.to_thread", _tracking_to_thread
+        )
+
+        lm = LoadedModel(
+            name="expired:latest",
+            hf_path="test/model",
+            model=MagicMock(),
+            tokenizer=MagicMock(),
+            expires_at=time.time() - 10,
+        )
+        manager._loaded["expired:latest"] = lm
+
+        await manager._expire_stale()
+
+        # The close was routed through to_thread (off-event-loop).
+        assert manager._close_loaded_model in to_thread_calls
+
+    @pytest.mark.asyncio
     async def test_expire_stale_releases_lock_before_closing(
         self, registry, mock_store
     ):
@@ -2908,7 +2966,10 @@ class TestEvictLruIfNeeded:
         assert any("weight-store-boom" in m for m in messages)
         # Decoder still closed despite both prior failures.
         decoder.close.assert_called_once()
-        assert lm.weight_store is None
+        # Failed close() leaves the reference alive — preserves the
+        # partially-closed object for inspection / retry. Successful
+        # decoder close still nulls its field.
+        assert lm.weight_store is weight_store
         assert lm.speculative_decoder is None
 
     def test_evict_absorbs_close_failure(

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -2005,6 +2005,15 @@ class TestExpiryChecker:
 
         Uses a weakref to assert the LoadedModel is unreachable at the
         moment gc.collect() runs — proving expired_lms was dropped.
+
+        Assumes CPython refcount semantics: an object with refcount 0 is
+        deallocated immediately, so the weakref resolves to None as soon
+        as the last strong reference goes away. On a non-refcounting
+        runtime (PyPy, Jython) a back-reference cycle introduced by
+        MagicMock could keep the LM alive — but we also monkeypatch
+        gc.collect here, so the cycle collector would not run to clean
+        it up. The codebase is CPython-only (uv-managed cpython-3.11),
+        so this is fine.
         """
         import weakref
 

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1895,15 +1895,7 @@ class TestExpiryChecker:
         )
         manager._loaded["expired:latest"] = lm
 
-        # Run one cycle of expiry check manually
-        now = time.time()
-        expired = [
-            name
-            for name, m in manager._loaded.items()
-            if m.expires_at is not None and m.expires_at <= now
-        ]
-        for name in expired:
-            del manager._loaded[name]
+        await manager._expire_stale()
 
         assert "expired:latest" not in manager._loaded
 
@@ -1919,14 +1911,7 @@ class TestExpiryChecker:
         )
         manager._loaded["active:latest"] = lm
 
-        now = time.time()
-        expired = [
-            name
-            for name, m in manager._loaded.items()
-            if m.expires_at is not None and m.expires_at <= now
-        ]
-        for name in expired:
-            del manager._loaded[name]
+        await manager._expire_stale()
 
         assert "active:latest" in manager._loaded
 
@@ -1944,15 +1929,7 @@ class TestExpiryChecker:
         )
         manager._loaded["busy:latest"] = lm
 
-        # Simulate one cycle of _check_expiry_loop logic
-        now = time.time()
-        expired = [
-            name
-            for name, m in manager._loaded.items()
-            if m.expires_at is not None and m.expires_at <= now and m.active_refs == 0
-        ]
-        for name in expired:
-            del manager._loaded[name]
+        await manager._expire_stale()
 
         assert "busy:latest" in manager._loaded
 
@@ -2669,6 +2646,38 @@ class TestEvictLruIfNeeded:
         manager._loaded["old"] = old
         manager._evict_lru_if_needed()
         assert "old" not in manager._loaded
+
+    def test_close_loaded_model_continues_on_failure(self, registry, mock_store):
+        """A raising prefetcher.close() must not skip weight_store/decoder cleanup.
+
+        Without try/finally chaining, a single resource failure during eviction
+        or expiry would leak the weight store's file descriptors and leave the
+        speculative decoder's GDN monkey-patch installed indefinitely.
+        """
+        manager = ModelManager(registry, mock_store)
+        prefetcher = MagicMock()
+        prefetcher.close.side_effect = RuntimeError("boom")
+        weight_store = MagicMock()
+        decoder = MagicMock()
+        flash_model = MagicMock()
+        flash_model.prefetcher = prefetcher
+        lm = LoadedModel(
+            name="x",
+            hf_path="x/x",
+            model=flash_model,
+            tokenizer=MagicMock(),
+            weight_store=weight_store,
+            speculative_decoder=decoder,
+            is_flash=True,
+        )
+
+        with pytest.raises(RuntimeError, match="boom"):
+            manager._close_loaded_model(lm)
+
+        # Both subsequent resources must still be released.
+        weight_store.close.assert_called_once()
+        decoder.close.assert_called_once()
+        assert lm.speculative_decoder is None
 
     def test_closes_flash_resources_on_evict(self, registry, mock_store, monkeypatch):
         """LRU eviction of a Flash model must close prefetcher + weight_store.

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -100,10 +100,16 @@ class TestModelManager:
         assert mock_manager.unload("nonexistent") is False
 
     def test_unload_active_refs_raises(self, mock_manager):
+        from olmlx.engine.model_manager import ActiveRequestsError
+
         lm = mock_manager._loaded["qwen3:latest"]
         lm.active_refs = 1
-        with pytest.raises(RuntimeError, match="active"):
+        # ActiveRequestsError is the narrow type the unload HTTP handler
+        # catches for 409. It also subclasses RuntimeError so legacy
+        # callers using ``except RuntimeError:`` continue to work.
+        with pytest.raises(ActiveRequestsError, match="active"):
             mock_manager.unload("qwen3")
+        assert issubclass(ActiveRequestsError, RuntimeError)
         assert len(mock_manager.get_loaded()) == 1  # still loaded
         lm.active_refs = 0
 
@@ -2104,6 +2110,12 @@ class TestExpiryChecker:
         per-layer file descriptors for every expired Flash model (issue #178).
         """
         manager = ModelManager(registry, mock_store)
+        # Wire both prefetcher and weight_store through the same ``parent``
+        # MagicMock so their .close() calls are recorded in a single ordered
+        # mock_calls list. _close_loaded_model accesses prefetcher via
+        # ``lm.model.prefetcher`` and weight_store via ``lm.weight_store``;
+        # both end up resolving to attributes on ``parent`` here, which is
+        # what makes the cross-resource ordering assertion work.
         parent = MagicMock()
         prefetcher = parent.prefetcher
         weight_store = parent.weight_store
@@ -2848,6 +2860,10 @@ class TestEvictLruIfNeeded:
         # Both subsequent resources must still be released.
         weight_store.close.assert_called_once()
         decoder.close.assert_called_once()
+        # LoadedModel-owned references are nulled so later code can't
+        # accidentally observe a closed resource. ``lm.model.prefetcher``
+        # is intentionally left alone — see helper docstring.
+        assert lm.weight_store is None
         assert lm.speculative_decoder is None
 
     def test_close_loaded_model_surfaces_multiple_failures(self, registry, mock_store):
@@ -2883,6 +2899,7 @@ class TestEvictLruIfNeeded:
         assert any("weight-store-boom" in m for m in messages)
         # Decoder still closed despite both prior failures.
         decoder.close.assert_called_once()
+        assert lm.weight_store is None
         assert lm.speculative_decoder is None
 
     def test_evict_absorbs_close_failure(
@@ -2926,6 +2943,9 @@ class TestEvictLruIfNeeded:
         """
         monkeypatch.setattr("olmlx.engine.model_manager.settings.max_loaded_models", 1)
         manager = ModelManager(registry, mock_store)
+        # Wire both resources through the same ``parent`` MagicMock so the
+        # cross-resource ordering assertion below has a single ordered call
+        # log to inspect. See the matching test in TestExpiryChecker.
         parent = MagicMock()
         prefetcher = parent.prefetcher
         weight_store = parent.weight_store

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -2764,6 +2764,74 @@ class TestEvictLruIfNeeded:
         decoder.close.assert_called_once()
         assert lm.speculative_decoder is None
 
+    def test_close_loaded_model_surfaces_multiple_failures(self, registry, mock_store):
+        """When two close() calls raise, both errors must surface.
+
+        Python's nested-try/finally silently replaces an earlier exception
+        with a later one. The per-resource try/except pattern collects all
+        failures and raises an ExceptionGroup so neither failure is hidden.
+        """
+        manager = ModelManager(registry, mock_store)
+        prefetcher = MagicMock()
+        prefetcher.close.side_effect = RuntimeError("prefetcher-boom")
+        weight_store = MagicMock()
+        weight_store.close.side_effect = RuntimeError("weight-store-boom")
+        decoder = MagicMock()
+        flash_model = MagicMock()
+        flash_model.prefetcher = prefetcher
+        lm = LoadedModel(
+            name="x",
+            hf_path="x/x",
+            model=flash_model,
+            tokenizer=MagicMock(),
+            weight_store=weight_store,
+            speculative_decoder=decoder,
+            is_flash=True,
+        )
+
+        with pytest.raises(ExceptionGroup) as exc_info:
+            manager._close_loaded_model(lm)
+
+        messages = [str(e) for e in exc_info.value.exceptions]
+        assert any("prefetcher-boom" in m for m in messages)
+        assert any("weight-store-boom" in m for m in messages)
+        # Decoder still closed despite both prior failures.
+        decoder.close.assert_called_once()
+        assert lm.speculative_decoder is None
+
+    def test_evict_absorbs_close_failure(
+        self, registry, mock_store, monkeypatch, caplog
+    ):
+        """LRU eviction must not propagate close() failures.
+
+        A stuck prefetcher would otherwise permanently block all future
+        model loads. The eviction site logs the error and continues.
+        """
+        monkeypatch.setattr("olmlx.engine.model_manager.settings.max_loaded_models", 1)
+        manager = ModelManager(registry, mock_store)
+        prefetcher = MagicMock()
+        prefetcher.close.side_effect = RuntimeError("stuck-prefetcher")
+        flash_model = MagicMock()
+        flash_model.prefetcher = prefetcher
+        old = LoadedModel(
+            name="old",
+            hf_path="o/o",
+            model=flash_model,
+            tokenizer=MagicMock(),
+            is_flash=True,
+            loaded_at=time.time() - 100,
+        )
+        manager._loaded["old"] = old
+
+        with caplog.at_level(logging.ERROR, logger="olmlx.engine.model_manager"):
+            manager._evict_lru_if_needed()  # must not raise
+
+        assert "old" not in manager._loaded
+        assert any(
+            "Error closing resources for evicted model old" in r.message
+            for r in caplog.records
+        )
+
     def test_closes_flash_resources_on_evict(self, registry, mock_store, monkeypatch):
         """LRU eviction of a Flash model must close prefetcher + weight_store.
 

--- a/tests/test_routers_manage.py
+++ b/tests/test_routers_manage.py
@@ -225,6 +225,10 @@ class TestManageRouter:
         "model has active requests". Post-PR the router narrows the
         409 path to ActiveRequestsError, and close failures surface
         as ExceptionGroup (a 500 by FastAPI default).
+
+        Uses ExceptionGroup as side_effect to match the real type
+        ``_close_loaded_model`` raises — self-documenting and proves
+        the router specifically does not catch ExceptionGroup as 409.
         """
         from unittest.mock import MagicMock
 
@@ -232,7 +236,10 @@ class TestManageRouter:
         lm = manager._loaded["qwen3:latest"]
         original_close = manager._close_loaded_model
         manager._close_loaded_model = MagicMock(
-            side_effect=RuntimeError("simulated close failure")
+            side_effect=ExceptionGroup(
+                "simulated close failure",
+                [RuntimeError("simulated prefetcher close failure")],
+            )
         )
         try:
             resp = await app_client.post("/api/unload", json={"model": "qwen3"})

--- a/tests/test_routers_manage.py
+++ b/tests/test_routers_manage.py
@@ -217,6 +217,33 @@ class TestManageRouter:
             lm.active_refs = 0
 
     @pytest.mark.asyncio
+    async def test_unload_close_failure_is_not_409(self, app_client):
+        """A close() failure must NOT be reported as 409.
+
+        Pre-PR the router caught bare RuntimeError, so a raising
+        prefetcher.close() would be confusingly returned as
+        "model has active requests". Post-PR the router narrows the
+        409 path to ActiveRequestsError, and close failures surface
+        as ExceptionGroup (a 500 by FastAPI default).
+        """
+        from unittest.mock import MagicMock
+
+        manager = app_client._transport.app.state.model_manager
+        lm = manager._loaded["qwen3:latest"]
+        original_close = manager._close_loaded_model
+        manager._close_loaded_model = MagicMock(
+            side_effect=RuntimeError("simulated close failure")
+        )
+        try:
+            resp = await app_client.post("/api/unload", json={"model": "qwen3"})
+            # Whatever the exact status, it must not be the active-refs 409.
+            assert resp.status_code != 409
+        finally:
+            manager._close_loaded_model = original_close
+            # Restore the LoadedModel since the failing close() popped it.
+            manager._loaded["qwen3:latest"] = lm
+
+    @pytest.mark.asyncio
     async def test_abort_returns_noop(self, app_client):
         resp = await app_client.post("/api/abort", json={"model": "qwen3"})
         assert resp.status_code == 200

--- a/tests/test_routers_manage.py
+++ b/tests/test_routers_manage.py
@@ -217,18 +217,19 @@ class TestManageRouter:
             lm.active_refs = 0
 
     @pytest.mark.asyncio
-    async def test_unload_close_failure_is_not_409(self, app_client):
-        """A close() failure must NOT be reported as 409.
+    async def test_unload_close_failure_returns_200(self, app_client):
+        """A close() failure absorbs cleanly: 200 with the model gone.
 
-        Pre-PR the router caught bare RuntimeError, so a raising
-        prefetcher.close() would be confusingly returned as
-        "model has active requests". Post-PR the router narrows the
-        409 path to ActiveRequestsError, and close failures surface
-        as ExceptionGroup (a 500 by FastAPI default).
+        The model is already removed from ``_loaded`` before the close
+        is attempted, so from the client's perspective the unload
+        succeeded — the per-resource log entries inside
+        ``_close_loaded_model`` capture what leaked. Routing the close
+        failure as 500 would prevent the client from distinguishing
+        "close failed, model is gone" from an unrelated 500, and either
+        way the model is gone.
 
-        Uses ExceptionGroup as side_effect to match the real type
-        ``_close_loaded_model`` raises — self-documenting and proves
-        the router specifically does not catch ExceptionGroup as 409.
+        This also confirms close failures are NOT misreported as 409,
+        which was the pre-PR bug (router caught bare RuntimeError).
         """
         from unittest.mock import MagicMock
 
@@ -243,11 +244,13 @@ class TestManageRouter:
         )
         try:
             resp = await app_client.post("/api/unload", json={"model": "qwen3"})
-            # Whatever the exact status, it must not be the active-refs 409.
-            assert resp.status_code != 409
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "unloaded"
+            # Model is in fact gone from _loaded even though close failed.
+            assert "qwen3:latest" not in manager._loaded
         finally:
             manager._close_loaded_model = original_close
-            # Restore the LoadedModel since the failing close() popped it.
+            # Restore the LoadedModel for subsequent tests.
             manager._loaded["qwen3:latest"] = lm
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Only `unload()` was releasing Flash resources. LRU eviction (`_evict_lru_if_needed`) and keep-alive expiry (`_expire_stale`) dropped the `LoadedModel` from `_loaded` without closing its prefetcher or weight store — leaking ThreadPoolExecutor workers (16 prefetch + 32 weight-store per model) and per-layer file descriptors on every Flash model rollover.
- Extracted `_close_loaded_model()` and routed all three lifecycle exits through it. Order is the documented invariant: prefetcher (its tasks submit into the weight store's pool) → weight_store → speculative_decoder.
- The existing `_expire_stale` tests inlined the expiry logic rather than invoking the method, which is why the leak went unnoticed. New tests call the real method.

Refs #178. Scope is narrower than the original issue: `MCPClientManager` is already closed correctly at its only call site (`cli.py:1825`), and `__del__` can't await transport teardown anyway, so no change there.

## Test plan

- [x] New tests fail against `main`: `TestEvictLruIfNeeded::test_closes_flash_resources_on_evict`, `TestExpiryChecker::test_expire_stale_closes_flash_resources`.
- [x] Both pass after the fix; ordering check (prefetcher.close before weight_store.close) holds.
- [x] `TestExpiryChecker::test_expire_stale_skips_active` guards against closing active models.
- [x] Full `tests/test_model_manager.py` suite passes (132 tests).
- [x] `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)