### PR TITLE
fix(engine): strip <|im_end|> leak on Qwen2.5-Coder-1.5B (#308)

### DIFF
--- a/olmlx/engine/flash/prepare.py
+++ b/olmlx/engine/flash/prepare.py
@@ -68,7 +68,9 @@ def load_model_with_strict_fallback(model_path: str, *, lazy: bool) -> tuple:
     from olmlx.engine.model_manager import _ensure_tokenizer_eos_in_stops
 
     try:
-        model, tokenizer = mlx_lm.load(model_path, lazy=lazy)
+        # mlx_lm.load returns 2- or 3-tuple depending on return_config; default
+        # is 2-tuple. Pyright can't narrow on the parameter default.
+        model, tokenizer = mlx_lm.load(model_path, lazy=lazy)  # pyright: ignore[reportAssignmentType]
     except ValueError as exc:
         if _STRICT_LOAD_ERROR not in str(exc):
             raise

--- a/olmlx/engine/flash/prepare.py
+++ b/olmlx/engine/flash/prepare.py
@@ -62,8 +62,13 @@ def load_model_with_strict_fallback(model_path: str, *, lazy: bool) -> tuple:
     """
     import mlx_lm
 
+    # Function-local import: model_manager doesn't import flash.prepare at
+    # module level, but a top-level import here would still cross a module
+    # boundary for an internal helper. Keep the dependency lazy.
+    from olmlx.engine.model_manager import _ensure_tokenizer_eos_in_stops
+
     try:
-        return mlx_lm.load(model_path, lazy=lazy)
+        model, tokenizer = mlx_lm.load(model_path, lazy=lazy)
     except ValueError as exc:
         if _STRICT_LOAD_ERROR not in str(exc):
             raise
@@ -82,7 +87,8 @@ def load_model_with_strict_fallback(model_path: str, *, lazy: bool) -> tuple:
         tokenizer = mlx_lm.utils.load_tokenizer(
             model_dir, eos_token_ids=[eos] if isinstance(eos, int) else eos
         )
-        return model, tokenizer
+    _ensure_tokenizer_eos_in_stops(tokenizer)
+    return model, tokenizer
 
 
 def _encode_tokens(tokenizer, text: str) -> list[int]:

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -177,8 +177,6 @@ def _load_with_model_type_fallback(mlx_lm, load_path, **kwargs):
     kwargs.setdefault("tokenizer_config", {"trust_remote_code": True})
     try:
         model, tokenizer = mlx_lm.load(str(load_path), **kwargs)
-        _ensure_tokenizer_eos_in_stops(tokenizer)
-        return model, tokenizer
     except (AttributeError, ValueError, KeyError) as exc:
         config_file = Path(load_path) / "config.json"
         if not config_file.exists():
@@ -215,8 +213,10 @@ def _load_with_model_type_fallback(mlx_lm, load_path, **kwargs):
             )
         finally:
             config_file.write_text(original_text)
-        _ensure_tokenizer_eos_in_stops(tokenizer)
-        return model, tokenizer
+    # Outside try/except: an AttributeError from the EOS helper must not
+    # trigger the model-type remapping fallback with a misleading error.
+    _ensure_tokenizer_eos_in_stops(tokenizer)
+    return model, tokenizer
 
 
 def _is_serializable_cache(cache: list) -> bool:

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -118,6 +118,15 @@ def _ensure_tokenizer_eos_in_stops(tokenizer: Any) -> None:
         return
     stops = getattr(tokenizer, "eos_token_ids", None)
     if not isinstance(stops, set):
+        # Symmetric with the missing-_tokenizer DEBUG log below: an mlx-lm
+        # change from set to list/frozenset/dict for eos_token_ids would
+        # otherwise silently disable the workaround.
+        logger.debug(
+            "TokenizerWrapper.eos_token_ids is %s (not set) on %s; eos "
+            "stop-set augmentation skipped (issue #308).",
+            type(stops).__name__,
+            type(tokenizer).__name__,
+        )
         return
     inner_tok = getattr(tokenizer, "_tokenizer", None)
     if inner_tok is None:

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -109,19 +109,30 @@ def _ensure_tokenizer_eos_in_stops(tokenizer: Any) -> None:
     so generation does not stop at the template's actual EOT and the EOT
     string leaks into the decoded response.
     """
-    add_eos = getattr(tokenizer, "add_eos_token", None)
-    if not callable(add_eos):
+    # ``add_eos_token`` is the TokenizerWrapper marker — keep the gate on it
+    # so plain HF tokenizers and mlx-vlm processors are skipped — but mutate
+    # the ``eos_token_ids`` set directly to bypass the wrapper's stringly-typed
+    # API (``add_eos_token(str)`` does ``int(token)`` first then a vocab
+    # lookup; we already have the integer so set-mutation is unambiguous).
+    if not callable(getattr(tokenizer, "add_eos_token", None)):
+        return
+    stops = getattr(tokenizer, "eos_token_ids", None)
+    if not isinstance(stops, set):
         return
     inner_eos = getattr(getattr(tokenizer, "_tokenizer", None), "eos_token_id", None)
     if not isinstance(inner_eos, int):
+        # mlx-lm renamed ``_tokenizer`` or the inner HF tokenizer lost its
+        # ``eos_token_id`` attribute. Log at debug so upstream API churn is
+        # visible rather than silently reintroducing the original bug.
+        logger.debug(
+            "Tokenizer wrapper present but inner eos_token_id missing "
+            "(type=%s); skipping eos stop-set augmentation.",
+            type(tokenizer).__name__,
+        )
         return
-    stops = getattr(tokenizer, "eos_token_ids", None)
-    if stops is not None and inner_eos in stops:
+    if inner_eos in stops:
         return
-    try:
-        add_eos(str(inner_eos))
-    except Exception:  # pragma: no cover — defensive against tokenizer variants
-        logger.debug("Could not add tokenizer eos_token_id to stops", exc_info=True)
+    stops.add(inner_eos)
 
 
 def _load_with_model_type_fallback(mlx_lm, load_path, **kwargs):

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -120,13 +120,20 @@ def _ensure_tokenizer_eos_in_stops(tokenizer: Any) -> None:
     if not isinstance(stops, set):
         return
     inner_eos = getattr(getattr(tokenizer, "_tokenizer", None), "eos_token_id", None)
+    if isinstance(inner_eos, list):
+        # Stock HF tokenizers always surface a single int here; defensive
+        # against custom trust_remote_code=True tokenizers that override
+        # ``eos_token_id`` to return list[int].
+        stops.update(t for t in inner_eos if isinstance(t, int))
+        return
     if not isinstance(inner_eos, int):
-        # mlx-lm renamed ``_tokenizer`` or the inner HF tokenizer lost its
-        # ``eos_token_id`` attribute. Log at debug so upstream API churn is
-        # visible rather than silently reintroducing the original bug.
+        # mlx-lm renamed ``_tokenizer`` or the inner HF tokenizer surfaces an
+        # unexpected type. Log at debug so upstream API churn is visible
+        # rather than silently reintroducing the original bug.
         logger.debug(
-            "Tokenizer wrapper present but inner eos_token_id missing "
-            "(type=%s); skipping eos stop-set augmentation.",
+            "Inner eos_token_id has unexpected type %s on %s; skipping "
+            "eos stop-set augmentation.",
+            type(inner_eos).__name__,
             type(tokenizer).__name__,
         )
         return

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -126,6 +126,10 @@ def _ensure_tokenizer_eos_in_stops(tokenizer: Any) -> None:
         # ``eos_token_id`` to return list[int].
         stops.update(t for t in inner_eos if isinstance(t, int))
         return
+    if inner_eos is None:
+        # Tokenizer has no EOS configured — legitimate for some HF tokenizers
+        # (e.g. base/non-instruction-tuned variants). Silent no-op.
+        return
     if not isinstance(inner_eos, int):
         # mlx-lm renamed ``_tokenizer`` or the inner HF tokenizer surfaces an
         # unexpected type. ``warning``, not ``debug``: this branch indicates

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -119,7 +119,19 @@ def _ensure_tokenizer_eos_in_stops(tokenizer: Any) -> None:
     stops = getattr(tokenizer, "eos_token_ids", None)
     if not isinstance(stops, set):
         return
-    inner_eos = getattr(getattr(tokenizer, "_tokenizer", None), "eos_token_id", None)
+    inner_tok = getattr(tokenizer, "_tokenizer", None)
+    if inner_tok is None:
+        # Past the ``add_eos_token`` gate but no ``_tokenizer`` attribute —
+        # mlx-lm likely renamed the field. Log at debug so the regression is
+        # discoverable in DEBUG-enabled environments without spamming the
+        # warning channel for a possibly-deliberate variant.
+        logger.debug(
+            "TokenizerWrapper._tokenizer not accessible on %s; eos stop-set "
+            "augmentation skipped (issue #308).",
+            type(tokenizer).__name__,
+        )
+        return
+    inner_eos = getattr(inner_tok, "eos_token_id", None)
     if isinstance(inner_eos, list):
         # Stock HF tokenizers always surface a single int here; defensive
         # against custom trust_remote_code=True tokenizers that override

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -98,6 +98,32 @@ def _sanitize_model_config_in_place(load_path) -> None:
             )
 
 
