### PR TITLE
fix(dflash): close training/inference gaps for draft acceptance (#317)

### DIFF
--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -2255,6 +2255,7 @@ def cmd_dflash_prepare(args):
         distill=args.distill,
         distill_alpha=args.distill_alpha,
         distill_temp=args.distill_temp,
+        position_decay_gamma=args.position_decay_gamma,
         use_precomputed=args.use_precomputed,
         progress_callback=_flash_progress,
     )
@@ -2657,22 +2658,22 @@ def build_parser() -> argparse.ArgumentParser:
     dflash_prepare_p.add_argument(
         "--block-size",
         type=int,
-        default=4,
-        help="Number of draft tokens per step (default: 4)",
+        default=16,
+        help="Number of draft tokens per step (default: 16, per paper)",
     )
     dflash_prepare_p.add_argument(
         "--num-hidden-layers",
         type=int,
-        default=4,
-        help="Draft model hidden layer count (default: 4)",
+        default=5,
+        help="Draft model hidden layer count (default: 5, per paper)",
     )
     dflash_prepare_p.add_argument(
         "--num-target-layers",
         type=int,
-        default=4,
+        default=5,
         help=(
-            "Number of target hidden states to extract (default: 4). "
-            "Ignored when --target-layer-ids is set."
+            "Number of target hidden states to extract (default: 5, "
+            "per paper). Ignored when --target-layer-ids is set."
         ),
     )
     dflash_prepare_p.add_argument(
@@ -2735,6 +2736,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Distillation temperature T (default: 2.0)",
     )
     dflash_prepare_p.add_argument(
+        "--position-decay-gamma",
+        type=float,
+        default=None,
+        help=(
+            "Per-position loss weight decay: w_k = exp(-(k-1)/gamma) for "
+            "k=1..block_size. Emphasises early positions because "
+            "acceptance length compounds. Default: block_size/2. Pass "
+            "0 (or negative) to disable and use the uniform-mean "
+            "reduction."
+        ),
+    )
+    dflash_prepare_p.add_argument(
         "--use-precomputed",
         type=str,
         default=None,
@@ -2771,8 +2784,8 @@ def build_parser() -> argparse.ArgumentParser:
     dflash_precompute_p.add_argument(
         "--num-target-layers",
         type=int,
-        default=4,
-        help="Number of target hidden states to extract (default: 4)",
+        default=5,
+        help="Number of target hidden states to extract (default: 5, per paper)",
     )
     dflash_precompute_p.add_argument(
         "--target-layer-ids",

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -2742,9 +2742,10 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Per-position loss weight decay: w_k = exp(-(k-1)/gamma) for "
             "k=1..block_size. Emphasises early positions because "
-            "acceptance length compounds. Default: block_size/2. Pass "
-            "0 (or negative) to disable and use the uniform-mean "
-            "reduction."
+            "acceptance length compounds. Pass 0 (or negative) to "
+            "disable and use the uniform-mean reduction (the default "
+            "when this flag is omitted). Suggested starting value: "
+            "block_size/2."
         ),
     )
     dflash_prepare_p.add_argument(

--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -209,7 +209,7 @@ class DFlashDecoder:
         target_model: nn.Module,
         draft_model: DFlashDraftModel,
         draft_config: DraftConfig,
-        block_size: int = 4,
+        block_size: int = 16,
     ):
         self._target = target_model
         self._draft = draft_model

--- a/olmlx/engine/dflash/prepare.py
+++ b/olmlx/engine/dflash/prepare.py
@@ -120,9 +120,13 @@ def _evenly_spaced(num_layers: int, k: int) -> list[int]:
     information). See gh#317 (Gap 4).
 
     Falls back to a centred 0..num_layers-1 spread when the upstream
