### PR TITLE
fix(routers): strip Gemma 4 channel tokens on Ollama and OpenAI paths

### DIFF
--- a/olmlx/engine/tool_parser.py
+++ b/olmlx/engine/tool_parser.py
@@ -579,6 +579,105 @@ def parse_model_output(
     return thinking, visible_text, tool_uses
 
 
+def fill_missing_required_args(
+    tool_uses: list[dict],
+    declared_tools: list[dict] | None,
+) -> None:
+    """Fill missing required string arguments in tool calls from the client's schema.
+
+    Models sometimes omit fields the client marks as required (e.g. opencode's
+    ``description`` on bash). Walk the declared tool schemas and inject an
+    empty string for any required string parameter the model left out, so
+    downstream Pydantic constructors (``ToolCallFunction.arguments``) don't
+    blow up on the omission. Mutates *tool_uses* in place.
+
+    Trade-off: injecting ``""`` prevents a Pydantic crash but produces a
+    semantically degraded tool call.  A ``bash`` tool receiving
+    ``command: ""`` runs nothing useful; a ``write_file`` tool receiving
+    ``path: ""`` may behave dangerously.  We log a warning per injection,
+    but callers should treat empty injected strings as "model failed to
+    populate this field" rather than a meaningful value.
+
+    Post-condition for any tool present in *declared_tools*: ``tu["input"]``
+    is a freshly-constructed ``dict`` (never ``None``), even when no
+    injection runs.  Tools NOT in *declared_tools* are left untouched, so
+    ``_build_tool_calls`` in ``routers/chat.py`` still needs an ``or {}``
+    guard — narrowed to the unknown-tool case, which this function cannot
+    normalize because it has no schema to reason about.
+    """
+    # ``not declared_tools`` covers both ``None`` (no tools field on the
+    # request) and ``[]`` (caller passed an explicit empty list).  Both
+    # mean "no schemas available to normalize against", so we leave
+    # ``tu["input"]`` untouched in either case.  The ``is None`` change
+    # at the per-tool loop below only affects how each individual tool's
+    # ``required_params`` is interpreted; this top-level guard is
+    # deliberately broader.
+    if not declared_tools:
+        return
+
+    # Build lookup: lowercase tool name -> {param: type} for required params
+    schema_by_tool: dict[str, dict[str, str]] = {}
+    for tool in declared_tools:
+        func = tool.get("function") or {}
+        name = (func.get("name") or "").lower()
+        params = func.get("parameters") or {}
+        required = set(params.get("required", []))
+        properties = params.get("properties") or {}
+        schema_by_tool[name] = {
+            k: v.get("type", "") for k, v in properties.items() if k in required
+        }
+
+    for tu in tool_uses:
+        required_params = schema_by_tool.get((tu.get("name") or "").lower())
+        # Intentionally ``is None`` rather than the old ``not required_params``
+        # check: the old guard skipped declared tools with zero required
+        # params too, leaving their ``input`` as-is (e.g. ``None`` from a
+        # gpt-oss ``null`` payload).  The new contract is unconditional
+        # normalization for *any* declared tool — only unknown tools (truly
+        # absent from the declared list) are skipped here.
+        if required_params is None:
+            continue
+        # Always materialize our own dict and write it back, even when
+        # ``required_params`` is empty (the tool exists in the declared
+        # list but declares no required params).  Two observable changes
+        # relative to the old version, both benign for current callers
+        # (which all build a ``ToolCall`` from the dict immediately):
+        #
+        # - ``tu["input"]`` is replaced with a fresh dict, so callers must
+        #   not rely on dict identity.
+        # - ``input is None`` is normalized to ``input == {}`` regardless
+        #   of whether any required-string injection runs.  An earlier
+        #   draft made this promotion conditional on the tool having ≥1
+        #   required param, which produced a footgun-y contract where
+        #   ``input is None`` meant something different depending on the
+        #   declared schema.
+        inp = dict(tu.get("input") or {})
+        tu["input"] = inp
+        for param, param_type in required_params.items():
+            if param not in inp or inp[param] is None:
+                if param_type == "string":
+                    logger.warning(
+                        "Tool '%s' missing required string param '%s', injecting empty string",
+                        tu.get("name"),
+                        param,
+                    )
+                    inp[param] = ""
+                else:
+                    # No safe default to inject for a non-string param;
+                    # the call WILL fail downstream (any executor that
+                    # validates required fields will reject the missing
+                    # key).  ``error`` rather than ``warning`` so the
+                    # severity matches the certainty of failure.
+                    logger.error(
+                        "Tool '%s' missing required param '%s' (type %r); "
+                        "forwarding call with the field absent — will fail "
+                        "in any executor that validates required fields",
+                        tu.get("name"),
+                        param,
+                        param_type,
+                    )
+
+
 def resolve_tool_names(
     tool_uses: list[dict], declared_tools: list[dict] | None
 ) -> None:

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -176,11 +176,15 @@ def _flush_split_thinking(state: dict) -> tuple[str, str]:
     If still in ``detect`` (no tag ever seen), treat as content.  In
     ``in_think`` (open tag without close), treat as thinking so the
     response isn't truncated.
+
+    Resets managed state keys to their initial values so a caller that
+    reuses the dict starts fresh — matches ``flush_thinking_buffer`` in
+    ``utils/streaming.py``.
     """
     buf = state.get("buffer", "")
     phase = state.get("phase", "detect")
     state["buffer"] = ""
-    state["phase"] = "passthrough"
+    state["phase"] = "detect"
     state["expected_close"] = ""
     if not buf:
         return "", ""
@@ -331,7 +335,7 @@ async def _stream_chat_with_tools(
         final = {
             "model": model_name,
             "created_at": now,
-            "message": Message(role="assistant", content="").model_dump(
+            "message": Message(role="assistant", content="", thinking=None).model_dump(
                 exclude_none=True
             ),
             "done": True,

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -1,14 +1,19 @@
 import json
 import logging
+from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
 from olmlx.engine.inference import INIT_ORPHAN_DETECT_LIMIT, generate_chat
-from olmlx.engine.tool_parser import parse_model_output
+from olmlx.engine.tool_parser import (
+    fill_missing_required_args,
+    parse_model_output,
+    resolve_tool_names,
+)
 from olmlx.routers.common import format_error
-from olmlx.schemas.chat import ChatRequest, Message
+from olmlx.schemas.chat import ChatRequest, Message, ToolCall, ToolCallFunction
 from olmlx.utils.streaming import safe_ndjson_stream
 
 logger = logging.getLogger(__name__)
@@ -16,51 +21,111 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+# Tag pairs the streaming splitter recognizes.  Adding a third entry
+# requires only updating this table — the state machine below is
+# tag-pair-aware.
+_THINKING_PAIRS: tuple[tuple[str, str], ...] = (
+    ("<think>", "</think>"),
+    ("<|channel>thought\n", "<channel|>"),
+)
+
+
+def _find_earliest_open(buf: str) -> tuple[int, str, str]:
+    """Earliest open-tag occurrence in *buf*.
+
+    Returns ``(idx, open_tag, paired_close)`` or ``(-1, "", "")`` if none.
+    """
+    best_idx = -1
+    best_open = ""
+    best_close = ""
+    for open_tag, close_tag in _THINKING_PAIRS:
+        idx = buf.find(open_tag)
+        if idx != -1 and (best_idx == -1 or idx < best_idx):
+            best_idx, best_open, best_close = idx, open_tag, close_tag
+    return best_idx, best_open, best_close
+
+
+def _find_earliest_close(buf: str) -> tuple[int, str]:
+    """Earliest close-tag occurrence (any pair) in *buf*.
+
+    Returns ``(idx, close_tag)`` or ``(-1, "")`` if none.
+    """
+    best_idx = -1
+    best_close = ""
+    for _, close_tag in _THINKING_PAIRS:
+        idx = buf.find(close_tag)
+        if idx != -1 and (best_idx == -1 or idx < best_idx):
+            best_idx, best_close = idx, close_tag
+    return best_idx, best_close
+
+
+def _longest_open_tag_suffix(buf: str) -> int:
+    """Largest ``k`` such that ``buf[-k:]`` is a prefix of some open tag.
+
+    Used in passthrough phase to hold back bytes that might be the start
+    of a tag straddling a chunk boundary.
+    """
+    longest = 0
+    for open_tag, _ in _THINKING_PAIRS:
+        for i in range(min(len(open_tag), len(buf)), longest, -1):
+            if open_tag.startswith(buf[-i:]):
+                longest = i
+                break
+    return longest
+
+
 def _split_thinking_streaming(text: str, state: dict) -> tuple[str, str]:
     """Split a streaming token into ``(thinking_chunk, content_chunk)``.
 
-    Mirrors ``_strip_thinking_streaming`` in the OpenAI router but routes the
-    thinking text into a separate output channel instead of discarding it,
-    so the Ollama API can populate ``message.thinking`` (issue #307).
+    Routes thinking text into a separate output channel so the Ollama API
+    can populate ``message.thinking`` (issue #307).  Recognizes both the
+    Qwen-style ``<think>...</think>`` and Gemma 4's
+    ``<|channel>thought\\n...<channel|>`` formats (issue #306).
 
     State keys:
-    - ``phase``: ``"detect"``, ``"in_think"``, ``"passthrough"``
-    - ``buffer``: accumulated text waiting to be resolved
-    - ``thinking_expected``: when True, the detect phase tolerates a
-      longer orphan-thinking preamble before giving up.
+
+    - ``phase`` – ``"detect"``, ``"in_think"``, ``"passthrough"``.
+    - ``buffer`` – accumulated text waiting to be resolved.
+    - ``expected_close`` – when in ``in_think``, the close tag paired
+      with the open tag we entered through; ensures cross-format
+      mentions inside thinking content can't end the block early.
+    - ``thinking_expected`` – when True, the detect phase tolerates a
+      longer orphan-thinking preamble before giving up
+      (``INIT_ORPHAN_DETECT_LIMIT``) and the orphan-close heuristic
+      fires.  Off-by-default keeps non-thinking models from
+      misclassifying a literal ``</think>``-in-prose as thinking.
     """
     buf = state.get("buffer", "") + text
     thinking_parts: list[str] = []
     content_parts: list[str] = []
     phase = state.get("phase", "detect")
+    expected_close = state.get("expected_close", "")
     thinking_expected = bool(state.get("thinking_expected"))
     detect_limit = INIT_ORPHAN_DETECT_LIMIT if thinking_expected else 200
 
     while buf:
         if phase == "detect":
-            open_idx = buf.find("<think>")
-            close_idx = buf.find("</think>")
+            open_idx, open_tag, paired_close = _find_earliest_open(buf)
+            close_idx, close_tag = _find_earliest_close(buf)
 
             if (
                 close_idx != -1
                 and (open_idx == -1 or close_idx < open_idx)
                 and thinking_expected
             ):
-                # Orphan `</think>`: prefix is thinking content.
-                # Gated on `thinking_expected` so a non-thinking model that
-                # legitimately mentions the literal `</think>` token isn't
-                # silently routed into `message.thinking`.
+                # Orphan close: prefix is thinking.  Gated on
+                # ``thinking_expected`` so a non-thinking model that
+                # legitimately mentions the literal token isn't routed
+                # to ``message.thinking``.
                 thinking_parts.append(buf[:close_idx])
-                buf = buf[close_idx + len("</think>") :].lstrip("\n")
+                buf = buf[close_idx + len(close_tag) :].lstrip("\n")
                 phase = "passthrough"
             elif open_idx != -1:
-                # Pre-think text is content; tag itself is consumed.
                 content_parts.append(buf[:open_idx])
-                buf = buf[open_idx + len("<think>") :]
+                buf = buf[open_idx + len(open_tag) :]
+                expected_close = paired_close
                 phase = "in_think"
             else:
-                # No tag yet.  Buffer until we can decide, then flush as
-                # content if no tag ever appears.
                 if len(buf) > detect_limit:
                     content_parts.append(buf)
                     buf = ""
@@ -68,29 +133,25 @@ def _split_thinking_streaming(text: str, state: dict) -> tuple[str, str]:
                 break
 
         elif phase == "in_think":
-            end = buf.find("</think>")
+            end = buf.find(expected_close)
             if end == -1:
-                # Hold back up to `len("</think>")` trailing chars in case
-                # the tag is split across two chunks; emit the rest as
-                # thinking.
-                if len(buf) > len("</think>"):
-                    thinking_parts.append(buf[: -len("</think>")])
-                    buf = buf[-len("</think>") :]
+                # Hold back up to ``len(expected_close)`` trailing chars so
+                # a close tag straddling a chunk boundary still matches on
+                # the next chunk; emit the rest as thinking.
+                hold = len(expected_close)
+                if len(buf) > hold:
+                    thinking_parts.append(buf[:-hold])
+                    buf = buf[-hold:]
                 break
             thinking_parts.append(buf[:end])
-            buf = buf[end + len("</think>") :].lstrip("\n")
+            buf = buf[end + len(expected_close) :].lstrip("\n")
+            expected_close = ""
             phase = "passthrough"
 
         else:  # passthrough
-            open_idx = buf.find("<think>")
+            open_idx, open_tag, paired_close = _find_earliest_open(buf)
             if open_idx == -1:
-                # Hold back any trailing prefix of `<think>` so a follow-up
-                # chunk can complete the tag (avoids loop-spin on bare "<").
-                longest_partial = 0
-                for i in range(1, min(len("<think>"), len(buf) + 1)):
-                    if "<think>".startswith(buf[-i:]):
-                        longest_partial = i
-                        break
+                longest_partial = _longest_open_tag_suffix(buf)
                 if longest_partial:
                     content_parts.append(buf[:-longest_partial])
                     buf = buf[-longest_partial:]
@@ -99,31 +160,189 @@ def _split_thinking_streaming(text: str, state: dict) -> tuple[str, str]:
                     buf = ""
                 break
             content_parts.append(buf[:open_idx])
-            buf = buf[open_idx + len("<think>") :]
+            buf = buf[open_idx + len(open_tag) :]
+            expected_close = paired_close
             phase = "in_think"
 
     state["buffer"] = buf
     state["phase"] = phase
+    state["expected_close"] = expected_close
     return "".join(thinking_parts), "".join(content_parts)
 
 
 def _flush_split_thinking(state: dict) -> tuple[str, str]:
     """Flush remaining buffer at stream end.
 
-    If the buffer is still in ``detect`` (no tag ever seen), treat it as
-    content.  In ``in_think`` (open tag without close), treat as thinking so
-    the response isn't truncated.
+    If still in ``detect`` (no tag ever seen), treat as content.  In
+    ``in_think`` (open tag without close), treat as thinking so the
+    response isn't truncated.
     """
     buf = state.get("buffer", "")
     phase = state.get("phase", "detect")
     state["buffer"] = ""
+    state["phase"] = "passthrough"
+    state["expected_close"] = ""
     if not buf:
         return "", ""
-    if phase == "detect":
-        return "", buf
     if phase == "in_think":
         return buf, ""
     return "", buf
+
+
+def _build_tool_calls(
+    raw_text: str,
+    tools: list[dict] | None,
+    thinking_expected: bool = False,
+) -> tuple[str, str, list[ToolCall] | None]:
+    """Parse *raw_text* into ``(thinking, visible_text, tool_calls)``.
+
+    Returns ``(thinking, visible_text, None)`` when no tool calls were
+    parsed.  When ``tools`` is ``None``, the tool-call branches inside
+    ``parse_model_output`` are skipped so tool-call markup is left in
+    ``visible_text`` verbatim; thinking blocks (``<think>...</think>``
+    and the Gemma 4 channel format) are still stripped unconditionally
+    because that handling runs above the ``has_tools`` gate.
+    """
+    thinking, visible_text, tool_uses = parse_model_output(
+        raw_text, has_tools=bool(tools), thinking_expected=thinking_expected
+    )
+    resolve_tool_names(tool_uses, tools)
+    fill_missing_required_args(tool_uses, tools)
+    if not tool_uses:
+        return thinking, visible_text, None
+    # ``fill_missing_required_args`` normalizes ``tu["input"]`` to a dict
+    # for every tool present in the declared list, so the ``or {}`` below
+    # is only load-bearing for *unknown* tool names (not in ``tools``) —
+    # those are left untouched on purpose, and their ``input`` may still
+    # be ``None`` (e.g. gpt-oss ``<|message|>null`` round-trips through
+    # ``json.loads`` as ``None``).  Keep the guard so
+    # ``ToolCallFunction.arguments`` (``dict[str, Any]``) never sees a
+    # bare ``None`` on those paths and the request doesn't 500 on
+    # Pydantic validation.
+    return (
+        thinking,
+        visible_text,
+        [
+            ToolCall(
+                function=ToolCallFunction(name=tu["name"], arguments=tu["input"] or {})
+            )
+            for tu in tool_uses
+        ],
+    )
+
+
+async def _stream_chat_with_tools(
+    result: AsyncGenerator[dict, None],
+    model_name: str,
+    tools: list[dict],
+) -> AsyncGenerator[str, None]:
+    """Buffer the full stream, parse tool calls, then emit two NDJSON lines.
+
+    The Ollama NDJSON protocol does not permit interleaving tool-call
+    deltas with content deltas the way OpenAI's SSE does, so when tools
+    are declared we trade progressive streaming for a correctly
+    structured result: one non-done message chunk carrying ``content``
+    (+ optional ``thinking``) + ``tool_calls``, followed by a done
+    chunk.  Mirrors ``_stream_openai_sse_with_tools``.
+    """
+    full_text = ""
+    raw_text = ""
+    thinking_expected = False
+    done_reason = "stop"
+    stats = None
+    try:
+        try:
+            async for chunk in result:
+                if chunk.get("cache_info"):
+                    continue
+                if "thinking_expected" in chunk:
+                    thinking_expected = bool(chunk["thinking_expected"])
+                    continue
+                if chunk.get("done"):
+                    # ``raw_text`` here is set by gpt-oss models so the
+                    # re-parse below sees the full channel-formatted
+                    # output (the visible-only ``text`` would lose
+                    # tool-call markup).  For Gemma 4 / Qwen ``raw_text``
+                    # is absent and we fall back to the accumulated
+                    # ``full_text``.  Invariant: ``generate_chat`` only
+                    # emits ``raw_text`` on the done chunk.
+                    raw_text = chunk.get("raw_text", raw_text)
+                    done_reason = chunk.get("done_reason", "stop")
+                    stats = chunk.get("stats")
+                    break
+                full_text += chunk.get("text", "")
+        except Exception as exc:
+            logger.error("Error during chat streaming (tools): %s", exc, exc_info=True)
+            yield format_error(model_name)
+            return
+    finally:
+        # ``result`` is the async generator from ``generate_chat``; we
+        # exit the inner loop via ``break`` on the done chunk, leaving
+        # the underlying ``CancellableStream`` suspended.  Calling
+        # ``aclose`` drains it and releases the inference lock — required
+        # on both the clean-break path and the inner-exception path.
+        #
+        # On the inner-exception path the inference lock stays held
+        # until the consumer pulls one more time after the error chunk:
+        # ``finally`` runs when the next ``__anext__`` executes
+        # ``return``, not when the caller awaits the ``yield
+        # format_error``.  Starlette iterates promptly so for this
+        # localhost-only server the window is negligible.
+        #
+        # We intentionally do NOT wrap this in a try/except.
+        # ``drain_and_join`` is the mechanism that releases the
+        # inference lock, so swallowing its exception risks a silently-
+        # leaked lock that wedges every subsequent request to this
+        # worker.  Matches the pattern in ``safe_ndjson_stream``.
+        await result.aclose()
+
+    try:
+        if raw_text and full_text:
+            logger.debug(
+                "raw_text supersedes %d-char accumulated full_text for "
+                "tool-call parsing (gpt-oss-style channel payload)",
+                len(full_text),
+            )
+        parse_text = raw_text or full_text
+        thinking, visible_text, tool_calls = _build_tool_calls(
+            parse_text, tools, thinking_expected=thinking_expected
+        )
+        now = datetime.now(timezone.utc).isoformat()
+        # Skip the non-done chunk when the model emitted only thinking
+        # with no visible text and no tool call: clients would otherwise
+        # see a spurious ``{"content": ""}`` line before the done chunk.
+        if visible_text or thinking or tool_calls:
+            yield (
+                json.dumps(
+                    {
+                        "model": model_name,
+                        "created_at": now,
+                        "message": Message(
+                            role="assistant",
+                            content=visible_text,
+                            thinking=thinking or None,
+                            tool_calls=tool_calls,
+                        ).model_dump(exclude_none=True),
+                        "done": False,
+                    }
+                )
+                + "\n"
+            )
+        final = {
+            "model": model_name,
+            "created_at": now,
+            "message": Message(role="assistant", content="").model_dump(
+                exclude_none=True
+            ),
+            "done": True,
+            "done_reason": done_reason,
+        }
+        if stats:
+            final.update(stats.to_dict())
+        yield json.dumps(final) + "\n"
+    except Exception as exc:
+        logger.error("Error building chat tool response: %s", exc, exc_info=True)
+        yield format_error(model_name)
 
 
 @router.post("/api/chat")
@@ -131,7 +350,7 @@ async def chat(req: ChatRequest, request: Request):
     manager = request.app.state.model_manager
     options = req.options.model_dump(exclude_none=True) if req.options else {}
     messages = [m.model_dump(exclude_none=True) for m in req.messages]
-    tools = [t.model_dump() for t in req.tools] if req.tools else None
+    tools = [t.model_dump(exclude_none=True) for t in req.tools] if req.tools else None
     max_tokens = options.pop("num_predict", 512)
     cache_id = request.headers.get("x-cache-id", "")[:256]
 
@@ -148,6 +367,17 @@ async def chat(req: ChatRequest, request: Request):
             cache_id=cache_id,
         )
 
+        if tools:
+            # Buffer the full stream so we can emit structured
+            # ``tool_calls``: the NDJSON protocol can't interleave
+            # tool-call deltas with content deltas the way OpenAI's
+            # SSE can, so progressive streaming is traded for correct
+            # structure here.
+            return StreamingResponse(
+                _stream_chat_with_tools(result, req.model, tools),
+                media_type="application/x-ndjson",
+            )
+
         think_state: dict = {}
 
         def format_chunk(chunk):
@@ -160,12 +390,12 @@ async def chat(req: ChatRequest, request: Request):
             if chunk.get("done"):
                 thinking_tail, content_tail = _flush_split_thinking(think_state)
                 stats = chunk.get("stats")
-                # Emit any held content as a regular non-done chunk *before*
-                # the done marker.  Ollama clients accumulate
-                # `message.content` from non-done chunks and the standard
-                # done frame has `content=""`; putting accumulated text in
-                # the done frame would silently drop it on those clients
-                # (issue #307 review round 9).
+                # Emit any held content as a regular non-done chunk
+                # *before* the done marker.  Ollama clients accumulate
+                # ``message.content`` from non-done chunks and the
+                # standard done frame has ``content=""``; putting
+                # accumulated text in the done frame would silently drop
+                # it on those clients.
                 pre_done = ""
                 if thinking_tail or content_tail:
                     pre_done = (
@@ -196,33 +426,18 @@ async def chat(req: ChatRequest, request: Request):
                     final.update(stats.to_dict())
                 return pre_done + json.dumps(final) + "\n"
             text = chunk.get("text", "")
-            # Fast path: when thinking is not expected, pass every token
-            # through immediately as content.  The detect buffer in
-            # `_split_thinking_streaming` would otherwise hold the first
-            # 200 chars of every Ollama response (issue #307 review).
+            # Always run the splitter, even when ``thinking_expected`` is
+            # False: Gemma 4 emits its channel-format thinking
+            # (``<|channel>thought\n...<channel|>``) regardless of the
+            # engine's thinking flag, and we still need to keep those
+            # tokens out of ``message.content`` (issue #306).  The
+            # splitter's detect buffer is bounded at 200 chars when
+            # ``thinking_expected`` is False so the latency impact stays
+            # within one chunk for non-thinking responses.
             #
-            # All emitter branches below use `model_dump(exclude_none=True)`
-            # so null `thinking` / `images` / `tool_calls` fields are
-            # suppressed from the wire payload.  This matches Ollama
-            # upstream behaviour and keeps the `thinking` field invisible
-            # to clients that pre-date its introduction.  Existing clients
-            # that read `content` / `role` are unaffected.
-            if not think_state.get("thinking_expected"):
-                if not text:
-                    return None
-                return (
-                    json.dumps(
-                        {
-                            "model": req.model,
-                            "created_at": now,
-                            "message": Message(
-                                role="assistant", content=text, thinking=None
-                            ).model_dump(exclude_none=True),
-                            "done": False,
-                        }
-                    )
-                    + "\n"
-                )
+            # All emitter branches below use ``exclude_none=True`` so
+            # null ``thinking`` / ``images`` / ``tool_calls`` fields are
+            # suppressed from the wire payload.
             thinking_chunk, content_chunk = _split_thinking_streaming(text, think_state)
             if not thinking_chunk and not content_chunk:
                 return None
@@ -266,20 +481,28 @@ async def chat(req: ChatRequest, request: Request):
         )
         now = datetime.now(timezone.utc).isoformat()
         stats = result.get("stats")
-        # `_full_completion` only populates `raw_text` for gpt-oss channel
-        # format (where `text` has the channel tokens stripped and
-        # `parse_model_output` needs the un-stripped form to find tool
-        # calls / thinking).  For every other model the `or` falls back
-        # to `text`, which is already the unstripped output.
-        raw = result.get("raw_text") or result.get("text", "")
-        # Pass `thinking_expected` so the orphan-`</think>` heuristic only
-        # fires when the engine actually requested thinking (issue #307
-        # review): keeps streaming and non-streaming behaviour symmetric
-        # and prevents a non-thinking model that mentions the literal
-        # token from having its prefix silently routed to thinking.
-        thinking, visible, _tool_uses = parse_model_output(
-            raw,
-            has_tools=bool(tools),
+        # ``_full_completion`` only populates ``raw_text`` for gpt-oss
+        # channel format (where ``text`` has the channel tokens
+        # stripped and ``parse_model_output`` needs the un-stripped form
+        # to find tool calls / thinking).  For every other model the
+        # ``or`` falls back to ``text``, which is already the unstripped
+        # output.
+        text = result.get("text", "")
+        parse_text = result.get("raw_text") or text
+        # Pass ``thinking_expected`` so the orphan-``</think>``
+        # heuristic only fires when the engine actually requested
+        # thinking — keeps streaming and non-streaming behaviour
+        # symmetric and prevents a non-thinking model that mentions
+        # the literal token from having its prefix silently routed to
+        # thinking.
+        #
+        # Unlike the streaming path, ``_build_tool_calls`` is left
+        # unguarded: the response hasn't started, so a parse failure
+        # surfaces as FastAPI's standard 500 — same convention as the
+        # OpenAI non-streaming path in ``routers/openai.py``.
+        thinking, visible_text, tool_calls = _build_tool_calls(
+            parse_text,
+            tools,
             thinking_expected=bool(result.get("thinking_expected")),
         )
         response = {
@@ -287,8 +510,9 @@ async def chat(req: ChatRequest, request: Request):
             "created_at": now,
             "message": Message(
                 role="assistant",
-                content=visible,
+                content=visible_text,
                 thinking=thinking or None,
+                tool_calls=tool_calls,
             ).model_dump(exclude_none=True),
             "done": True,
             "done_reason": result.get("done_reason", "stop"),

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -13,8 +13,13 @@ from olmlx.engine.inference import (
     generate_completion,
     generate_embeddings,
 )
-from olmlx.engine.tool_parser import parse_model_output, resolve_tool_names
+from olmlx.engine.tool_parser import (
+    fill_missing_required_args,
+    parse_model_output,
+    resolve_tool_names,
+)
 from olmlx.routers.common import build_inference_options
+from olmlx.utils.streaming import flush_thinking_buffer, strip_thinking_streaming
 from olmlx.schemas.openai import (
     OpenAIChatMessage,
     OpenAIChatRequest,
@@ -44,59 +49,6 @@ def _make_id() -> str:
     return f"chatcmpl-{uuid.uuid4().hex[:8]}"
 
 
-def _fill_missing_required_args(
-    tool_uses: list[dict],
-    declared_tools: list[dict] | None,
-) -> None:
-    """Fill missing required string arguments in tool calls from the client's schema.
-
-    Models sometimes omit fields the client marks as required (e.g. opencode's
-    ``description`` on bash).  Walk the declared tool schemas and inject an
-    empty string for any required string parameter the model left out.
-    Mutates *tool_uses* in place.
-    """
-    if not declared_tools:
-        return
-
-    # Build lookup: lowercase tool name -> {param: type} for required params
-    schema_by_tool: dict[str, dict[str, str]] = {}
-    for tool in declared_tools:
-        func = tool.get("function") or {}
-        name = (func.get("name") or "").lower()
-        params = func.get("parameters") or {}
-        required = set(params.get("required", []))
-        properties = params.get("properties") or {}
-        schema_by_tool[name] = {
-            k: v.get("type", "") for k, v in properties.items() if k in required
-        }
-
-    for tu in tool_uses:
-        required_params = schema_by_tool.get((tu.get("name") or "").lower())
-        if not required_params:
-            continue
-        inp = tu.get("input") or {}
-        changed = False
-        for param, param_type in required_params.items():
-            if param not in inp or inp[param] is None:
-                if param_type == "string":
-                    logger.warning(
-                        "Tool '%s' missing required string param '%s', injecting empty string",
-                        tu.get("name"),
-                        param,
-                    )
-                    inp[param] = ""
-                    changed = True
-                else:
-                    logger.warning(
-                        "Tool '%s' missing required param '%s' (type %r), cannot inject default",
-                        tu.get("name"),
-                        param,
-                        param_type,
-                    )
-        if changed:
-            tu["input"] = inp
-
-
 def _to_openai_tool_calls(tool_uses: list[dict]) -> list[dict]:
     """Convert parsed tool_use blocks to OpenAI tool_calls format."""
     return [
@@ -110,121 +62,6 @@ def _to_openai_tool_calls(tool_uses: list[dict]) -> list[dict]:
         }
         for tu in tool_uses
     ]
-
-
-def _strip_thinking_streaming(text: str, state: dict) -> str:
-    """Strip ``<think>...</think>`` blocks from streaming text chunks.
-
-    Uses *state* dict to track position across calls.  Keys:
-
-    - ``phase``: one of ``"detect"``, ``"in_think"``, ``"passthrough"``
-    - ``buffer``: accumulated text waiting to be resolved
-
-    **Phases:**
-
-    ``detect`` (initial) — The chat template may have opened ``<think>``
-    inside the prompt, so the generated text could start mid-think with
-    only a closing ``</think>``.  We buffer all content until we can
-    determine which case we're in:
-
-    * ``</think>`` seen first → discard buffer (orphaned thinking),
-      switch to ``passthrough``.
-    * ``<think>`` seen first → emit buffer, switch to ``in_think``.
-    * Neither tag after the stream ends → emit buffer (no thinking).
-
-    ``in_think`` — Inside a ``<think>`` block; discard until ``</think>``.
-
-    ``passthrough`` — Emit everything, but still strip any new
-    ``<think>...</think>`` blocks that appear later.
-    """
-    buf = state.get("buffer", "") + text
-    out_parts: list[str] = []
-    phase = state.get("phase", "detect")
-
-    thinking_expected = state.get("thinking_expected", False)
-    while buf:
-        if phase == "detect":
-            open_idx = buf.find("<think>")
-            close_idx = buf.find("</think>")
-
-            if (
-                close_idx != -1
-                and (open_idx == -1 or close_idx < open_idx)
-                and thinking_expected
-            ):
-                # Orphaned </think> — discard everything before it.
-                # Only fires when thinking is actually expected for this
-                # request; otherwise the model is just mentioning the
-                # literal token and we leave the text untouched.
-                buf = buf[close_idx + len("</think>") :]
-                phase = "passthrough"
-            elif open_idx != -1:
-                # Normal <think> — emit text before it, enter in_think.
-                out_parts.append(buf[:open_idx])
-                buf = buf[open_idx + len("<think>") :]
-                phase = "in_think"
-            else:
-                # Neither tag yet.  Keep buffering to detect a potential
-                # orphaned </think> at the start of the stream.  Once the
-                # buffer grows large enough that an orphaned tag is very
-                # unlikely, emit the safe prefix and transition to
-                # passthrough so non-thinking models stream progressively.
-                # When the caller knows thinking is expected (issue #307),
-                # the limit is raised so Qwen3.5/3.6's long orphan-prefix
-                # thinking is detected even though `</think>` arrives only
-                # after several thousand characters.
-                detect_limit = state.get("detect_limit", 200)
-                if len(buf) > detect_limit:
-                    out_parts.append(buf)
-                    buf = ""
-                    phase = "passthrough"
-                break
-
-        elif phase == "in_think":
-            end = buf.find("</think>")
-            if end == -1:
-                buf = ""
-            else:
-                buf = buf[end + len("</think>") :]
-                phase = "passthrough"
-
-        else:  # passthrough
-            open_idx = buf.find("<think>")
-            if open_idx == -1:
-                longest_partial = 0
-                for i in range(1, min(len("<think>"), len(buf) + 1)):
-                    if "<think>".startswith(buf[-i:]):
-                        longest_partial = i
-                        break
-                if longest_partial:
-                    out_parts.append(buf[:-longest_partial])
-                    buf = buf[-longest_partial:]
-                    break
-                else:
-                    out_parts.append(buf)
-                    buf = ""
-            else:
-                out_parts.append(buf[:open_idx])
-                buf = buf[open_idx + len("<think>") :]
-                phase = "in_think"
-
-    state["buffer"] = buf
-    state["phase"] = phase
-    return "".join(out_parts)
-
-
-def _flush_thinking_buffer(state: dict) -> str:
-    """Flush any remaining buffer when the stream ends.
-
-    If we're still in ``detect`` phase (never saw any think tag),
-    the buffered content is real output — emit it.
-    """
-    buf = state.get("buffer", "")
-    phase = state.get("phase", "detect")
-    state["buffer"] = ""
-    if phase == "detect":
-        return buf
-    return ""
 
 
 async def _stream_openai_sse(
@@ -260,7 +97,7 @@ async def _stream_openai_sse(
             if chunk.get("done"):
                 # Flush any buffered content from thinking detection.
                 if strip_thinking:
-                    flushed = _flush_thinking_buffer(think_state)
+                    flushed = flush_thinking_buffer(think_state)
                     if flushed:
                         data = {
                             "id": response_id,
@@ -290,7 +127,7 @@ async def _stream_openai_sse(
             else:
                 text = chunk.get("text", "")
                 if strip_thinking:
-                    text = _strip_thinking_streaming(text, think_state)
+                    text = strip_thinking_streaming(text, think_state)
                 if not text:
                     continue
                 data = {
@@ -361,7 +198,7 @@ async def _stream_openai_sse_with_tools(
             text_for_parsing, True, thinking_expected=thinking_expected
         )
         resolve_tool_names(tool_uses, declared_tools)
-        _fill_missing_required_args(tool_uses, declared_tools)
+        fill_missing_required_args(tool_uses, declared_tools)
         logger.debug(
             "Buffered tool stream (%d chars): thinking=%d visible=%d tool_uses=%d raw=%s",
             len(full_text),
@@ -547,8 +384,11 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
             cache_id=cache_id,
         )
         text = result.get("text", "")
-        # Use raw_text for tool parsing (preserves gpt-oss channel tokens)
-        parse_text = result.get("raw_text", text)
+        # Use raw_text for tool parsing (preserves gpt-oss channel tokens);
+        # ``or text`` (not ``.get(key, text)``) so an empty-string ``raw_text``
+        # from generate_chat also falls back to the cleaned text, matching
+        # the streaming path above and the Ollama chat router.
+        parse_text = result.get("raw_text") or text
         logger.debug(
             "Raw model output (%d chars): %s", len(parse_text), parse_text[:1000]
         )
@@ -565,7 +405,7 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
             thinking_expected=bool(result.get("thinking_expected")),
         )
         resolve_tool_names(tool_uses, req.tools)
-        _fill_missing_required_args(tool_uses, req.tools)
+        fill_missing_required_args(tool_uses, req.tools)
 
         tool_calls = _to_openai_tool_calls(tool_uses) if tool_uses else None
         done_reason = result.get("done_reason")

--- a/olmlx/utils/streaming.py
+++ b/olmlx/utils/streaming.py
@@ -10,6 +10,304 @@ from typing import Any, Callable, cast
 logger = logging.getLogger(__name__)
 
 
+# --- Streaming thinking-block stripping ---
+#
+# Open/close tag pairs recognized by ``strip_thinking_streaming``.  Each model
+# family emits its own delimiter pair; we strip them all.
+#
+# - ``<think>...</think>``: Qwen, DeepSeek, and others
+# - ``<|channel>thought\n...<channel|>``: Gemma 4 (issue #306)
+#
+# Tags are stored as paired ``(open, close)`` so that, once we enter an
+# ``in_think`` block, we only look for the *matching* close tag.  Matching any
+# close tag here would let a ``<think>`` block whose thinking content mentions
+# the literal string ``<channel|>`` (common in code-gen prompts that discuss
+# token formats) exit prematurely and leak thinking content.
+#
+# The Gemma 4 open tag pins the literal channel name ``thought`` because that
+# is the only channel emitted by every current Gemma 4 checkpoint (validated
+# against the ``mlx-community/gemma-4-*-OptiQ-4bit`` family in issue #306).
+# Future variants that introduce additional channel names (``thinking``,
+# ``reasoning``, …) need a new entry here or the streaming filter will miss
+# the open and rely on the orphan-close path within ``_STREAM_DETECT_LIMIT``.
+#
+# Limitation 1: when ``skip_special_tokens`` strips the Gemma 4 ``<|channel>``
+# opener, the decoded stream starts with bare ``thought\n``.  We do not list
+# ``thought\n`` as a standalone open tag because it would false-positive on
+# legitimate prose (e.g. "I had a thought\n…") and silently drop the rest of
+# the response.  The orphan-close handling on ``<channel|>`` still recovers
+# short thinking blocks; only thinking longer than ``_STREAM_DETECT_LIMIT``
+# bytes with a stripped opener leaks through this filter.  The non-streaming
+# path uses ``parse_model_output``'s optional-prefix regex and handles that
+# case correctly.
+#
+# Limitation 2: in ``detect`` we strip an "orphaned" close tag when
+# ``thinking_expected`` is set (the chat template can pre-open a thinking
+# block in the prompt so the generated text starts mid-think with only a
+# closing tag).  PR #314 added the ``thinking_expected`` gate so a
+# non-thinking response that legitimately mentions ``<channel|>`` or
+# ``</think>`` in prose is no longer truncated — the orphan branch
+# requires the engine to have signalled incoming thinking.
+# ``test_orphaned_channel_close_in_prose_preserved_when_not_thinking``
+# in ``tests/test_routers_openai.py`` pins this.  When
+# ``thinking_expected=True`` and the response's first
+# ``detect_limit`` bytes do happen to contain a literal close tag in
+# prose, the prefix is still dropped — accepted because the
+# ``thinking_expected`` signal is per-model and a thinking-capable
+# checkpoint that emits non-thinking content discussing its own
+# delimiters is a corner case.
+_THINKING_TAG_PAIRS: tuple[tuple[str, str], ...] = (
+    ("<think>", "</think>"),
+    ("<|channel>thought\n", "<channel|>"),
+)
+_THINKING_OPEN_TAGS: tuple[str, ...] = tuple(p[0] for p in _THINKING_TAG_PAIRS)
+_THINKING_CLOSE_TAGS: tuple[str, ...] = tuple(p[1] for p in _THINKING_TAG_PAIRS)
+_CLOSE_FOR_OPEN: dict[str, str] = dict(_THINKING_TAG_PAIRS)
+
+# Maximum buffer size in the ``detect`` phase before giving up on finding an
+# orphaned close tag and transitioning to ``passthrough``.  Sized to let
+# non-thinking models start streaming quickly (the user sees output after
+# ~50 tokens) while still catching the orphaned ``</think>`` that a chat
+# template may have pre-opened in the prompt.  A larger limit would close
+# Limitation 1 below for the stripped-Gemma-4-opener case but would also
+# blank-screen the much more common non-thinking response, so we keep the
+# tight bound here and accept the limitation.
+#
+# Cost: every streaming response (Ollama ``/api/chat`` and OpenAI
+# ``/v1/chat/completions`` without tools) now pays the up-to-200-byte detect
+# buffer on first connect.  A targeted optimization that consults
+# ``template_caps.py`` to disable thinking-strip for non-thinking models is
+# possible but requires plumbing the per-model capability through to the
+# router, which is out of scope for issue #306.
+#
+# This limit only applies on the "no tag seen at all" branch.  Once an open
+# OR close tag is found the corresponding branch fires immediately, so an
+# orphaned close tag well beyond this offset is still consumed correctly
+# (and the preceding bytes still discarded) without ever consulting this
+# constant.
+_STREAM_DETECT_LIMIT = 200
+
+
+def _find_earliest(tags: tuple[str, ...], s: str) -> tuple[str, int]:
+    """Return (tag, index) of the earliest occurrence of any *tag* in *s*.
+
+    Returns ``("", -1)`` when no tag is found; callers gate on the index.
+    """
+    best_idx = -1
+    best_tag = ""
+    for t in tags:
+        i = s.find(t)
+        if i != -1 and (best_idx == -1 or i < best_idx):
+            best_idx = i
+            best_tag = t
+    return best_tag, best_idx
+
+
+def _longest_partial_suffix(buf: str, tags: tuple[str, ...]) -> int:
+    """Largest k such that ``buf[-k:]`` is a prefix of some tag.
+
+    Used to retain enough tail bytes that a tag spanning a chunk boundary is
+    still recognized on the next chunk — symmetrically for open tags
+    (passthrough phase) and close tags (in_think phase).
+    """
+    longest = 0
+    for tag in tags:
+        for i in range(min(len(tag), len(buf)), longest, -1):
+            if tag.startswith(buf[-i:]):
+                longest = i
+                break
+    return longest
+
+
+def strip_thinking_streaming(text: str, state: dict) -> str:
+    """Strip thinking blocks from streaming text chunks.
+
+    Recognizes two formats and any orphaned closing tag:
+
+    - ``<think>...</think>`` (Qwen, DeepSeek, ...)
+    - ``<|channel>thought\\n...<channel|>`` (Gemma 4)
+
+    Uses *state* dict to track position across calls.  Keys:
+
+    - ``phase``: one of ``"detect"``, ``"in_think"``, ``"passthrough"``
+    - ``buffer``: accumulated text waiting to be resolved
+    - ``expected_close``: the close tag paired with the open tag that
+      started the current ``in_think`` block.  Set on entry to
+      ``in_think``; cleared on exit.  Looking only for this specific
+      tag (instead of any close tag) prevents a cross-format close
+      mentioned inside thinking content from ending the block early.
+    - ``thinking_expected``: when True, the detect phase fires the
+      orphan-close heuristic (template-pre-opened thinking) and
+      raises the detect buffer to ``detect_limit`` (default
+      ``INIT_ORPHAN_DETECT_LIMIT``); when False (default), an orphan
+      close tag is left in the output so a non-thinking model that
+      mentions the literal token isn't truncated (issue #307).
+    - ``detect_limit``: bytes to buffer in detect phase before giving
+      up the orphan-close hunt and transitioning to passthrough.
+      Defaults to ``_STREAM_DETECT_LIMIT`` (200) when thinking is not
+      expected; callers that know thinking is incoming should set
+      this to ``INIT_ORPHAN_DETECT_LIMIT`` so a multi-thousand-char
+      reasoning preamble is still recognized.
+
+    **Phases:**
+
+    ``detect`` (initial) — The chat template may have opened a thinking
+    block inside the prompt, so the generated text could start mid-think
+    with only a closing tag.  We buffer all content until we can
+    determine which case we're in:
+
+    * A close tag seen first → discard buffer (orphaned thinking),
+      switch to ``passthrough``.
+    * An open tag seen first → emit text before it, switch to ``in_think``.
+    * Neither tag after the buffer grows large → emit buffer (no thinking).
+
+    ``in_think`` — Inside a thinking block; discard until the matching
+    close tag (``expected_close``).
+
+    ``passthrough`` — Emit everything, but still strip any new thinking
+    blocks that appear later.
+    """
+    buf = state.get("buffer", "") + text
+    out_parts: list[str] = []
+    phase = state.get("phase", "detect")
+
+    expected_close = state.get("expected_close", "")
+    thinking_expected = bool(state.get("thinking_expected"))
+    detect_limit = int(state.get("detect_limit", _STREAM_DETECT_LIMIT))
+
+    while buf:
+        if phase == "detect":
+            open_tag, open_idx = _find_earliest(_THINKING_OPEN_TAGS, buf)
+            close_tag, close_idx = _find_earliest(_THINKING_CLOSE_TAGS, buf)
+
+            if (
+                close_idx != -1
+                and (open_idx == -1 or close_idx < open_idx)
+                and thinking_expected
+            ):
+                # Orphaned close — discard everything before it.  No ``break``
+                # here: any remaining buffer after the close must be
+                # processed immediately in ``passthrough`` on the next loop
+                # iteration so a follow-up open tag in the same chunk is not
+                # missed.
+                #
+                # Debug-logged because this branch fires in two legitimate
+                # scenarios (chat template pre-opened thinking; Gemma 4
+                # stream with stripped ``<|channel>`` opener) and one
+                # pathological one ("Limitation 2": a literal
+                # ``<channel|>`` / ``</think>`` in non-thinking prose,
+                # which silently truncates the prefix).  Logged at DEBUG
+                # rather than WARNING so the legitimate cases don't spam
+                # ops; raise the level if missing content is reported and
+                # ``skip_special_tokens`` may be eating the opener.
+                logger.debug(
+                    "strip_thinking_streaming: orphaned %r at byte %d, "
+                    "discarding %d-byte prefix",
+                    close_tag,
+                    close_idx,
+                    close_idx,
+                )
+                buf = buf[close_idx + len(close_tag) :]
+                # Clear ``expected_close`` for symmetry with the
+                # ``in_think → passthrough`` transition at line 233.  The
+                # current state machine never re-reads it from
+                # ``passthrough`` (it is overwritten on the next ``in_think``
+                # entry), but leaving stale state across phase transitions
+                # invites bugs if the machine is later extended.
+                expected_close = ""
+                phase = "passthrough"
+            elif open_idx != -1:
+                # Normal open — emit text before it, enter in_think with the
+                # matching close tag remembered so cross-format mentions
+                # inside the thinking content can't end the block early.
+                out_parts.append(buf[:open_idx])
+                buf = buf[open_idx + len(open_tag) :]
+                expected_close = _CLOSE_FOR_OPEN[open_tag]
+                phase = "in_think"
+            else:
+                if len(buf) > detect_limit:
+                    # Hold back any partial *open*-tag suffix so a tag
+                    # straddling the detect→passthrough transition is still
+                    # recognized on the next chunk.  Close-tag partials are
+                    # deliberately not retained here: ``detect_limit`` bytes
+                    # without any tag means this is a non-thinking response,
+                    # so a later ``<channel|>`` or ``</think>`` is literal
+                    # text and should pass through unmodified.
+                    partial = _longest_partial_suffix(buf, _THINKING_OPEN_TAGS)
+                    out_parts.append(buf[:-partial] if partial else buf)
+                    buf = buf[-partial:] if partial else ""
+                    phase = "passthrough"
+                break
+
+        elif phase == "in_think":
+            close_idx = buf.find(expected_close)
+            if close_idx == -1:
+                # The expected close may straddle a chunk boundary.  Keep just
+                # enough tail so the suffix can complete on the next chunk;
+                # without this, splits like ``"</thi" + "nk>"`` would leave
+                # the filter stuck in_think and silently drop the rest of the
+                # stream.
+                longest_partial = _longest_partial_suffix(buf, (expected_close,))
+                buf = buf[-longest_partial:] if longest_partial else ""
+                break
+            else:
+                buf = buf[close_idx + len(expected_close) :]
+                expected_close = ""
+                phase = "passthrough"
+
+        else:  # passthrough
+            open_tag, open_idx = _find_earliest(_THINKING_OPEN_TAGS, buf)
+            if open_idx == -1:
+                longest_partial = _longest_partial_suffix(buf, _THINKING_OPEN_TAGS)
+                if longest_partial:
+                    out_parts.append(buf[:-longest_partial])
+                    buf = buf[-longest_partial:]
+                    break
+                else:
+                    out_parts.append(buf)
+                    buf = ""
+            else:
+                out_parts.append(buf[:open_idx])
+                buf = buf[open_idx + len(open_tag) :]
+                expected_close = _CLOSE_FOR_OPEN[open_tag]
+                phase = "in_think"
+
+    state["buffer"] = buf
+    state["phase"] = phase
+    state["expected_close"] = expected_close
+    return "".join(out_parts)
+
+
+def flush_thinking_buffer(state: dict) -> str:
+    """Flush any remaining buffer when the stream ends.
+
+    In ``detect`` the buffer holds the entire pre-tag output; in
+    ``passthrough`` it may hold a partial open-tag suffix that was withheld
+    in case a tag straddled a chunk boundary.  Both are real visible bytes
+    once we know no more chunks are coming, so we return them.  ``in_think``
+    state is thinking content and stays dropped.
+
+    Note: returning the ``passthrough`` buffer is a fix relative to the
+    earlier router-local implementation, which only flushed in ``detect`` and
+    silently dropped a held partial-open suffix at end-of-stream.  The
+    OpenAI streaming path picks up this fix transitively now that both
+    routers share this implementation.
+
+    All managed state keys are reset to their initial values before
+    returning so the post-flush dict is consistent (an empty buffer
+    implies the ``detect`` phase with no expected close), in case a
+    caller reuses the state dict.
+    """
+    buf = state.get("buffer", "")
+    phase = state.get("phase", "detect")
+    state["buffer"] = ""
+    state["phase"] = "detect"
+    state["expected_close"] = ""
+    if phase in ("detect", "passthrough"):
+        return buf
+    return ""
+
+
 async def safe_ndjson_stream(
     source, format_chunk, format_error, log, log_prefix="streaming"
 ):
@@ -17,8 +315,11 @@ async def safe_ndjson_stream(
 
     Args:
         source: Async iterator to consume (must support aclose()).
-        format_chunk: Callable(item) -> str for each yielded item.
-            Return None to skip an item.
+        format_chunk: Callable(item) -> ``str | list[str] | None`` for each
+            yielded item.  Return ``None`` to skip an item; return a list to
+            emit multiple NDJSON lines for a single source item (the
+            terminal done chunk on the Ollama chat path uses this to flush a
+            trailing thinking-detect buffer alongside the done marker).
         format_error: Callable(Exception) -> str for error formatting.
         log: Logger instance for error reporting.
         log_prefix: Prefix for error log messages.
@@ -29,7 +330,17 @@ async def safe_ndjson_stream(
             # intentional — once streaming has started the HTTP status is 200,
             # so the best we can do is emit an error payload and log it.
             formatted = format_chunk(item)
-            if formatted is not None:
+            if formatted is None:
+                continue
+            if isinstance(formatted, list):
+                for line in formatted:
+                    # Defensive: drop ``None`` items even though the
+                    # documented element type is ``str``.  Cheap to filter
+                    # here so a future caller returning ``[None, "ok"]``
+                    # doesn't propagate ``None`` into Starlette's writer.
+                    if line is not None:
+                        yield line
+            else:
                 yield formatted
     except Exception as exc:
         log.error("Error during %s: %s", log_prefix, exc, exc_info=True)

--- a/tests/test_fill_missing_args.py
+++ b/tests/test_fill_missing_args.py
@@ -1,6 +1,6 @@
-"""Tests for _fill_missing_required_args in the OpenAI router."""
+"""Tests for ``fill_missing_required_args``."""
 
-from olmlx.routers.openai import _fill_missing_required_args
+from olmlx.engine.tool_parser import fill_missing_required_args
 
 
 def _make_tool_def(name: str, properties: dict, required: list[str]) -> dict:
@@ -37,7 +37,7 @@ class TestFillMissingRequiredArgs:
         ]
         tool_uses = [_make_tool_use("bash", {"command": "ls -F"})]
 
-        _fill_missing_required_args(tool_uses, tools)
+        fill_missing_required_args(tool_uses, tools)
 
         assert tool_uses[0]["input"]["description"] == ""
         assert tool_uses[0]["input"]["command"] == "ls -F"
@@ -58,7 +58,7 @@ class TestFillMissingRequiredArgs:
             _make_tool_use("bash", {"command": "ls", "description": "List files"})
         ]
 
-        _fill_missing_required_args(tool_uses, tools)
+        fill_missing_required_args(tool_uses, tools)
 
         assert tool_uses[0]["input"]["description"] == "List files"
 
@@ -73,7 +73,7 @@ class TestFillMissingRequiredArgs:
         ]
         tool_uses = [_make_tool_use("bash", {"command": None})]
 
-        _fill_missing_required_args(tool_uses, tools)
+        fill_missing_required_args(tool_uses, tools)
 
         assert tool_uses[0]["input"]["command"] == ""
 
@@ -91,7 +91,7 @@ class TestFillMissingRequiredArgs:
         ]
         tool_uses = [_make_tool_use("search", {"query": "foo"})]
 
-        _fill_missing_required_args(tool_uses, tools)
+        fill_missing_required_args(tool_uses, tools)
 
         assert "limit" not in tool_uses[0]["input"]
 
@@ -109,20 +109,55 @@ class TestFillMissingRequiredArgs:
         ]
         tool_uses = [_make_tool_use("search", {"query": "foo", "limit": None})]
 
-        _fill_missing_required_args(tool_uses, tools)
+        fill_missing_required_args(tool_uses, tools)
 
         assert tool_uses[0]["input"]["limit"] is None
 
     def test_no_op_when_tools_none(self):
         """None declared_tools is a safe no-op."""
         tool_uses = [_make_tool_use("bash", {"command": "ls"})]
-        _fill_missing_required_args(tool_uses, None)
+        fill_missing_required_args(tool_uses, None)
         assert tool_uses[0]["input"] == {"command": "ls"}
+
+    def test_input_none_is_promoted_to_empty_dict(self):
+        """When a tool_use arrives with ``input=None`` and matches a declared
+        tool, ``input`` is replaced with an empty dict — even when no
+        required string injection runs.  Documents the deliberate
+        ``None → {}`` promotion called out in the function's docstring."""
+        tools = [_make_tool_def("noop", {"count": {"type": "integer"}}, ["count"])]
+        tool_uses = [{"type": "tool_use", "id": "x", "name": "noop", "input": None}]
+        fill_missing_required_args(tool_uses, tools)
+        assert tool_uses[0]["input"] == {}
+
+    def test_input_none_normalized_when_tool_has_no_required_params(self):
+        """``None → {}`` is unconditional for any tool present in the
+        declared list, including ones with zero required params.  Pins the
+        contract so callers can always treat ``tu["input"]`` as a dict
+        after the call without an ``or {}`` guard."""
+        tools = [
+            _make_tool_def(
+                "noop",
+                {"count": {"type": "integer"}},
+                [],  # no required params
+            )
+        ]
+        tool_uses = [{"type": "tool_use", "id": "x", "name": "noop", "input": None}]
+        fill_missing_required_args(tool_uses, tools)
+        assert tool_uses[0]["input"] == {}
+
+    def test_input_none_preserved_for_unknown_tool(self):
+        """If the tool is not in the declared list, ``input`` is left
+        untouched (None stays None).  We have no schema to normalize
+        against, so the caller decides what to do with the unknown call."""
+        tools = [_make_tool_def("known", {}, [])]
+        tool_uses = [{"type": "tool_use", "id": "x", "name": "unknown", "input": None}]
+        fill_missing_required_args(tool_uses, tools)
+        assert tool_uses[0]["input"] is None
 
     def test_no_op_when_tools_empty(self):
         """Empty declared_tools is a safe no-op."""
         tool_uses = [_make_tool_use("bash", {"command": "ls"})]
-        _fill_missing_required_args(tool_uses, [])
+        fill_missing_required_args(tool_uses, [])
         assert tool_uses[0]["input"] == {"command": "ls"}
 
     def test_unmatched_tool_name_ignored(self):
@@ -136,7 +171,7 @@ class TestFillMissingRequiredArgs:
         ]
         tool_uses = [_make_tool_use("bash", {"command": "ls"})]
 
-        _fill_missing_required_args(tool_uses, tools)
+        fill_missing_required_args(tool_uses, tools)
 
         assert tool_uses[0]["input"] == {"command": "ls"}
 
@@ -157,7 +192,7 @@ class TestFillMissingRequiredArgs:
             _make_tool_use("bash", {"command": "pwd", "description": "Print dir"}),
         ]
 
-        _fill_missing_required_args(tool_uses, tools)
+        fill_missing_required_args(tool_uses, tools)
 
         assert tool_uses[0]["input"]["description"] == ""
         assert tool_uses[1]["input"]["description"] == "Print dir"
@@ -176,7 +211,7 @@ class TestFillMissingRequiredArgs:
         ]
         tool_uses = [_make_tool_use("bash", {"command": "ls"})]
 
-        _fill_missing_required_args(tool_uses, tools)
+        fill_missing_required_args(tool_uses, tools)
 
         assert tool_uses[0]["input"]["description"] == ""
 
@@ -194,7 +229,7 @@ class TestFillMissingRequiredArgs:
         ]
         tool_uses = [_make_tool_use("BASH", {"command": "ls"})]
 