+def _ensure_tokenizer_eos_in_stops(tokenizer: Any) -> None:
+    """Add the tokenizer's own ``eos_token_id`` to its stop-token set.
+
+    Workaround for repos (e.g. ``mlx-community/Qwen2.5-Coder-1.5B-Instruct-4bit``,
+    issue #308) whose ``config.json`` declares ``eos_token_id`` as a token
+    different from the chat template's real end-of-turn token (the
+    ``eos_token`` field in ``tokenizer_config.json``). mlx-lm's ``load()``
+    feeds only the config.json value into ``TokenizerWrapper.eos_token_ids``,
+    so generation does not stop at the template's actual EOT and the EOT
+    string leaks into the decoded response.
+    """
+    add_eos = getattr(tokenizer, "add_eos_token", None)
+    if not callable(add_eos):
+        return
+    inner_eos = getattr(getattr(tokenizer, "_tokenizer", None), "eos_token_id", None)
+    if not isinstance(inner_eos, int):
+        return
+    stops = getattr(tokenizer, "eos_token_ids", None)
+    if stops is not None and inner_eos in stops:
+        return
+    try:
+        add_eos(str(inner_eos))
+    except Exception:  # pragma: no cover — defensive against tokenizer variants
+        logger.debug("Could not add tokenizer eos_token_id to stops", exc_info=True)
+
+
 def _load_with_model_type_fallback(mlx_lm, load_path, **kwargs):
     """Load model + tokenizer, remapping unrecognised model_type if needed.
 
@@ -113,7 +139,9 @@ def _load_with_model_type_fallback(mlx_lm, load_path, **kwargs):
     _sanitize_model_config_in_place(load_path)
     kwargs.setdefault("tokenizer_config", {"trust_remote_code": True})
     try:
-        return mlx_lm.load(str(load_path), **kwargs)
+        model, tokenizer = mlx_lm.load(str(load_path), **kwargs)
+        _ensure_tokenizer_eos_in_stops(tokenizer)
+        return model, tokenizer
     except (AttributeError, ValueError, KeyError) as exc:
         config_file = Path(load_path) / "config.json"
         if not config_file.exists():
@@ -150,6 +178,7 @@ def _load_with_model_type_fallback(mlx_lm, load_path, **kwargs):
             )
         finally:
             config_file.write_text(original_text)
+        _ensure_tokenizer_eos_in_stops(tokenizer)
         return model, tokenizer
 
 

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -128,11 +128,14 @@ def _ensure_tokenizer_eos_in_stops(tokenizer: Any) -> None:
         return
     if not isinstance(inner_eos, int):
         # mlx-lm renamed ``_tokenizer`` or the inner HF tokenizer surfaces an
-        # unexpected type. Log at debug so upstream API churn is visible
-        # rather than silently reintroducing the original bug.
-        logger.debug(
+        # unexpected type. ``warning``, not ``debug``: this branch indicates
+        # the #308 workaround has silently regressed because mlx-lm changed
+        # its internals, and we recover by no-op'ing — operators need to see
+        # the signal in default logging configs, not only under DEBUG.
+        logger.warning(
             "Inner eos_token_id has unexpected type %s on %s; skipping "
-            "eos stop-set augmentation.",
+            "eos stop-set augmentation (issue #308 workaround may have "
+            "regressed against mlx-lm internals).",
             type(inner_eos).__name__,
             type(tokenizer).__name__,
         )

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1943,10 +1943,13 @@ class TestEnsureTokenizerEosInStops:
         _ensure_tokenizer_eos_in_stops(tok)
         assert tok.eos_token_ids == {151645}
 
-    def test_noop_when_inner_eos_missing(self):
+    def test_noop_when_inner_eos_missing(self, caplog):
+        # None is legitimate (HF tokenizers without an EOS); must not warn.
         tok = _FakeTokenizerWrapper(inner_eos=None, stops={151643})
-        _ensure_tokenizer_eos_in_stops(tok)
+        with caplog.at_level(logging.WARNING):
+            _ensure_tokenizer_eos_in_stops(tok)
         assert tok.eos_token_ids == {151643}
+        assert not caplog.records, f"unexpected warnings: {caplog.records}"
 
     def test_adds_list_inner_eos(self):
         # Defensive: HF stock tokenizers expose eos_token_id as a single int,

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1983,9 +1983,15 @@ class TestLoadWithModelTypeFallbackEosFix:
         # Exercises the model_type-remapping branch: mlx_lm.load raises, then
         # load_model + load_tokenizer are called with the stripped model_type.
         # Same EOS mismatch scenario as the main path must still be repaired.
+        # We patch transformers' CONFIG_MAPPING so the test owns its
+        # precondition — without the patch a future transformers release
+        # dropping the chosen model_type would silently re-raise instead of
+        # exercising the fallback.
+        import transformers.models.auto.configuration_auto as auto_cfg
+
         from olmlx.engine.model_manager import _load_with_model_type_fallback
 
-        original_cfg = {"model_type": "deepseek_v32", "eos_token_id": 151643}
+        original_cfg = {"model_type": "fakemodel2", "eos_token_id": 151643}
         (tmp_path / "config.json").write_text(json.dumps(original_cfg))
 
         tok = _FakeTokenizerWrapper(inner_eos=151645, stops={151643})
@@ -1997,7 +2003,8 @@ class TestLoadWithModelTypeFallbackEosFix:
         )
         mock_mlx_lm.utils.load_tokenizer.return_value = tok
 
-        _, returned = _load_with_model_type_fallback(mock_mlx_lm, str(tmp_path))
+        with patch.object(auto_cfg, "CONFIG_MAPPING", {"fakemodel": object()}):
+            _, returned = _load_with_model_type_fallback(mock_mlx_lm, str(tmp_path))
         assert returned is tok
         assert 151645 in tok.eos_token_ids
         assert 151643 in tok.eos_token_ids

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1945,8 +1945,10 @@ class TestEnsureTokenizerEosInStops:
 
     def test_noop_when_inner_eos_missing(self, caplog):
         # None is legitimate (HF tokenizers without an EOS); must not warn.
+        # Scope caplog to our logger to avoid spurious failures from unrelated
+        # WARNING-level emissions (e.g. deprecation notices from pytest plugins).
         tok = _FakeTokenizerWrapper(inner_eos=None, stops={151643})
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.WARNING, logger="olmlx.engine.model_manager"):
             _ensure_tokenizer_eos_in_stops(tok)
         assert tok.eos_token_ids == {151643}
         assert not caplog.records, f"unexpected warnings: {caplog.records}"

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1958,6 +1958,13 @@ class TestEnsureTokenizerEosInStops:
         _ensure_tokenizer_eos_in_stops(tok)
         assert tok.eos_token_ids == {151643, 151645}
 
+    def test_noop_when_stops_not_a_set(self):
+        # A wrapper with add_eos_token but eos_token_ids=None must not crash;
+        # the guard returns early so the stop set is left unchanged.
+        tok = _FakeTokenizerWrapper(inner_eos=151645, stops=None)
+        _ensure_tokenizer_eos_in_stops(tok)
+        assert tok.eos_token_ids is None
+
     def test_warns_on_unexpected_type(self, caplog):
         # Defends against a refactor that accidentally skips the warning
         # branch or promotes/demotes its log level.
@@ -1991,6 +1998,29 @@ class TestLoadWithModelTypeFallbackEosFix:
         assert returned is tok
         assert 151645 in tok.eos_token_ids
         assert 151643 in tok.eos_token_ids
+
+    def test_flash_strict_fallback_path_augments_stops(self, tmp_path):
+        # When mlx_lm.load raises "parameters not in model", flash/prepare's
+        # strict-fallback branch reloads via load_model + load_tokenizer; the
+        # EOS augmentation must still run after that branch.
+        from olmlx.engine.flash.prepare import (
+            _STRICT_LOAD_ERROR,
+            load_model_with_strict_fallback,
+        )
+
+        tok = _FakeTokenizerWrapper(inner_eos=151645, stops={151643})
+        mock_mlx_lm = MagicMock()
+        mock_mlx_lm.load.side_effect = ValueError(_STRICT_LOAD_ERROR)
+        mock_mlx_lm.utils.load_model.return_value = (
+            MagicMock(),
+            {"eos_token_id": 151643},
+        )
+        mock_mlx_lm.utils.load_tokenizer.return_value = tok
+
+        with patch.dict("sys.modules", {"mlx_lm": mock_mlx_lm}):
+            _, returned = load_model_with_strict_fallback(str(tmp_path), lazy=False)
+        assert returned is tok
+        assert 151645 in tok.eos_token_ids
 
     def test_flash_load_path_augments_stops(self, tmp_path):
         # Flash mode bypasses _load_with_model_type_fallback and calls

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1958,6 +1958,16 @@ class TestEnsureTokenizerEosInStops:
         _ensure_tokenizer_eos_in_stops(tok)
         assert tok.eos_token_ids == {151643, 151645}
 
+    def test_warns_on_unexpected_type(self, caplog):
+        # Defends against a refactor that accidentally skips the warning
+        # branch or promotes/demotes its log level.
+        tok = _FakeTokenizerWrapper(inner_eos=None, stops={151643})
+        tok._tokenizer.eos_token_id = 3.14  # float: not int, list, or None
+        with caplog.at_level(logging.WARNING, logger="olmlx.engine.model_manager"):
+            _ensure_tokenizer_eos_in_stops(tok)
+        assert tok.eos_token_ids == {151643}  # unchanged
+        assert any("unexpected type" in r.message for r in caplog.records)
+
     def test_noop_on_non_wrapper(self):
         # mlx-vlm processors / plain HF tokenizers don't expose add_eos_token.
         processor = MagicMock(spec=["tokenizer", "eos_token_id"])

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1965,6 +1965,17 @@ class TestEnsureTokenizerEosInStops:
         _ensure_tokenizer_eos_in_stops(tok)
         assert tok.eos_token_ids is None
 
+    def test_debug_logs_when_tokenizer_attr_missing(self, caplog):
+        # Past the add_eos_token gate but no _tokenizer attribute — mlx-lm
+        # likely renamed the field. Must log at DEBUG so the regression is
+        # discoverable without spamming WARNING for deliberate variants.
+        tok = _FakeTokenizerWrapper(inner_eos=151645, stops={151643})
+        del tok._tokenizer
+        with caplog.at_level(logging.DEBUG, logger="olmlx.engine.model_manager"):
+            _ensure_tokenizer_eos_in_stops(tok)
+        assert tok.eos_token_ids == {151643}
+        assert any("not accessible" in r.message for r in caplog.records)
+
     def test_warns_on_unexpected_type(self, caplog):
         # Defends against a refactor that accidentally skips the warning
         # branch or promotes/demotes its log level.

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1960,12 +1960,16 @@ class TestEnsureTokenizerEosInStops:
         _ensure_tokenizer_eos_in_stops(tok)
         assert tok.eos_token_ids == {151643, 151645}
 
-    def test_noop_when_stops_not_a_set(self):
+    def test_noop_when_stops_not_a_set(self, caplog):
         # A wrapper with add_eos_token but eos_token_ids=None must not crash;
-        # the guard returns early so the stop set is left unchanged.
+        # the guard returns early so the stop set is left unchanged. Should
+        # also DEBUG-log so a future mlx-lm change of the stop-set type is
+        # discoverable rather than silently disabling the workaround.
         tok = _FakeTokenizerWrapper(inner_eos=151645, stops=None)
-        _ensure_tokenizer_eos_in_stops(tok)
+        with caplog.at_level(logging.DEBUG, logger="olmlx.engine.model_manager"):
+            _ensure_tokenizer_eos_in_stops(tok)
         assert tok.eos_token_ids is None
+        assert any("not set" in r.message for r in caplog.records)
 
     def test_debug_logs_when_tokenizer_attr_missing(self, caplog):
         # Past the add_eos_token gate but no _tokenizer attribute — mlx-lm
@@ -2076,6 +2080,10 @@ class TestLoadWithModelTypeFallbackEosFix:
         )
         mock_mlx_lm.utils.load_tokenizer.return_value = tok
 
+        # "fakemodel2" → strips last digit → "fakemodel" via the regex
+        # ``re.sub(r"\d+$", lambda m: m.group()[:-1], ...)`` in
+        # _load_with_model_type_fallback. CONFIG_MAPPING must contain
+        # "fakemodel" for the fallback branch to proceed.
         with patch.object(auto_cfg, "CONFIG_MAPPING", {"fakemodel": object()}):
             _, returned = _load_with_model_type_fallback(mock_mlx_lm, str(tmp_path))
         assert returned is tok

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1968,6 +1968,31 @@ class TestLoadWithModelTypeFallbackEosFix:
         assert 151645 in tok.eos_token_ids
         assert 151643 in tok.eos_token_ids
 
+    def test_fallback_path_augments_stops(self, tmp_path):
+        # Exercises the model_type-remapping branch: mlx_lm.load raises, then
+        # load_model + load_tokenizer are called with the stripped model_type.
+        # Same EOS mismatch scenario as the main path must still be repaired.
+        from olmlx.engine.model_manager import _load_with_model_type_fallback
+
+        original_cfg = {"model_type": "deepseek_v32", "eos_token_id": 151643}
+        (tmp_path / "config.json").write_text(json.dumps(original_cfg))
+
+        tok = _FakeTokenizerWrapper(inner_eos=151645, stops={151643})
+        mock_mlx_lm = MagicMock()
+        mock_mlx_lm.load.side_effect = ValueError("unsupported model_type")
+        mock_mlx_lm.utils.load_model.return_value = (
+            MagicMock(),
+            {"eos_token_id": 151643},
+        )
+        mock_mlx_lm.utils.load_tokenizer.return_value = tok
+
+        _, returned = _load_with_model_type_fallback(mock_mlx_lm, str(tmp_path))
+        assert returned is tok
+        assert 151645 in tok.eos_token_ids
+        assert 151643 in tok.eos_token_ids
+        # config.json must be restored after the temporary remap.
+        assert json.loads((tmp_path / "config.json").read_text()) == original_cfg
+
 
 class TestExpiryChecker:
     @pytest.mark.asyncio

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1912,7 +1912,11 @@ class TestTryLmThenVlmFallback:
 class _FakeTokenizerWrapper:
     """Minimal stand-in for mlx-lm's TokenizerWrapper for stop-token tests."""
 
