### PR TITLE
fix(schemas): reject empty embedding input and empty messages arrays

### DIFF
--- a/olmlx/schemas/anthropic.py
+++ b/olmlx/schemas/anthropic.py
@@ -76,6 +76,15 @@ class AnthropicMessagesRequest(BaseModel):
 
         return validate_token_limit(v, "max_tokens")
 
+    @field_validator("messages")
+    @classmethod
+    def validate_messages_non_empty(
+        cls, v: list[AnthropicMessage]
+    ) -> list[AnthropicMessage]:
+        if not v:
+            raise ValueError("messages cannot be empty")
+        return v
+
     temperature: float | None = Field(None, ge=0, le=1)
     top_p: float | None = Field(None, ge=0, le=1)
     top_k: int | None = Field(None, ge=1)  # Anthropic spec: top_k >= 1

--- a/olmlx/schemas/chat.py
+++ b/olmlx/schemas/chat.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from olmlx.schemas.common import ModelName, ModelOptions
 
@@ -35,6 +35,13 @@ class ChatRequest(BaseModel):
     stream: bool = True
     options: ModelOptions | None = None
     keep_alive: str | None = None
+
+    @field_validator("messages")
+    @classmethod
+    def validate_messages_non_empty(cls, v: list[Message]) -> list[Message]:
+        if not v:
+            raise ValueError("messages cannot be empty")
+        return v
 
 
 class ChatResponse(BaseModel):

--- a/olmlx/schemas/common.py
+++ b/olmlx/schemas/common.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, overload
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -16,15 +16,14 @@ def validate_token_limit(v: int, field_name: str) -> int:
     return v
 
 
+@overload
+def validate_non_empty_text_input(v: str, field_name: str) -> str: ...
+@overload
+def validate_non_empty_text_input(v: list[str], field_name: str) -> list[str]: ...
 def validate_non_empty_text_input(
     v: str | list[str], field_name: str
 ) -> str | list[str]:
-    """Reject empty strings, empty lists, and lists containing empty strings.
-
-    Shared by request schemas where a ``str | list[str]`` field is fed to
-    inference — empty values would otherwise leak raw MLX errors (#311) or
-    IndexErrors (e.g. ``req.prompt[0]`` on an empty list).
-    """
+    """Reject empty string, empty list, or list containing an empty string."""
     if isinstance(v, str):
         if not v:
             raise ValueError(f"{field_name} cannot be empty")

--- a/olmlx/schemas/common.py
+++ b/olmlx/schemas/common.py
@@ -16,6 +16,26 @@ def validate_token_limit(v: int, field_name: str) -> int:
     return v
 
 
+def validate_non_empty_text_input(
+    v: str | list[str], field_name: str
+) -> str | list[str]:
+    """Reject empty strings, empty lists, and lists containing empty strings.
+
+    Shared by request schemas where a ``str | list[str]`` field is fed to
+    inference — empty values would otherwise leak raw MLX errors (#311) or
+    IndexErrors (e.g. ``req.prompt[0]`` on an empty list).
+    """
+    if isinstance(v, str):
+        if not v:
+            raise ValueError(f"{field_name} cannot be empty")
+    else:
+        if not v:
+            raise ValueError(f"{field_name} cannot be an empty list")
+        if any(not s for s in v):
+            raise ValueError(f"{field_name} cannot contain empty strings")
+    return v
+
+
 class ModelOptions(BaseModel):
     """Ollama model options / parameters."""
 

--- a/olmlx/schemas/embed.py
+++ b/olmlx/schemas/embed.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from olmlx.schemas.common import ModelName
 
@@ -9,6 +9,19 @@ class EmbedRequest(BaseModel):
     truncate: bool = True
     options: dict | None = None
     keep_alive: str | None = None
+
+    @field_validator("input")
+    @classmethod
+    def validate_input_non_empty(cls, v: str | list[str]) -> str | list[str]:
+        if isinstance(v, str):
+            if not v:
+                raise ValueError("input cannot be empty")
+        else:
+            if not v:
+                raise ValueError("input cannot be an empty list")
+            if any(not s for s in v):
+                raise ValueError("input cannot contain empty strings")
+        return v
 
 
 class EmbedResponse(BaseModel):
@@ -24,6 +37,13 @@ class EmbeddingsRequest(BaseModel):
     prompt: str
     options: dict | None = None
     keep_alive: str | None = None