-        _fill_missing_required_args(tool_uses, tools)
+        fill_missing_required_args(tool_uses, tools)
 
         assert tool_uses[0]["input"]["description"] == ""
 
@@ -212,7 +247,7 @@ class TestFillMissingRequiredArgs:
         ]
         tool_uses = [_make_tool_use("bash", {})]
 
-        _fill_missing_required_args(tool_uses, tools)
+        fill_missing_required_args(tool_uses, tools)
 
         assert tool_uses[0]["input"] == {"command": "", "description": ""}
 
@@ -221,6 +256,6 @@ class TestFillMissingRequiredArgs:
         tools = [{"type": "function", "function": {"name": "noop"}}]
         tool_uses = [_make_tool_use("noop", {})]
 
-        _fill_missing_required_args(tool_uses, tools)
+        fill_missing_required_args(tool_uses, tools)
 
         assert tool_uses[0]["input"] == {}

--- a/tests/test_routers_chat.py
+++ b/tests/test_routers_chat.py
@@ -34,6 +34,531 @@ class TestSplitThinkingStreaming:
 
 class TestChatRouter:
     @pytest.mark.asyncio
+    async def test_chat_non_streaming_strips_gemma4_channel(self, app_client):
+        """Gemma 4 channel-thinking tokens must not leak into message.content (#306)."""
+        stats = TimingStats(eval_count=10)
+        mock_result = {
+            "text": "<|channel>thought\nLet me think about this.\n<channel|>391",
+            "done": True,
+            "stats": stats,
+        }
+
+        with patch(
+            "olmlx.routers.chat.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "gemma4",
+                    "messages": [{"role": "user", "content": "What is 17 * 23?"}],
+                    "stream": False,
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        content = data["message"]["content"]
+        assert "<|channel>" not in content
+        assert "<channel|>" not in content
+        assert "thought" not in content
+        assert "391" in content
+
+    @pytest.mark.asyncio
+    async def test_chat_streaming_strips_gemma4_channel(self, app_client):
+        """Gemma 4 channel tokens must not leak through the streaming path."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": "<|channel>thought\n", "done": False}
+                yield {"text": "Let me think.", "done": False}
+                yield {"text": "<channel|>", "done": False}
+                yield {"text": "391", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.chat.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "gemma4",
+                    "messages": [{"role": "user", "content": "What is 17 * 23?"}],
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        lines = [line for line in resp.text.strip().split("\n") if line.strip()]
+        joined = "".join(json.loads(line)["message"]["content"] for line in lines)
+        assert "<|channel>" not in joined
+        assert "<channel|>" not in joined
+        assert "Let me think." not in joined
+        assert "391" in joined
+
+    @pytest.mark.asyncio
+    async def test_chat_streaming_short_response_emits_content_chunk(self, app_client):
+        """A short, no-thinking response must be emitted as a non-done chunk.
+
+        Regression: putting the detect-phase buffer in the final done chunk
+        is invisible to Ollama clients that ignore done-chunk content.
+        """
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": "hello", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.chat.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        lines = [
+            json.loads(line) for line in resp.text.strip().split("\n") if line.strip()
+        ]
+        non_done = [line for line in lines if not line.get("done")]
+        joined_non_done = "".join(c["message"]["content"] for c in non_done)
+        assert "hello" in joined_non_done
+
+    @pytest.mark.asyncio
+    async def test_chat_non_streaming_returns_tool_calls(self, app_client):
+        """Parsed tool calls must be returned in message.tool_calls, not stripped."""
+        stats = TimingStats(eval_count=10)
+        mock_result = {
+            "text": '<tool_call>{"name": "get_weather", "arguments": {"city": "Paris"}}</tool_call>',
+            "done": True,
+            "stats": stats,
+        }
+
+        with patch(
+            "olmlx.routers.chat.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "weather in Paris"}],
+                    "stream": False,
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "description": "Get the weather",
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {"city": {"type": "string"}},
+                                    "required": ["city"],
+                                },
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        tool_calls = data["message"].get("tool_calls")
+        assert tool_calls, f"Expected tool_calls in response, got {data['message']}"
+        assert tool_calls[0]["function"]["name"] == "get_weather"
+        assert tool_calls[0]["function"]["arguments"] == {"city": "Paris"}
+
+    @pytest.mark.asyncio
+    async def test_chat_non_streaming_tool_call_with_null_arguments(self, app_client):
+        """A tool call whose arguments parse to JSON ``null`` must not crash
+        the ``ToolCallFunction`` Pydantic construction.  Regression: the
+        Ollama path passed ``tu["input"]`` to ``arguments: dict[str, Any]``
+        unguarded, and gpt-oss-style channel parsing can emit ``input=None``
+        when the tool-call ``<|message|>`` payload is the literal string
+        ``null``."""
+        stats = TimingStats(eval_count=10)
+        # Emit a gpt-oss harmony block whose message payload is JSON null.
+        raw = (
+            "<|start|>assistant<|channel|>commentary to=functions.ping"
+            "<|message|>null<|call|>"
+        )
+        mock_result = {
+            "text": "",
+            "raw_text": raw,
+            "done": True,
+            "stats": stats,
+        }
+
+        with patch(
+            "olmlx.routers.chat.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "gpt-oss",
+                    "messages": [{"role": "user", "content": "ping?"}],
+                    "stream": False,
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "ping",
+                                "parameters": {"type": "object"},
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        tool_calls = data["message"].get("tool_calls")
+        assert tool_calls
+        # Null payload should coerce to an empty dict, not propagate as None.
+        assert tool_calls[0]["function"]["arguments"] == {}
+
+    @pytest.mark.asyncio
+    async def test_chat_streaming_with_tools_text_only_omits_tool_calls_key(
+        self, app_client
+    ):
+        """When tools are declared but the model returns only text, the
+        emitted ``message`` must omit the ``tool_calls`` key entirely
+        rather than serialising it as ``null``.  Ollama clients that use
+        ``"tool_calls" in chunk["message"]`` to detect tool responses
+        would otherwise see a false positive on every text-only chunk on
+        this path."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": "just answering normally", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.chat.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "x",
+                                "parameters": {"type": "object"},
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert resp.status_code == 200
+        lines = [
+            json.loads(line) for line in resp.text.strip().split("\n") if line.strip()
+        ]
+        for line in lines:
+            msg = line.get("message") or {}
+            assert "tool_calls" not in msg, (
+                f"text-only response leaked tool_calls key: {line}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_chat_streaming_with_tools_thinking_only_no_empty_content_chunk(
+        self, app_client
+    ):
+        """If the model's entire output is a thinking block, the
+        streaming-with-tools path must surface that thinking via
+        ``message.thinking`` rather than dropping it.  The pre-done chunk
+        must NOT carry an empty ``content`` field (regression from PR
+        #313: without the visible/thinking/tool_calls guard, an
+        all-thinking response produced a spurious
+        ``{"content": ""}`` line before the done chunk)."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {
+                    "text": "<think>just thinking out loud</think>",
+                    "done": False,
+                }
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.chat.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "x",
+                                "parameters": {"type": "object"},
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert resp.status_code == 200
+        lines = [
+            json.loads(line) for line in resp.text.strip().split("\n") if line.strip()
+        ]
+        non_done = [line for line in lines if not line.get("done")]
+        # Exactly one non-done chunk, carrying the thinking content.
+        # ``content`` may be present as an empty string (Ollama protocol
+        # keeps the field on every message), but the thinking text is
+        # what makes the chunk non-spurious.
+        assert len(non_done) == 1, (
+            f"expected one non-done chunk for thinking content, got {non_done}"
+        )
+        msg = non_done[0]["message"]
+        assert "just thinking out loud" in msg.get("thinking", ""), (
+            f"thinking content missing: {msg}"
+        )
+        # The done chunk must still close the stream cleanly.
+        assert lines and lines[-1].get("done") is True
+
+    @pytest.mark.asyncio
+    async def test_chat_streaming_with_tools_uses_raw_text_for_parsing(
+        self, app_client
+    ):
+        """When ``generate_chat`` sets ``raw_text`` on the done chunk (gpt-oss
+        models route their channel-formatted output that way), the
+        streaming-with-tools path must parse against ``raw_text`` rather than
+        the accumulated visible-only ``full_text``.  Without this the
+        tool-call markup encoded in the channel block is invisible to
+        ``parse_model_output`` and ``tool_calls`` comes back empty."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                # Visible chunks carry no tool-call text; the channel-
+                # formatted call lives only in ``raw_text`` on the done
+                # chunk, mimicking the gpt-oss code path.
+                yield {"text": "Looking up the time...", "done": False}
+                yield {
+                    "text": "",
+                    "raw_text": (
+                        "<|start|>assistant<|channel|>commentary "
+                        "to=functions.get_time"
+                        '<|message|>{"tz": "UTC"}<|call|>'
+                    ),
+                    "done": True,
+                    "stats": TimingStats(),
+                }
+
+            return gen()
+
+        with patch("olmlx.routers.chat.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "gpt-oss",
+                    "messages": [{"role": "user", "content": "what time is it?"}],
+                    "stream": True,
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "get_time",
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {"tz": {"type": "string"}},
+                                },
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert resp.status_code == 200
+        lines = [
+            json.loads(line) for line in resp.text.strip().split("\n") if line.strip()
+        ]
+        tool_calls = []
+        for line in lines:
+            tc = (line.get("message") or {}).get("tool_calls")
+            if tc:
+                tool_calls.extend(tc)
+        assert tool_calls, f"expected raw_text-sourced tool_calls, got {lines}"
+        assert tool_calls[0]["function"]["name"] == "get_time"
+        assert tool_calls[0]["function"]["arguments"] == {"tz": "UTC"}
+
+    @pytest.mark.asyncio
+    async def test_chat_streaming_with_tools_post_parse_error_yields_error_chunk(
+        self, app_client
+    ):
+        """An exception raised after the stream is drained (e.g. in
+        ``_build_tool_calls``) must surface as an NDJSON error line, not a
+        silent truncation."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": "anything", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with (
+            patch("olmlx.routers.chat.generate_chat", side_effect=mock_stream),
+            patch(
+                "olmlx.routers.chat._build_tool_calls",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "x",
+                                "parameters": {"type": "object"},
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert resp.status_code == 200
+        lines = [
+            json.loads(line) for line in resp.text.strip().split("\n") if line.strip()
+        ]
+        assert lines, "expected at least one NDJSON line on error"
+        last = lines[-1]
+        assert "error" in last, f"expected error chunk, got {last}"
+        assert last.get("done") is True
+
+    @pytest.mark.asyncio
+    async def test_chat_streaming_with_tools_emits_structured_tool_calls(
+        self, app_client
+    ):
+        """Streaming ``/api/chat`` with tools must surface structured
+        ``message.tool_calls`` instead of leaking the raw markup."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {
+                    "text": '<tool_call>{"name": "get_weather", '
+                    '"arguments": {"city": "Paris"}}</tool_call>',
+                    "done": False,
+                }
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.chat.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "weather in Paris"}],
+                    "stream": True,
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "description": "Get the weather",
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {"city": {"type": "string"}},
+                                    "required": ["city"],
+                                },
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert resp.status_code == 200
+        lines = [
+            json.loads(line) for line in resp.text.strip().split("\n") if line.strip()
+        ]
+        # Collect tool_calls from any chunk.
+        tool_calls = []
+        for line in lines:
+            tc = (line.get("message") or {}).get("tool_calls")
+            if tc:
+                tool_calls.extend(tc)
+            # Markup must not leak in content.
+            content = (line.get("message") or {}).get("content") or ""
+            assert "<tool_call>" not in content, (
+                f"raw markup leaked in streaming response: {line}"
+            )
+        assert tool_calls, f"Expected structured tool_calls in stream, got {lines}"
+        assert tool_calls[0]["function"]["name"] == "get_weather"
+        assert tool_calls[0]["function"]["arguments"] == {"city": "Paris"}
+
+    @pytest.mark.asyncio
+    async def test_chat_non_streaming_fills_missing_required_args(self, app_client):
+        """If the model omits a required string arg, the router must inject
+        an empty string so ``ToolCallFunction`` construction succeeds
+        (mirrors the OpenAI router's behavior).
+        """
+        stats = TimingStats(eval_count=10)
+        mock_result = {
+            "text": '<tool_call>{"name": "bash", "arguments": {"command": "ls"}}</tool_call>',
+            "done": True,
+            "stats": stats,
+        }
+
+        with patch(
+            "olmlx.routers.chat.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "list files"}],
+                    "stream": False,
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "bash",
+                                "description": "Run a shell command",
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {
+                                        "command": {"type": "string"},
+                                        "description": {"type": "string"},
+                                    },
+                                    "required": ["command", "description"],
+                                },
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        tool_calls = data["message"].get("tool_calls")
+        assert tool_calls
+        args = tool_calls[0]["function"]["arguments"]
+        assert args.get("command") == "ls"
+        assert args.get("description") == "", (
+            f"Missing required string arg should be filled, got {args}"
+        )
+
+    @pytest.mark.asyncio
     async def test_chat_non_streaming(self, app_client):
         stats = TimingStats(eval_count=10)
         mock_result = {"text": "Hello!", "done": True, "stats": stats}

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -7,22 +7,19 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from olmlx.engine.inference import INIT_ORPHAN_DETECT_LIMIT
-from olmlx.routers.openai import (
-    JSON_MODE_SYSTEM_MSG,
-    _flush_thinking_buffer,
-    _strip_thinking_streaming,
-)
+from olmlx.routers.openai import JSON_MODE_SYSTEM_MSG
+from olmlx.utils.streaming import flush_thinking_buffer, strip_thinking_streaming
 from olmlx.utils.timing import TimingStats
 
 
 class TestStripThinkingStreaming:
-    """Unit tests for _strip_thinking_streaming."""
+    """Unit tests for strip_thinking_streaming."""
 
     def _stream(self, chunks, thinking_expected=False):
-        """Feed chunks through _strip_thinking_streaming, return list of outputs.
+        """Feed chunks through strip_thinking_streaming, return list of outputs.
 
         ``thinking_expected`` mirrors the router-side meta chunk: when True,
-        the orphan `</think>` branch is enabled and the detect buffer is
+        the orphan ``</think>`` branch is enabled and the detect buffer is
         raised to the same generous limit used in production.
         """
         state: dict = {}
@@ -31,9 +28,9 @@ class TestStripThinkingStreaming:
             state["detect_limit"] = INIT_ORPHAN_DETECT_LIMIT
         results = []
         for chunk in chunks:
-            out = _strip_thinking_streaming(chunk, state)
+            out = strip_thinking_streaming(chunk, state)
             results.append(out)
-        flushed = _flush_thinking_buffer(state)
+        flushed = flush_thinking_buffer(state)
         if flushed:
             results.append(flushed)
         return results
@@ -80,6 +77,139 @@ class TestStripThinkingStreaming:
         assert "thinking" not in full
         assert "visible" in full
 
+    def test_gemma4_channel_block_stripped(self):
+        """Gemma 4 ``<|channel>thought\\n...<channel|>`` blocks must be stripped."""
+        chunks = [
+            "<|channel>thought\n",
+            "Let me think.",
+            "<channel|>",
+            "The answer is 391.",
+        ]
+        results = self._stream(chunks)
+        full = "".join(results)
+        assert "Let me think." not in full
+        assert "<|channel>" not in full
+        assert "<channel|>" not in full
+        assert "The answer is 391." in full
+
+    def test_close_tag_split_across_chunks_in_think_phase(self):
+        """A close tag straddling a chunk boundary must still be detected.
+
+        Regression: in ``in_think`` phase, clearing ``buf`` discards any
+        partial close-tag suffix, which would leave the stream stuck in
+        ``in_think`` and silently drop all subsequent output.
+        """
+        chunks = ["<think>", "reasoning</thi", "nk>", "visible"]
+        results = self._stream(chunks)
+        full = "".join(results)
+        assert "reasoning" not in full
+        assert "</think>" not in full
+        assert "visible" in full
+
+    def test_orphaned_gemma4_close_channel_stripped(self):
+        """Orphaned ``<channel|>`` (template pre-opened thought) must be
+        stripped when the engine signalled ``thinking_expected``: the
+        prefix is thinking content from a template-pre-opened block."""
+        chunks = ["internal thoughts ", "more thinking", "<channel|>", "visible"]
+        results = self._stream(chunks, thinking_expected=True)
+        full = "".join(results)
+        assert "internal" not in full
+        assert "more thinking" not in full
+        assert "<channel|>" not in full
+        assert "visible" in full
+
+    def test_orphaned_channel_close_in_prose_preserved_when_not_thinking(self):
+        """A literal ``<channel|>`` in non-thinking prose must survive.
+
+        With the ``thinking_expected`` gate added in PR #314, the
+        orphan-close branch only fires when the engine reports that
+        thinking is incoming.  For a code-gen reply that explains
+        Gemma 4's delimiter syntax (``thinking_expected=False``), the
+        prefix is no longer silently truncated.  This pins the fix so
+        the Limitation 2 regression cannot return for non-thinking
+        responses.
+        """
+        chunks = [
+            "Gemma 4 uses ",
+            "<channel|>",
+            " to close a channel block.",
+        ]
+        results = self._stream(chunks, thinking_expected=False)
+        full = "".join(results)
+        assert "Gemma 4 uses" in full, (
+            f"prose prefix dropped despite thinking_expected=False: {full!r}"
+        )
+        assert " to close a channel block." in full
+        # The literal token survives in the output too — we no longer
+        # consume it as an "orphan close".
+        assert "<channel|>" in full
+
+    def test_detect_limit_holds_partial_open_tag_at_tail(self):
+        """When the detect-limit fires, a partial open-tag at the tail must
+        be held back so the next chunk can complete the tag.
+
+        Without this, a non-thinking prefix ending with ``"<|channel>though"``
+        would emit those bytes verbatim and then enter ``passthrough``
+        unaware it was mid-tag.
+        """
+        # Build a single chunk: prefix that's > 200 chars + partial open tag at end
+        prefix = "x" * 210
+        chunks = [prefix + "<|channel>though", "t\nthinking", "<channel|>", "visible"]
+        results = self._stream(chunks)
+        full = "".join(results)
+        assert "<|channel>" not in full
+        assert "thinking" not in full
+        assert prefix in full
+        assert "visible" in full
+
+    def test_passthrough_flush_returns_held_partial_open_tag(self):
+        """A stream ending in passthrough with a held partial open-tag suffix
+        must surface those bytes — they are real visible content.
+        """
+        # 250-char prefix → exits detect into passthrough; then end with a
+        # partial open-tag suffix the stream never completes.
+        chunks = ["x" * 250, "<thi"]
+        results = self._stream(chunks)
+        full = "".join(results)
+        assert full.endswith("<thi"), f"Held partial dropped: {full[-10:]!r}"
+
+    def test_think_block_with_literal_channel_close_in_content(self):
+        """A ``<think>`` block whose thinking content mentions the literal
+        string ``<channel|>`` must NOT exit early on that string.
+
+        Regression: if ``in_think`` matched any close tag (``</think>`` OR
+        ``<channel|>``), thinking content discussing Gemma 4's delimiters
+        would leak into the visible output.
+        """
+        chunks = [
+            "<think>",
+            "Gemma 4 uses <channel|> as its close marker.",
+            "</think>",
+            "visible answer",
+        ]
+        results = self._stream(chunks)
+        full = "".join(results)
+        assert "Gemma" not in full
+        assert "<channel|>" not in full
+        assert "</think>" not in full
+        assert "visible answer" in full
+
+    def test_gemma4_block_with_literal_think_close_in_content(self):
+        """A Gemma 4 channel block containing the literal ``</think>`` must
+        only close on its paired ``<channel|>``."""
+        chunks = [
+            "<|channel>thought\n",
+            "Qwen uses </think> as its close marker.",
+            "<channel|>",
+            "visible answer",
+        ]
+        results = self._stream(chunks)
+        full = "".join(results)
+        assert "Qwen" not in full
+        assert "</think>" not in full
+        assert "<channel|>" not in full
+        assert "visible answer" in full
+
     def test_passthrough_partial_think_prefix_does_not_hang(self):
         """Regression: a buffer equal to a prefix of ``<think>`` must not loop.
 