-    def __init__(self, inner_eos: int | None, stops: set[int] | None):
+    def __init__(
+        self,
+        inner_eos: int | list[int] | None,
+        stops: set[int] | None,
+    ):
         inner = MagicMock()
         inner.eos_token_id = inner_eos
         self._tokenizer = inner
@@ -1943,6 +1947,13 @@ class TestEnsureTokenizerEosInStops:
         tok = _FakeTokenizerWrapper(inner_eos=None, stops={151643})
         _ensure_tokenizer_eos_in_stops(tok)
         assert tok.eos_token_ids == {151643}
+
+    def test_adds_list_inner_eos(self):
+        # Defensive: HF stock tokenizers expose eos_token_id as a single int,
+        # but custom trust_remote_code=True tokenizers may surface list[int].
+        tok = _FakeTokenizerWrapper(inner_eos=[151645, 151643], stops={151643})
+        _ensure_tokenizer_eos_in_stops(tok)
+        assert tok.eos_token_ids == {151643, 151645}
 
     def test_noop_on_non_wrapper(self):
         # mlx-vlm processors / plain HF tokenizers don't expose add_eos_token.

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1992,6 +1992,23 @@ class TestLoadWithModelTypeFallbackEosFix:
         assert 151645 in tok.eos_token_ids
         assert 151643 in tok.eos_token_ids
 
