### PR TITLE
fix(thinking): handle Qwen3.5/3.6 orphan </think> across streaming routers

### DIFF
--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -985,6 +985,11 @@ class ChatSession:
                 template_has_thinking=template_has_thinking,
             )
 
+            # Captured from the engine's `thinking_expected` meta chunk so
+            # `parse_model_output` only fires the orphan-`</think>`
+            # heuristic when thinking was actually requested (issue #307).
+            thinking_expected = False
+
             async for chunk in await generate_chat(
                 self.manager,
                 self.config.model_name,
@@ -998,6 +1003,9 @@ class ChatSession:
                 enable_thinking=self.config.thinking,
             ):
                 if chunk.get("cache_info"):
+                    continue
+                if "thinking_expected" in chunk:
+                    thinking_expected = bool(chunk["thinking_expected"])
                     continue
                 if chunk.get("done"):
                     break
@@ -1046,7 +1054,9 @@ class ChatSession:
 
             try:
                 _, visible_text, tool_uses = parse_model_output(
-                    full_text, has_tools=(mcp_tools is not None)
+                    full_text,
+                    has_tools=(mcp_tools is not None),
+                    thinking_expected=thinking_expected,
                 )
             except Exception as exc:
                 logger.error(

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -3079,10 +3079,15 @@ async def generate_chat(
 #   * Qwen3.5/3.6's orphan-thinking preamble for reasoning tasks is
 #     typically a few hundred characters before `</think>` arrives.
 #   * For thinking-capable models that produce a direct answer (no
-#     thinking block at all), every byte of this buffer is a TTFB
-#     delay since nothing reaches the client until the limit is hit.
-# 1024 chars covers all observed orphan preambles while keeping
-# direct-answer streaming latency to roughly one chunk's worth.
+#     thinking block at all), every byte of this buffer adds TTFB
+#     latency — at ~1000 chars/s the worst case is roughly one second
+#     before any text reaches the client.  Keep-alive pings cover the
+#     wait but it's still a visible regression vs streaming a
+#     non-thinking model.  1024 was picked over the reviewer-suggested
+#     512 to keep margin for longer Qwen3.5 reasoning traces (the
+#     observed in-issue example is ~280 chars but production traces
+#     can exceed that for non-trivial prompts); revisit if real-world
+#     direct-answer TTFB becomes a complaint.
 INIT_ORPHAN_DETECT_LIMIT = 1024
 
 

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -3067,11 +3067,19 @@ async def generate_chat(
         )
 
 
-# Generous upper bound on how long a Qwen3.5/3.6-style orphan thinking
-# preamble may run before `</think>` arrives.  Streaming routers consult
-# this when the engine signals `thinking_expected=True` (issue #307);
-# centralised here so all three routers stay in sync.
-INIT_ORPHAN_DETECT_LIMIT = 65536
+# Streaming routers consult this when the engine signals
+# `thinking_expected=True` (issue #307): how many characters of leading
+# output to buffer while waiting for an orphan `</think>` before giving
+# up and emitting the held text as content.  Tuned for the tension
+# between two concerns:
+#   * Qwen3.5/3.6's orphan-thinking preamble for reasoning tasks is
+#     typically a few hundred characters before `</think>` arrives.
+#   * For thinking-capable models that produce a direct answer (no
+#     thinking block at all), every byte of this buffer is a TTFB
+#     delay since nothing reaches the client until the limit is hit.
+# 1024 chars covers all observed orphan preambles while keeping
+# direct-answer streaming latency to roughly one chunk's worth.
+INIT_ORPHAN_DETECT_LIMIT = 1024
 
 
 async def _prepend_meta(

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -3062,9 +3062,13 @@ async def generate_chat(
             {"thinking_expected": thinking_expected},
         )
     else:
-        return await _full_completion(
+        result = await _full_completion(
             lm, prompt, mt, gen_kwargs, stats, images, has_tools=bool(tools)
         )
+        # Mirror the streaming meta chunk so non-streaming routers can gate
+        # orphan `</think>` handling on the same signal (issue #307).
+        result["thinking_expected"] = thinking_expected
+        return result
 
 
 # Streaming routers consult this when the engine signals

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -3027,22 +3027,57 @@ async def generate_chat(
             make_prompt_cache is not None,
         )
 
+    # Compute the *effective* thinking decision so streaming routers can tell
+    # whether to wait for a (possibly orphaned, see #307) `</think>` token.
+    # Mirrors the resolution in `_apply_chat_template`.
+    effective_thinking_kwarg: bool | None
+    if caps.supports_enable_thinking:
+        if enable_thinking is not None:
+            effective_thinking_kwarg = enable_thinking
+        elif tools:
+            effective_thinking_kwarg = False
+        else:
+            effective_thinking_kwarg = True
+    else:
+        effective_thinking_kwarg = None
+    thinking_expected = bool(effective_thinking_kwarg)
+
     if stream:
-        return _stream_completion(
-            lm,
-            prompt,
-            mt,
-            gen_kwargs,
-            stats,
-            images,
-            use_prompt_cache=use_prompt_cache,
-            prompt_tokens=prompt_tokens,
-            cache_id=cache_id,
+        return _prepend_meta(
+            _stream_completion(
+                lm,
+                prompt,
+                mt,
+                gen_kwargs,
+                stats,
+                images,
+                use_prompt_cache=use_prompt_cache,
+                prompt_tokens=prompt_tokens,
+                cache_id=cache_id,
+            ),
+            {"thinking_expected": thinking_expected},
         )
     else:
         return await _full_completion(
             lm, prompt, mt, gen_kwargs, stats, images, has_tools=bool(tools)
         )
+
+
+async def _prepend_meta(
+    stream: AsyncGenerator[dict, None],
+    meta: dict,
+) -> AsyncGenerator[dict, None]:
+    """Yield ``meta`` as the first chunk, then forward ``stream``.
+
+    Used so routers learn streaming-level metadata (e.g. whether thinking is
+    expected — issue #307) before any text chunks arrive.
+    """
+    try:
+        yield meta
+        async for chunk in stream:
+            yield chunk
+    finally:
+        await stream.aclose()
 
 
 async def generate_embeddings(

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -3088,6 +3088,19 @@ async def generate_chat(
 #     observed in-issue example is ~280 chars but production traces
 #     can exceed that for non-trivial prompts); revisit if real-world
 #     direct-answer TTFB becomes a complaint.
+#
+# KNOWN LIMITATION: when a thinking preamble exceeds this limit before
+# `</think>` arrives, the streaming routers fall through to text /
+# passthrough state and emit the buffered content as visible text.  The
+# `</think>` that arrives later is then surfaced as a literal token in
+# the visible content (no retroactive reclassification is possible in a
+# streaming path).  Practical impact: a complex multi-step reasoning
+# trace that runs longer than ~1024 characters before closing its
+# thinking block will leak the preamble into the response.  Mitigations
+# the operator can apply: bump this constant (trades TTFB for
+# correctness margin), use the non-streaming endpoint (always re-parses
+# the full text), or use a model that emits the standard `<think>...`
+# opener (which is detected at any position).
 INIT_ORPHAN_DETECT_LIMIT = 1024
 
 

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1352,6 +1352,26 @@ def _get_chat_template_text(tokenizer: Any) -> str:
     return tpl if isinstance(tpl, str) else ""
 
 
+def _resolve_thinking_active(
+    caps: TemplateCaps,
+    tools: list[dict] | None,
+    enable_thinking: bool | None,
+) -> bool:
+    """Return whether the chat template will request thinking for this call.
+
+    Centralises the resolution rules used both inside ``_apply_chat_template``
+    (to set the ``enable_thinking`` kwarg) and by ``generate_chat`` (to tell
+    streaming routers whether to wait for an orphan `</think>` — issue #307).
+    """
+    if not caps.supports_enable_thinking:
+        return False
+    if enable_thinking is not None:
+        return enable_thinking
+    # Default: think unless tools were declared (backward compat for
+    # non-Anthropic callers that expect tool calls without thinking).
+    return not bool(tools)
+
+
 def _apply_chat_template(
     tokenizer: Any,
     messages: list[dict],
@@ -1380,14 +1400,9 @@ def _apply_chat_template(
         messages = _inject_tools_into_system(messages, tools)
 
     if caps.supports_enable_thinking:
-        if enable_thinking is not None:
-            kwargs["enable_thinking"] = enable_thinking
-        elif tools:
-            kwargs["enable_thinking"] = (
-                False  # backward compat for non-Anthropic callers
-            )
-        else:
-            kwargs["enable_thinking"] = True
+        kwargs["enable_thinking"] = _resolve_thinking_active(
+            caps, tools, enable_thinking
+        )
 
     try:
         return tokenizer.apply_chat_template(messages, **kwargs)
@@ -3027,20 +3042,9 @@ async def generate_chat(
             make_prompt_cache is not None,
         )
 
-    # Compute the *effective* thinking decision so streaming routers can tell
-    # whether to wait for a (possibly orphaned, see #307) `</think>` token.
-    # Mirrors the resolution in `_apply_chat_template`.
-    effective_thinking_kwarg: bool | None
-    if caps.supports_enable_thinking:
-        if enable_thinking is not None:
-            effective_thinking_kwarg = enable_thinking
-        elif tools:
-            effective_thinking_kwarg = False
-        else:
-            effective_thinking_kwarg = True
-    else:
-        effective_thinking_kwarg = None
-    thinking_expected = bool(effective_thinking_kwarg)
+    # Tell streaming routers whether to wait for a (possibly orphaned, see
+    # #307) `</think>` token — shares the rules with `_apply_chat_template`.
+    thinking_expected = _resolve_thinking_active(caps, tools, enable_thinking)
 
     if stream:
         return _prepend_meta(
@@ -3061,6 +3065,13 @@ async def generate_chat(
         return await _full_completion(
             lm, prompt, mt, gen_kwargs, stats, images, has_tools=bool(tools)
         )
+
+
+# Generous upper bound on how long a Qwen3.5/3.6-style orphan thinking
+# preamble may run before `</think>` arrives.  Streaming routers consult
+# this when the engine signals `thinking_expected=True` (issue #307);
+# centralised here so all three routers stay in sync.
+INIT_ORPHAN_DETECT_LIMIT = 65536
 
 
 async def _prepend_meta(

--- a/olmlx/engine/tool_parser.py
+++ b/olmlx/engine/tool_parser.py
@@ -494,20 +494,21 @@ def parse_model_output(
     text: str,
     has_tools: bool,
     *,
-    thinking_expected: bool = True,
+    thinking_expected: bool = False,
 ) -> tuple[str, str, list[dict]]:
     """Parse raw model output into (thinking_text, visible_text, tool_use_blocks).
 
     Args:
         text: Raw model output text.
         has_tools: Whether tools were provided in the request.
-        thinking_expected: When False, skip the orphan `</think>` heuristic
-            so a non-thinking model that legitimately mentions the literal
-            token does not have its prefix silently routed into thinking
-            (issue #307 review).  Standard `<think>...</think>` pairs and
-            Gemma4 channel format are always extracted — those tags are
-            unambiguous.  Defaults to True for backward compatibility with
-            callers that have not been updated to plumb the flag.
+        thinking_expected: When True, fire the orphan `</think>` heuristic
+            that strips any leading text preceding a lone `</think>` token
+            into the thinking channel.  Standard `<think>...</think>` pairs
+            and Gemma4 channel format are always extracted — those tags are
+            unambiguous — so this only controls the orphan path.  Defaults
+            to False (conservative): a new caller that forgets to plumb the
+            flag will preserve the literal token in visible content rather
+            than silently misclassifying it (issue #307 review).
     """
     # Try gpt-oss channel format first
     gpt_oss_result = _parse_gpt_oss_channels(text, has_tools)

--- a/olmlx/engine/tool_parser.py
+++ b/olmlx/engine/tool_parser.py
@@ -493,12 +493,21 @@ def _parse_gpt_oss_channels(
 def parse_model_output(
     text: str,
     has_tools: bool,
+    *,
+    thinking_expected: bool = True,
 ) -> tuple[str, str, list[dict]]:
     """Parse raw model output into (thinking_text, visible_text, tool_use_blocks).
 
     Args:
         text: Raw model output text.
         has_tools: Whether tools were provided in the request.
+        thinking_expected: When False, skip the orphan `</think>` heuristic
+            so a non-thinking model that legitimately mentions the literal
+            token does not have its prefix silently routed into thinking
+            (issue #307 review).  Standard `<think>...</think>` pairs and
+            Gemma4 channel format are always extracted — those tags are
+            unambiguous.  Defaults to True for backward compatibility with
+            callers that have not been updated to plumb the flag.
     """
     # Try gpt-oss channel format first
     gpt_oss_result = _parse_gpt_oss_channels(text, has_tools)
@@ -521,16 +530,19 @@ def parse_model_output(
 
     # Handle orphaned </think> — the chat template may open <think> in the
     # prompt so the generated text starts mid-think with only a closing tag.
-    orphan_idx = text.find("</think>")
-    if orphan_idx != -1:
-        orphan_thinking = text[:orphan_idx].strip()
-        if orphan_thinking:
-            thinking = (
-                f"{thinking}\n{orphan_thinking}".strip()
-                if thinking
-                else orphan_thinking
-            )
-        text = text[orphan_idx + len("</think>") :].lstrip("\n")
+    # Gated on `thinking_expected` so a non-thinking model that mentions the
+    # literal token is not misclassified (issue #307).
+    if thinking_expected:
+        orphan_idx = text.find("</think>")
+        if orphan_idx != -1:
+            orphan_thinking = text[:orphan_idx].strip()
+            if orphan_thinking:
+                thinking = (
+                    f"{thinking}\n{orphan_thinking}".strip()
+                    if thinking
+                    else orphan_thinking
+                )
+            text = text[orphan_idx + len("</think>") :].lstrip("\n")
 
     tool_uses: list[dict] = []
     if has_tools:

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -641,15 +641,20 @@ async def _stream_thinking_state_machine(result):
                     # the standard `<think>` branch instead of swallowing the
                     # `<think>` opener as orphan content.
                     orphan_thinking = buffer[:close_idx]
-                    yield _sse(
-                        "content_block_start",
-                        {
-                            "type": "content_block_start",
-                            "index": block_idx,
-                            "content_block": {"type": "thinking", "thinking": ""},
-                        },
-                    )
+                    # Skip the whole content block when `</think>` is the
+                    # very first token — emitting an empty thinking block
+                    # would diverge from the non-streaming path which
+                    # produces no block in that case (issue #307 review
+                    # round 10).
                     if orphan_thinking:
+                        yield _sse(
+                            "content_block_start",
+                            {
+                                "type": "content_block_start",
+                                "index": block_idx,
+                                "content_block": {"type": "thinking", "thinking": ""},
+                            },
+                        )
                         yield _sse(
                             "content_block_delta",
                             {
@@ -661,11 +666,11 @@ async def _stream_thinking_state_machine(result):
                                 },
                             },
                         )
-                    yield _sse(
-                        "content_block_stop",
-                        {"type": "content_block_stop", "index": block_idx},
-                    )
-                    block_idx += 1
+                        yield _sse(
+                            "content_block_stop",
+                            {"type": "content_block_stop", "index": block_idx},
+                        )
+                        block_idx += 1
                     buffer = buffer[close_idx + len("</think>") :].lstrip("\n")
                     state = "text"
                 elif len(buffer) < 7 and "<think>".startswith(buffer):
@@ -673,7 +678,7 @@ async def _stream_thinking_state_machine(result):
                 elif (
                     thinking_expected
                     and close_idx == -1
-                    and len(buffer) < INIT_ORPHAN_DETECT_LIMIT
+                    and len(buffer) <= INIT_ORPHAN_DETECT_LIMIT
                 ):
                     # Keep waiting for a (possibly orphaned) `</think>`.
                     # Gated on `close_idx == -1`: once we've seen `</think>`

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -355,6 +355,12 @@ async def _stream_buffered_with_tools(
             yield chunk  # Forward to stream_sse for message_start
             continue
         if isinstance(chunk, dict) and "thinking_expected" in chunk:
+            # Tools path buffers the full output and re-parses via
+            # `parse_model_output` on the `done` chunk; that helper applies
+            # its own orphan-`</think>` heuristic without consulting this
+            # flag.  Same known false-positive risk as the non-streaming
+            # path for non-thinking models that emit the literal token
+            # while tools are declared (issue #307 review).
             continue
         if chunk.get("done"):
             stats = chunk.get("stats")
@@ -656,11 +662,12 @@ async def _stream_thinking_state_machine(result):
                     break
                 elif thinking_expected and len(buffer) < INIT_ORPHAN_DETECT_LIMIT:
                     # Keep waiting for a (possibly orphaned) `</think>`.
-                    # NOTE: this can delay the first `text_delta` event by up
-                    # to ~64 KB for a thinking-capable model that produces a
+                    # NOTE: this can delay the first `text_delta` event by
+                    # up to `INIT_ORPHAN_DETECT_LIMIT` characters (currently
+                    # 1024) for a thinking-capable model that produces a
                     # short direct answer with no `</think>`; the keep-alive
-                    # ping loop covers the wait, and the buffered content is
-                    # emitted at stream end via `_flush_thinking_buffer`.
+                    # ping loop covers the wait, and the buffered content
+                    # is emitted at stream end via `_flush_thinking_buffer`.
                     break
                 else:
                     state = "text"

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -984,10 +984,13 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
             visible_text = text
             resolve_tool_names(tool_uses, tools)
         else:
-            # Parse normally for other model formats
+            # Pass `thinking_expected` so the orphan-`</think>` heuristic
+            # only fires when the engine actually requested thinking
+            # (issue #307 review — symmetric with the Ollama fix).
             thinking_parsed, visible_text, tool_uses = parse_model_output(
                 text,
                 has_tools,
+                thinking_expected=bool(result.get("thinking_expected")),
             )
             thinking = thinking or thinking_parsed
             resolve_tool_names(tool_uses, tools)

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -666,12 +666,21 @@ async def _stream_thinking_state_machine(result):
                         {"type": "content_block_stop", "index": block_idx},
                     )
                     block_idx += 1
-                    buffer = buffer[close_idx + 8 :].lstrip("\n")
+                    buffer = buffer[close_idx + len("</think>") :].lstrip("\n")
                     state = "text"
                 elif len(buffer) < 7 and "<think>".startswith(buffer):
                     break
-                elif thinking_expected and len(buffer) < INIT_ORPHAN_DETECT_LIMIT:
+                elif (
+                    thinking_expected
+                    and close_idx == -1
+                    and len(buffer) < INIT_ORPHAN_DETECT_LIMIT
+                ):
                     # Keep waiting for a (possibly orphaned) `</think>`.
+                    # Gated on `close_idx == -1`: once we've seen `</think>`
+                    # we have enough information to make a decision (either
+                    # the orphan branch above already fired, or the text
+                    # state will emit the buffered content) — no point
+                    # waiting longer.
                     # NOTE: this can delay the first `text_delta` event by
                     # up to `INIT_ORPHAN_DETECT_LIMIT` characters (currently
                     # 1024) for a thinking-capable model that produces a
@@ -703,11 +712,11 @@ async def _stream_thinking_state_machine(result):
                         {"type": "content_block_stop", "index": block_idx},
                     )
                     block_idx += 1
-                    buffer = buffer[end_idx + 8 :]
+                    buffer = buffer[end_idx + len("</think>") :]
                     state = "text"
-                elif len(buffer) > 8:
-                    safe = buffer[:-8]
-                    buffer = buffer[-8:]
+                elif len(buffer) > len("</think>"):
+                    safe = buffer[: -len("</think>")]
+                    buffer = buffer[-len("</think>") :]
                     yield _sse(
                         "content_block_delta",
                         {

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -349,6 +349,8 @@ async def _stream_buffered_with_tools(
         if isinstance(chunk, dict) and chunk.get("cache_info"):
             yield chunk  # Forward to stream_sse for message_start
             continue
+        if isinstance(chunk, dict) and "thinking_expected" in chunk:
+            continue
         if chunk.get("done"):
             stats = chunk.get("stats")
             if stats:
@@ -547,6 +549,9 @@ def _flush_thinking_buffer(
     return events, block_idx
 
 
+_INIT_ORPHAN_DETECT_LIMIT = 65536
+
+
 async def _stream_thinking_state_machine(result):
     """Stream incrementally with thinking state machine. Yields a final dict with metadata."""
     block_idx = 0
@@ -555,6 +560,10 @@ async def _stream_thinking_state_machine(result):
     state = "init"  # "init", "thinking", "text"
     text_block_started = False
     done_reason = None
+    # Engine forwards this via a meta chunk; when set, we wait for an orphan
+    # `</think>` to classify the leading buffer as thinking instead of text
+    # (issue #307 — Qwen3.5/3.6 emit thinking without the `<think>` opener).
+    thinking_expected = False
 
     async for chunk in _with_keepalive_pings(result, interval=KEEPALIVE_PING_INTERVAL):
         if chunk is _PING_SENTINEL:
@@ -562,6 +571,9 @@ async def _stream_thinking_state_machine(result):
             continue
         if isinstance(chunk, dict) and chunk.get("cache_info"):
             yield chunk  # Forward to stream_sse for message_start
+            continue
+        if isinstance(chunk, dict) and "thinking_expected" in chunk:
+            thinking_expected = bool(chunk["thinking_expected"])
             continue
         if chunk.get("done"):
             stats = chunk.get("stats")
@@ -575,6 +587,7 @@ async def _stream_thinking_state_machine(result):
 
         while buffer:
             if state == "init":
+                close_idx = buffer.find("</think>")
                 if buffer.startswith("<think>"):
                     state = "thinking"
                     buffer = buffer[7:]
@@ -586,7 +599,42 @@ async def _stream_thinking_state_machine(result):
                             "content_block": {"type": "thinking", "thinking": ""},
                         },
                     )
+                elif close_idx >= 0:
+                    # Orphaned `</think>` — Qwen3.5/3.6 chat templates miss
+                    # the `<think>` opener but still emit the closer (#307).
+                    # Everything buffered before it is the thinking block.
+                    orphan_thinking = buffer[:close_idx]
+                    yield _sse(
+                        "content_block_start",
+                        {
+                            "type": "content_block_start",
+                            "index": block_idx,
+                            "content_block": {"type": "thinking", "thinking": ""},
+                        },
+                    )
+                    if orphan_thinking:
+                        yield _sse(
+                            "content_block_delta",
+                            {
+                                "type": "content_block_delta",
+                                "index": block_idx,
+                                "delta": {
+                                    "type": "thinking_delta",
+                                    "thinking": orphan_thinking,
+                                },
+                            },
+                        )
+                    yield _sse(
+                        "content_block_stop",
+                        {"type": "content_block_stop", "index": block_idx},
+                    )
+                    block_idx += 1
+                    buffer = buffer[close_idx + 8 :].lstrip("\n")
+                    state = "text"
                 elif len(buffer) < 7 and "<think>".startswith(buffer):
+                    break
+                elif thinking_expected and len(buffer) < _INIT_ORPHAN_DETECT_LIMIT:
+                    # Keep waiting for a (possibly orphaned) `</think>`.
                     break
                 else:
                     state = "text"

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -346,6 +346,10 @@ async def _stream_buffered_with_tools(
     text_chunks: list[str] = []
     raw_text = ""
     output_tokens = 0
+    # Engine meta chunk arrives before any text — capture it so the orphan
+    # `</think>` heuristic in `parse_model_output` is gated symmetrically
+    # with the non-tools paths (issue #307 review round 5).
+    thinking_expected = False
 
     async for chunk in _with_keepalive_pings(result, interval=KEEPALIVE_PING_INTERVAL):
         if chunk is _PING_SENTINEL:
@@ -355,12 +359,7 @@ async def _stream_buffered_with_tools(
             yield chunk  # Forward to stream_sse for message_start
             continue
         if isinstance(chunk, dict) and "thinking_expected" in chunk:
-            # Tools path buffers the full output and re-parses via
-            # `parse_model_output` on the `done` chunk; that helper applies
-            # its own orphan-`</think>` heuristic without consulting this
-            # flag.  Same known false-positive risk as the non-streaming
-            # path for non-thinking models that emit the literal token
-            # while tools are declared (issue #307 review).
+            thinking_expected = bool(chunk["thinking_expected"])
             continue
         if chunk.get("done"):
             stats = chunk.get("stats")
@@ -391,6 +390,7 @@ async def _stream_buffered_with_tools(
     thinking, visible_text, tool_uses = parse_model_output(
         text_for_parsing,
         True,
+        thinking_expected=thinking_expected,
     )
 
     resolve_tool_names(tool_uses, declared_tools)
@@ -611,6 +611,7 @@ async def _stream_thinking_state_machine(result):
 
         while buffer:
             if state == "init":
+                open_idx = buffer.find("<think>")
                 close_idx = buffer.find("</think>")
                 if buffer.startswith("<think>"):
                     state = "thinking"
@@ -623,13 +624,22 @@ async def _stream_thinking_state_machine(result):
                             "content_block": {"type": "thinking", "thinking": ""},
                         },
                     )
-                elif close_idx >= 0 and thinking_expected:
+                elif (
+                    close_idx >= 0
+                    and thinking_expected
+                    and (open_idx == -1 or close_idx < open_idx)
+                ):
                     # Orphaned `</think>` — Qwen3.5/3.6 chat templates miss
                     # the `<think>` opener but still emit the closer (#307).
                     # Everything buffered before it is the thinking block.
                     # Gated on `thinking_expected` so a non-thinking model
                     # that legitimately mentions the literal `</think>`
-                    # token isn't silently reclassified as thinking.
+                    # token isn't silently reclassified as thinking, and on
+                    # the open/close order so that a buffer assembled with
+                    # `preamble<think>...</think>answer` (text-before-tag,
+                    # uncommon but real for slow first tokens) routes through
+                    # the standard `<think>` branch instead of swallowing the
+                    # `<think>` opener as orphan content.
                     orphan_thinking = buffer[:close_idx]
                     yield _sse(
                         "content_block_start",

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -10,7 +10,12 @@ from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
 from olmlx.config import settings
-from olmlx.engine.inference import _inference_ref, count_chat_tokens, generate_chat
+from olmlx.engine.inference import (
+    INIT_ORPHAN_DETECT_LIMIT,
+    _inference_ref,
+    count_chat_tokens,
+    generate_chat,
+)
 from olmlx.routers.common import build_inference_options
 from olmlx.engine.tool_parser import (
     _make_tool_use_id,
@@ -529,7 +534,12 @@ def _flush_thinking_buffer(
             )
         )
     else:
-        # state == "init" — no output at all, emit empty text block
+        # state == "init" — the stream ended before we could classify the
+        # leading buffer.  This happens when `thinking_expected` held the
+        # init state waiting for an orphan `</think>` that never arrived
+        # (issue #307 — short non-thinking output on a thinking-capable
+        # model).  Emit any held content as a text block so the response
+        # isn't dropped.
         events.append(
             _sse(
                 "content_block_start",
@@ -540,6 +550,17 @@ def _flush_thinking_buffer(
                 },
             )
         )
+        if buffer:
+            events.append(
+                _sse(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": block_idx,
+                        "delta": {"type": "text_delta", "text": buffer},
+                    },
+                )
+            )
         events.append(
             _sse(
                 "content_block_stop",
@@ -547,9 +568,6 @@ def _flush_thinking_buffer(
             )
         )
     return events, block_idx
-
-
-_INIT_ORPHAN_DETECT_LIMIT = 65536
 
 
 async def _stream_thinking_state_machine(result):
@@ -599,10 +617,13 @@ async def _stream_thinking_state_machine(result):
                             "content_block": {"type": "thinking", "thinking": ""},
                         },
                     )
-                elif close_idx >= 0:
+                elif close_idx >= 0 and thinking_expected:
                     # Orphaned `</think>` — Qwen3.5/3.6 chat templates miss
                     # the `<think>` opener but still emit the closer (#307).
                     # Everything buffered before it is the thinking block.
+                    # Gated on `thinking_expected` so a non-thinking model
+                    # that legitimately mentions the literal `</think>`
+                    # token isn't silently reclassified as thinking.
                     orphan_thinking = buffer[:close_idx]
                     yield _sse(
                         "content_block_start",
@@ -633,8 +654,13 @@ async def _stream_thinking_state_machine(result):
                     state = "text"
                 elif len(buffer) < 7 and "<think>".startswith(buffer):
                     break
-                elif thinking_expected and len(buffer) < _INIT_ORPHAN_DETECT_LIMIT:
+                elif thinking_expected and len(buffer) < INIT_ORPHAN_DETECT_LIMIT:
                     # Keep waiting for a (possibly orphaned) `</think>`.
+                    # NOTE: this can delay the first `text_delta` event by up
+                    # to ~64 KB for a thinking-capable model that produces a
+                    # short direct answer with no `</think>`; the keep-alive
+                    # ping loop covers the wait, and the buffered content is
+                    # emitted at stream end via `_flush_thinking_buffer`.
                     break
                 else:
                     state = "text"

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -244,17 +244,16 @@ async def chat(req: ChatRequest, request: Request):
         # calls / thinking).  For every other model the `or` falls back
         # to `text`, which is already the unstripped output.
         raw = result.get("raw_text") or result.get("text", "")
-        # Gate thinking-extraction on the engine-resolved `thinking_expected`
-        # so the streaming and non-streaming paths agree (issue #307 review):
-        # a non-thinking model that legitimately mentions the literal
-        # `</think>` token would otherwise have its prefix silently routed
-        # into `message.thinking` here while streaming preserves it.
-        if result.get("thinking_expected"):
-            thinking, visible, _tool_uses = parse_model_output(
-                raw, has_tools=bool(tools)
-            )
-        else:
-            thinking, visible = "", raw
+        # Pass `thinking_expected` so the orphan-`</think>` heuristic only
+        # fires when the engine actually requested thinking (issue #307
+        # review): keeps streaming and non-streaming behaviour symmetric
+        # and prevents a non-thinking model that mentions the literal
+        # token from having its prefix silently routed to thinking.
+        thinking, visible, _tool_uses = parse_model_output(
+            raw,
+            has_tools=bool(tools),
+            thinking_expected=bool(result.get("thinking_expected")),
+        )
         response = {
             "model": req.model,
             "created_at": now,

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
 from olmlx.engine.inference import generate_chat
+from olmlx.engine.tool_parser import parse_model_output
 from olmlx.routers.common import format_error
 from olmlx.schemas.chat import ChatRequest, Message
 from olmlx.utils.streaming import safe_ndjson_stream
@@ -13,6 +14,114 @@ from olmlx.utils.streaming import safe_ndjson_stream
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+# Generous upper bound on how long a Qwen3.5/3.6-style orphan thinking
+# preamble may run before `</think>` arrives.  Matches the OpenAI router's
+# limit (issue #307).  Only consulted when the engine signals
+# `thinking_expected=True` via the stream meta chunk.
+_INIT_ORPHAN_DETECT_LIMIT = 65536
+
+
+def _split_thinking_streaming(text: str, state: dict) -> tuple[str, str]:
+    """Split a streaming token into ``(thinking_chunk, content_chunk)``.
+
+    Mirrors ``_strip_thinking_streaming`` in the OpenAI router but routes the
+    thinking text into a separate output channel instead of discarding it,
+    so the Ollama API can populate ``message.thinking`` (issue #307).
+
+    State keys:
+    - ``phase``: ``"detect"``, ``"in_think"``, ``"passthrough"``
+    - ``buffer``: accumulated text waiting to be resolved
+    - ``thinking_expected``: when True, the detect phase tolerates a
+      longer orphan-thinking preamble before giving up.
+    """
+    buf = state.get("buffer", "") + text
+    thinking_parts: list[str] = []
+    content_parts: list[str] = []
+    phase = state.get("phase", "detect")
+    detect_limit = _INIT_ORPHAN_DETECT_LIMIT if state.get("thinking_expected") else 200
+
+    while buf:
+        if phase == "detect":
+            open_idx = buf.find("<think>")
+            close_idx = buf.find("</think>")
+
+            if close_idx != -1 and (open_idx == -1 or close_idx < open_idx):
+                # Orphan `</think>`: prefix is thinking content.
+                thinking_parts.append(buf[:close_idx])
+                buf = buf[close_idx + len("</think>") :].lstrip("\n")
+                phase = "passthrough"
+            elif open_idx != -1:
+                # Pre-think text is content; tag itself is consumed.
+                content_parts.append(buf[:open_idx])
+                buf = buf[open_idx + len("<think>") :]
+                phase = "in_think"
+            else:
+                # No tag yet.  Buffer until we can decide, then flush as
+                # content if no tag ever appears.
+                if len(buf) > detect_limit:
+                    content_parts.append(buf)
+                    buf = ""
+                    phase = "passthrough"
+                break
+
+        elif phase == "in_think":
+            end = buf.find("</think>")
+            if end == -1:
+                # Hold back up to 7 trailing chars in case `</think>` is
+                # split across two chunks; emit the rest as thinking.
+                if len(buf) > 8:
+                    thinking_parts.append(buf[:-8])
+                    buf = buf[-8:]
+                break
+            thinking_parts.append(buf[:end])
+            buf = buf[end + len("</think>") :].lstrip("\n")
+            phase = "passthrough"
+
+        else:  # passthrough
+            open_idx = buf.find("<think>")
+            if open_idx == -1:
+                # Hold back any trailing prefix of `<think>` so a follow-up
+                # chunk can complete the tag (avoids loop-spin on bare "<").
+                longest_partial = 0
+                for i in range(1, min(len("<think>"), len(buf) + 1)):
+                    if "<think>".startswith(buf[-i:]):
+                        longest_partial = i
+                        break
+                if longest_partial:
+                    content_parts.append(buf[:-longest_partial])
+                    buf = buf[-longest_partial:]
+                else:
+                    content_parts.append(buf)
+                    buf = ""
+                break
+            content_parts.append(buf[:open_idx])
+            buf = buf[open_idx + len("<think>") :]
+            phase = "in_think"
+
+    state["buffer"] = buf
+    state["phase"] = phase
+    return "".join(thinking_parts), "".join(content_parts)
+
+
+def _flush_split_thinking(state: dict) -> tuple[str, str]:
+    """Flush remaining buffer at stream end.
+
+    If the buffer is still in ``detect`` (no tag ever seen), treat it as
+    content.  In ``in_think`` (open tag without close), treat as thinking so
+    the response isn't truncated.
+    """
+    buf = state.get("buffer", "")
+    phase = state.get("phase", "detect")
+    state["buffer"] = ""
+    if not buf:
+        return "", ""
+    if phase == "detect":
+        return "", buf
+    if phase == "in_think":
+        return buf, ""
+    return "", buf
 
 
 @router.post("/api/chat")
@@ -37,29 +146,47 @@ async def chat(req: ChatRequest, request: Request):
             cache_id=cache_id,
         )
 
+        think_state: dict = {}
+
         def format_chunk(chunk):
             if chunk.get("cache_info"):
                 return None
+            if "thinking_expected" in chunk:
+                think_state["thinking_expected"] = bool(chunk["thinking_expected"])
+                return None
             now = datetime.now(timezone.utc).isoformat()
             if chunk.get("done"):
+                thinking_tail, content_tail = _flush_split_thinking(think_state)
                 stats = chunk.get("stats")
                 final = {
                     "model": req.model,
                     "created_at": now,
-                    "message": Message(role="assistant", content="").model_dump(),
+                    "message": Message(
+                        role="assistant",
+                        content=content_tail,
+                        thinking=thinking_tail or None,
+                    ).model_dump(exclude_none=True),
                     "done": True,
                     "done_reason": chunk.get("done_reason", "stop"),
                 }
                 if stats:
                     final.update(stats.to_dict())
                 return json.dumps(final) + "\n"
-            text = chunk.get("text", "")
+            thinking_chunk, content_chunk = _split_thinking_streaming(
+                chunk.get("text", ""), think_state
+            )
+            if not thinking_chunk and not content_chunk:
+                return None
             return (
                 json.dumps(
                     {
                         "model": req.model,
                         "created_at": now,
-                        "message": Message(role="assistant", content=text).model_dump(),
+                        "message": Message(
+                            role="assistant",
+                            content=content_chunk,
+                            thinking=thinking_chunk or None,
+                        ).model_dump(exclude_none=True),
                         "done": False,
                     }
                 )
@@ -90,12 +217,17 @@ async def chat(req: ChatRequest, request: Request):
         )
         now = datetime.now(timezone.utc).isoformat()
         stats = result.get("stats")
+        # Use raw_text when present (gpt-oss channel format), else text.
+        raw = result.get("raw_text") or result.get("text", "")
+        thinking, visible, _tool_uses = parse_model_output(raw, has_tools=bool(tools))
         response = {
             "model": req.model,
             "created_at": now,
             "message": Message(
-                role="assistant", content=result.get("text", "")
-            ).model_dump(),
+                role="assistant",
+                content=visible,
+                thinking=thinking or None,
+            ).model_dump(exclude_none=True),
             "done": True,
             "done_reason": result.get("done_reason", "stop"),
         }

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -70,12 +70,12 @@ def _split_thinking_streaming(text: str, state: dict) -> tuple[str, str]:
         elif phase == "in_think":
             end = buf.find("</think>")
             if end == -1:
-                # Hold back up to 8 trailing chars (the length of `</think>`)
-                # in case the tag is split across two chunks; emit the rest
-                # as thinking.
-                if len(buf) > 8:
-                    thinking_parts.append(buf[:-8])
-                    buf = buf[-8:]
+                # Hold back up to `len("</think>")` trailing chars in case
+                # the tag is split across two chunks; emit the rest as
+                # thinking.
+                if len(buf) > len("</think>"):
+                    thinking_parts.append(buf[: -len("</think>")])
+                    buf = buf[-len("</think>") :]
                 break
             thinking_parts.append(buf[:end])
             buf = buf[end + len("</think>") :].lstrip("\n")
@@ -200,6 +200,13 @@ async def chat(req: ChatRequest, request: Request):
             # through immediately as content.  The detect buffer in
             # `_split_thinking_streaming` would otherwise hold the first
             # 200 chars of every Ollama response (issue #307 review).
+            #
+            # All emitter branches below use `model_dump(exclude_none=True)`
+            # so null `thinking` / `images` / `tool_calls` fields are
+            # suppressed from the wire payload.  This matches Ollama
+            # upstream behaviour and keeps the `thinking` field invisible
+            # to clients that pre-date its introduction.  Existing clients
+            # that read `content` / `role` are unaffected.
             if not think_state.get("thinking_expected"):
                 if not text:
                     return None

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -244,7 +244,17 @@ async def chat(req: ChatRequest, request: Request):
         # calls / thinking).  For every other model the `or` falls back
         # to `text`, which is already the unstripped output.
         raw = result.get("raw_text") or result.get("text", "")
-        thinking, visible, _tool_uses = parse_model_output(raw, has_tools=bool(tools))
+        # Gate thinking-extraction on the engine-resolved `thinking_expected`
+        # so the streaming and non-streaming paths agree (issue #307 review):
+        # a non-thinking model that legitimately mentions the literal
+        # `</think>` token would otherwise have its prefix silently routed
+        # into `message.thinking` here while streaming preserves it.
+        if result.get("thinking_expected"):
+            thinking, visible, _tool_uses = parse_model_output(
+                raw, has_tools=bool(tools)
+            )
+        else:
+            thinking, visible = "", raw
         response = {
             "model": req.model,
             "created_at": now,

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -188,7 +188,7 @@ async def chat(req: ChatRequest, request: Request):
                             "model": req.model,
                             "created_at": now,
                             "message": Message(
-                                role="assistant", content=text
+                                role="assistant", content=text, thinking=None
                             ).model_dump(exclude_none=True),
                             "done": False,
                         }

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
-from olmlx.engine.inference import generate_chat
+from olmlx.engine.inference import INIT_ORPHAN_DETECT_LIMIT, generate_chat
 from olmlx.engine.tool_parser import parse_model_output
 from olmlx.routers.common import format_error
 from olmlx.schemas.chat import ChatRequest, Message
@@ -14,13 +14,6 @@ from olmlx.utils.streaming import safe_ndjson_stream
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-
-# Generous upper bound on how long a Qwen3.5/3.6-style orphan thinking
-# preamble may run before `</think>` arrives.  Matches the OpenAI router's
-# limit (issue #307).  Only consulted when the engine signals
-# `thinking_expected=True` via the stream meta chunk.
-_INIT_ORPHAN_DETECT_LIMIT = 65536
 
 
 def _split_thinking_streaming(text: str, state: dict) -> tuple[str, str]:
@@ -40,15 +33,23 @@ def _split_thinking_streaming(text: str, state: dict) -> tuple[str, str]:
     thinking_parts: list[str] = []
     content_parts: list[str] = []
     phase = state.get("phase", "detect")
-    detect_limit = _INIT_ORPHAN_DETECT_LIMIT if state.get("thinking_expected") else 200
+    thinking_expected = bool(state.get("thinking_expected"))
+    detect_limit = INIT_ORPHAN_DETECT_LIMIT if thinking_expected else 200
 
     while buf:
         if phase == "detect":
             open_idx = buf.find("<think>")
             close_idx = buf.find("</think>")
 
-            if close_idx != -1 and (open_idx == -1 or close_idx < open_idx):
+            if (
+                close_idx != -1
+                and (open_idx == -1 or close_idx < open_idx)
+                and thinking_expected
+            ):
                 # Orphan `</think>`: prefix is thinking content.
+                # Gated on `thinking_expected` so a non-thinking model that
+                # legitimately mentions the literal `</think>` token isn't
+                # silently routed into `message.thinking`.
                 thinking_parts.append(buf[:close_idx])
                 buf = buf[close_idx + len("</think>") :].lstrip("\n")
                 phase = "passthrough"
@@ -69,8 +70,9 @@ def _split_thinking_streaming(text: str, state: dict) -> tuple[str, str]:
         elif phase == "in_think":
             end = buf.find("</think>")
             if end == -1:
-                # Hold back up to 7 trailing chars in case `</think>` is
-                # split across two chunks; emit the rest as thinking.
+                # Hold back up to 8 trailing chars (the length of `</think>`)
+                # in case the tag is split across two chunks; emit the rest
+                # as thinking.
                 if len(buf) > 8:
                     thinking_parts.append(buf[:-8])
                     buf = buf[-8:]

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -160,20 +160,41 @@ async def chat(req: ChatRequest, request: Request):
             if chunk.get("done"):
                 thinking_tail, content_tail = _flush_split_thinking(think_state)
                 stats = chunk.get("stats")
+                # Emit any held content as a regular non-done chunk *before*
+                # the done marker.  Ollama clients accumulate
+                # `message.content` from non-done chunks and the standard
+                # done frame has `content=""`; putting accumulated text in
+                # the done frame would silently drop it on those clients
+                # (issue #307 review round 9).
+                pre_done = ""
+                if thinking_tail or content_tail:
+                    pre_done = (
+                        json.dumps(
+                            {
+                                "model": req.model,
+                                "created_at": now,
+                                "message": Message(
+                                    role="assistant",
+                                    content=content_tail,
+                                    thinking=thinking_tail or None,
+                                ).model_dump(exclude_none=True),
+                                "done": False,
+                            }
+                        )
+                        + "\n"
+                    )
                 final = {
                     "model": req.model,
                     "created_at": now,
                     "message": Message(
-                        role="assistant",
-                        content=content_tail,
-                        thinking=thinking_tail or None,
+                        role="assistant", content="", thinking=None
                     ).model_dump(exclude_none=True),
                     "done": True,
                     "done_reason": chunk.get("done_reason", "stop"),
                 }
                 if stats:
                     final.update(stats.to_dict())
-                return json.dumps(final) + "\n"
+                return pre_done + json.dumps(final) + "\n"
             text = chunk.get("text", "")
             # Fast path: when thinking is not expected, pass every token
             # through immediately as content.  The detect buffer in

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -174,9 +174,28 @@ async def chat(req: ChatRequest, request: Request):
                 if stats:
                     final.update(stats.to_dict())
                 return json.dumps(final) + "\n"
-            thinking_chunk, content_chunk = _split_thinking_streaming(
-                chunk.get("text", ""), think_state
-            )
+            text = chunk.get("text", "")
+            # Fast path: when thinking is not expected, pass every token
+            # through immediately as content.  The detect buffer in
+            # `_split_thinking_streaming` would otherwise hold the first
+            # 200 chars of every Ollama response (issue #307 review).
+            if not think_state.get("thinking_expected"):
+                if not text:
+                    return None
+                return (
+                    json.dumps(
+                        {
+                            "model": req.model,
+                            "created_at": now,
+                            "message": Message(
+                                role="assistant", content=text
+                            ).model_dump(exclude_none=True),
+                            "done": False,
+                        }
+                    )
+                    + "\n"
+                )
+            thinking_chunk, content_chunk = _split_thinking_streaming(text, think_state)
             if not thinking_chunk and not content_chunk:
                 return None
             return (
@@ -219,7 +238,11 @@ async def chat(req: ChatRequest, request: Request):
         )
         now = datetime.now(timezone.utc).isoformat()
         stats = result.get("stats")
-        # Use raw_text when present (gpt-oss channel format), else text.
+        # `_full_completion` only populates `raw_text` for gpt-oss channel
+        # format (where `text` has the channel tokens stripped and
+        # `parse_model_output` needs the un-stripped form to find tool
+        # calls / thinking).  For every other model the `or` falls back
+        # to `text`, which is already the unstripped output.
         raw = result.get("raw_text") or result.get("text", "")
         thinking, visible, _tool_uses = parse_model_output(raw, has_tools=bool(tools))
         response = {

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -160,11 +160,12 @@ def _strip_thinking_streaming(text: str, state: dict) -> str:
                 # buffer grows large enough that an orphaned tag is very
                 # unlikely, emit the safe prefix and transition to
                 # passthrough so non-thinking models stream progressively.
-                # The threshold is generous to catch real orphaned tags
-                # (thinking content before </think>) while avoiding
-                # unbounded buffering for non-thinking models.
-                _DETECT_LIMIT = 200
-                if len(buf) > _DETECT_LIMIT:
+                # When the caller knows thinking is expected (issue #307),
+                # the limit is raised so Qwen3.5/3.6's long orphan-prefix
+                # thinking is detected even though `</think>` arrives only
+                # after several thousand characters.
+                detect_limit = state.get("detect_limit", 200)
+                if len(buf) > detect_limit:
                     out_parts.append(buf)
                     buf = ""
                     phase = "passthrough"
@@ -236,6 +237,12 @@ async def _stream_openai_sse(
     try:
         async for chunk in result:
             if chunk.get("cache_info"):
+                continue
+            if "thinking_expected" in chunk:
+                # Engine-emitted meta: tells the thinking stripper how long
+                # to wait for an orphan </think> (issue #307).
+                if chunk["thinking_expected"]:
+                    think_state["detect_limit"] = 65536
                 continue
             if chunk.get("done"):
                 # Flush any buffered content from thinking detection.
@@ -318,7 +325,7 @@ async def _stream_openai_sse_with_tools(
     done_reason = None
     try:
         async for chunk in result:
-            if chunk.get("cache_info"):
+            if chunk.get("cache_info") or "thinking_expected" in chunk:
                 continue
             if chunk.get("done"):
                 # Read raw_text from done chunk for gpt-oss tool call parsing

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -338,7 +338,15 @@ async def _stream_openai_sse_with_tools(
     done_reason = None
     try:
         async for chunk in result:
-            if chunk.get("cache_info") or "thinking_expected" in chunk:
+            if chunk.get("cache_info"):
+                continue
+            if "thinking_expected" in chunk:
+                # Tools path buffers the full output and re-parses via
+                # `parse_model_output` once the stream is done; that helper
+                # has its own (currently always-on) orphan-`</think>`
+                # heuristic, so this flag isn't consulted here.  Known
+                # gap for non-thinking models that emit the literal token
+                # while declaring tools (issue #307 review).
                 continue
             if chunk.get("done"):
                 # Read raw_text from done chunk for gpt-oss tool call parsing

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -336,17 +336,16 @@ async def _stream_openai_sse_with_tools(
     full_text = ""
     raw_text = ""
     done_reason = None
+    # Engine meta chunk arrives before any text — capture it so the orphan
+    # `</think>` heuristic in `parse_model_output` is gated symmetrically
+    # with the non-tools paths (issue #307 review round 5).
+    thinking_expected = False
     try:
         async for chunk in result:
             if chunk.get("cache_info"):
                 continue
             if "thinking_expected" in chunk:
-                # Tools path buffers the full output and re-parses via
-                # `parse_model_output` once the stream is done; that helper
-                # has its own (currently always-on) orphan-`</think>`
-                # heuristic, so this flag isn't consulted here.  Known
-                # gap for non-thinking models that emit the literal token
-                # while declaring tools (issue #307 review).
+                thinking_expected = bool(chunk["thinking_expected"])
                 continue
             if chunk.get("done"):
                 # Read raw_text from done chunk for gpt-oss tool call parsing
@@ -358,7 +357,9 @@ async def _stream_openai_sse_with_tools(
         # Use raw_text for parsing so channel-format tool calls aren't lost;
         # fall back to full_text for non-gpt-oss models
         text_for_parsing = raw_text if raw_text else full_text
-        _thinking, visible_text, tool_uses = parse_model_output(text_for_parsing, True)
+        _thinking, visible_text, tool_uses = parse_model_output(
+            text_for_parsing, True, thinking_expected=thinking_expected
+        )
         resolve_tool_names(tool_uses, declared_tools)
         _fill_missing_required_args(tool_uses, declared_tools)
         logger.debug(

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -554,7 +554,15 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
         usage = OpenAIUsage.from_stats(result.get("stats"))
 
         has_tools = bool(req.tools)
-        _thinking, visible_text, tool_uses = parse_model_output(parse_text, has_tools)
+        # Pass `thinking_expected` so the orphan-`</think>` heuristic only
+        # fires when the engine actually requested thinking (issue #307
+        # review): a non-thinking model that mentions the literal token
+        # would otherwise have its prefix silently dropped from content.
+        _thinking, visible_text, tool_uses = parse_model_output(
+            parse_text,
+            has_tools,
+            thinking_expected=bool(result.get("thinking_expected")),
+        )
         resolve_tool_names(tool_uses, req.tools)
         _fill_missing_required_args(tool_uses, req.tools)
 

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
 from olmlx.engine.inference import (
+    INIT_ORPHAN_DETECT_LIMIT,
     generate_chat,
     generate_completion,
     generate_embeddings,
@@ -140,13 +141,21 @@ def _strip_thinking_streaming(text: str, state: dict) -> str:
     out_parts: list[str] = []
     phase = state.get("phase", "detect")
 
+    thinking_expected = state.get("thinking_expected", False)
     while buf:
         if phase == "detect":
             open_idx = buf.find("<think>")
             close_idx = buf.find("</think>")
 
-            if close_idx != -1 and (open_idx == -1 or close_idx < open_idx):
+            if (
+                close_idx != -1
+                and (open_idx == -1 or close_idx < open_idx)
+                and thinking_expected
+            ):
                 # Orphaned </think> — discard everything before it.
+                # Only fires when thinking is actually expected for this
+                # request; otherwise the model is just mentioning the
+                # literal token and we leave the text untouched.
                 buf = buf[close_idx + len("</think>") :]
                 phase = "passthrough"
             elif open_idx != -1:
@@ -239,10 +248,14 @@ async def _stream_openai_sse(
             if chunk.get("cache_info"):
                 continue
             if "thinking_expected" in chunk:
-                # Engine-emitted meta: tells the thinking stripper how long
-                # to wait for an orphan </think> (issue #307).
+                # Engine-emitted meta: tells the thinking stripper whether
+                # to wait for an orphan </think> (issue #307).  Without
+                # `thinking_expected`, a model that legitimately mentions
+                # the literal `</think>` token would have its prefix
+                # silently reclassified as thinking.
                 if chunk["thinking_expected"]:
-                    think_state["detect_limit"] = 65536
+                    think_state["thinking_expected"] = True
+                    think_state["detect_limit"] = INIT_ORPHAN_DETECT_LIMIT
                 continue
             if chunk.get("done"):
                 # Flush any buffered content from thinking detection.

--- a/olmlx/schemas/chat.py
+++ b/olmlx/schemas/chat.py
@@ -17,6 +17,7 @@ class ToolCall(BaseModel):
 class Message(BaseModel):
     role: str
     content: str = Field("", max_length=1_000_000)
+    thinking: str | None = Field(None, max_length=1_000_000)
     images: list[str] | None = None
     tool_calls: list[ToolCall] | None = None
 

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -1163,9 +1163,16 @@ class TestCacheStatsInCacheInfoChunk:
             async for chunk in gen:
                 chunks.append(chunk)
 
-        # First chunk should be cache_info
-        cache_info = chunks[0]
-        assert cache_info.get("cache_info") is True
+        # cache_info must arrive before any text/done chunk; a leading
+        # ``thinking_expected`` meta chunk (issue #307) may precede it.
+        cache_info_idx = next(
+            i for i, c in enumerate(chunks) if c.get("cache_info") is True
+        )
+        first_text_or_done_idx = next(
+            i for i, c in enumerate(chunks) if "text" in c or c.get("done") is True
+        )
+        assert cache_info_idx < first_text_or_done_idx
+        cache_info = chunks[cache_info_idx]
         assert cache_info["cache_read_tokens"] == 5
         assert cache_info["cache_creation_tokens"] == 3
 
@@ -1266,8 +1273,7 @@ class TestCacheExactMatchTrimAlignment:
         # tokens whose KV entries are actually reused from cache.  The token at
         # suffix_start is re-processed by stream_generate, so its KV is not
         # served from cache.
-        cache_info = chunks[0]
-        assert cache_info.get("cache_info") is True
+        cache_info = next(c for c in chunks if c.get("cache_info") is True)
         assert cache_info["cache_read_tokens"] == 2
         assert cache_info["cache_creation_tokens"] == 1
 
@@ -1313,9 +1319,13 @@ class TestLockReleasedOnCacheInfoDisconnect:
                 [{"role": "user", "content": "hi"}],
                 stream=True,
             )
-            # Read only the cache_info chunk, then close (simulates client disconnect)
-            first = await gen.__anext__()
-            assert first.get("cache_info") is True
+            # Read up to and including the cache_info chunk, then close
+            # (simulates client disconnect).  The engine may prepend a
+            # ``thinking_expected`` meta chunk (issue #307) before cache_info.
+            while True:
+                chunk = await gen.__anext__()
+                if chunk.get("cache_info") is True:
+                    break
             await gen.aclose()
 
         # Lock must be released — if not, this acquire would deadlock

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -1033,6 +1033,52 @@ class TestAnthropicEndpoint:
         assert "answer" in visible_text
 
     @pytest.mark.asyncio
+    async def test_streaming_orphan_close_at_position_zero_no_empty_thinking_block(
+        self, app_client
+    ):
+        """Issue #307 review round 10: when `</think>` is the very first
+        token in the stream (close_idx == 0), the orphan branch must NOT
+        emit an empty thinking content block — the non-streaming path
+        skips it entirely, and emitting an empty block diverges from that
+        behaviour."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"thinking_expected": True}
+                yield {"text": "</think>\n", "done": False}
+                yield {"text": "The answer is 42.", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.anthropic.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "?"}],
+                    "max_tokens": 100,
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        # No content_block of type "thinking" should appear at all (the
+        # non-streaming path produces none for an empty orphan prefix).
+        for line in resp.text.splitlines():
+            if not line.startswith("data: "):
+                continue
+            try:
+                payload = json.loads(line[6:])
+            except json.JSONDecodeError:
+                continue
+            if payload.get("type") != "content_block_start":
+                continue
+            assert payload["content_block"]["type"] != "thinking", (
+                "Empty orphan prefix must not emit a thinking content block"
+            )
+
+    @pytest.mark.asyncio
     async def test_streaming_overflow_when_close_think_never_arrives(self, app_client):
         """When `thinking_expected=True` but no `</think>` arrives before the
         buffer crosses `INIT_ORPHAN_DETECT_LIMIT`, the state machine must

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -924,6 +924,60 @@ class TestAnthropicEndpoint:
         assert visible_text.strip() == "391"
 
     @pytest.mark.asyncio
+    async def test_streaming_thinking_expected_but_direct_answer(self, app_client):
+        """Issue #307 review: when `thinking_expected=True` and the model
+        produces a direct answer (no `<think>` / `</think>` tags at all),
+        the state machine must still emit the buffered content as a
+        `text_delta` rather than silently swallow it.
+
+        Exercises the full SSE path through `_stream_thinking_state_machine`
+        → init-state wait for orphan close → stream end → flush via
+        `_flush_thinking_buffer`.
+        """
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"thinking_expected": True}
+                # Direct, short answer — no <think> or </think> anywhere.
+                yield {"text": "The answer is ", "done": False}
+                yield {"text": "42.", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.anthropic.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "what is 6*7?"}],
+                    "max_tokens": 100,
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        thinking_text = ""
+        text_text = ""
+        for line in resp.text.splitlines():
+            if not line.startswith("data: "):
+                continue
+            try:
+                payload = json.loads(line[6:])
+            except json.JSONDecodeError:
+                continue
+            if payload.get("type") != "content_block_delta":
+                continue
+            delta = payload.get("delta", {})
+            if delta.get("type") == "thinking_delta":
+                thinking_text += delta.get("thinking", "")
+            elif delta.get("type") == "text_delta":
+                text_text += delta.get("text", "")
+
+        assert thinking_text == ""
+        assert text_text == "The answer is 42."
+
+    @pytest.mark.asyncio
     async def test_streaming_literal_close_think_preserved_when_not_thinking(
         self, app_client
     ):

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -853,6 +853,77 @@ class TestAnthropicEndpoint:
         assert "tool_use" in text
 
     @pytest.mark.asyncio
+    async def test_streaming_orphaned_close_think_classified_as_thinking(
+        self, app_client
+    ):
+        """Issue #307: Qwen3.5/3.6 emit thinking without ``<think>`` opener.
+
+        Streaming-without-tools previously fell through the state machine's
+        ``init`` branch (which only entered the thinking state when the
+        buffer started with ``<think>``) and emitted the entire reasoning
+        preamble as ``text_delta``. With the orphan-handling fix the prefix
+        before ``</think>`` must be emitted as ``thinking_delta``.
+        """
+        # Multi-line preamble exceeds any plausible "give-up" buffer.
+        preamble = (
+            "Thinking Process:\n\n"
+            "1. Analyze the Request: The user wants 17 * 23.\n"
+            "2. Recall multiplication: 17 * 23 = 17 * (20 + 3) = 340 + 51 = 391.\n"
+            "3. Sanity check: 17 * 25 = 425, minus 2*17 = 34, gives 391. OK.\n"
+            "4. Format the answer: just the number, no prose.\n"
+            "5. Construct Final Response: 391"
+        )
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"thinking_expected": True}
+                # Many small chunks, like real generation
+                for i in range(0, len(preamble), 16):
+                    yield {"text": preamble[i : i + 16], "done": False}
+                yield {"text": "\n</think>\n\n", "done": False}
+                yield {"text": "391", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.anthropic.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "17*23"}],
+                    "max_tokens": 100,
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        # Reassemble the per-block content.
+        thinking_text = ""
+        visible_text = ""
+        for line in resp.text.splitlines():
+            if not line.startswith("data: "):
+                continue
+            try:
+                payload = json.loads(line[6:])
+            except json.JSONDecodeError:
+                continue
+            if payload.get("type") != "content_block_delta":
+                continue
+            delta = payload.get("delta", {})
+            if delta.get("type") == "thinking_delta":
+                thinking_text += delta.get("thinking", "")
+            elif delta.get("type") == "text_delta":
+                visible_text += delta.get("text", "")
+
+        assert "Thinking Process" in thinking_text
+        assert "Sanity check" in thinking_text
+        assert "Thinking Process" not in visible_text
+        assert "</think>" not in visible_text
+        assert "</think>" not in thinking_text
+        assert visible_text.strip() == "391"
+
+    @pytest.mark.asyncio
     async def test_streaming_partial_think_tag(self, app_client):
         """Test state machine when <think> tag arrives across multiple tokens."""
 

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -961,6 +961,117 @@ class TestAnthropicEndpoint:
         assert visible_text.strip() == "391"
 
     @pytest.mark.asyncio
+    async def test_streaming_text_before_standard_think_pair_not_eaten_as_orphan(
+        self, app_client
+    ):
+        """Issue #307 review round 5: when the buffer assembles into
+        ``preamble<think>...</think>answer`` (text before the opener — rare
+        but real for slow first tokens), the state machine must NOT fire
+        the orphan branch on the late `</think>` and swallow the `<think>`
+        opener as part of a thinking content block. The opener-before-closer
+        order signals a standard `<think>...</think>` pair."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"thinking_expected": True}
+                # Single fat chunk so the state machine sees both tags at once
+                yield {
+                    "text": "preamble <think>thoughts</think>answer",
+                    "done": False,
+                }
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.anthropic.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 100,
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        thinking_text = ""
+        visible_text = ""
+        for line in resp.text.splitlines():
+            if not line.startswith("data: "):
+                continue
+            try:
+                payload = json.loads(line[6:])
+            except json.JSONDecodeError:
+                continue
+            if payload.get("type") != "content_block_delta":
+                continue
+            delta = payload.get("delta", {})
+            if delta.get("type") == "thinking_delta":
+                thinking_text += delta.get("thinking", "")
+            elif delta.get("type") == "text_delta":
+                visible_text += delta.get("text", "")
+
+        # Neither the `<think>` opener nor "preamble" should appear in
+        # thinking — `preamble` must stay in text content.
+        assert "<think>" not in thinking_text
+        assert "preamble" not in thinking_text
+        assert "preamble" in visible_text
+        assert "answer" in visible_text
+
+    @pytest.mark.asyncio
+    async def test_streaming_overflow_when_close_think_never_arrives(self, app_client):
+        """When `thinking_expected=True` but no `</think>` arrives before the
+        buffer crosses `INIT_ORPHAN_DETECT_LIMIT`, the state machine must
+        give up and emit the buffered content as text_delta rather than
+        silently dropping it."""
+        from olmlx.engine.inference import INIT_ORPHAN_DETECT_LIMIT
+
+        long_text = "x" * (INIT_ORPHAN_DETECT_LIMIT + 50)
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"thinking_expected": True}
+                # Chunk in moderately-sized pieces.
+                for i in range(0, len(long_text), 128):
+                    yield {"text": long_text[i : i + 128], "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.anthropic.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 8192,
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        thinking_text = ""
+        text_text = ""
+        for line in resp.text.splitlines():
+            if not line.startswith("data: "):
+                continue
+            try:
+                payload = json.loads(line[6:])
+            except json.JSONDecodeError:
+                continue
+            if payload.get("type") != "content_block_delta":
+                continue
+            delta = payload.get("delta", {})
+            if delta.get("type") == "thinking_delta":
+                thinking_text += delta.get("thinking", "")
+            elif delta.get("type") == "text_delta":
+                text_text += delta.get("text", "")
+
+        assert thinking_text == ""
+        assert text_text == long_text
+
+    @pytest.mark.asyncio
     async def test_streaming_thinking_expected_but_direct_answer(self, app_client):
         """Issue #307 review: when `thinking_expected=True` and the model
         produces a direct answer (no `<think>` / `</think>` tags at all),

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -924,6 +924,58 @@ class TestAnthropicEndpoint:
         assert visible_text.strip() == "391"
 
     @pytest.mark.asyncio
+    async def test_streaming_literal_close_think_preserved_when_not_thinking(
+        self, app_client
+    ):
+        """When `thinking_expected=False`, a literal `</think>` in the
+        output (e.g. a non-thinking model explaining the syntax) must be
+        kept as text rather than reclassified as a thinking block."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"thinking_expected": False}
+                yield {
+                    "text": "Use </think> to close the thought block.",
+                    "done": False,
+                }
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.anthropic.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "syntax?"}],
+                    "max_tokens": 100,
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        thinking_text = ""
+        text_text = ""
+        for line in resp.text.splitlines():
+            if not line.startswith("data: "):
+                continue
+            try:
+                payload = json.loads(line[6:])
+            except json.JSONDecodeError:
+                continue
+            if payload.get("type") != "content_block_delta":
+                continue
+            delta = payload.get("delta", {})
+            if delta.get("type") == "thinking_delta":
+                thinking_text += delta.get("thinking", "")
+            elif delta.get("type") == "text_delta":
+                text_text += delta.get("text", "")
+
+        assert thinking_text == ""
+        assert "</think>" in text_text
+        assert text_text == "Use </think> to close the thought block."
+
+    @pytest.mark.asyncio
     async def test_streaming_partial_think_tag(self, app_client):
         """Test state machine when <think> tag arrives across multiple tokens."""
 
@@ -2431,4 +2483,26 @@ class TestFlushThinkingBuffer:
         assert '"content_block_start"' in events[0]
         assert '"type": "text"' in events[0]
         assert '"content_block_stop"' in events[1]
+        assert new_idx == 0
+
+    def test_flush_init_state_with_buffer(self):
+        """Issue #307: when `thinking_expected` holds the init state waiting
+        for an orphan `</think>` that never arrives (short non-thinking
+        response on a thinking-capable model), the buffered content must be
+        emitted as a text block — not silently dropped."""
+        from olmlx.routers.anthropic import _flush_thinking_buffer
+
+        events, new_idx = _flush_thinking_buffer(
+            state="init",
+            buffer="Streamed text",
+            block_idx=0,
+            text_block_started=False,
+        )
+        # Should emit: text start + delta + stop
+        assert len(events) == 3
+        assert '"content_block_start"' in events[0]
+        assert '"type": "text"' in events[0]
+        assert '"text_delta"' in events[1]
+        assert "Streamed text" in events[1]
+        assert '"content_block_stop"' in events[2]
         assert new_idx == 0

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -969,7 +969,16 @@ class TestAnthropicEndpoint:
         but real for slow first tokens), the state machine must NOT fire
         the orphan branch on the late `</think>` and swallow the `<think>`
         opener as part of a thinking content block. The opener-before-closer
-        order signals a standard `<think>...</think>` pair."""
+        order signals a standard `<think>...</think>` pair.
+
+        Pre-existing limitation: the Anthropic ``text`` state does not
+        re-detect a mid-text ``<think>`` block (interleaving thinking into
+        an in-flight text block is awkward in the SSE content-block model),
+        so the literal tags currently survive into the text delta for this
+        assembly pattern. The OpenAI passthrough state does re-detect. Out
+        of scope for #307; this test only asserts the orphan-branch
+        correctness — that ``<think>``/``thoughts``/``preamble`` are NOT
+        misclassified as thinking content."""
 
         async def mock_stream(*args, **kwargs):
             async def gen():
@@ -1012,9 +1021,13 @@ class TestAnthropicEndpoint:
             elif delta.get("type") == "text_delta":
                 visible_text += delta.get("text", "")
 
-        # Neither the `<think>` opener nor "preamble" should appear in
-        # thinking — `preamble` must stay in text content.
+        # Critical: the orphan branch must NOT fire when `<think>` comes
+        # first.  Neither the literal opener nor "preamble" nor the
+        # thinking content should appear in a thinking_delta — they must
+        # stay in text (where the literal tag survives, per the docstring
+        # note above).
         assert "<think>" not in thinking_text
+        assert "thoughts" not in thinking_text
         assert "preamble" not in thinking_text
         assert "preamble" in visible_text
         assert "answer" in visible_text

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -421,12 +421,49 @@ class TestAnthropicEndpoint:
         assert data["usage"]["output_tokens"] == 20
 
     @pytest.mark.asyncio
+    async def test_non_streaming_literal_close_think_preserved_when_not_thinking(
+        self, app_client
+    ):
+        """Issue #307 review: a non-thinking model that legitimately mentions
+        the literal `</think>` token (e.g. explaining the syntax) must keep
+        it in the text block on the non-streaming path, not have its prefix
+        silently routed into a thinking block."""
+        raw = "Use </think> to close the thought block."
+        stats = TimingStats()
+        mock_result = {
+            "text": raw,
+            "done": True,
+            "stats": stats,
+            "thinking_expected": False,
+        }
+
+        with patch(
+            "olmlx.routers.anthropic.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "syntax?"}],
+                    "max_tokens": 100,
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        content_types = [b["type"] for b in data["content"]]
+        assert "thinking" not in content_types
+        assert any(b.get("text") == raw for b in data["content"])
+
+    @pytest.mark.asyncio
     async def test_non_streaming_with_thinking(self, app_client):
         stats = TimingStats()
         mock_result = {
             "text": "<think>reasoning</think>The answer is 42.",
             "done": True,
             "stats": stats,
+            "thinking_expected": True,
         }
 
         with patch(

--- a/tests/test_routers_chat.py
+++ b/tests/test_routers_chat.py
@@ -93,7 +93,14 @@ class TestChatRouter:
             "</think>\n\n"
             "391"
         )
-        mock_result = {"text": raw, "done": True, "stats": TimingStats(eval_count=10)}
+        # Engine signals thinking_expected via the non-streaming result dict,
+        # mirroring the streaming meta chunk (issue #307 review).
+        mock_result = {
+            "text": raw,
+            "done": True,
+            "stats": TimingStats(eval_count=10),
+            "thinking_expected": True,
+        }
 
         with patch(
             "olmlx.routers.chat.generate_chat", new_callable=AsyncMock
@@ -171,6 +178,41 @@ class TestChatRouter:
         assert "</think>" not in content
         assert "</think>" not in thinking
         assert content.strip() == "391"
+
+    @pytest.mark.asyncio
+    async def test_chat_non_streaming_literal_close_think_preserved_when_not_thinking(
+        self, app_client
+    ):
+        """Issue #307 review: the non-streaming path must agree with the
+        streaming path — a literal `</think>` token from a non-thinking
+        model must stay in `message.content`, not be silently routed to
+        `message.thinking`."""
+        raw = "Use </think> to close the thought block."
+        mock_result = {
+            "text": raw,
+            "done": True,
+            "stats": TimingStats(eval_count=10),
+            "thinking_expected": False,
+        }
+
+        with patch(
+            "olmlx.routers.chat.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "syntax?"}],
+                    "stream": False,
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        msg = data["message"]
+        assert msg["content"] == raw
+        assert "thinking" not in msg or msg["thinking"] is None
 
     @pytest.mark.asyncio
     async def test_chat_streaming_literal_close_think_preserved_when_not_thinking(

--- a/tests/test_routers_chat.py
+++ b/tests/test_routers_chat.py
@@ -5,7 +5,31 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from olmlx.routers.chat import _flush_split_thinking, _split_thinking_streaming
 from olmlx.utils.timing import TimingStats
+
+
+class TestSplitThinkingStreaming:
+    """Unit tests for the Ollama-side thinking splitter (issue #307)."""
+
+    def test_flush_in_think_phase_treats_buffer_as_thinking(self):
+        """If the stream ends with an open `<think>` and no closer, the held
+        buffer must be returned as thinking content (not silently lost)."""
+        # Walk through chunks ending mid-think.
+        state: dict = {}
+        thinking, content = _split_thinking_streaming("<think>partial reasoning", state)
+        # `<think>` consumed; "partial reasoning" is 17 chars in `in_think`
+        # phase — the splitter emits all but the last 8 chars and holds the
+        # tail in case `</think>` is straddling a chunk boundary.
+        assert thinking == "partial r"
+        assert content == ""
+        assert state["phase"] == "in_think"
+        assert state["buffer"] == "easoning"
+
+        # Stream ends — flush must surface the buffered remainder as thinking.
+        tail_thinking, tail_content = _flush_split_thinking(state)
+        assert tail_thinking == "easoning"
+        assert tail_content == ""
 
 
 class TestChatRouter:

--- a/tests/test_routers_chat.py
+++ b/tests/test_routers_chat.py
@@ -173,6 +173,50 @@ class TestChatRouter:
         assert content.strip() == "391"
 
     @pytest.mark.asyncio
+    async def test_chat_streaming_literal_close_think_preserved_when_not_thinking(
+        self, app_client
+    ):
+        """When `thinking_expected=False`, a literal `</think>` in the
+        output must stay in `message.content` and not be silently routed
+        to `message.thinking`."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"thinking_expected": False}
+                yield {
+                    "text": "Use </think> to close the thought block.",
+                    "done": False,
+                }
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.chat.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "syntax?"}],
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        content = ""
+        thinking = ""
+        for line in resp.text.strip().split("\n"):
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            msg = payload.get("message", {})
+            content += msg.get("content", "")
+            thinking += msg.get("thinking", "") or ""
+
+        assert thinking == ""
+        assert "</think>" in content
+        assert content == "Use </think> to close the thought block."
+
+    @pytest.mark.asyncio
     async def test_chat_streaming_error_mid_stream(self, app_client):
         """Error during streaming emits an NDJSON error line instead of crashing."""
 

--- a/tests/test_routers_chat.py
+++ b/tests/test_routers_chat.py
@@ -80,6 +80,99 @@ class TestChatRouter:
         assert call_args[1]["max_tokens"] == 100
 
     @pytest.mark.asyncio
+    async def test_chat_non_streaming_separates_thinking_from_content(self, app_client):
+        """Issue #307: ``<think>...</think>`` and Qwen3.5-style orphan
+        ``</think>`` thinking must be separated from ``message.content`` and
+        surfaced under ``message.thinking`` to match Ollama's API."""
+        # Qwen3.5 case: no opening <think>, closing tag present.
+        raw = (
+            "Thinking Process:\n\n"
+            "1. Analyze the Request: The user wants 17 * 23.\n"
+            "2. Compute: 17 * 23 = 391.\n"
+            "3. Construct Final Response: 391\n"
+            "</think>\n\n"
+            "391"
+        )
+        mock_result = {"text": raw, "done": True, "stats": TimingStats(eval_count=10)}
+
+        with patch(
+            "olmlx.routers.chat.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "17*23"}],
+                    "stream": False,
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        msg = data["message"]
+        assert msg["content"].strip() == "391"
+        assert "</think>" not in msg["content"]
+        assert "Thinking Process" not in msg["content"]
+        assert "Thinking Process" in msg.get("thinking", "")
+        assert "</think>" not in msg.get("thinking", "")
+
+    @pytest.mark.asyncio
+    async def test_chat_streaming_separates_thinking_from_content(self, app_client):
+        """Issue #307: streaming path must put thinking into ``message.thinking``
+        and not leak it into ``message.content`` — even when the orphan
+        preamble is longer than the conservative non-thinking buffer."""
+        preamble = (
+            "Thinking Process:\n\n"
+            "1. Analyze the Request: The user wants the product of 17 and 23.\n"
+            "2. Compute: 17 * 23 = (17 * 20) + (17 * 3) = 340 + 51 = 391.\n"
+            "3. Sanity check: 17 * 25 - 2 * 17 = 425 - 34 = 391.\n"
+            "4. Format: just the number, no prose.\n"
+            "5. Construct Final Response: 391"
+        )
+        # Must exceed the conservative 200-char limit used when thinking is
+        # not expected so the test actually exercises the plumbed path.
+        assert len(preamble) > 200
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"thinking_expected": True}
+                for i in range(0, len(preamble), 16):
+                    yield {"text": preamble[i : i + 16], "done": False}
+                yield {"text": "\n</think>\n\n", "done": False}
+                yield {"text": "391", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.chat.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "17*23"}],
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        content = ""
+        thinking = ""
+        for line in resp.text.strip().split("\n"):
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            msg = payload.get("message", {})
+            content += msg.get("content", "")
+            thinking += msg.get("thinking", "") or ""
+
+        assert "Thinking Process" in thinking
+        assert "Thinking Process" not in content
+        assert "</think>" not in content
+        assert "</think>" not in thinking
+        assert content.strip() == "391"
+
+    @pytest.mark.asyncio
     async def test_chat_streaming_error_mid_stream(self, app_client):
         """Error during streaming emits an NDJSON error line instead of crashing."""
 

--- a/tests/test_routers_chat.py
+++ b/tests/test_routers_chat.py
@@ -204,6 +204,53 @@ class TestChatRouter:
         assert content.strip() == "391"
 
     @pytest.mark.asyncio
+    async def test_chat_streaming_short_direct_answer_in_non_done_chunk(
+        self, app_client
+    ):
+        """Issue #307 review round 9: when `thinking_expected=True` and the
+        model gives a short direct answer (fits in the orphan-detect buffer
+        without any `</think>`), the buffered content must be flushed to a
+        non-done chunk before the done marker.  Standard Ollama clients
+        only accumulate `message.content` from non-done chunks; putting
+        accumulated content in the done frame's `message.content` would
+        be silently dropped."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"thinking_expected": True}
+                yield {"text": "The answer is 42.", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.chat.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "?"}],
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        lines = [line for line in resp.text.strip().split("\n") if line.strip()]
+        # Walk all lines; non-done chunks should carry the content.
+        non_done_content = ""
+        done_content = ""
+        for line in lines:
+            payload = json.loads(line)
+            msg = payload.get("message", {})
+            if payload.get("done"):
+                done_content += msg.get("content", "")
+            else:
+                non_done_content += msg.get("content", "")
+        # All content must be in non-done chunks; the done marker carries
+        # an empty content field per the Ollama convention.
+        assert non_done_content == "The answer is 42."
+        assert done_content == ""
+
+    @pytest.mark.asyncio
     async def test_chat_non_streaming_literal_close_think_preserved_when_not_thinking(
         self, app_client
     ):

--- a/tests/test_routers_chat.py
+++ b/tests/test_routers_chat.py
@@ -204,6 +204,62 @@ class TestChatRouter:
         assert content.strip() == "391"
 
     @pytest.mark.asyncio
+    async def test_chat_streaming_orphan_preamble_over_limit_leaks_to_content(
+        self, app_client
+    ):
+        """Documents the known limitation flagged in #307 review round 11:
+        when an orphan thinking preamble exceeds ``INIT_ORPHAN_DETECT_LIMIT``
+        (1024 chars), the streaming router falls through to passthrough
+        before ``</think>`` arrives and the preamble + close tag end up
+        verbatim in ``message.content``.  Mitigations are documented on
+        the constant; this test pins the current behaviour so future
+        tuning of the limit is a deliberate choice."""
+        from olmlx.engine.inference import INIT_ORPHAN_DETECT_LIMIT
+
+        # 1100 chars of orphan thinking — pushes past the 1024 limit before
+        # `</think>` arrives.
+        long_preamble = "thought " * ((INIT_ORPHAN_DETECT_LIMIT // 8) + 10)
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"thinking_expected": True}
+                for i in range(0, len(long_preamble), 64):
+                    yield {"text": long_preamble[i : i + 64], "done": False}
+                yield {"text": "</think>\nanswer", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.chat.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "?"}],
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        content = ""
+        thinking = ""
+        for line in resp.text.strip().split("\n"):
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            msg = payload.get("message", {})
+            content += msg.get("content", "")
+            thinking += msg.get("thinking", "") or ""
+
+        # Current behaviour (known limitation): once the detect buffer is
+        # exhausted the preamble is emitted as content and the late
+        # `</think>` arrives in passthrough where it is forwarded verbatim.
+        # `answer` still makes it through.
+        assert "answer" in content
+        assert thinking == ""
+        assert "</think>" in content
+
+    @pytest.mark.asyncio
     async def test_chat_streaming_short_direct_answer_in_non_done_chunk(
         self, app_client
     ):

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from olmlx.engine.inference import INIT_ORPHAN_DETECT_LIMIT
 from olmlx.routers.openai import (
     JSON_MODE_SYSTEM_MSG,
     _flush_thinking_buffer,
@@ -27,7 +28,7 @@ class TestStripThinkingStreaming:
         state: dict = {}
         if thinking_expected:
             state["thinking_expected"] = True
-            state["detect_limit"] = 65536
+            state["detect_limit"] = INIT_ORPHAN_DETECT_LIMIT
         results = []
         for chunk in chunks:
             out = _strip_thinking_streaming(chunk, state)

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -17,11 +17,17 @@ from olmlx.utils.timing import TimingStats
 class TestStripThinkingStreaming:
     """Unit tests for _strip_thinking_streaming."""
 
-    def _stream(self, chunks, detect_limit=None):
-        """Feed chunks through _strip_thinking_streaming, return list of outputs."""
+    def _stream(self, chunks, thinking_expected=False):
+        """Feed chunks through _strip_thinking_streaming, return list of outputs.
+
+        ``thinking_expected`` mirrors the router-side meta chunk: when True,
+        the orphan `</think>` branch is enabled and the detect buffer is
+        raised to the same generous limit used in production.
+        """
         state: dict = {}
-        if detect_limit is not None:
-            state["detect_limit"] = detect_limit
+        if thinking_expected:
+            state["thinking_expected"] = True
+            state["detect_limit"] = 65536
         results = []
         for chunk in chunks:
             out = _strip_thinking_streaming(chunk, state)
@@ -59,10 +65,15 @@ class TestStripThinkingStreaming:
         assert "reasoning" not in full
         assert "The answer." in full
 
-    def test_orphaned_close_think_still_stripped(self):
-        """Orphaned </think> must still be detected and stripped."""
+    def test_orphaned_close_think_stripped_when_thinking_expected(self):
+        """When thinking is expected, an orphan `</think>` strips its prefix.
+
+        The gate matters: a non-thinking model that emits the literal token
+        must keep it (covered by
+        ``test_literal_close_think_preserved_when_thinking_not_expected``).
+        """
         chunks = ["internal ", "thinking", "</think>", "visible"]
-        results = self._stream(chunks)
+        results = self._stream(chunks, thinking_expected=True)
         full = "".join(results)
         assert "internal" not in full
         assert "thinking" not in full
@@ -101,6 +112,22 @@ class TestStripThinkingStreaming:
             "Default detect_limit must keep non-thinking models progressive"
         )
 
+    def test_literal_close_think_preserved_when_thinking_not_expected(self):
+        """A model that doesn't support thinking and happens to emit the
+        literal `</think>` token (e.g. explaining thinking-tag syntax)
+        must not have its content silently reclassified."""
+        chunks = [
+            "When the assistant writes ",
+            "</think>",
+            " the closer ends the thought block.",
+        ]
+        results = self._stream(chunks)  # no detect_limit → not thinking
+        full = "".join(results)
+        # Every character is content; the literal tag survives intact.
+        assert "When the assistant writes" in full
+        assert "</think>" in full
+        assert "the closer ends the thought block." in full
+
     def test_long_orphaned_thinking_preamble_stripped(self):
         """Issue #307: Qwen3.5/3.6 emit thinking without ``<think>`` opener.
 
@@ -126,9 +153,10 @@ class TestStripThinkingStreaming:
             "\n</think>\n\n",
             "391",
         ]
-        # Mirror the router: when thinking is expected, the detect limit is
-        # raised so the orphan handler can wait for the late `</think>`.
-        results = self._stream(chunks, detect_limit=65536)
+        # Mirror the router: when thinking is expected, the orphan branch
+        # is enabled and the detect buffer is raised so the late `</think>`
+        # is caught.
+        results = self._stream(chunks, thinking_expected=True)
         full = "".join(results)
         assert "Thinking Process" not in full
         assert "Sanity check" not in full
@@ -1155,10 +1183,12 @@ class TestToolCallParsing:
     @pytest.mark.asyncio
     async def test_streaming_orphaned_think_close(self, app_client):
         """When the template opens <think> in the prompt, generated text starts
-        mid-think with only </think> — the thinking content must be stripped."""
+        mid-think with only </think> — the thinking content must be stripped.
+        Engine signals `thinking_expected=True` via the meta chunk."""
 
         async def mock_stream(*args, **kwargs):
             async def gen():
+                yield {"thinking_expected": True}
                 yield {"text": "reasoning about", "done": False}
                 yield {"text": " the problem\n", "done": False}
                 yield {"text": "</think>\n", "done": False}

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -1064,6 +1064,38 @@ class TestToolCallParsing:
         assert len(tool_chunks) == 0
 
     @pytest.mark.asyncio
+    async def test_non_streaming_literal_close_think_preserved_when_not_thinking(
+        self, app_client
+    ):
+        """Issue #307 review: a non-thinking model that mentions the literal
+        `</think>` token in a non-streaming response must keep it in
+        `message.content` rather than have its prefix silently dropped by
+        the orphan-`</think>` heuristic."""
+        raw = "Use </think> to close the thought block."
+        mock_result = {
+            "text": raw,
+            "done": True,
+            "stats": TimingStats(prompt_eval_count=10, eval_count=5),
+            "thinking_expected": False,
+        }
+
+        with patch(
+            "olmlx.routers.openai.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "syntax?"}],
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["choices"][0]["message"]["content"] == raw
+
+    @pytest.mark.asyncio
     async def test_non_streaming_thinking_stripped_without_tools(self, app_client):
         """Thinking blocks are stripped even when no tools are in the request."""
         mock_result = {

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -17,9 +17,11 @@ from olmlx.utils.timing import TimingStats
 class TestStripThinkingStreaming:
     """Unit tests for _strip_thinking_streaming."""
 
-    def _stream(self, chunks):
+    def _stream(self, chunks, detect_limit=None):
         """Feed chunks through _strip_thinking_streaming, return list of outputs."""
-        state = {}
+        state: dict = {}
+        if detect_limit is not None:
+            state["detect_limit"] = detect_limit
         results = []
         for chunk in chunks:
             out = _strip_thinking_streaming(chunk, state)
@@ -87,6 +89,51 @@ class TestStripThinkingStreaming:
         out2 = _strip_thinking_streaming(" hello", state)
         assert out2 == "< hello"
         assert state["buffer"] == ""
+
+    def test_default_detect_limit_unchanged_for_non_thinking(self):
+        """Without a router-supplied detect_limit, the legacy 200-char
+        threshold applies so non-thinking models stream progressively."""
+        # 280 chars of plain text — must exit detect phase under the default
+        chunks = [f"token_{i} " for i in range(40)]
+        results = self._stream(chunks)
+        non_empty = [r for r in results if r]
+        assert len(non_empty) > 1, (
+            "Default detect_limit must keep non-thinking models progressive"
+        )
+
+    def test_long_orphaned_thinking_preamble_stripped(self):
+        """Issue #307: Qwen3.5/3.6 emit thinking without ``<think>`` opener.
+
+        The orphan ``</think>`` arrives only after several hundred characters
+        of structured thinking text. The detect-mode buffer must not give up
+        before the orphan tag arrives — otherwise the thinking leaks into
+        ``message.content``.
+        """
+        # Simulate a Qwen3.5-style thinking preamble exceeding the legacy
+        # 200-char detect threshold (here ~600 chars), followed by </think>
+        # and the visible answer.
+        preamble = (
+            "Thinking Process:\n\n"
+            "1. Analyze the Request: The user wants 17 * 23.\n"
+            "2. Recall multiplication: 17 * 23 = 17 * (20 + 3) = 340 + 51 = 391.\n"
+            "3. Sanity check: 17 * 25 = 425, minus 2*17 = 34, gives 391. OK.\n"
+            "4. Format the answer: just the number, no prose.\n"
+            "5. Final answer: 391.\n"
+            "6. Construct Final Response: 391"
+        )
+        assert len(preamble) > 200, "preamble must exceed legacy detect limit"
+        chunks = [preamble[i : i + 16] for i in range(0, len(preamble), 16)] + [
+            "\n</think>\n\n",
+            "391",
+        ]
+        # Mirror the router: when thinking is expected, the detect limit is
+        # raised so the orphan handler can wait for the late `</think>`.
+        results = self._stream(chunks, detect_limit=65536)
+        full = "".join(results)
+        assert "Thinking Process" not in full
+        assert "Sanity check" not in full
+        assert "</think>" not in full
+        assert full.strip() == "391"
 
 
 class TestOpenAIRouter:
@@ -1055,6 +1102,55 @@ class TestToolCallParsing:
         assert "reasoning here" not in full_content
         assert "<think>" not in full_content
         assert "The answer is 42." in full_content
+
+    @pytest.mark.asyncio
+    async def test_streaming_qwen35_long_orphaned_thinking(self, app_client):
+        """Issue #307: Qwen3.5/3.6 stream their thinking without ``<think>``
+        opener; the orphan ``</think>`` arrives only after several hundred
+        characters. The router must wait for it before flushing, otherwise
+        the entire reasoning preamble leaks into ``message.content``."""
+        preamble = (
+            "Thinking Process:\n\n"
+            "1. Analyze the Request: The user wants 17 * 23.\n"
+            "2. Compute: 17 * 23 = (17 * 20) + (17 * 3) = 340 + 51 = 391.\n"
+            "3. Sanity check: 17 * 25 - 2*17 = 425 - 34 = 391.\n"
+            "4. Format: just the number, no prose.\n"
+            "5. Construct Final Response: 391"
+        )
+        assert len(preamble) > 200
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"thinking_expected": True}
+                for i in range(0, len(preamble), 16):
+                    yield {"text": preamble[i : i + 16], "done": False}
+                yield {"text": "\n</think>\n\n", "done": False}
+                yield {"text": "391", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.openai.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "17*23"}],
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        full_content = ""
+        for line in resp.text.strip().split("\n"):
+            if line.startswith("data: ") and line.strip() != "data: [DONE]":
+                payload = json.loads(line[6:])
+                delta = payload.get("choices", [{}])[0].get("delta", {})
+                full_content += delta.get("content", "") or ""
+        assert "Thinking Process" not in full_content
+        assert "Sanity check" not in full_content
+        assert "</think>" not in full_content
+        assert full_content.strip() == "391"
 
     @pytest.mark.asyncio
     async def test_streaming_orphaned_think_close(self, app_client):

--- a/tests/test_tool_parser.py
+++ b/tests/test_tool_parser.py
@@ -593,9 +593,13 @@ class TestParseModelOutput:
 
     def test_thinking_without_opening_tag(self):
         """When the chat template opens <think> in the prompt, generated text
-        starts mid-think with only a closing </think> tag."""
+        starts mid-think with only a closing </think> tag.  The orphan
+        heuristic is opt-in (issue #307 review): callers that know thinking
+        is active pass `thinking_expected=True`."""
         text = "reasoning about the problem\n</think>\nThe answer is 42."
-        thinking, visible, tools = parse_model_output(text, has_tools=False)
+        thinking, visible, tools = parse_model_output(
+            text, has_tools=False, thinking_expected=True
+        )
         assert "reasoning about the problem" in thinking
         assert "<think>" not in visible
         assert "</think>" not in visible
@@ -607,10 +611,22 @@ class TestParseModelOutput:
             "I should search for this\n</think>\n"
             '<tool_call>\n{"name": "search", "arguments": {"q": "test"}}\n</tool_call>'
         )
-        thinking, visible, tools = parse_model_output(text, has_tools=True)
+        thinking, visible, tools = parse_model_output(
+            text, has_tools=True, thinking_expected=True
+        )
         assert "I should search" in thinking
         assert len(tools) == 1
         assert tools[0]["name"] == "search"
+
+    def test_thinking_expected_false_preserves_literal_close_think(self):
+        """Issue #307 review round 11: a non-thinking caller (the new
+        default) must not have its prefix stripped by the orphan
+        heuristic when the model mentions the literal `</think>` token."""
+        text = "Use </think> to close the thought block."
+        thinking, visible, tools = parse_model_output(text, has_tools=False)
+        assert thinking == ""
+        assert visible == text
+        assert tools == []
 
     def test_no_tool_parsing_when_has_tools_false(self):
         text = '<tool_call>{"name": "search", "arguments": {"q": "test"}}</tool_call>'


### PR DESCRIPTION
## Summary
- Closes #307. Qwen3.5/3.6 emit thinking with no `<think>` opener but a real `</think>` closer; the orphan heuristic that already existed in `parse_model_output` was missing from three streaming paths, so the full reasoning preamble was leaking into visible content.
- Plumb a `thinking_expected` meta chunk from `generate_chat` (resolved from `template_caps.supports_enable_thinking` + the effective `enable_thinking`) and have the OpenAI / Anthropic / Ollama streaming filters consult it.
- OpenAI streaming raises its detect-buffer limit to 64K when thinking is expected (200-char fast path preserved for non-thinking models). Anthropic's `_stream_thinking_state_machine` learns to emit an orphan-prefix as a `thinking` content block. Ollama `/api/chat` now splits output into `message.thinking` / `message.content` (matches Ollama upstream); added `thinking` to the `Message` schema.

## Test plan
- [x] `uv run pytest` — 2546 passed, 3 skipped
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] New unit test: long-orphan preamble in `_strip_thinking_streaming`
- [x] New integration tests for all three routers with mocked Qwen3.5-style chunked streams
- [ ] Manual smoke test on `mlx-community/Qwen3.5-4B-4bit` against `/api/chat`, `/v1/chat/completions`, `/v1/messages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)