@@ -91,14 +221,14 @@ class TestStripThinkingStreaming:
         # First chunk long enough to exit detect phase into passthrough.
         long_chunk = "x" * 250
         state: dict = {}
-        _strip_thinking_streaming(long_chunk, state)
+        strip_thinking_streaming(long_chunk, state)
         # Now feed a bare "<" — a legitimate prefix of "<think>".
-        out = _strip_thinking_streaming("<", state)
+        out = strip_thinking_streaming("<", state)
         # Must return without hanging; the "<" is held for the next chunk.
         assert out == ""
         assert state["buffer"] == "<"
         # Follow-up chunk that is NOT a think tag must flush cleanly.
-        out2 = _strip_thinking_streaming(" hello", state)
+        out2 = strip_thinking_streaming(" hello", state)
         assert out2 == "< hello"
         assert state["buffer"] == ""
 
@@ -391,6 +521,53 @@ class TestOpenAIRouter:
         options = mock_gen.call_args[0][3]
         assert "frequency_penalty" not in options
         assert "presence_penalty" not in options
+
+    @pytest.mark.asyncio
+    async def test_chat_streaming_flushes_held_partial_open_tag_suffix(
+        self, app_client
+    ):
+        """An OpenAI streaming response that ends with a held partial open-tag
+        suffix (e.g. ``"<thi"``) must surface those bytes — they are real
+        visible content, not the start of a thinking block that never
+        materialized.  Regression for the shared
+        ``flush_thinking_buffer`` fix (issue #306 review).
+        """
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                # 250-char prefix → exits detect into passthrough.
+                yield {"text": "x" * 250, "done": False}
+                # Trailing partial open-tag suffix that never completes.
+                yield {"text": "<thi", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.openai.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        full = ""
+        for line in resp.text.strip().split("\n"):
+            line = line.strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[5:].strip()
+            if payload == "[DONE]":
+                continue
+            chunk = json.loads(payload)
+            delta = chunk["choices"][0].get("delta") or {}
+            full += delta.get("content") or ""
+        assert full.endswith("<thi"), (
+            f"held partial open-tag suffix dropped at end-of-stream: {full[-10:]!r}"
+        )
 
     @pytest.mark.asyncio
     async def test_chat_streaming_error_mid_stream(self, app_client):


### PR DESCRIPTION
## Summary
- Fixes #306. `<|channel>thought\n...<channel|>` markers no longer leak into `message.content` on `/api/chat` or `/v1/chat/completions`.
- Generalizes the OpenAI streaming thinking-stripper to a small tag-pair table that handles both `<think>...</think>` and the Gemma 4 channel format (plus the orphaned-close case the chat template can produce).
- Wires the shared stripper into `/api/chat` streaming, and runs `/api/chat` non-streaming output through `parse_model_output` so `visible_text` is what reaches the client.

## Test plan
- [x] `uv run pytest tests/test_routers_chat.py tests/test_routers_openai.py tests/test_routers_anthropic.py tests/test_tool_parser.py` (254 passed)
- [x] `uv run pytest` (full suite — 2590 passed, 3 skipped)
- [x] `uv run ruff check olmlx tests` + `uv run ruff format --check olmlx tests`
- [x] New unit tests for the extended streaming stripper (block + orphaned close)
- [x] New integration tests for `/api/chat` streaming + non-streaming with the exact channel-marker payload from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)