-    range is degenerate (``num_layers - 3 < 1``); returns
-    ``list(range(num_layers))`` when ``k >= num_layers`` and ``[]``
-    when ``k <= 0``.
+    range ``[1, num_layers - 3]`` is too small to fit ``k`` unique
+    indices (i.e. ``num_layers - 3 < k``); note this fallback **can
+    return layer 0**, in contradiction with the no-layer-0 invariant
+    of the non-degenerate path — the trade is intentional so small
+    synthetic targets in unit tests still produce ``k`` distinct
+    indices. Returns ``list(range(num_layers))`` when ``k >=
+    num_layers`` and ``[]`` when ``k <= 0``.
     """
     if k <= 0:
         return []
@@ -607,10 +611,12 @@ def prepare_dflash_draft(
 
     ``position_decay_gamma``: per-position loss weighting decay
     constant ``γ`` in ``w_k = exp(-(k-1)/γ)`` (k=1..block_size). When
-    ``None``, defaults to ``block_size / 2`` (the issue's suggested
-    starting point — the paper does not publicly pin a single value).
-    Pass ``0`` or a negative value to disable the weighting and recover
-    the uniform-mean reduction. See gh#317 (Gap 2).
+    ``None`` (the default), the weighting is disabled and the
+    reduction is a uniform mean over positions — matching legacy
+    behaviour bit-for-bit. The issue's suggested starting value to
+    sweep is ``block_size / 2``; the paper does not publicly pin a
+    single value. ``0`` or a negative value also disables the
+    weighting. See gh#317 (Gap 2).
 
     ``use_precomputed``: read precomputed (input_ids, hidden) shards
     from this directory instead of running the target each step. Skips

--- a/olmlx/engine/dflash/prepare.py
+++ b/olmlx/engine/dflash/prepare.py
@@ -61,8 +61,13 @@ logger = logging.getLogger(__name__)
 # Defaults
 # ---------------------------------------------------------------------------
 
-DEFAULT_NUM_HIDDEN_LAYERS = 4
-DEFAULT_BLOCK_SIZE = 4  # number of draft tokens per step (== MASK count)
+# Paper-reported configuration (arxiv:2602.06036): 5 draft layers, 5
+# target hidden states, block_size=16. The pre-#317 defaults of 4/4/4
+# were ad-hoc and have not been bench-validated since the paper was
+# published. See gh#317 (Gap 3).
+DEFAULT_NUM_HIDDEN_LAYERS = 5
+DEFAULT_NUM_TARGET_LAYERS = 5
+DEFAULT_BLOCK_SIZE = 16  # number of draft tokens per step (== MASK count)
 DEFAULT_STEPS = 2000
 DEFAULT_BATCH_SIZE = 4
 DEFAULT_SEQ_LEN = 2048
@@ -104,26 +109,48 @@ def _text_config(target_cfg: dict[str, Any]) -> dict[str, Any]:
 
 
 def _evenly_spaced(num_layers: int, k: int) -> list[int]:
-    """Pick ``k`` layer indices from ``[0, num_layers)`` evenly spaced.
+    """Pick ``k`` target-layer indices following the upstream DFlash recipe.
 
-    For the default ``num_target_layers=4`` and a 32-layer target this
-    gives ``[6, 12, 19, 25]`` (``step = 31/5 = 6.2``, positions rounded)
-    — the upstream papers show middle/late layers carry the most useful
-    signal. Edge layers are intentionally avoided (the draft already
-    sees the input via embed_tokens, and the final-layer hidden is
-    roughly equivalent to the LM head's pre-projection signal).
+    Returns ``k`` indices evenly distributed across ``[1, num_layers - 3]``
+    (inclusive), early-biased to match upstream
+    ``build_target_layer_ids`` in z-lab/dflash. For ``num_layers=32,
+    k=5`` this gives ``[1, 8, 15, 22, 29]``. The range avoids layer 0
+    (the draft already sees that signal through ``embed_tokens``) and
+    the final two layers (the bound ``lm_head`` already carries that
+    information). See gh#317 (Gap 4).
+
+    Falls back to a centred 0..num_layers-1 spread when the upstream
+    range is degenerate (``num_layers - 3 < 1``); returns
+    ``list(range(num_layers))`` when ``k >= num_layers`` and ``[]``
+    when ``k <= 0``.
     """
     if k <= 0:
         return []
     if k >= num_layers:
         return list(range(num_layers))