+
+    @field_validator("prompt")
+    @classmethod
+    def validate_prompt_non_empty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("prompt cannot be empty")
+        return v
 
 
 class EmbeddingsResponse(BaseModel):

--- a/olmlx/schemas/embed.py
+++ b/olmlx/schemas/embed.py
@@ -33,8 +33,7 @@ class EmbeddingsRequest(BaseModel):
     @field_validator("prompt")
     @classmethod
     def validate_prompt_non_empty(cls, v: str) -> str:
-        validate_non_empty_text_input(v, "prompt")
-        return v
+        return validate_non_empty_text_input(v, "prompt")
 
 
 class EmbeddingsResponse(BaseModel):

--- a/olmlx/schemas/embed.py
+++ b/olmlx/schemas/embed.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, field_validator
 
-from olmlx.schemas.common import ModelName
+from olmlx.schemas.common import ModelName, validate_non_empty_text_input
 
 
 class EmbedRequest(BaseModel):
@@ -13,15 +13,7 @@ class EmbedRequest(BaseModel):
     @field_validator("input")
     @classmethod
     def validate_input_non_empty(cls, v: str | list[str]) -> str | list[str]:
-        if isinstance(v, str):
-            if not v:
-                raise ValueError("input cannot be empty")
-        else:
-            if not v:
-                raise ValueError("input cannot be an empty list")
-            if any(not s for s in v):
-                raise ValueError("input cannot contain empty strings")
-        return v
+        return validate_non_empty_text_input(v, "input")
 
 
 class EmbedResponse(BaseModel):
@@ -41,8 +33,7 @@ class EmbeddingsRequest(BaseModel):
     @field_validator("prompt")
     @classmethod
     def validate_prompt_non_empty(cls, v: str) -> str:
-        if not v:
-            raise ValueError("prompt cannot be empty")
+        validate_non_empty_text_input(v, "prompt")
         return v
 
 

--- a/olmlx/schemas/generate.py
+++ b/olmlx/schemas/generate.py
@@ -1,11 +1,15 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
-from olmlx.schemas.common import ModelName, ModelOptions
+from olmlx.schemas.common import (
+    ModelName,
+    ModelOptions,
+    validate_non_empty_text_input,
+)
 
 
 class GenerateRequest(BaseModel):
     model: ModelName
-    prompt: str = Field("", max_length=1_000_000)
+    prompt: str = Field(..., max_length=1_000_000)
     suffix: str | None = None
     images: list[str] | None = None
     system: str | None = None
@@ -16,6 +20,11 @@ class GenerateRequest(BaseModel):
     format: str | None = None
     options: ModelOptions | None = None
     keep_alive: str | None = None
+
+    @field_validator("prompt")
+    @classmethod
+    def validate_prompt_non_empty(cls, v: str) -> str:
+        return validate_non_empty_text_input(v, "prompt")
 
 
 class GenerateResponse(BaseModel):

--- a/olmlx/schemas/openai.py
+++ b/olmlx/schemas/openai.py
@@ -134,6 +134,13 @@ class OpenAICompletionRequest(BaseModel):
 
         return validate_token_limit(v, "max_tokens")
 
+    @field_validator("prompt")
+    @classmethod
+    def validate_prompt_non_empty(cls, v: str | list[str]) -> str | list[str]:
+        from olmlx.schemas.common import validate_non_empty_text_input
+
+        return validate_non_empty_text_input(v, "prompt")
+
 
 class OpenAICompletionChoice(BaseModel):
     index: int = 0
@@ -176,15 +183,9 @@ class OpenAIEmbeddingRequest(BaseModel):
     @field_validator("input")
     @classmethod
     def validate_input_non_empty(cls, v: str | list[str]) -> str | list[str]:
-        if isinstance(v, str):
-            if not v:
-                raise ValueError("input cannot be empty")
-        else:
-            if not v:
-                raise ValueError("input cannot be an empty list")
-            if any(not s for s in v):
-                raise ValueError("input cannot contain empty strings")
-        return v
+        from olmlx.schemas.common import validate_non_empty_text_input
+
+        return validate_non_empty_text_input(v, "input")
 
 
 class OpenAIEmbeddingData(BaseModel):

--- a/olmlx/schemas/openai.py
+++ b/olmlx/schemas/openai.py
@@ -64,6 +64,15 @@ class OpenAIChatRequest(BaseModel):
 
         return validate_token_limit(v, "max_tokens")
 