+    def test_flash_load_path_augments_stops(self, tmp_path):
+        # Flash mode bypasses _load_with_model_type_fallback and calls
+        # mlx_lm.load() directly via load_model_with_strict_fallback. That
+        # path must also apply the EOS workaround — otherwise Flash-mode
+        # Qwen2.5-Coder-1.5B-Instruct would still leak <|im_end|>.
+        from olmlx.engine.flash.prepare import load_model_with_strict_fallback
+
+        tok = _FakeTokenizerWrapper(inner_eos=151645, stops={151643})
+        mock_mlx_lm = MagicMock()
+        mock_mlx_lm.load.return_value = (MagicMock(), tok)
+
+        with patch.dict("sys.modules", {"mlx_lm": mock_mlx_lm}):
+            _, returned = load_model_with_strict_fallback(str(tmp_path), lazy=False)
+        assert returned is tok
+        assert 151645 in tok.eos_token_ids
+        assert 151643 in tok.eos_token_ids
+
     def test_fallback_path_augments_stops(self, tmp_path):
         # Exercises the model_type-remapping branch: mlx_lm.load raises, then
         # load_model + load_tokenizer are called with the stripped model_type.

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -14,6 +14,7 @@ from olmlx.engine.model_manager import (
     LoadedModel,
     ModelLoadTimeoutError,
     ModelManager,
+    _ensure_tokenizer_eos_in_stops,
     parse_keep_alive,
 )
 from olmlx.engine.registry import SpeculativeConfig