-    step = (num_layers - 1) / (k + 1)
+
+    end = num_layers - 3
+    if end < k:
+        # Degenerate: the upstream [1, N-3] range is too small to fit
+        # ``k`` unique indices (e.g. ``num_layers=4, k=2`` has range
+        # size 1, ``num_layers=5, k=3`` has range size 2). Fall back
+        # to a centred spread across the full layer range so small
+        # synthetic targets used in unit tests still produce sensible
+        # (and unique) indices.
+        if k == 1:
+            return [num_layers // 2]
+        fallback_step = (num_layers - 1) / (k - 1)
+        return sorted({int(round(i * fallback_step)) for i in range(k)})
+
+    if k == 1:
+        return [1]
+    step = (end - 1) / (k - 1)
     # Dedupe + sort: rounding can collide for small ``num_layers``
-    # close to ``k`` (e.g. ``num_layers=5, k=4`` → step 0.8 →
-    # ``[1, 2, 2, 3]``). Duplicates would double-wrap the repeated
-    # layer in ``_LayerHook`` and ``_unpatch_model`` only strips one
-    # level — the dangling hook would corrupt subsequent captures.
-    result = sorted({int(round((i + 1) * step)) for i in range(k)})
+    # close to ``k`` (e.g. ``num_layers=5, k=4`` would otherwise hit
+    # duplicates). Duplicates would double-wrap the repeated layer in
+    # ``_LayerHook`` and ``_unpatch_model`` only strips one level —
+    # the dangling hook would corrupt subsequent captures.
+    result = sorted({int(round(1 + i * step)) for i in range(k)})
     if len(result) < k:
         # Operator surprise: ``--num-target-layers`` won't match the
         # final ``num_target_layers`` baked into the saved
@@ -167,7 +194,7 @@ def _resolve_target_layer_ids(
                 f"target_layer_ids contains duplicate indices: {requested}"
             )
         return sorted(requested)
-    k = num_target_layers or DEFAULT_NUM_HIDDEN_LAYERS
+    k = num_target_layers or DEFAULT_NUM_TARGET_LAYERS
     return _evenly_spaced(target_num_layers, k)
 
 
@@ -349,6 +376,7 @@ def _draft_loss(
     distill_alpha: float = 0.0,
     distill_temp: float = 1.0,
     pad_token_id: int | None = None,
+    position_decay_gamma: float | None = None,
 ) -> mx.array:
     """Loss on the masked positions: cross-entropy + optional KL distillation.
 
@@ -374,25 +402,54 @@ def _draft_loss(
     which equals the target after MASK==PAD aliasing) — contaminating
     the running average without contributing any gradient. The mask
     makes such batches deliver an honest no-op step instead.
+
+    When ``position_decay_gamma`` is provided (positive float), apply
+    the paper's per-position weighting ``w_k = exp(-(k-1)/gamma)`` for
+    ``k = 1..block_size`` (so position 0 has weight 1.0, decaying to
+    ``exp(-(N-1)/gamma)`` at position N-1). This emphasises early
+    positions because acceptance length compounds — a wrong token at
+    position 1 wastes the remaining positions 2..N regardless of how
+    correct they would have been. With ``None`` (or ``<= 0``) the
+    reduction stays a uniform mean (legacy behaviour). See gh#317
+    (Gap 2).
     """
     draft_logits = draft(block_input, target_hidden, cache, logits_start=1)
     log_probs = nn.log_softmax(draft_logits, axis=-1)
     nll = -mx.take_along_axis(log_probs, targets[..., None], axis=-1).squeeze(-1)
 
+    # ``pos_weights`` has shape ``(block_size,)`` and broadcasts against
+    # the ``(B, block_size)`` per-position NLL / KL arrays. When
+    # ``position_decay_gamma`` is unset, fall back to ones so the
+    # weighted-mean reduction collapses to the legacy uniform mean.
+    if position_decay_gamma is not None and position_decay_gamma > 0:
+        block_size = nll.shape[-1]
+        pos = mx.arange(block_size, dtype=nll.dtype)
+        pos_weights = mx.exp(-pos / float(position_decay_gamma))
+    else:
+        pos_weights = None
+
     # Initialise upfront so the type checker can see ``denom`` is in
-    # scope when the KL branch reaches for it (it's only meaningful when
-    # ``valid is not None``, which is equivalent to ``pad_token_id is not
-    # None``, but the type narrowing isn't trivially derivable).
+    # scope when the KL branch reaches for it.
     valid: mx.array | None = None
     denom: mx.array | None = None
     if pad_token_id is not None:
         valid = (targets != pad_token_id).astype(nll.dtype)
+        # Combine pad mask with per-position weights when both are
+        # active. The pad path's invariant — sum(weights) >= 0 across
+        # all-pad batches collapses to exactly 0.0 — is preserved
+        # because positive ``pos_weights`` only scale a zero mask.
+        combined = valid if pos_weights is None else valid * pos_weights
         # ``valid.sum().clip(1.0, ...)`` keeps the divisor from hitting
         # zero when the entire window is pad. Combined with the
         # zero-weighted nll the result is an exact 0.0 — the optimizer
         # update then has zero gradient (flowing back through 0/1).
-        denom = mx.maximum(valid.sum(), mx.array(1.0, dtype=nll.dtype))
-        ce = (nll * valid).sum() / denom
+        denom = mx.maximum(combined.sum(), mx.array(1.0, dtype=nll.dtype))
+        ce = (nll * combined).sum() / denom
+    elif pos_weights is not None:
+        # Pure position-weighted mean: sum(w * nll) / sum(w). ``denom``
+        # stays ``None`` here — the KL branch below recomputes its own
+        # denominator using the same weights.
+        ce = (nll * pos_weights).sum() / (pos_weights.sum() * nll.shape[0])
     else:
         ce = mx.mean(nll)
 
@@ -410,16 +467,13 @@ def _draft_loss(
     if valid is not None:
         # ``valid`` and ``denom`` are co-assigned in the
         # ``pad_token_id is not None`` branch above, so checking
-        # ``valid`` alone implies ``denom`` is non-None. ``denom`` is
-        # reused here instead of re-running ``valid.sum()`` and the
-        # maximum-with-1.0 floor a second time — the two
-        # ``valid.sum()`` calls would produce the same value differing
-        # only in dtype, so an ``astype`` cast is sufficient.
-        # Use ``typing.cast`` rather than an ``assert`` for type
-        # narrowing because Python ``-O`` strips assertions, and a
-        # training pipeline can plausibly run optimised.
+        # ``valid`` alone implies ``denom`` is non-None. Reuse the
+        # combined-weights ``denom`` via dtype cast.
         denom_kl = cast(mx.array, denom)
-        kl_loss = (kl * valid).sum() / denom_kl.astype(kl.dtype) * (t * t)
+        combined_kl = valid if pos_weights is None else valid * pos_weights
+        kl_loss = (kl * combined_kl).sum() / denom_kl.astype(kl.dtype) * (t * t)
+    elif pos_weights is not None:
+        kl_loss = (kl * pos_weights).sum() / (pos_weights.sum() * kl.shape[0]) * (t * t)
     else:
         kl_loss = mx.mean(kl) * (t * t)
 
@@ -538,6 +592,7 @@ def prepare_dflash_draft(
     distill: bool = False,
     distill_alpha: float = 0.5,
     distill_temp: float = 2.0,
+    position_decay_gamma: float | None = None,
     use_precomputed: str | Path | None = None,
     _target_loader: Callable[[str], tuple[Any, Any]] | None = None,
     _batch_iterator: Any = None,
@@ -549,6 +604,13 @@ def prepare_dflash_draft(
     ``(1 - alpha) * CE + alpha * T^2 * KL``. Requires running the
     target online — incompatible with ``use_precomputed`` (precomputed
     shards store hiddens but not vocab-size logits).
+
+    ``position_decay_gamma``: per-position loss weighting decay
+    constant ``γ`` in ``w_k = exp(-(k-1)/γ)`` (k=1..block_size). When
+    ``None``, defaults to ``block_size / 2`` (the issue's suggested
+    starting point — the paper does not publicly pin a single value).
+    Pass ``0`` or a negative value to disable the weighting and recover
+    the uniform-mean reduction. See gh#317 (Gap 2).
 
     ``use_precomputed``: read precomputed (input_ids, hidden) shards
     from this directory instead of running the target each step. Skips
@@ -569,6 +631,16 @@ def prepare_dflash_draft(
         raise ValueError(f"distill_alpha must be in [0, 1], got {distill_alpha}")
     if distill_temp <= 0:
         raise ValueError(f"distill_temp must be > 0, got {distill_temp}")
+    # ``position_decay_gamma`` defaults to ``None`` (disabled) — the
+    # uniform-mean reduction matches legacy behaviour bit-for-bit. The
+    # issue (gh#317 Gap 2) flags this as a hyperparameter to sweep,
+    # not a definitively-correct default; operators opt in via the
+    # ``--position-decay-gamma`` CLI flag (suggested starting point:
+    # ``block_size / 2``). ``0`` or a negative value explicitly
+    # disables and is normalised to ``None`` so the loss branches stay
+    # simple.
+    if position_decay_gamma is not None and position_decay_gamma <= 0:
+        position_decay_gamma = None
     if block_size < 1:
         # ``block_size == 0`` builds zero-length mask/target tensors,
         # ``_draft_loss`` then returns 0 with no gradient, and the
@@ -738,6 +810,7 @@ def prepare_dflash_draft(
             distill_alpha=distill_alpha if distill else 0.0,
             distill_temp=distill_temp,
             pad_token_id=pad_for_loss,
+            position_decay_gamma=position_decay_gamma,
         )
 
     loss_and_grad = nn.value_and_grad(draft, loss_fn)
@@ -1000,7 +1073,18 @@ def prepare_dflash_draft(
             )
             block_input = mx.concatenate([pending, mask_block], axis=1)
             targets = input_ids[:, p + 1 : p + 1 + block_size]
-            target_hidden = target_hidden_full[:, : p + 1, :]
+            # Slice ctx to positions 0..p-1 so the draft sees the same
+            # hidden-state distribution at training and inference time.
+            # At inference, ctx covers 0..L-1 and pending sits at RoPE
+            # position L (the position pending's content actually
+            # corresponds to). A prior version sliced ``[:, :p+1, :]``,
+            # which (a) gave the draft the target's own hidden for the
+            # pending position — a copy-shortcut that doesn't exist at
+            # inference — and (b) pushed proposal RoPE positions to
+            # p+1..p+block_size+1 instead of p..p+block_size. The pivot
+            # range guarantees ``p >= block_size >= 1`` so the slice is
+            # non-empty. See gh#317 (Gap 1).
+            target_hidden = target_hidden_full[:, :p, :]
 
             target_logits_window: mx.array | None = None
             if distill and target_logits_full is not None:

--- a/tests/test_dflash_prepare.py
+++ b/tests/test_dflash_prepare.py
@@ -111,17 +111,32 @@ def _mock_target_loader(vocab_size: int, hidden_size: int, num_layers: int):
 def _synthetic_batches(vocab: int, batch_size: int, seq_len: int, n: int):
     """Deterministic batch iterator so tests don't hit the network.
 
-    Emits tokens in ``[1, vocab)`` rather than ``[0, vocab)`` because
-    ``_MockTokenizer.pad_token_id == 0`` and the trainer's pad-aware
-    pivot helper would otherwise treat any random 0 as padding and
-    shrink the valid pivot range. Tests that need to exercise the
-    pad-aware path build batches explicitly with pad tokens (see
-    ``TestPivotSelection``).
+    Emits sequences whose next-token IS the previous-token + 1 (mod
+    ``vocab - 1``, then shifted into ``[1, vocab)``) so there's *actual*
+    learnable structure for the loss-decrease sanity check. Previous
+    versions yielded pure ``mx.random.randint`` noise, which worked
+    only because the pre-#317 training pipeline let the draft cheat
+    via a target-hidden copy shortcut at the pending position (the
+    very bug gh#317 Gap 1 fixes). With the shortcut removed the draft
+    can't reduce CE on noise — so the synthetic data must carry a
+    pattern.
+
+    Tokens stay in ``[1, vocab)`` because ``_MockTokenizer.pad_token_id
+    == 0`` and the trainer's pad-aware pivot helper would otherwise
+    treat any 0 as padding and shrink the valid pivot range. Tests
+    that need to exercise the pad-aware path build batches explicitly
+    with pad tokens (see ``TestPivotSelection``).
     """
-    rng = mx.random.key(0)
-    for _ in range(n):
-        rng, sub = mx.random.split(rng)
-        yield mx.random.randint(1, vocab, (batch_size, seq_len), key=sub)
+    # Build a deterministic per-batch starting offset, then walk
+    # ``seq_len`` consecutive tokens in 1..vocab-1.
+    period = vocab - 1
+    for i in range(n):
+        offsets = mx.arange(seq_len, dtype=mx.int32) + i
+        # Each row starts at a slightly different offset so batches
+        # don't all carry the same window.
+        per_row = mx.arange(batch_size, dtype=mx.int32)[:, None] * 7
+        tokens = (offsets[None, :] + per_row) % period + 1
+        yield tokens
 
 
 def _write_target_config(tmp_path: Path, vocab_size: int, hidden_size: int) -> Path:
@@ -165,6 +180,32 @@ class TestEvenlySpaced:
         ids = _evenly_spaced(2, 4)
         # When k >= num_layers, returns the full layer range.
         assert ids == [0, 1]
+
+    def test_matches_upstream_recipe_for_n32_k5(self):
+        """Upstream ``build_target_layer_ids(32, 5) == [1, 8, 15, 22,
+        29]``: indices evenly spread over ``[1, N-3]`` (early-biased,
+        skipping the embedding-adjacent layer 0 and the lm_head-adjacent
+        last two layers). See gh#317 (Gap 4).
+        """
+        from olmlx.engine.dflash.prepare import _evenly_spaced
+
+        assert _evenly_spaced(32, 5) == [1, 8, 15, 22, 29]
+
+    def test_skips_layer_zero_and_last_two_layers(self):
+        """The upstream recipe explicitly avoids layer 0 (its signal
+        duplicates ``embed_tokens``) and the last 2 layers (their
+        signal duplicates the bound ``lm_head``). Regression guard:
+        any non-degenerate selection must respect the boundary.
+        """
+        from olmlx.engine.dflash.prepare import _evenly_spaced
+
+        for n in (12, 24, 32, 48, 80):
+            for k in range(2, min(n - 3, 8) + 1):
+                ids = _evenly_spaced(n, k)
+                assert min(ids) >= 1, f"_evenly_spaced({n},{k}) included layer 0"
+                assert max(ids) <= n - 3, (
+                    f"_evenly_spaced({n},{k}) reached layer {max(ids)} > {n - 3}"
+                )
 
 
 class TestResolveTargetLayerIds:
@@ -695,6 +736,198 @@ class TestDraftLossPadMasking:
         # both CE and KL → 0. Without masking, CE would be ~13.3
         # (one near-zero + two ~20s averaged).
         assert float(loss) < 1e-3
+
+
+class TestPerPositionLossWeighting:
+    """Gap 2 (gh#317): the paper trains with ``w_k = exp(-(k-1)/gamma)``
+    to emphasise early positions because acceptance length compounds —
+    a wrong token at position 1 wastes positions 2..N regardless of
+    how correct those would have been. Without the weighting the
+    optimizer spends equal gradient budget on positions whose impact
+    is only conditional on every earlier position being accepted.
+    """
+
+    def test_legacy_uniform_mean_when_gamma_none(self):
+        """When ``position_decay_gamma`` is omitted (or ``None``), the
+        reduction collapses to the legacy uniform mean — required so
+        the existing tests pass unchanged and existing checkpoints
+        remain reproducible.
+        """
+        from olmlx.engine.dflash.prepare import _draft_loss
+
+        vocab = 8
+        # Construct a CE that depends on position so weighted and
+        # uniform mean give visibly different numbers.
+        # Logits peak sharply at id=1 for position 0 only; positions 1..2
+        # peak at id=2. With targets [1, 1, 1] only position 0 is near-zero
+        # NLL; positions 1-2 have very high NLL (~20 each).
+        per_pos_peaks = [1, 2, 2]
+        target_id = 1
+        peak = 20.0
+        # Build logits manually so each position uses a different peak id.
+        arr = mx.zeros((1, 3, vocab))
+        for k, pid in enumerate(per_pos_peaks):
+            arr = arr.at[:, k, pid].add(peak)
+        targets = mx.array([[target_id, target_id, target_id]])
+        loss = _draft_loss(
+            _FakeDraft(arr),
+            block_input=mx.zeros((1, 4), dtype=mx.int32),
+            target_hidden=mx.zeros((1, 1, 1)),
+            targets=targets,
+            cache=[],
+        )
+        # Legacy uniform mean over 3 positions: (~0 + ~20 + ~20) / 3 ≈ 13.3.
+        assert 12.0 < float(loss) < 15.0
+
+    def test_weighted_mean_emphasises_early_positions(self):
+        """With ``position_decay_gamma`` set, the weighted mean must
+        upweight the first (easy) position and downweight the later
+        (hard) ones, producing a lower aggregate loss than the
+        uniform-mean baseline on the same logits.
+        """
+        from olmlx.engine.dflash.prepare import _draft_loss
+
+        vocab = 8
+        per_pos_peaks = [1, 2, 2]
+        target_id = 1
+        peak = 20.0
+        arr = mx.zeros((1, 3, vocab))
+        for k, pid in enumerate(per_pos_peaks):
+            arr = arr.at[:, k, pid].add(peak)
+        targets = mx.array([[target_id, target_id, target_id]])
+        # gamma=1 strongly downweights positions 1..2 (weights ~ [1.0,
+        # 0.37, 0.14]). Weighted mean: (0*1 + 20*0.37 + 20*0.14) /
+        # (1 + 0.37 + 0.14) ≈ 6.7 — well below the uniform-mean ~13.3.
+        loss = _draft_loss(
+            _FakeDraft(arr),
+            block_input=mx.zeros((1, 4), dtype=mx.int32),
+            target_hidden=mx.zeros((1, 1, 1)),
+            targets=targets,
+            cache=[],
+            position_decay_gamma=1.0,
+        )
+        assert 5.0 < float(loss) < 9.0
+
+    def test_disabled_when_gamma_non_positive(self):
+        """``position_decay_gamma`` of 0 (or negative) disables the
+        weighting and recovers the uniform-mean reduction. Important
+        for the CLI's escape hatch (operators sweeping the
+        hyperparameter who want a no-weighting baseline).
+        """
+        from olmlx.engine.dflash.prepare import _draft_loss
+
+        vocab = 8
+        per_pos_peaks = [1, 2, 2]
+        arr = mx.zeros((1, 3, vocab))
+        for k, pid in enumerate(per_pos_peaks):
+            arr = arr.at[:, k, pid].add(20.0)
+        targets = mx.array([[1, 1, 1]])
+        loss_uniform = _draft_loss(
+            _FakeDraft(arr),
+            block_input=mx.zeros((1, 4), dtype=mx.int32),
+            target_hidden=mx.zeros((1, 1, 1)),
+            targets=targets,
+            cache=[],
+        )
+        loss_disabled = _draft_loss(
+            _FakeDraft(arr),
+            block_input=mx.zeros((1, 4), dtype=mx.int32),
+            target_hidden=mx.zeros((1, 1, 1)),
+            targets=targets,
+            cache=[],
+            position_decay_gamma=0.0,
+        )
+        assert float(loss_disabled) == pytest.approx(float(loss_uniform), abs=1e-6)
+
+    def test_weighting_combines_with_pad_mask(self):
+        """The pad mask and per-position weighting must compose: pad
+        positions stay zero-weighted, and the remaining real positions
+        are reduced via the weighted mean. The all-pad case must still
+        deliver exact 0.0 so the optimizer takes an honest no-op step.
+        """
+        from olmlx.engine.dflash.prepare import _draft_loss
+
+        vocab = 8
+        # All targets are pad → loss must be exactly 0 regardless of
+        # the weighting.
+        bad_logits = _logits_with_target_at_index(1, 3, vocab, target_id=1, peak=20.0)
+        targets = mx.array([[5, 5, 5]])
+        loss = _draft_loss(
+            _FakeDraft(bad_logits),
+            block_input=mx.zeros((1, 4), dtype=mx.int32),
+            target_hidden=mx.zeros((1, 1, 1)),
+            targets=targets,
+            cache=[],
+            pad_token_id=5,
+            position_decay_gamma=1.0,
+        )
+        assert float(loss) == 0.0
+
+
+class TestSliceMatchesInferenceConvention:
+    """Gap 1 (gh#317): training must slice ``target_hidden_full[:, :p,
+    :]`` — ctx covers positions 0..p-1 and pending sits at position p.
+    The pre-fix slice ``[:, :p+1, :]`` included the target's hidden
+    for the pending position itself, giving the draft a copy-shortcut
+    that didn't exist at inference and silently mis-aligning the
+    proposal RoPE positions by 1.
+    """
+
+    def test_target_hidden_slice_excludes_pending_position(self, tmp_path, monkeypatch):
+        """Inspect the ``target_hidden`` shape fed into ``_draft_loss``:
+        its sequence dim must equal the pivot ``p``, not ``p + 1``.
+        """
+        from olmlx.engine.dflash import prepare as prepare_mod
+        from olmlx.engine.dflash.prepare import prepare_dflash_draft
+
+        vocab, hidden, num_layers = 64, 16, 4
+        _write_target_config(tmp_path, vocab, hidden)
+
+        # ``_select_pivot`` returns a host int, so we can record the
+        # pivot directly. Capture (pivot, target_hidden.shape[1]) pairs
+        # to verify equality.
+        observed_pivots: list[int] = []
+        original_select = prepare_mod._select_pivot
+
+        def recording_select(input_ids, pad_token_id, block_size):
+            p = original_select(input_ids, pad_token_id, block_size)
+            if p is not None:
+                observed_pivots.append(p)
+            return p
+
+        original_loss = prepare_mod._draft_loss
+        observed_shapes: list[int] = []
+
+        def recording_loss(draft, block_input, target_hidden, *args, **kwargs):
+            observed_shapes.append(target_hidden.shape[1])
+            return original_loss(draft, block_input, target_hidden, *args, **kwargs)
+
+        monkeypatch.setattr(prepare_mod, "_select_pivot", recording_select)
+        monkeypatch.setattr(prepare_mod, "_draft_loss", recording_loss)
+
+        prepare_dflash_draft(
+            tmp_path,
+            steps=3,
+            batch_size=2,
+            seq_len=32,
+            block_size=2,
+            num_hidden_layers=1,
+            num_target_layers=2,
+            lr=1e-2,
+            output_dir=tmp_path / "dflash_out",
+            _target_loader=_mock_target_loader(vocab, hidden, num_layers),
+            _batch_iterator=_synthetic_batches(vocab, batch_size=2, seq_len=32, n=3),
+        )
+
+        assert observed_pivots, "expected at least one pivot to be recorded"
+        assert len(observed_shapes) == len(observed_pivots)
+        for p, ctx_len in zip(observed_pivots, observed_shapes):
+            assert ctx_len == p, (
+                f"target_hidden ctx len = {ctx_len}, expected {p} so that "
+                "the draft conditions on positions 0..p-1 and pending sits "
+                "at RoPE position p (matching inference's convention "
+                "where ctx covers 0..L-1 and pending is at L)"
+            )
 
 
 class TestPivotSelection:

--- a/tests/test_dflash_prepare.py
+++ b/tests/test_dflash_prepare.py
@@ -191,11 +191,14 @@ class TestEvenlySpaced:
 
         assert _evenly_spaced(32, 5) == [1, 8, 15, 22, 29]
 
-    def test_skips_layer_zero_and_last_two_layers(self):
+    def test_non_degenerate_skips_layer_zero_and_last_two_layers(self):
         """The upstream recipe explicitly avoids layer 0 (its signal
         duplicates ``embed_tokens``) and the last 2 layers (their
-        signal duplicates the bound ``lm_head``). Regression guard:
-        any non-degenerate selection must respect the boundary.
+        signal duplicates the bound ``lm_head``). Regression guard
+        for the *non-degenerate* path only: any selection where the
+        ``[1, N-3]`` range can fit ``k`` unique indices must respect
+        the boundary. The degenerate fallback (``N-3 < k``) is
+        covered by ``test_degenerate_fallback_returns_k_unique_indices``.
         """
         from olmlx.engine.dflash.prepare import _evenly_spaced
 
@@ -206,6 +209,41 @@ class TestEvenlySpaced:
                 assert max(ids) <= n - 3, (
                     f"_evenly_spaced({n},{k}) reached layer {max(ids)} > {n - 3}"
                 )
+
+    def test_degenerate_fallback_returns_k_unique_indices(self):
+        """When the upstream ``[1, N-3]`` range is too small to fit
+        ``k`` unique indices (``N - 3 < k`` but ``k < N``), the
+        fallback spreads across the full ``0..N-1`` range. The
+        contract here is **k unique indices, no rounding collisions**
+        — and in this regime layer 0 *can* appear, in contradiction
+        with the non-degenerate path's invariant. The trade is
+        intentional so small synthetic targets in unit tests still
+        produce ``k`` distinct hidden-state hooks; documenting it as
+        an explicit test prevents a future refactor from silently
+        re-introducing the rounding-collision bug.
+        """
+        from olmlx.engine.dflash.prepare import _evenly_spaced
+
+        # ``(num_layers, k)`` pairs that exercise the fallback:
+        # ``num_layers - 3 < k`` but ``k < num_layers``.
+        cases = [
+            (6, 4),  # end=3 < 4
+            (5, 3),  # end=2 < 3
+            (7, 5),  # end=4 < 5
+            (4, 2),  # end=1 < 2 — the test fixture in TestPrepareDflashDraft
+        ]
+        for n, k in cases:
+            ids = _evenly_spaced(n, k)
+            assert len(ids) == k, (
+                f"_evenly_spaced({n},{k}) returned {ids} ({len(ids)} indices, "
+                f"expected {k}); rounding collision in the fallback"
+            )
+            assert len(set(ids)) == k, (
+                f"_evenly_spaced({n},{k}) returned duplicates: {ids}"
+            )
+            assert all(0 <= i < n for i in ids), (
+                f"_evenly_spaced({n},{k}) returned out-of-range index: {ids}"
+            )
 
 
 class TestResolveTargetLayerIds:


### PR DESCRIPTION
## Summary
Address gaps 1-4 from gh#317 — likely root causes of the ~2% acceptance rate locally-trained DFlash drafts hit vs. paper-reported numbers.

- **Gap 1 — slice off-by-one**: `target_hidden = target_hidden_full[:, :p, :]` (was `[:, :p+1, :]`). Training now matches inference's convention where ctx covers `0..L-1` and pending sits at position `L`. The pre-fix slice gave the draft a copy-shortcut through the target's own hidden at the pending position — dead at inference.
- **Gap 2 — per-position loss weighting**: optional `w_k = exp(-(k-1)/γ)` via new `--position-decay-gamma` CLI flag. Default off (legacy uniform mean); suggested starting value `block_size/2`.
- **Gap 3 — defaults match paper**: `block_size` 4→16, draft `num_hidden_layers` 4→5, `num_target_layers` 4→5. `DFlashDecoder.__init__` fallback bumped to 16.
- **Gap 4 — upstream layer-selection**: `_evenly_spaced` now spreads indices across `[1, N-3]` (early-biased — skips embedding-adjacent layer 0 and lm_head-adjacent last two). N=32, K=5 → `[1, 8, 15, 22, 29]`. Falls back to a centred spread when the range is too small to fit `k` unique indices.

Gaps 5 (one window per sequence) and 6 (sliding-attention non-causal mask) deferred per the issue's recommended order — Gap 5 is documented as known under-utilization, Gap 6 is dead code path for Qwen3/3.5 targets.

## Test plan
- [x] `uv run pytest tests/test_dflash*.py` — 94 passed
- [x] `uv run pytest --ignore=tests/test_bench_*` — 2652 passed, 3 skipped (bench files are untracked WIP unrelated to this PR)
- [x] `uv run ruff check` + `ruff format --check` — clean
- [ ] Bench validation against a real Qwen3.5 target before updating CLAUDE.md's empirical recommendation that classic beats DFlash

🤖 Generated with [Claude Code](https://claude.com/claude-code)