+    @field_validator("messages")
+    @classmethod
+    def validate_messages_non_empty(
+        cls, v: list[OpenAIChatMessage]
+    ) -> list[OpenAIChatMessage]:
+        if not v:
+            raise ValueError("messages cannot be empty")
+        return v
+
 
 class OpenAIUsage(BaseModel):
     prompt_tokens: int = 0
@@ -163,6 +172,19 @@ class OpenAIEmbeddingRequest(BaseModel):
     model: ModelName
     input: str | list[str]
     encoding_format: str = "float"
+
+    @field_validator("input")
+    @classmethod
+    def validate_input_non_empty(cls, v: str | list[str]) -> str | list[str]:
+        if isinstance(v, str):
+            if not v:
+                raise ValueError("input cannot be empty")
+        else:
+            if not v:
+                raise ValueError("input cannot be an empty list")
+            if any(not s for s in v):
+                raise ValueError("input cannot contain empty strings")
+        return v
 
 
 class OpenAIEmbeddingData(BaseModel):

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -1435,6 +1435,19 @@ class TestAnthropicEndpoint:
         assert "internal server error" in error_data["error"]["message"]
 
 
+class TestEmptyMessagesRejected:
+    @pytest.mark.asyncio
+    async def test_messages_rejects_empty_messages_array(self, app_client):
+        resp = await app_client.post(
+            "/v1/messages",
+            json={"model": "qwen3", "messages": [], "max_tokens": 100},
+        )
+        assert resp.status_code == 422
+        body = resp.text.lower()
+        assert "messages" in body
+        assert "empty" in body
+
+
 class TestCountTokens:
     @pytest.mark.asyncio
     async def test_simple_message(self, app_client, mock_loaded_model):

--- a/tests/test_routers_chat.py
+++ b/tests/test_routers_chat.py
@@ -942,6 +942,19 @@ class TestChatRouter:
         assert "created_at" in last_line
 
 
+class TestEmptyMessagesRejected:
+    @pytest.mark.asyncio
+    async def test_api_chat_rejects_empty_messages(self, app_client):
+        resp = await app_client.post(
+            "/api/chat",
+            json={"model": "qwen3", "messages": []},
+        )
+        assert resp.status_code == 422
+        body = resp.text.lower()
+        assert "messages" in body
+        assert "empty" in body
+
+
 class TestXCacheIDHeader:
     @pytest.mark.asyncio
     async def test_header_passed_to_generate_chat(self, app_client):

--- a/tests/test_routers_embed.py
+++ b/tests/test_routers_embed.py
@@ -61,3 +61,33 @@ class TestEmbedRouter:
         assert resp.status_code == 200
         data = resp.json()
         assert data["embedding"] == [0.5, 0.6]
+
+    @pytest.mark.asyncio
+    async def test_embed_rejects_empty_string_input(self, app_client):
+        resp = await app_client.post(
+            "/api/embed",
+            json={"model": "qwen3", "input": ""},
+        )
+        assert resp.status_code == 422
+        assert "input" in resp.text.lower()
+        assert "empty" in resp.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_embed_rejects_empty_list_input(self, app_client):
+        resp = await app_client.post(
+            "/api/embed",
+            json={"model": "qwen3", "input": []},
+        )
+        assert resp.status_code == 422
+        assert "input" in resp.text.lower()
+        assert "empty" in resp.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_embeddings_legacy_rejects_empty_prompt(self, app_client):
+        resp = await app_client.post(
+            "/api/embeddings",
+            json={"model": "qwen3", "prompt": ""},
+        )
+        assert resp.status_code == 422
+        assert "prompt" in resp.text.lower()
+        assert "empty" in resp.text.lower()

--- a/tests/test_routers_generate.py
+++ b/tests/test_routers_generate.py
@@ -177,3 +177,26 @@ class TestGenerateRouter:
         assert last_line["done_reason"] == "error"
         assert last_line["model"] == "qwen3"
         assert "created_at" in last_line
+
+
+class TestEmptyPromptRejected:
+    @pytest.mark.asyncio
+    async def test_api_generate_rejects_empty_prompt(self, app_client):
+        resp = await app_client.post(
+            "/api/generate",
+            json={"model": "qwen3", "prompt": ""},
+        )
+        assert resp.status_code == 422
+        body = resp.text.lower()
+        assert "prompt" in body
+        assert "empty" in body
+
+    @pytest.mark.asyncio
+    async def test_api_generate_rejects_missing_prompt(self, app_client):
+        resp = await app_client.post(
+            "/api/generate",
+            json={"model": "qwen3"},
+        )
+        assert resp.status_code == 422
+        body = resp.text.lower()
+        assert "prompt" in body

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -637,6 +637,28 @@ class TestEmptyInputRejected:
         assert "input" in body
         assert "empty" in body
 
