### PR TITLE
fix(flash): enforce prefetcher submit_bulk concurrency invariant

### DIFF
--- a/olmlx/engine/flash/prefetch.py
+++ b/olmlx/engine/flash/prefetch.py
@@ -84,6 +84,7 @@ class Prefetcher:
 
         self._lock = threading.Lock()
         self._pending: dict[int, _LayerPrefetchState] = {}
+        self._predict_in_flight = 0
         self.stats = PrefetchStats()
 
     @property
@@ -131,6 +132,7 @@ class Prefetcher:
         state = _LayerPrefetchState()
         with self._lock:
             self._pending[next_layer] = state
+            self._predict_in_flight += 1
 
         try:
             self._predict_executor.submit(
@@ -139,6 +141,7 @@ class Prefetcher:
         except RuntimeError:
             with self._lock:
                 self._pending.pop(next_layer, None)
+                self._predict_in_flight -= 1
             state.done.set()  # unblock any concurrent wait()
 
     def wait(self, layer_idx: int) -> None:
@@ -172,7 +175,14 @@ class Prefetcher:
            would deadlock with the concurrent ``mx.eval`` on the prediction
            thread.  Current callers (``_submit_draft_prefetch``) invoke this
            between forward-pass steps when no prediction is in-flight.
+           Enforced at runtime: raises :class:`RuntimeError` if violated.
         """
+        with self._lock:
+            if self._predict_in_flight > 0:
+                raise RuntimeError(
+                    "submit_bulk() called while a submit() prediction is in flight; "
+                    "concurrent mx.eval would deadlock Metal (see issue #242)"
+                )
         for layer_idx, hidden in layer_hidden_states.items():
             if layer_idx >= self._num_layers:
                 continue
@@ -212,6 +222,9 @@ class Prefetcher:
             with self._lock:
                 self.stats.failures += 1
             state.done.set()
+        finally:
+            with self._lock:
+                self._predict_in_flight -= 1
 
     def _predict(self, layer_idx: int, hidden_state: mx.array) -> list[int]:
         flat = hidden_state.reshape(-1, hidden_state.shape[-1])

--- a/olmlx/engine/flash/prefetch.py
+++ b/olmlx/engine/flash/prefetch.py
@@ -217,12 +217,18 @@ class Prefetcher:
     ) -> None:
         """Run on the prediction thread: predict next layer then submit I/O."""
         next_layer = layer_idx + 1
+        indices: list[int] | None = None
+        # _predict() is the only mx.eval-bearing region; the counter tracks
+        # mx.eval residency so submit_bulk()'s guard can decide whether a
+        # concurrent mx.eval is possible.  Decrement before _enqueue_io so
+        # that the I/O thread's state.done.set() (which can fire synchronously
+        # for empty indices, or on a fast cache hit) cannot unblock wait()
+        # before the counter drops back to 0.
         try:
             if self._lookahead_bank is not None:
                 indices = self._predict_lookahead(layer_idx, hidden_state)
             else:
                 indices = self._predict(next_layer, hidden_state)
-            self._enqueue_io(next_layer, indices, state)
         except Exception:
             logger.warning("Prediction failed for layer %d", next_layer, exc_info=True)
             with self._lock:
@@ -231,6 +237,9 @@ class Prefetcher:
         finally:
             with self._lock:
                 self._predict_in_flight -= 1
+
+        if indices is not None:
+            self._enqueue_io(next_layer, indices, state)
 
     def _predict(self, layer_idx: int, hidden_state: mx.array) -> list[int]:
         flat = hidden_state.reshape(-1, hidden_state.shape[-1])

--- a/olmlx/engine/flash/prefetch.py
+++ b/olmlx/engine/flash/prefetch.py
@@ -220,10 +220,10 @@ class Prefetcher:
         indices: list[int] | None = None
         # _predict() is the only mx.eval-bearing region; the counter tracks
         # mx.eval residency so submit_bulk()'s guard can decide whether a
-        # concurrent mx.eval is possible.  Decrement before _enqueue_io so
-        # that the I/O thread's state.done.set() (which can fire synchronously
-        # for empty indices, or on a fast cache hit) cannot unblock wait()
-        # before the counter drops back to 0.
+        # concurrent mx.eval is possible.  Decrement before *any*
+        # state.done.set() — both the _enqueue_io path and the failed-predict
+        # path — so a wait() that wakes on state.done.set() never observes a
+        # stale _predict_in_flight > 0.
         try:
             if self._lookahead_bank is not None:
                 indices = self._predict_lookahead(layer_idx, hidden_state)
@@ -233,12 +233,13 @@ class Prefetcher:
             logger.warning("Prediction failed for layer %d", next_layer, exc_info=True)
             with self._lock:
                 self.stats.failures += 1
-            state.done.set()
         finally:
             with self._lock:
                 self._predict_in_flight -= 1
 
-        if indices is not None:
+        if indices is None:
+            state.done.set()
+        else:
             self._enqueue_io(next_layer, indices, state)
 
     def _predict(self, layer_idx: int, hidden_state: mx.array) -> list[int]:

--- a/olmlx/engine/flash/prefetch.py
+++ b/olmlx/engine/flash/prefetch.py
@@ -177,6 +177,12 @@ class Prefetcher:
            between forward-pass steps when no prediction is in-flight.
            Enforced at runtime: raises :class:`RuntimeError` if violated.
         """
+        # The check + per-layer _predict() loop is not mutually exclusive with
+        # submit(): a submit() call landing between the check and the first
+        # _predict() would bypass this guard.  Sound today because both paths
+        # are driven by the single forward-pass thread; the runtime check just
+        # turns the documented invariant into a fail-fast error rather than a
+        # full mutex.
         with self._lock:
             if self._predict_in_flight > 0:
                 raise RuntimeError(

--- a/tests/test_flash_prefetch.py
+++ b/tests/test_flash_prefetch.py
@@ -480,6 +480,32 @@ class TestAsyncPrediction:
             prefetcher.wait(i)
         prefetcher.close()
 
+    def test_submit_bulk_no_false_positive_after_failed_predict(self, prefetch_setup):
+        """submit_bulk() must not raise after a failed prediction drains.
+
+        Regression: on the prediction-failure path, ``state.done.set()`` and
+        the ``_predict_in_flight`` decrement must run in an order such that a
+        thread that wakes on ``wait()`` cannot then observe a stale counter
+        and trip the guard.
+        """
+        from unittest.mock import patch
+
+        prefetcher, _, _, hidden, _, num_layers = prefetch_setup
+        x = mx.random.normal((1, hidden)).astype(mx.float16)
+
+        def failing_predict(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        with patch.object(prefetcher, "_predict", side_effect=failing_predict):
+            prefetcher.submit(0, x)
+            prefetcher.wait(1)
+
+        # Counter must be back to 0 — submit_bulk must NOT raise here.
+        prefetcher.submit_bulk({i: x for i in range(num_layers)})
+        for i in range(num_layers):
+            prefetcher.wait(i)
+        prefetcher.close()
+
     def test_cancel_then_submit_bulk_does_not_falsely_trigger_guard(
         self, prefetch_setup
     ):

--- a/tests/test_flash_prefetch.py
+++ b/tests/test_flash_prefetch.py
@@ -468,9 +468,38 @@ class TestAsyncPrediction:
                 prefetcher.submit_bulk(layer_states)
 
             release.set()
-            prefetcher.wait(1)  # drain the in-flight predict
+            # wait(1) unblocks on state.done.set() inside _enqueue_io's I/O
+            # task.  _do_predict_and_io's finally decrements _predict_in_flight
+            # *before* invoking _enqueue_io, so by the time wait() returns the
+            # counter is guaranteed to be back at 0.
+            prefetcher.wait(1)
 
         # After the in-flight predict drains, submit_bulk works again.
+        prefetcher.submit_bulk({i: x for i in range(num_layers)})
+        for i in range(num_layers):
+            prefetcher.wait(i)
+        prefetcher.close()
+
+    def test_cancel_then_submit_bulk_does_not_falsely_trigger_guard(
+        self, prefetch_setup
+    ):
+        """cancel() followed by submit_bulk() must not raise.
+
+        This is the SpeculativeFlashDecoder steady-state pattern:
+        ``_after_verify`` calls ``cancel()`` after the target forward pass has
+        fully exited (all submit() predicts already waited on at their paired
+        layer), then the next iteration's ``_after_draft`` calls
+        ``submit_bulk()``.  Pin the invariant that the guard does not fire on
+        this path.
+        """
+        prefetcher, _, _, hidden, _, num_layers = prefetch_setup
+        x = mx.random.normal((1, hidden)).astype(mx.float16)
+
+        prefetcher.submit(0, x)
+        prefetcher.wait(1)  # mirrors the forward-pass wait that drains predicts
+        prefetcher.cancel()
+
+        # Must not raise — no predict is in flight after the wait above.
         prefetcher.submit_bulk({i: x for i in range(num_layers)})
         for i in range(num_layers):
             prefetcher.wait(i)

--- a/tests/test_flash_prefetch.py
+++ b/tests/test_flash_prefetch.py
@@ -437,6 +437,45 @@ class TestAsyncPrediction:
         # Should not raise
         prefetcher.submit(0, x)
 
+    def test_submit_bulk_rejects_concurrent_predict(self, prefetch_setup):
+        """submit_bulk() must raise if a submit() prediction is in flight.
+
+        Both paths call ``mx.eval`` inside ``_predict()``; running them
+        concurrently would deadlock Metal. The runtime guard turns this
+        documented invariant into an enforced one (issue #242).
+        """
+        import threading
+        from unittest.mock import patch
+
+        prefetcher, _, _, hidden, _, num_layers = prefetch_setup
+        x = mx.random.normal((1, hidden)).astype(mx.float16)
+
+        in_predict = threading.Event()
+        release = threading.Event()
+        original_predict = prefetcher._predict
+
+        def blocking_predict(*args, **kwargs):
+            in_predict.set()
+            release.wait(timeout=5.0)
+            return original_predict(*args, **kwargs)
+
+        with patch.object(prefetcher, "_predict", side_effect=blocking_predict):
+            prefetcher.submit(0, x)
+            assert in_predict.wait(timeout=2.0), "background predict never started"
+
+            layer_states = {i: x for i in range(num_layers)}
+            with pytest.raises(RuntimeError, match="in flight"):
+                prefetcher.submit_bulk(layer_states)
+
+            release.set()
+            prefetcher.wait(1)  # drain the in-flight predict
+
+        # After the in-flight predict drains, submit_bulk works again.
+        prefetcher.submit_bulk({i: x for i in range(num_layers)})
+        for i in range(num_layers):
+            prefetcher.wait(i)
+        prefetcher.close()
+
 
 # ---------------------------------------------------------------------------
 # FlashMLP + Prefetcher integration tests


### PR DESCRIPTION
## Summary
- `Prefetcher.submit_bulk()` documents a hard invariant: it must not run while a `submit()`-based prediction is in flight, because both paths call `mx.eval` inside `_predict()` and concurrent `mx.eval` deadlocks Metal. Previously the invariant was enforced only by convention.
- Add a `_predict_in_flight` counter that is incremented when `submit()` enqueues prediction work and decremented in `_do_predict_and_io`'s `finally`. `submit_bulk()` raises `RuntimeError` if the counter is non-zero, turning the documented precondition into an enforced one.
- Closes #242.

## Test plan
- [x] New regression test `test_submit_bulk_rejects_concurrent_predict` blocks the prediction thread mid-flight, asserts the guard fires, then confirms `submit_bulk()` recovers once the in-flight prediction drains.
- [x] Without the guard, the same test crashes pytest by reproducing the Metal `mx.eval` deadlock — confirming the test exercises the bug.
- [x] `uv run pytest tests/test_flash_prefetch.py` — 53 passed.
- [x] `uv run ruff check && uv run ruff format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)