### PR TITLE
fix(anthropic): forward cache token stats on non-streaming path

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -2999,6 +2999,9 @@ async def generate_chat(
     # Disabled in distributed mode because rank 0 processes only suffix tokens
     # on cache hits while workers process the full prompt, causing all_sum
     # call count mismatch and deadlock.
+    # When enabling for non-streaming, also surface cache_creation_tokens /
+    # cache_read_tokens in _full_completion's result dict so routers can
+    # forward them (Anthropic /v1/messages already reads these keys).
     use_prompt_cache = (
         settings.prompt_cache
         and stream

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -2999,15 +2999,15 @@ async def generate_chat(
     # Disabled in distributed mode because rank 0 processes only suffix tokens
     # on cache hits while workers process the full prompt, causing all_sum
     # call count mismatch and deadlock.
-    # When enabling for non-streaming, also surface cache_creation_tokens /
-    # cache_read_tokens in _full_completion's result dict so routers can
-    # forward them (Anthropic /v1/messages already reads these keys).
     use_prompt_cache = (
         settings.prompt_cache
         and stream
         and make_prompt_cache is not None
         and not lm.is_distributed
     )
+    # TODO: when enabling prompt cache for non-streaming, also surface
+    # cache_creation_tokens / cache_read_tokens in _full_completion's result
+    # dict — the Anthropic router already reads these keys.
     prompt_tokens = None
     if use_prompt_cache:
         prompt_tokens = tokenize_for_cache(lm.text_tokenizer, prompt)

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -917,8 +917,8 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
         usage = AnthropicUsage(
             input_tokens=stats.prompt_eval_count if stats else 0,
             output_tokens=stats.eval_count if stats else 0,
-            cache_creation_input_tokens=result.get("cache_creation_tokens", 0),
-            cache_read_input_tokens=result.get("cache_read_tokens", 0),
+            cache_creation_input_tokens=result.get("cache_creation_tokens") or 0,
+            cache_read_input_tokens=result.get("cache_read_tokens") or 0,
         )
         return AnthropicMessagesResponse(
             id=msg_id,

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -917,6 +917,8 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
         usage = AnthropicUsage(
             input_tokens=stats.prompt_eval_count if stats else 0,
             output_tokens=stats.eval_count if stats else 0,
+            cache_creation_input_tokens=result.get("cache_creation_tokens", 0),
+            cache_read_input_tokens=result.get("cache_read_tokens", 0),
         )
         return AnthropicMessagesResponse(
             id=msg_id,

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -771,8 +771,8 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
                 meta = {}
                 async for event in path:
                     if isinstance(event, dict) and event.get("cache_info"):
-                        cache_read = event.get("cache_read_tokens", 0)
-                        cache_creation = event.get("cache_creation_tokens", 0)
+                        cache_read = event.get("cache_read_tokens") or 0
+                        cache_creation = event.get("cache_creation_tokens") or 0
                         logger.debug(
                             "Cache stats for message_start: read=%d creation=%d",
                             cache_read,

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -512,6 +512,65 @@ class TestAnthropicEndpoint:
         assert data["content"][0]["type"] == "text"
 
     @pytest.mark.asyncio
+    async def test_non_streaming_forwards_cache_stats(self, app_client):
+        """Issue #244: non-streaming response must forward cache_creation_tokens
+        / cache_read_tokens from the engine result dict into AnthropicUsage,
+        symmetric with the streaming path's cache_info events."""
+        stats = TimingStats(prompt_eval_count=10, eval_count=20)
+        mock_result = {
+            "text": "Hello",
+            "done": True,
+            "stats": stats,
+            "cache_read_tokens": 42,
+            "cache_creation_tokens": 8,
+        }
+
+        with patch(
+            "olmlx.routers.anthropic.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 100,
+                },
+            )
+
+        assert resp.status_code == 200
+        usage = resp.json()["usage"]
+        assert usage["input_tokens"] == 10
+        assert usage["output_tokens"] == 20
+        assert usage["cache_read_input_tokens"] == 42
+        assert usage["cache_creation_input_tokens"] == 8
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_cache_stats_default_zero(self, app_client):
+        """When the engine omits cache stats (no prompt cache for this path),
+        the response still reports them as 0 rather than raising."""
+        stats = TimingStats(prompt_eval_count=5, eval_count=3)
+        mock_result = {"text": "ok", "done": True, "stats": stats}
+
+        with patch(
+            "olmlx.routers.anthropic.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 100,
+                },
+            )
+
+        assert resp.status_code == 200
+        usage = resp.json()["usage"]
+        assert usage["cache_read_input_tokens"] == 0
+        assert usage["cache_creation_input_tokens"] == 0
+
+    @pytest.mark.asyncio
     async def test_streaming(self, app_client):
         async def mock_stream(*args, **kwargs):
             async def gen():

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -1328,6 +1328,48 @@ class TestPingBeforeCacheInfo:
         else:
             pytest.fail("message_start event not found in SSE output")
 
+    @pytest.mark.asyncio
+    async def test_cache_info_with_none_token_counts(self, app_client):
+        """If a cache_info event arrives with explicit None values, the
+        streaming path must coerce them to 0 — emitting JSON null would
+        violate the Anthropic SSE protocol."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {
+                    "cache_info": True,
+                    "cache_read_tokens": None,
+                    "cache_creation_tokens": None,
+                }
+                yield {"text": "Hello", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats(eval_count=1)}
+
+            return gen()
+
+        with patch("olmlx.routers.anthropic.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 100,
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        text = resp.text
+
+        for line in text.split("\n"):
+            if line.startswith("data:") and "message_start" in line:
+                data = json.loads(line[5:])
+                usage = data["message"]["usage"]
+                assert usage["cache_read_input_tokens"] == 0
+                assert usage["cache_creation_input_tokens"] == 0
+                break
+        else:
+            pytest.fail("message_start event not found in SSE output")
+
 
 class TestResolveAnthropicModel:
     def test_no_mapping_returns_unchanged(self):

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -571,6 +571,38 @@ class TestAnthropicEndpoint:
         assert usage["cache_creation_input_tokens"] == 0
 
     @pytest.mark.asyncio
+    async def test_non_streaming_cache_stats_none_coerced_to_zero(self, app_client):
+        """If the engine sets cache keys to None, the router must coerce to 0
+        rather than letting None reach AnthropicUsage's int field (Pydantic
+        would raise ValidationError)."""
+        stats = TimingStats(prompt_eval_count=5, eval_count=3)
+        mock_result = {
+            "text": "ok",
+            "done": True,
+            "stats": stats,
+            "cache_read_tokens": None,
+            "cache_creation_tokens": None,
+        }
+
+        with patch(
+            "olmlx.routers.anthropic.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 100,
+                },
+            )
+
+        assert resp.status_code == 200
+        usage = resp.json()["usage"]
+        assert usage["cache_read_input_tokens"] == 0
+        assert usage["cache_creation_input_tokens"] == 0
+
+    @pytest.mark.asyncio
     async def test_streaming(self, app_client):
         async def mock_stream(*args, **kwargs):
             async def gen():


### PR DESCRIPTION
## Summary
- Closes #244
- Non-streaming `/v1/messages` was leaving `cache_creation_input_tokens` and `cache_read_input_tokens` at the schema default of `0`, asymmetric with the streaming path which emits real values via `cache_info` events.
- Forward `cache_creation_tokens` / `cache_read_tokens` from the engine's result dict into `AnthropicUsage` so the wiring is symmetric. Values default to `0` when the engine omits them (current behavior, since the non-streaming engine path does not enable prompt cache), so this is observably a no-op today — but the wiring is in place and tested.

## Test plan
- [x] `uv run pytest tests/test_routers_anthropic.py` — 112 passed
- [x] New `test_non_streaming_forwards_cache_stats` verifies values are forwarded when the engine reports them
- [x] New `test_non_streaming_cache_stats_default_zero` verifies graceful default when engine omits cache keys
- [x] `uv run ruff check` / `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)