+    @pytest.mark.asyncio
+    async def test_completions_rejects_empty_prompt(self, app_client):
+        resp = await app_client.post(
+            "/v1/completions",
+            json={"model": "qwen3", "prompt": ""},
+        )
+        assert resp.status_code == 422
+        body = resp.text.lower()
+        assert "prompt" in body
+        assert "empty" in body
+
+    @pytest.mark.asyncio
+    async def test_completions_rejects_empty_list_prompt(self, app_client):
+        resp = await app_client.post(
+            "/v1/completions",
+            json={"model": "qwen3", "prompt": []},
+        )
+        assert resp.status_code == 422
+        body = resp.text.lower()
+        assert "prompt" in body
+        assert "empty" in body
+
 
 class TestXCacheIDHeader:
     @pytest.mark.asyncio

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -603,6 +603,41 @@ class TestOpenAIRouter:
         assert any("[DONE]" in line for line in lines)
 
 
+class TestEmptyInputRejected:
+    @pytest.mark.asyncio
+    async def test_chat_completions_rejects_empty_messages(self, app_client):
+        resp = await app_client.post(
+            "/v1/chat/completions",
+            json={"model": "qwen3", "messages": []},
+        )
+        assert resp.status_code == 422
+        body = resp.text.lower()
+        assert "messages" in body
+        assert "empty" in body
+
+    @pytest.mark.asyncio
+    async def test_embeddings_rejects_empty_string_input(self, app_client):
+        resp = await app_client.post(
+            "/v1/embeddings",
+            json={"model": "qwen3", "input": ""},
+        )
+        assert resp.status_code == 422
+        body = resp.text.lower()
+        assert "input" in body
+        assert "empty" in body
+
+    @pytest.mark.asyncio
+    async def test_embeddings_rejects_empty_list_input(self, app_client):
+        resp = await app_client.post(
+            "/v1/embeddings",
+            json={"model": "qwen3", "input": []},
+        )
+        assert resp.status_code == 422
+        body = resp.text.lower()
+        assert "input" in body
+        assert "empty" in body
+
+
 class TestXCacheIDHeader:
     @pytest.mark.asyncio
     async def test_header_passed_to_generate_chat(self, app_client):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -128,10 +128,17 @@ class TestCommonSchemas:
 
 class TestGenerateSchemas:
     def test_generate_request_defaults(self):
-        req = GenerateRequest(model="test")
-        assert req.prompt == ""
+        req = GenerateRequest(model="test", prompt="hi")
         assert req.stream is True
         assert req.raw is False