@@ -1906,6 +1907,66 @@ class TestTryLmThenVlmFallback:
         with patch.dict("sys.modules", {"mlx_lm": mock_mlx_lm}):
             with pytest.raises(MemoryError):
                 manager._try_lm_then_vlm("test/path", "test")
+
+
+class _FakeTokenizerWrapper:
+    """Minimal stand-in for mlx-lm's TokenizerWrapper for stop-token tests."""
+
+    def __init__(self, inner_eos: int | None, stops: set[int] | None):
+        inner = MagicMock()
+        inner.eos_token_id = inner_eos
+        self._tokenizer = inner
+        self.eos_token_ids: set[int] | None = stops
+
+    def add_eos_token(self, token: str) -> None:
+        assert self.eos_token_ids is not None
+        self.eos_token_ids.add(int(token))
+
+
+class TestEnsureTokenizerEosInStops:
+    """Issue #308: <|im_end|> leaks when config.json eos_token_id != template EOT."""
+
+    def test_adds_inner_eos_when_missing(self):
+        # Repro: Qwen2.5-Coder-1.5B has config.eos_token_id=151643 (<|endoftext|>)
+        # but tokenizer_config eos_token=<|im_end|> (151645). The chat template
+        # ends turns with 151645, so it must be in the stop set.
+        tok = _FakeTokenizerWrapper(inner_eos=151645, stops={151643})
+        _ensure_tokenizer_eos_in_stops(tok)
+        assert tok.eos_token_ids == {151643, 151645}
+
+    def test_noop_when_already_present(self):
+        tok = _FakeTokenizerWrapper(inner_eos=151645, stops={151645})
+        _ensure_tokenizer_eos_in_stops(tok)
+        assert tok.eos_token_ids == {151645}
+
+    def test_noop_when_inner_eos_missing(self):
+        tok = _FakeTokenizerWrapper(inner_eos=None, stops={151643})
+        _ensure_tokenizer_eos_in_stops(tok)
+        assert tok.eos_token_ids == {151643}
+
+    def test_noop_on_non_wrapper(self):
+        # mlx-vlm processors / plain HF tokenizers don't expose add_eos_token.
+        processor = MagicMock(spec=["tokenizer", "eos_token_id"])
+        # Calling on a non-wrapper must not raise.
+        _ensure_tokenizer_eos_in_stops(processor)
+
+
+class TestLoadWithModelTypeFallbackEosFix:
+    """Issue #308: _load_with_model_type_fallback must augment stop tokens."""
+
+    def test_main_path_augments_stops(self, tmp_path):
+        from olmlx.engine.model_manager import _load_with_model_type_fallback
+
+        (tmp_path / "config.json").write_text("{}")
+
+        tok = _FakeTokenizerWrapper(inner_eos=151645, stops={151643})
+        mock_mlx_lm = MagicMock()
+        mock_mlx_lm.load.return_value = (MagicMock(), tok)
+
+        _, returned = _load_with_model_type_fallback(mock_mlx_lm, str(tmp_path))
+        assert returned is tok
+        assert 151645 in tok.eos_token_ids
+        assert 151643 in tok.eos_token_ids
 
 
 class TestExpiryChecker:


### PR DESCRIPTION
## Summary
- Some repos (`mlx-community/Qwen2.5-Coder-1.5B-Instruct-4bit`) ship `config.json` with `eos_token_id: 151643` (`<|endoftext|>`) while `tokenizer_config.json` sets `eos_token: "<|im_end|>"` (151645). mlx-lm's `load()` only feeds the config.json value into `TokenizerWrapper.eos_token_ids`, so generation runs past the chat template's actual EOT and the literal `<|im_end|>` lands in `message.content`.
- Add `_ensure_tokenizer_eos_in_stops()` and call it after every mlx-lm load path in `_load_with_model_type_fallback` to add the tokenizer's own `eos_token_id` to the stop set when missing.
- No-op for mlx-vlm processors and any tokenizer without `add_eos_token`, so other paths are unaffected.

Fixes #308.

## Test plan
- [x] New unit tests `TestEnsureTokenizerEosInStops` (4 cases) and `TestLoadWithModelTypeFallbackEosFix`
- [x] `uv run pytest tests/test_model_manager.py` — 134 passed
- [x] `uv run ruff check` + `uv run ruff format --check` — clean
- [ ] Repro from #308 against the affected model: `curl -s http://localhost:11434/api/chat ...` returns `"391"` (no trailing `<|im_end|>\n`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)