+
+    def test_generate_request_requires_prompt(self):
+        with pytest.raises(ValidationError, match="prompt"):
+            GenerateRequest(model="test")
+
+    def test_generate_request_rejects_empty_prompt(self):
+        with pytest.raises(ValidationError, match="prompt"):
+            GenerateRequest(model="test", prompt="")
 
     def test_generate_response(self):
         resp = GenerateResponse(

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -324,6 +324,18 @@ class TestOpenAISchemas:
         req = OpenAICompletionRequest(model="test", prompt="hello")
         assert req.stream is False
 
+    def test_completion_request_rejects_empty_prompt_string(self):
+        with pytest.raises(ValidationError, match="prompt"):
+            OpenAICompletionRequest(model="test", prompt="")
+
+    def test_completion_request_rejects_empty_prompt_list(self):
+        with pytest.raises(ValidationError, match="prompt"):
+            OpenAICompletionRequest(model="test", prompt=[])
+
+    def test_completion_request_rejects_list_with_empty_string(self):
+        with pytest.raises(ValidationError, match="prompt"):
+            OpenAICompletionRequest(model="test", prompt=["hello", ""])
+
     def test_completion_response(self):
         resp = OpenAICompletionResponse(
             id="test",

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -171,6 +171,10 @@ class TestChatSchemas:
         )
         assert resp.done is True
 
+    def test_chat_request_rejects_empty_messages(self):
+        with pytest.raises(ValidationError, match="messages"):
+            ChatRequest(model="test", messages=[])
+
 
 class TestModelSchemas:
     def test_model_details_defaults(self):
@@ -215,6 +219,22 @@ class TestEmbedSchemas:
     def test_embeddings_request(self):
         req = EmbeddingsRequest(model="test", prompt="hello")
         assert req.prompt == "hello"
+
+    def test_embed_request_rejects_empty_string(self):
+        with pytest.raises(ValidationError, match="input"):
+            EmbedRequest(model="test", input="")
+
+    def test_embed_request_rejects_empty_list(self):
+        with pytest.raises(ValidationError, match="input"):
+            EmbedRequest(model="test", input=[])
+
+    def test_embed_request_rejects_list_with_empty_string(self):
+        with pytest.raises(ValidationError, match="input"):
+            EmbedRequest(model="test", input=["hello", ""])
+
+    def test_embeddings_request_rejects_empty_prompt(self):
+        with pytest.raises(ValidationError, match="prompt"):
+            EmbeddingsRequest(model="test", prompt="")
 
 
 class TestManageSchemas:
@@ -325,6 +345,22 @@ class TestOpenAISchemas:
     def test_embedding_request_string(self):
         req = OpenAIEmbeddingRequest(model="test", input="hello")
         assert req.encoding_format == "float"
+
+    def test_embedding_request_rejects_empty_string(self):
+        with pytest.raises(ValidationError, match="input"):
+            OpenAIEmbeddingRequest(model="test", input="")
+
+    def test_embedding_request_rejects_empty_list(self):
+        with pytest.raises(ValidationError, match="input"):
+            OpenAIEmbeddingRequest(model="test", input=[])
+
+    def test_embedding_request_rejects_list_with_empty_string(self):
+        with pytest.raises(ValidationError, match="input"):
+            OpenAIEmbeddingRequest(model="test", input=["hello", ""])
+
+    def test_chat_request_rejects_empty_messages(self):
+        with pytest.raises(ValidationError, match="messages"):
+            OpenAIChatRequest(model="test", messages=[])
 
     def test_embedding_response(self):
         resp = OpenAIEmbeddingResponse(
@@ -579,6 +615,10 @@ class TestAnthropicSchemas:
                 messages=[AnthropicMessage(role="user", content="hi")],
                 max_tokens=0,
             )
+
+    def test_messages_request_rejects_empty_messages(self):
+        with pytest.raises(ValidationError, match="messages"):
+            AnthropicMessagesRequest(model="test", messages=[])
 
     def test_usage(self):
         u = AnthropicUsage()


### PR DESCRIPTION
## Summary

Rejects empty input at the pydantic schema boundary across the embedding, completion, chat-completion, generate, and messages endpoints. Closes the gaps where empty values leaked raw MLX errors (`[gather] Got indices with invalid dtype`) or crashed as 500 server_errors (`list index out of range`, `IndexError` on `req.prompt[0]`) — both of which cause clients to retry on what should be permanent client errors.

Endpoints/fields newly validated:
- `OpenAIEmbeddingRequest.input` and `EmbedRequest.input` (`""`, `[]`, lists containing `""`)
- `EmbeddingsRequest.prompt` (Ollama legacy single-string)
- `OpenAICompletionRequest.prompt` (str + list[str])
- `OpenAIChatRequest.messages`, `ChatRequest.messages`, `AnthropicMessagesRequest.messages`
- `GenerateRequest.prompt` — see breaking change below

Shared helper `validate_non_empty_text_input(v, field_name)` lives in `olmlx/schemas/common.py` with `@overload` for clean str/list[str] narrowing.

## Breaking change

`GenerateRequest.prompt` is now required (previously defaulted to `""`). The default was nominally for Ollama's context-only continuation feature, but `req.context` is never wired through to the inference engine, so the default served no functional purpose — it just allowed empty input to leak the same MLX error. Matches Ollama's spec, which lists `prompt` as required. Callers that omitted `prompt` will now get 422 with `"prompt: field required"`.

## Status code

422 (FastAPI default for pydantic `ValidationError`) — the issue titles say "400" but 422 is the correct semantic ("Unprocessable Entity": syntactically valid JSON failing validation), and matches the existing schema validators in these files (`max_tokens=0`, `temperature=-0.1`, etc.).

## Test plan

- [x] Schema-level rejection tests in `test_schemas.py` for every new validator
- [x] HTTP-level tests in `test_routers_{embed,chat,openai,anthropic,generate}.py` asserting 422 + field name + "empty" in body
- [x] Full unit suite: `uv run pytest --ignore=tests/integration` → 2625 passed, 4 skipped
- [x] `ruff check`, `ruff format --check`, `pyright` clean on touched files

Closes #311
Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)