### PR TITLE
feat(bench): wire quality grading + thinking toggle into bench runner

### DIFF
--- a/olmlx/bench/results.py
+++ b/olmlx/bench/results.py
@@ -139,6 +139,15 @@ class RunResult:
     git_sha: str | None
     scenarios: list[ScenarioResult]
     max_tokens_override: int | None = None
+    # Which prompt set was run (throughput / quality / all). None means the
+    # run predates this field — load it as a legacy throughput run rather
+    # than fail to parse.
+    prompt_set: str | None = None
+    # Bench-level env knobs captured at run time so an A/B (e.g. think on
+    # vs off) is self-describing from the saved JSON alone. Scenario-level
+    # ``env_overrides`` cover the per-scenario knobs that the runner sets;
+    # this captures the operator-set, runner-wide ones.
+    bench_env: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
@@ -146,6 +155,8 @@ class RunResult:
             "timestamp": self.timestamp,
             "git_sha": self.git_sha,
             "max_tokens_override": self.max_tokens_override,
+            "prompt_set": self.prompt_set,
+            "bench_env": self.bench_env,
             "scenarios": [s.to_dict() for s in self.scenarios],
         }
 
@@ -156,6 +167,8 @@ class RunResult:
             timestamp=d["timestamp"],
             git_sha=d.get("git_sha"),
             max_tokens_override=d.get("max_tokens_override"),
+            prompt_set=d.get("prompt_set"),
+            bench_env=dict(d.get("bench_env") or {}),
             scenarios=[ScenarioResult.from_dict(s) for s in d.get("scenarios", [])],
         )
 
@@ -300,6 +313,8 @@ def create_run_result(
     model: str,
     scenarios: list[ScenarioResult],
     max_tokens_override: int | None = None,
+    prompt_set: str | None = None,
+    bench_env: dict[str, str] | None = None,
 ) -> RunResult:
     return RunResult(
         model=model,
@@ -307,6 +322,8 @@ def create_run_result(
         git_sha=_git_sha(),
         scenarios=scenarios,
         max_tokens_override=max_tokens_override,
+        prompt_set=prompt_set,
+        bench_env=dict(bench_env or {}),
     )
 
 

--- a/olmlx/bench/results.py
+++ b/olmlx/bench/results.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+from olmlx.bench.quality import QualityResult
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_BENCH_DIR = Path.home() / ".olmlx" / "bench" / "runs"
@@ -26,6 +28,10 @@ class PromptResult:
     prompt_eval_count: int = 0
     prompt_eval_duration_ns: int = 0
     total_duration_ns: int = 0
+    # Quality grading (populated in the parent after the worker returns;
+    # None for pure-throughput prompts that carry no grader).
+    grader: str | None = None
+    quality: QualityResult | None = None
 
     @property
     def tokens_per_second(self) -> float:
@@ -53,10 +59,13 @@ class PromptResult:
             "total_duration_ns": self.total_duration_ns,
             "tokens_per_second": round(self.tokens_per_second, 2),
             "prompt_tokens_per_second": round(self.prompt_tokens_per_second, 2),
+            "grader": self.grader,
+            "quality": self.quality.to_dict() if self.quality else None,
         }
 
     @classmethod
     def from_dict(cls, d: dict) -> PromptResult:
+        quality = d.get("quality")
         return cls(
             prompt_name=d["prompt_name"],
             category=d["category"],
@@ -68,6 +77,8 @@ class PromptResult:
             prompt_eval_count=d.get("prompt_eval_count", 0),
             prompt_eval_duration_ns=d.get("prompt_eval_duration_ns", 0),
             total_duration_ns=d.get("total_duration_ns", 0),
+            grader=d.get("grader"),
+            quality=QualityResult.from_dict(quality) if quality else None,
         )
 
 
@@ -79,6 +90,23 @@ class ScenarioResult:
     prompt_results: list[PromptResult]
     skipped: bool = False
     skip_reason: str | None = None
+
+    def quality_summary(self) -> tuple[int, int]:
+        """Return (passed, graded_total) across this scenario's prompts.
+
+        Only prompts whose grader returned a definite verdict
+        (``quality.passed is not None``) count toward the total — ungraded,
+        disabled, or grader-errored prompts are excluded so a skipped grader
+        never drags the reported pass rate down.
+        """
+        passed = 0
+        graded = 0
+        for r in self.prompt_results:
+            if r.quality is not None and r.quality.passed is not None:
+                graded += 1
+                if r.quality.passed:
+                    passed += 1
+        return passed, graded
 
     def to_dict(self) -> dict:
         return {

--- a/olmlx/bench/runner.py
+++ b/olmlx/bench/runner.py
@@ -169,8 +169,13 @@ def apply_graders(
         expected = dict(prompt.get("expected") or {})
         if grader_name == "code_exec" and enable_code_exec:
             expected["_enabled"] = True
+        # Compute first, assign together — if ``grade`` ever raises (its
+        # current contract says it can't), the exception propagates with
+        # ``r.grader`` and ``r.quality`` both still ``None``, preserving
+        # the documented invariant against a future regression.
+        quality = grade(grader_name, r.output_text, expected)
         r.grader = grader_name
-        r.quality = grade(grader_name, r.output_text, expected)
+        r.quality = quality
 
 
 def _find_free_port() -> int:
@@ -400,7 +405,7 @@ def _run_worker(
                     category="error",
                     output_text="",
                     status_code=0,
-                    error=f"Worker timed out after {worker_timeout}s",
+                    error=f"Worker timed out after {worker_timeout:.0f}s",
                 )
             ]
 

--- a/olmlx/bench/runner.py
+++ b/olmlx/bench/runner.py
@@ -187,6 +187,9 @@ def run_bench(
     scenarios = get_scenarios(scenario_names)
     model_path = _resolve_model_path(model)
     prompts_data = [p.to_dict() for p in build_prompts(prompt_set)]
+    # Log the resolved worker timeout once so a post-hoc "why did my run
+    # get killed" investigation has a record of what limit was in effect.
+    logger.info("Bench worker timeout: %.0fs", _worker_timeout())
 
     scenario_results: list[ScenarioResult] = []
 

--- a/olmlx/bench/runner.py
+++ b/olmlx/bench/runner.py
@@ -47,6 +47,11 @@ def _capture_bench_env() -> dict[str, str]:
     back to engine default) does **not** land in the saved JSON, so an
     operator reading the run record can trust that what's there reflects
     the run that happened.
+
+    Maintenance: when adding a new experiment-defining env var, extend
+    this function explicitly. The enumeration is deliberately not
+    pattern-based (no ``OLMLX_BENCH_*`` glob) so operational variables
+    aren't accidentally promoted to the experiment record.
     """
     from olmlx.bench.worker import is_recognized_think_value
 
@@ -114,6 +119,18 @@ def build_prompts(prompt_set: str) -> list[BenchPrompt]:
     from olmlx.bench.task_prompts import PROMPT_SETS
 
     graded = [p for sets in PROMPT_SETS.values() for p in sets]
+    # Same collision rationale as the ``all`` branch below, but within the
+    # graded set itself — if two entries across the GSM8K / MMLU / HumanEval
+    # sub-sets ever share a name, ``apply_graders``'s ``by_name`` dict
+    # silently keeps the last and mis-grades the first matching result.
+    graded_dupes = sorted(
+        n for n, c in Counter(p.name for p in graded).items() if c > 1
+    )
+    if graded_dupes:
+        raise ValueError(
+            f"Duplicate prompt names within quality set: {graded_dupes!r}. "
+            f"Rename to keep prompt names unique."
+        )
     if prompt_set == "quality":
         return graded
     if prompt_set == "all":
@@ -264,6 +281,18 @@ def run_bench(
     # from the same single read of ``OLMLX_BENCH_WORKER_TIMEOUT``.
     worker_timeout = _worker_timeout()
     logger.info("Bench worker timeout: %.0fs", worker_timeout)
+    # If think is being toggled while running ``--prompt-set all``, the
+    # throughput probes run in think mode too. The summary line later
+    # combines tok/s and quality, but the tok/s figure won't be a
+    # standard baseline comparable to a non-think throughput run; warn
+    # so the operator doesn't misread.
+    if prompt_set == "all" and os.environ.get("OLMLX_BENCH_THINK"):
+        print(
+            "  note: OLMLX_BENCH_THINK is set with --prompt-set all — throughput "
+            "probes also run in thinking mode, so the tok/s figure is not a "
+            "standard baseline.",
+            file=sys.stderr,
+        )
 
     scenario_results: list[ScenarioResult] = []
 

--- a/olmlx/bench/runner.py
+++ b/olmlx/bench/runner.py
@@ -16,7 +16,7 @@ import urllib.request
 from pathlib import Path
 
 from olmlx.bench.prompts import PROMPTS, BenchPrompt
-from olmlx.bench.quality import grade
+from olmlx.bench.quality import QualityResult, grade
 from olmlx.bench.results import (
     DEFAULT_BENCH_DIR,
     PromptResult,
@@ -116,15 +116,16 @@ def build_prompts(prompt_set: str) -> list[BenchPrompt]:
     if prompt_set == "quality":
         return graded
     if prompt_set == "all":
+        from collections import Counter
+
         combined = list(PROMPTS) + graded
         # apply_graders joins PromptResult → prompt by name. A duplicate
         # name across throughput and graded sets would silently grade a
         # throughput result against the colliding graded prompt's grader.
         # Catch the collision here, at construction, rather than letting it
         # slip through into a saved run.
-        names = [p.name for p in combined]
-        if len(names) != len(set(names)):
-            dupes = sorted({n for n in names if names.count(n) > 1})
+        dupes = sorted(n for n, c in Counter(p.name for p in combined).items() if c > 1)
+        if dupes:
             raise ValueError(
                 f"Duplicate prompt names across throughput + quality sets: "
                 f"{dupes!r}. Rename to keep prompt names unique."
@@ -139,7 +140,7 @@ def apply_graders(
     results: list[PromptResult],
     prompts: list[dict],
     enable_code_exec: bool,
-) -> None:
+) -> dict[str, int]:
     """Grade prompt results in place against their prompt metadata.
 
     Graders are pure functions run here in the parent (the worker only
@@ -159,12 +160,24 @@ def apply_graders(
     ``enable_code_exec`` is set, signalled to the grader via a private
     ``_enabled`` flag injected into a *copy* of the expected payload (the
     caller's dict is never mutated).
+
+    ``prompts`` is a list of dicts (not ``BenchPrompt`` objects) because
+    the same list is what gets JSON-serialised and shipped to the worker
+    subprocess — keeping a single representation avoids parallel state.
+
+    Returns a stats dict: ``{"code_exec_excluded": N}`` where N counts
+    prompts that hit the ``code_exec`` grader while
+    ``enable_code_exec=False``. The runner uses this for the
+    "pass --enable-code-exec" notice rather than re-inferring the count
+    from ``r.quality.passed is None``, which would also match grader
+    exceptions or other future ``passed=None`` paths.
     """
     # Only graded prompts can match — excluding ungraded throughput
     # prompts from the lookup avoids a last-wins collision in the dict
     # comprehension if a graded and an ungraded prompt ever share a name
     # under ``--prompt-set all``.
     by_name = {p["name"]: p for p in prompts if p.get("grader")}
+    stats = {"code_exec_excluded": 0}
     for r in results:
         prompt = by_name.get(r.prompt_name)
         if prompt is None:
@@ -173,15 +186,34 @@ def apply_graders(
             continue
         grader_name = prompt["grader"]
         expected = dict(prompt.get("expected") or {})
-        if grader_name == "code_exec" and enable_code_exec:
-            expected["_enabled"] = True
-        # Compute first, assign together — if ``grade`` ever raises (its
-        # current contract says it can't), the exception propagates with
-        # ``r.grader`` and ``r.quality`` both still ``None``, preserving
-        # the documented invariant against a future regression.
-        quality = grade(grader_name, r.output_text, expected)
+        if grader_name == "code_exec":
+            if enable_code_exec:
+                expected["_enabled"] = True
+            else:
+                stats["code_exec_excluded"] += 1
+        # Wrap defensively: ``grade`` is contracted not to raise (it has
+        # its own ``except Exception`` returning ``passed=None``), but a
+        # future regression there shouldn't abort a long graded run mid-way
+        # and lose every result accumulated so far. The fallback preserves
+        # the ``r.grader ⇔ r.quality`` invariant.
+        try:
+            quality = grade(grader_name, r.output_text, expected)
+        except Exception as exc:  # belt-and-suspenders, not the live path
+            logger.warning(
+                "Grader %r raised on prompt %r: %s",
+                grader_name,
+                r.prompt_name,
+                exc,
+            )
+            quality = QualityResult(
+                grader=grader_name,
+                passed=None,
+                score=None,
+                detail=f"apply_graders caught: {exc!r}",
+            )
         r.grader = grader_name
         r.quality = quality
+    return stats
 
 
 def _find_free_port() -> int:
@@ -256,7 +288,7 @@ def run_bench(
             )
 
         # Grade in the parent (the worker only returns raw output_text).
-        apply_graders(prompt_results, prompts_data, enable_code_exec)
+        grade_stats = apply_graders(prompt_results, prompts_data, enable_code_exec)
 
         sc_result = ScenarioResult(
             scenario_name=scenario.name,
@@ -287,28 +319,16 @@ def run_bench(
         # Surface code_exec exclusion explicitly — otherwise an operator
         # who omits ``--enable-code-exec`` sees e.g. ``quality 20/40``
         # without realising 10 HumanEval prompts were excluded from the
-        # denominator. Counts results where the grader ran but returned
-        # passed=None. Gated on ``enable_code_exec=False`` so this only
-        # triggers in the actually-disabled case: under that gate
-        # ``grade_code_exec`` returns its disabled sentinel without
-        # executing anything, so the grade()-level exception path
-        # (also passed=None) is unreachable for code_exec here. A
-        # passed=None code_exec result we see here is therefore the
-        # disabled path, not a crashing grader.
-        if not enable_code_exec:
-            excluded = sum(
-                1
-                for r in prompt_results
-                if r.grader == "code_exec"
-                and r.quality is not None
-                and r.quality.passed is None
+        # denominator. The count comes directly from apply_graders so it
+        # can't be confused with grader exceptions or any other future
+        # ``passed=None`` path.
+        excluded = grade_stats["code_exec_excluded"]
+        if excluded:
+            print(
+                f"  ({excluded} code_exec prompts excluded — pass "
+                "--enable-code-exec to grade them)",
+                file=sys.stderr,
             )
-            if excluded:
-                print(
-                    f"  ({excluded} code_exec prompts excluded — pass "
-                    "--enable-code-exec to grade them)",
-                    file=sys.stderr,
-                )
 
         scenario_results.append(sc_result)
 

--- a/olmlx/bench/runner.py
+++ b/olmlx/bench/runner.py
@@ -33,9 +33,11 @@ logger = logging.getLogger(__name__)
 
 
 # Bench-level env vars worth recording in the saved run. Limited to the
-# operator-facing toggles so the saved JSON stays a clean record of the
-# A/B variable(s) without dragging in unrelated process environment.
-_RECORDED_BENCH_ENV = ("OLMLX_BENCH_THINK", "OLMLX_BENCH_WORKER_TIMEOUT")
+# experiment-defining toggles so a saved run's ``bench_env`` is a clean
+# record of the A/B variable(s). Operational knobs like the worker kill
+# timeout are intentionally excluded — they don't change how to interpret
+# the result and are logged separately at run start.
+_RECORDED_BENCH_ENV = ("OLMLX_BENCH_THINK",)
 
 
 def _capture_bench_env() -> dict[str, str]:
@@ -108,7 +110,20 @@ def build_prompts(prompt_set: str) -> list[BenchPrompt]:
     if prompt_set == "quality":
         return graded
     if prompt_set == "all":
-        return list(PROMPTS) + graded
+        combined = list(PROMPTS) + graded
+        # apply_graders joins PromptResult → prompt by name. A duplicate
+        # name across throughput and graded sets would silently grade a
+        # throughput result against the colliding graded prompt's grader.
+        # Catch the collision here, at construction, rather than letting it
+        # slip through into a saved run.
+        names = [p.name for p in combined]
+        if len(names) != len(set(names)):
+            dupes = sorted({n for n in names if names.count(n) > 1})
+            raise ValueError(
+                f"Duplicate prompt names across throughput + quality sets: "
+                f"{dupes!r}. Rename to keep prompt names unique."
+            )
+        return combined
     raise ValueError(
         f"Unknown prompt set {prompt_set!r}. Available: throughput, quality, all"
     )
@@ -139,16 +154,18 @@ def apply_graders(
     ``_enabled`` flag injected into a *copy* of the expected payload (the
     caller's dict is never mutated).
     """
-    by_name = {p["name"]: p for p in prompts}
+    # Only graded prompts can match — excluding ungraded throughput
+    # prompts from the lookup avoids a last-wins collision in the dict
+    # comprehension if a graded and an ungraded prompt ever share a name
+    # under ``--prompt-set all``.
+    by_name = {p["name"]: p for p in prompts if p.get("grader")}
     for r in results:
         prompt = by_name.get(r.prompt_name)
         if prompt is None:
             continue
-        grader_name = prompt.get("grader")
-        if not grader_name:
-            continue
         if r.status_code != 200:
             continue
+        grader_name = prompt["grader"]
         expected = dict(prompt.get("expected") or {})
         if grader_name == "code_exec" and enable_code_exec:
             expected["_enabled"] = True
@@ -187,9 +204,11 @@ def run_bench(
     scenarios = get_scenarios(scenario_names)
     model_path = _resolve_model_path(model)
     prompts_data = [p.to_dict() for p in build_prompts(prompt_set)]
-    # Log the resolved worker timeout once so a post-hoc "why did my run
-    # get killed" investigation has a record of what limit was in effect.
-    logger.info("Bench worker timeout: %.0fs", _worker_timeout())
+    # Resolve the worker timeout once so the value logged and the value
+    # actually passed to ``subprocess.run`` can never diverge — both come
+    # from the same single read of ``OLMLX_BENCH_WORKER_TIMEOUT``.
+    worker_timeout = _worker_timeout()
+    logger.info("Bench worker timeout: %.0fs", worker_timeout)
 
     scenario_results: list[ScenarioResult] = []
 
@@ -221,7 +240,9 @@ def run_bench(
                 model, scenario, prompts_data, max_tokens
             )
         else:
-            prompt_results = _run_worker(model, scenario, prompts_data, max_tokens)
+            prompt_results = _run_worker(
+                model, scenario, prompts_data, max_tokens, worker_timeout
+            )
 
         # Grade in the parent (the worker only returns raw output_text).
         apply_graders(prompt_results, prompts_data, enable_code_exec)
@@ -252,6 +273,25 @@ def run_bench(
             f"avg {avg_tps:.1f} tok/s{quality_str}",
             file=sys.stderr,
         )
+        # Surface code_exec exclusion explicitly — otherwise an operator
+        # who omits ``--enable-code-exec`` sees e.g. ``quality 20/40``
+        # without realising 10 HumanEval prompts were excluded from the
+        # denominator. Counts results where the grader ran but returned
+        # passed=None, which is the disabled-code_exec signature.
+        if not enable_code_exec:
+            excluded = sum(
+                1
+                for r in prompt_results
+                if r.grader == "code_exec"
+                and r.quality is not None
+                and r.quality.passed is None
+            )
+            if excluded:
+                print(
+                    f"  ({excluded} code_exec prompts excluded — pass "
+                    "--enable-code-exec to grade them)",
+                    file=sys.stderr,
+                )
 
         scenario_results.append(sc_result)
 
@@ -285,6 +325,7 @@ def _run_worker(
     scenario: Scenario,
     prompts_data: list[dict],
     max_tokens: int | None,
+    worker_timeout: float,
 ) -> list[PromptResult]:
     """Spawn a subprocess for a single scenario and collect results."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -313,7 +354,6 @@ def _run_worker(
         if max_tokens is not None:
             cmd.extend(["--max-tokens", str(max_tokens)])
 
-        worker_timeout = _worker_timeout()
         try:
             result = subprocess.run(
                 cmd,

--- a/olmlx/bench/runner.py
+++ b/olmlx/bench/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import socket
 import subprocess
@@ -47,6 +48,9 @@ def _capture_bench_env() -> dict[str, str]:
     return captured
 
 
+_DEFAULT_WORKER_TIMEOUT = 600.0
+
+
 def _worker_timeout() -> float:
     """Per-scenario worker kill timeout, in seconds.
 
@@ -54,13 +58,35 @@ def _worker_timeout() -> float:
     quality set (especially with thinking on and a high ``--max-tokens``)
     can run much longer, so it is overridable via
     ``OLMLX_BENCH_WORKER_TIMEOUT`` rather than hard-failing a long graded run.
+
+    Rejects ``inf`` / ``nan`` (these would silently disable the kill switch
+    in ``subprocess.run``) and warns on unparseable values so an ignored
+    override is diagnosable instead of vanishing into the default.
     """
     raw = os.environ.get("OLMLX_BENCH_WORKER_TIMEOUT", "")
+    if not raw:
+        return _DEFAULT_WORKER_TIMEOUT
     try:
         value = float(raw)
     except ValueError:
-        return 600.0
-    return value if value > 0 else 600.0
+        logger.warning(
+            "Ignoring OLMLX_BENCH_WORKER_TIMEOUT=%r: not a number; using %.0fs",
+            raw,
+            _DEFAULT_WORKER_TIMEOUT,
+        )
+        return _DEFAULT_WORKER_TIMEOUT
+    # math.isfinite covers inf, -inf, and nan in one call. Negative or zero
+    # values fall through to the same warning rather than silently flipping
+    # to the default with no diagnostic.
+    if not math.isfinite(value) or value <= 0:
+        logger.warning(
+            "Ignoring OLMLX_BENCH_WORKER_TIMEOUT=%r: must be a positive finite "
+            "number; using %.0fs",
+            raw,
+            _DEFAULT_WORKER_TIMEOUT,
+        )
+        return _DEFAULT_WORKER_TIMEOUT
+    return value
 
 
 def build_prompts(prompt_set: str) -> list[BenchPrompt]:
@@ -69,12 +95,16 @@ def build_prompts(prompt_set: str) -> list[BenchPrompt]:
     - ``throughput``: the 7 ungraded throughput probes (tok/s only).
     - ``quality``: GSM8K + MMLU + HumanEval mini-sets (all graded).
     - ``all``: throughput probes followed by the graded sets.
+
+    The throughput path returns before importing ``task_prompts`` so a
+    plain ``olmlx bench run`` doesn't construct the ~50 graded prompts.
     """
+    if prompt_set == "throughput":
+        return list(PROMPTS)
+
     from olmlx.bench.task_prompts import PROMPT_SETS
 
     graded = [p for sets in PROMPT_SETS.values() for p in sets]
-    if prompt_set == "throughput":
-        return list(PROMPTS)
     if prompt_set == "quality":
         return graded
     if prompt_set == "all":
@@ -93,13 +123,21 @@ def apply_graders(
 
     Graders are pure functions run here in the parent (the worker only
     produces ``output_text``). Only successful (HTTP 200) responses to
-    prompts that carry a grader are scored; everything else is left
-    ungraded — both ``r.grader`` and ``r.quality`` stay ``None`` so the
-    pair maintains the invariant ``r.grader is not None ⇔ r.quality is
-    not None``. ``code_exec`` runs untrusted model code, so it stays
-    disabled unless ``enable_code_exec`` is set, signalled to the grader
-    via a private ``_enabled`` flag injected into a *copy* of the expected
-    payload (the caller's dict is never mutated).
+    prompts that carry a grader are scored; non-200 responses and prompts
+    without a grader leave ``r.grader`` and ``r.quality`` untouched (both
+    stay ``None``). The pair always satisfies ``r.grader is not None ⇔
+    r.quality is not None``.
+
+    A grader that runs may still return ``passed=None`` to signal "no
+    verdict reached" — e.g. ``code_exec`` when ``enable_code_exec`` is
+    false. That is a graded verdict, distinct from never having run a
+    grader at all; ``ScenarioResult.quality_summary`` excludes both from
+    its passed/total tally.
+
+    ``code_exec`` runs untrusted model code, so it stays disabled unless
+    ``enable_code_exec`` is set, signalled to the grader via a private
+    ``_enabled`` flag injected into a *copy* of the expected payload (the
+    caller's dict is never mutated).
     """
     by_name = {p["name"]: p for p in prompts}
     for r in results:

--- a/olmlx/bench/runner.py
+++ b/olmlx/bench/runner.py
@@ -32,21 +32,27 @@ from olmlx.bench.scenarios import Scenario, get_scenarios
 logger = logging.getLogger(__name__)
 
 
-# Bench-level env vars worth recording in the saved run. Limited to the
-# experiment-defining toggles so a saved run's ``bench_env`` is a clean
-# record of the A/B variable(s). Operational knobs like the worker kill
-# timeout are intentionally excluded — they don't change how to interpret
-# the result and are logged separately at run start.
-_RECORDED_BENCH_ENV = ("OLMLX_BENCH_THINK",)
-
-
 def _capture_bench_env() -> dict[str, str]:
-    """Capture the bench-relevant env knobs set when ``run_bench`` was called."""
+    """Capture the bench-relevant env knobs set when ``run_bench`` was called.
+
+    Limited to the experiment-defining toggles so a saved run's
+    ``bench_env`` is a clean record of the A/B variable(s). Operational
+    knobs like the worker kill timeout are intentionally excluded — they
+    don't change how to interpret the result and are logged separately at
+    run start.
+
+    Only records values the worker will actually honour — a typo'd
+    ``OLMLX_BENCH_THINK=tru`` (which the worker warns about and falls
+    back to engine default) does **not** land in the saved JSON, so an
+    operator reading the run record can trust that what's there reflects
+    the run that happened.
+    """
+    from olmlx.bench.worker import is_recognized_think_value
+
     captured: dict[str, str] = {}
-    for key in _RECORDED_BENCH_ENV:
-        value = os.environ.get(key)
-        if value is not None and value != "":
-            captured[key] = value
+    think_raw = os.environ.get("OLMLX_BENCH_THINK", "")
+    if think_raw and is_recognized_think_value(think_raw):
+        captured["OLMLX_BENCH_THINK"] = think_raw
     return captured
 
 
@@ -282,7 +288,13 @@ def run_bench(
         # who omits ``--enable-code-exec`` sees e.g. ``quality 20/40``
         # without realising 10 HumanEval prompts were excluded from the
         # denominator. Counts results where the grader ran but returned
-        # passed=None, which is the disabled-code_exec signature.
+        # passed=None. Gated on ``enable_code_exec=False`` so this only
+        # triggers in the actually-disabled case: under that gate
+        # ``grade_code_exec`` returns its disabled sentinel without
+        # executing anything, so the grade()-level exception path
+        # (also passed=None) is unreachable for code_exec here. A
+        # passed=None code_exec result we see here is therefore the
+        # disabled path, not a crashing grader.
         if not enable_code_exec:
             excluded = sum(
                 1

--- a/olmlx/bench/runner.py
+++ b/olmlx/bench/runner.py
@@ -31,6 +31,22 @@ from olmlx.bench.scenarios import Scenario, get_scenarios
 logger = logging.getLogger(__name__)
 
 
+# Bench-level env vars worth recording in the saved run. Limited to the
+# operator-facing toggles so the saved JSON stays a clean record of the
+# A/B variable(s) without dragging in unrelated process environment.
+_RECORDED_BENCH_ENV = ("OLMLX_BENCH_THINK", "OLMLX_BENCH_WORKER_TIMEOUT")
+
+
+def _capture_bench_env() -> dict[str, str]:
+    """Capture the bench-relevant env knobs set when ``run_bench`` was called."""
+    captured: dict[str, str] = {}
+    for key in _RECORDED_BENCH_ENV:
+        value = os.environ.get(key)
+        if value is not None and value != "":
+            captured[key] = value
+    return captured
+
+
 def _worker_timeout() -> float:
     """Per-scenario worker kill timeout, in seconds.
 
@@ -78,10 +94,12 @@ def apply_graders(
     Graders are pure functions run here in the parent (the worker only
     produces ``output_text``). Only successful (HTTP 200) responses to
     prompts that carry a grader are scored; everything else is left
-    ungraded. ``code_exec`` runs untrusted model code, so it stays disabled
-    unless ``enable_code_exec`` is set, signalled to the grader via a private
-    ``_enabled`` flag injected into a *copy* of the expected payload (the
-    caller's dict is never mutated).
+    ungraded — both ``r.grader`` and ``r.quality`` stay ``None`` so the
+    pair maintains the invariant ``r.grader is not None ⇔ r.quality is
+    not None``. ``code_exec`` runs untrusted model code, so it stays
+    disabled unless ``enable_code_exec`` is set, signalled to the grader
+    via a private ``_enabled`` flag injected into a *copy* of the expected
+    payload (the caller's dict is never mutated).
     """
     by_name = {p["name"]: p for p in prompts}
     for r in results:
@@ -91,12 +109,12 @@ def apply_graders(
         grader_name = prompt.get("grader")
         if not grader_name:
             continue
-        r.grader = grader_name
         if r.status_code != 200:
             continue
         expected = dict(prompt.get("expected") or {})
         if grader_name == "code_exec" and enable_code_exec:
             expected["_enabled"] = True
+        r.grader = grader_name
         r.quality = grade(grader_name, r.output_text, expected)
 
 
@@ -200,6 +218,8 @@ def run_bench(
         model=model,
         scenarios=scenario_results,
         max_tokens_override=max_tokens,
+        prompt_set=prompt_set,
+        bench_env=_capture_bench_env(),
     )
     run_dir = save_run(run, bench_dir)
     print(f"\nResults saved to {run_dir}", file=sys.stderr)

--- a/olmlx/bench/runner.py
+++ b/olmlx/bench/runner.py
@@ -13,6 +13,7 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
+from collections import Counter
 from pathlib import Path
 
 from olmlx.bench.prompts import PROMPTS, BenchPrompt
@@ -116,8 +117,6 @@ def build_prompts(prompt_set: str) -> list[BenchPrompt]:
     if prompt_set == "quality":
         return graded
     if prompt_set == "all":
-        from collections import Counter
-
         combined = list(PROMPTS) + graded
         # apply_graders joins PromptResult → prompt by name. A duplicate
         # name across throughput and graded sets would silently grade a
@@ -185,12 +184,25 @@ def apply_graders(
         if r.status_code != 200:
             continue
         grader_name = prompt["grader"]
+        # Enforce the code_exec opt-in *here*, not by trusting
+        # ``grade_code_exec`` to look at an ``_enabled`` key. Otherwise
+        # a future refactor of the grader's internal gate (rename, default
+        # change) would silently let untrusted code run with
+        # ``enable_code_exec=False``. Synthesise the disabled verdict and
+        # skip the grader call entirely.
+        if grader_name == "code_exec" and not enable_code_exec:
+            stats["code_exec_excluded"] += 1
+            r.grader = grader_name
+            r.quality = QualityResult(
+                grader="code_exec",
+                passed=None,
+                score=None,
+                detail="code_exec disabled (pass --enable-code-exec)",
+            )
+            continue
         expected = dict(prompt.get("expected") or {})
         if grader_name == "code_exec":
-            if enable_code_exec:
-                expected["_enabled"] = True
-            else:
-                stats["code_exec_excluded"] += 1
+            expected["_enabled"] = True
         # Wrap defensively: ``grade`` is contracted not to raise (it has
         # its own ``except Exception`` returning ``passed=None``), but a
         # future regression there shouldn't abort a long graded run mid-way

--- a/olmlx/bench/runner.py
+++ b/olmlx/bench/runner.py
@@ -14,7 +14,8 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-from olmlx.bench.prompts import PROMPTS
+from olmlx.bench.prompts import PROMPTS, BenchPrompt
+from olmlx.bench.quality import grade
 from olmlx.bench.results import (
     DEFAULT_BENCH_DIR,
     PromptResult,
@@ -29,7 +30,74 @@ from olmlx.bench.scenarios import Scenario, get_scenarios
 
 logger = logging.getLogger(__name__)
 
-_WORKER_TIMEOUT = 600  # seconds before killing a worker subprocess
+
+def _worker_timeout() -> float:
+    """Per-scenario worker kill timeout, in seconds.
+
+    Defaults to 600s — fine for the 7-prompt throughput set. The 50-prompt
+    quality set (especially with thinking on and a high ``--max-tokens``)
+    can run much longer, so it is overridable via
+    ``OLMLX_BENCH_WORKER_TIMEOUT`` rather than hard-failing a long graded run.
+    """
+    raw = os.environ.get("OLMLX_BENCH_WORKER_TIMEOUT", "")
+    try:
+        value = float(raw)
+    except ValueError:
+        return 600.0
+    return value if value > 0 else 600.0
+
+
+def build_prompts(prompt_set: str) -> list[BenchPrompt]:
+    """Resolve a prompt-set name to its list of prompts.
+
+    - ``throughput``: the 7 ungraded throughput probes (tok/s only).
+    - ``quality``: GSM8K + MMLU + HumanEval mini-sets (all graded).
+    - ``all``: throughput probes followed by the graded sets.
+    """
+    from olmlx.bench.task_prompts import PROMPT_SETS
+
+    graded = [p for sets in PROMPT_SETS.values() for p in sets]
+    if prompt_set == "throughput":
+        return list(PROMPTS)
+    if prompt_set == "quality":
+        return graded
+    if prompt_set == "all":
+        return list(PROMPTS) + graded
+    raise ValueError(
+        f"Unknown prompt set {prompt_set!r}. Available: throughput, quality, all"
+    )
+
+
+def apply_graders(
+    results: list[PromptResult],
+    prompts: list[dict],
+    enable_code_exec: bool,
+) -> None:
+    """Grade prompt results in place against their prompt metadata.
+
+    Graders are pure functions run here in the parent (the worker only
+    produces ``output_text``). Only successful (HTTP 200) responses to
+    prompts that carry a grader are scored; everything else is left
+    ungraded. ``code_exec`` runs untrusted model code, so it stays disabled
+    unless ``enable_code_exec`` is set, signalled to the grader via a private
+    ``_enabled`` flag injected into a *copy* of the expected payload (the
+    caller's dict is never mutated).
+    """
+    by_name = {p["name"]: p for p in prompts}
+    for r in results:
+        prompt = by_name.get(r.prompt_name)
+        if prompt is None:
+            continue
+        grader_name = prompt.get("grader")
+        if not grader_name:
+            continue
+        r.grader = grader_name
+        if r.status_code != 200:
+            continue
+        expected = dict(prompt.get("expected") or {})
+        if grader_name == "code_exec" and enable_code_exec:
+            expected["_enabled"] = True
+        r.quality = grade(grader_name, r.output_text, expected)
 
 
 def _find_free_port() -> int:
@@ -56,11 +124,13 @@ def run_bench(
     scenario_names: list[str] | None = None,
     max_tokens: int | None = None,
     bench_dir: Path = DEFAULT_BENCH_DIR,
+    prompt_set: str = "throughput",
+    enable_code_exec: bool = False,
 ) -> RunResult:
     """Run all scenarios and return aggregated results."""
     scenarios = get_scenarios(scenario_names)
     model_path = _resolve_model_path(model)
-    prompts_data = [p.to_dict() for p in PROMPTS]
+    prompts_data = [p.to_dict() for p in build_prompts(prompt_set)]
 
     scenario_results: list[ScenarioResult] = []
 
@@ -94,6 +164,16 @@ def run_bench(
         else:
             prompt_results = _run_worker(model, scenario, prompts_data, max_tokens)
 
+        # Grade in the parent (the worker only returns raw output_text).
+        apply_graders(prompt_results, prompts_data, enable_code_exec)
+
+        sc_result = ScenarioResult(
+            scenario_name=scenario.name,
+            scenario_description=scenario.description,
+            env_overrides=scenario.env_overrides,
+            prompt_results=prompt_results,
+        )
+
         # Report summary
         ok = sum(1 for r in prompt_results if r.status_code == 200)
         fail = len(prompt_results) - ok
@@ -104,19 +184,17 @@ def run_bench(
         if tps_values:
             avg_tps = sum(tps_values) / len(tps_values)
         status = "OK" if fail == 0 else f"{fail} FAILED"
+        passed, graded = sc_result.quality_summary()
+        quality_str = ""
+        if graded:
+            quality_str = f", quality {passed}/{graded} ({passed / graded:.0%})"
         print(
-            f"  {status} — {ok}/{len(prompt_results)} prompts, avg {avg_tps:.1f} tok/s",
+            f"  {status} — {ok}/{len(prompt_results)} prompts, "
+            f"avg {avg_tps:.1f} tok/s{quality_str}",
             file=sys.stderr,
         )
 
-        scenario_results.append(
-            ScenarioResult(
-                scenario_name=scenario.name,
-                scenario_description=scenario.description,
-                env_overrides=scenario.env_overrides,
-                prompt_results=prompt_results,
-            )
-        )
+        scenario_results.append(sc_result)
 
     run = create_run_result(
         model=model,
@@ -174,13 +252,14 @@ def _run_worker(
         if max_tokens is not None:
             cmd.extend(["--max-tokens", str(max_tokens)])
 
+        worker_timeout = _worker_timeout()
         try:
             result = subprocess.run(
                 cmd,
                 env=env,
                 capture_output=True,
                 text=True,
-                timeout=_WORKER_TIMEOUT,
+                timeout=worker_timeout,
             )
             if result.returncode != 0:
                 logger.error(
@@ -220,7 +299,7 @@ def _run_worker(
                     category="error",
                     output_text="",
                     status_code=0,
-                    error=f"Worker timed out after {_WORKER_TIMEOUT}s",
+                    error=f"Worker timed out after {worker_timeout}s",
                 )
             ]
 

--- a/olmlx/bench/worker.py
+++ b/olmlx/bench/worker.py
@@ -46,15 +46,37 @@ def _wait_for_server(port: int, proc: subprocess.Popen, timeout: float) -> bool:
     return False
 
 
+_THINK_TRUE = {"true", "1", "on", "yes"}
+_THINK_FALSE = {"false", "0", "off", "no"}
+
+
+def _resolve_bench_think(env: dict[str, str]) -> bool | None:
+    """Resolve the bench thinking toggle from ``OLMLX_BENCH_THINK``.
+
+    Returns ``True``/``False`` to force the Ollama ``think`` field on/off,
+    or ``None`` to omit it (engine default: think-unless-tools). Lets a bench
+    operator A/B the same model with and without thinking without touching the
+    prompt set. Unrecognized values fall back to the engine default rather than
+    silently picking a side.
+    """
+    raw = env.get("OLMLX_BENCH_THINK", "").strip().lower()
+    if raw in _THINK_TRUE:
+        return True
+    if raw in _THINK_FALSE:
+        return False
+    return None
+
+
 def _run_prompts(
     port: int, model: str, prompts: list[dict], max_tokens_override: int | None
 ) -> list[dict]:
     """Send prompts to a running server over HTTP."""
     url = f"http://127.0.0.1:{port}/api/chat"
+    think = _resolve_bench_think(os.environ)
     results = []
     for prompt in prompts:
         tok_limit = max_tokens_override or prompt.get("max_tokens", 256)
-        body = {
+        body: dict = {
             "model": model,
             "stream": False,
             "messages": prompt["messages"],
@@ -64,6 +86,8 @@ def _run_prompts(
                 "num_predict": tok_limit,
             },
         }
+        if think is not None:
+            body["think"] = think
         try:
             req = urllib.request.Request(
                 url,

--- a/olmlx/bench/worker.py
+++ b/olmlx/bench/worker.py
@@ -50,6 +50,7 @@ def _wait_for_server(port: int, proc: subprocess.Popen, timeout: float) -> bool:
 
 THINK_TRUE = {"true", "1", "on", "yes"}
 THINK_FALSE = {"false", "0", "off", "no"}
+_ALL_THINK_VALUES = THINK_TRUE | THINK_FALSE
 
 
 def is_recognized_think_value(raw: str) -> bool:
@@ -60,7 +61,7 @@ def is_recognized_think_value(raw: str) -> bool:
     ``OLMLX_BENCH_THINK=tru`` would land in the saved A/B JSON as if think
     were toggled, even though the worker fell back to the engine default.
     """
-    return raw.strip().lower() in THINK_TRUE | THINK_FALSE
+    return raw.strip().lower() in _ALL_THINK_VALUES
 
 
 def _resolve_bench_think(env: Mapping[str, str]) -> bool | None:

--- a/olmlx/bench/worker.py
+++ b/olmlx/bench/worker.py
@@ -56,14 +56,28 @@ def _resolve_bench_think(env: dict[str, str]) -> bool | None:
     Returns ``True``/``False`` to force the Ollama ``think`` field on/off,
     or ``None`` to omit it (engine default: think-unless-tools). Lets a bench
     operator A/B the same model with and without thinking without touching the
-    prompt set. Unrecognized values fall back to the engine default rather than
-    silently picking a side.
+    prompt set.
+
+    An unset or empty value resolves to ``None`` quietly (engine default). A
+    *non-empty* unrecognized value (e.g. ``"tru"``, ``"enabled"``) also
+    resolves to ``None`` but warns — otherwise an A/B with a typo on one
+    arm silently runs engine-default on both arms with no signal anything
+    went wrong.
     """
-    raw = env.get("OLMLX_BENCH_THINK", "").strip().lower()
+    raw_str = env.get("OLMLX_BENCH_THINK", "")
+    raw = raw_str.strip().lower()
+    if not raw:
+        return None
     if raw in _THINK_TRUE:
         return True
     if raw in _THINK_FALSE:
         return False
+    logger.warning(
+        "Ignoring OLMLX_BENCH_THINK=%r: expected one of %s; falling back to "
+        "engine default",
+        raw_str,
+        sorted(_THINK_TRUE | _THINK_FALSE),
+    )
     return None
 
 

--- a/olmlx/bench/worker.py
+++ b/olmlx/bench/worker.py
@@ -19,7 +19,9 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -46,11 +48,22 @@ def _wait_for_server(port: int, proc: subprocess.Popen, timeout: float) -> bool:
     return False
 
 
-_THINK_TRUE = {"true", "1", "on", "yes"}
-_THINK_FALSE = {"false", "0", "off", "no"}
+THINK_TRUE = {"true", "1", "on", "yes"}
+THINK_FALSE = {"false", "0", "off", "no"}
 
 
-def _resolve_bench_think(env: dict[str, str]) -> bool | None:
+def is_recognized_think_value(raw: str) -> bool:
+    """Whether ``raw`` parses as a valid ``OLMLX_BENCH_THINK`` value.
+
+    Shared with ``runner._capture_bench_env`` so ``bench_env`` only records
+    values the worker will actually honour — otherwise a typo'd
+    ``OLMLX_BENCH_THINK=tru`` would land in the saved A/B JSON as if think
+    were toggled, even though the worker fell back to the engine default.
+    """
+    return raw.strip().lower() in THINK_TRUE | THINK_FALSE
+
+
+def _resolve_bench_think(env: Mapping[str, str]) -> bool | None:
     """Resolve the bench thinking toggle from ``OLMLX_BENCH_THINK``.
 
     Returns ``True``/``False`` to force the Ollama ``think`` field on/off,
@@ -68,15 +81,15 @@ def _resolve_bench_think(env: dict[str, str]) -> bool | None:
     raw = raw_str.strip().lower()
     if not raw:
         return None
-    if raw in _THINK_TRUE:
+    if raw in THINK_TRUE:
         return True
-    if raw in _THINK_FALSE:
+    if raw in THINK_FALSE:
         return False
     logger.warning(
         "Ignoring OLMLX_BENCH_THINK=%r: expected one of %s; falling back to "
         "engine default",
         raw_str,
-        sorted(_THINK_TRUE | _THINK_FALSE),
+        sorted(THINK_TRUE | THINK_FALSE),
     )
     return None
 
@@ -90,7 +103,7 @@ def _run_prompts(
     results = []
     for prompt in prompts:
         tok_limit = max_tokens_override or prompt.get("max_tokens", 256)
-        body: dict = {
+        body: dict[str, Any] = {
             "model": model,
             "stream": False,
             "messages": prompt["messages"],

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -2213,6 +2213,8 @@ def cmd_bench_run(args):
         scenario_names=scenario_names,
         max_tokens=args.max_tokens,
         bench_dir=bench_dir,
+        prompt_set=args.prompt_set,
+        enable_code_exec=args.enable_code_exec,
     )
 
 
@@ -3340,6 +3342,24 @@ def build_parser() -> argparse.ArgumentParser:
         type=str,
         default=None,
         help="Comma-separated scenario names (default: all)",
+    )
+    bench_run.add_argument(
+        "--prompt-set",
+        choices=["throughput", "quality", "all"],
+        default="throughput",
+        help=(
+            "Which prompts to run: 'throughput' (7 tok/s probes, default), "
+            "'quality' (GSM8K+MMLU+HumanEval graded sets), or 'all'"
+        ),
+    )
+    bench_run.add_argument(
+        "--enable-code-exec",
+        action="store_true",
+        help=(
+            "Run model-generated code for the HumanEval code_exec grader in a "
+            "resource-limited subprocess (off by default; only the local user's "
+            "chosen model produces this code)"
+        ),
     )
     bench_run.add_argument(
         "--bench-dir",

--- a/tests/test_bench_quality_wiring.py
+++ b/tests/test_bench_quality_wiring.py
@@ -1,0 +1,172 @@
+"""Tests for wiring quality graders into the bench runner.
+
+Covers the integration glue (prompt-set selection, grader application,
+quality serialization, scenario aggregation) — the graders themselves are
+tested in test_bench_quality.py.
+"""
+
+from __future__ import annotations
+
+from olmlx.bench.results import PromptResult, ScenarioResult
+from olmlx.bench.runner import apply_graders, build_prompts
+from olmlx.bench.quality import QualityResult
+
+
+class TestBuildPrompts:
+    def test_throughput_set_has_no_graders(self):
+        prompts = build_prompts("throughput")
+        assert len(prompts) == 7
+        assert all(p.grader is None for p in prompts)
+
+    def test_quality_set_is_all_graded(self):
+        prompts = build_prompts("quality")
+        # gsm8k(20) + mmlu(20) + humaneval(10)
+        assert len(prompts) == 50
+        assert all(p.grader is not None for p in prompts)
+
+    def test_all_set_is_union(self):
+        assert len(build_prompts("all")) == 57
+
+    def test_unknown_set_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError):
+            build_prompts("bogus")
+
+
+class TestApplyGraders:
+    def _result(self, name, output, status=200):
+        return PromptResult(
+            prompt_name=name,
+            category="gsm8k",
+            output_text=output,
+            status_code=status,
+        )
+
+    def test_numeric_pass_attaches_quality(self):
+        results = [self._result("p1", "The answer is #### 18")]
+        prompts = [
+            {"name": "p1", "grader": "numeric", "expected": {"answer": 18, "tol": 0.0}}
+        ]
+        apply_graders(results, prompts, enable_code_exec=False)
+        assert results[0].grader == "numeric"
+        assert results[0].quality is not None
+        assert results[0].quality.passed is True
+
+    def test_numeric_fail(self):
+        results = [self._result("p1", "#### 7")]
+        prompts = [
+            {"name": "p1", "grader": "numeric", "expected": {"answer": 18, "tol": 0.0}}
+        ]
+        apply_graders(results, prompts, enable_code_exec=False)
+        assert results[0].quality.passed is False
+
+    def test_ungraded_prompt_left_alone(self):
+        results = [self._result("p1", "anything")]
+        prompts = [{"name": "p1", "grader": None, "expected": {}}]
+        apply_graders(results, prompts, enable_code_exec=False)
+        assert results[0].grader is None
+        assert results[0].quality is None
+
+    def test_non_200_not_graded(self):
+        results = [self._result("p1", "", status=503)]
+        prompts = [{"name": "p1", "grader": "numeric", "expected": {"answer": 18}}]
+        apply_graders(results, prompts, enable_code_exec=False)
+        assert results[0].quality is None
+
+    def test_code_exec_disabled_by_default(self):
+        results = [self._result("p1", "```python\ndef f():\n    return 1\n```")]
+        prompts = [
+            {
+                "name": "p1",
+                "grader": "code_exec",
+                "expected": {
+                    "prompt": "",
+                    "tests": "def check(f):\n    assert f() == 1\n",
+                    "entry_point": "f",
+                },
+            }
+        ]
+        apply_graders(results, prompts, enable_code_exec=False)
+        # Grader runs but returns ungraded (passed=None) when not enabled.
+        assert results[0].quality is not None
+        assert results[0].quality.passed is None
+
+    def test_code_exec_enabled_injects_flag(self):
+        results = [self._result("p1", "```python\ndef f():\n    return 1\n```")]
+        prompts = [
+            {
+                "name": "p1",
+                "grader": "code_exec",
+                "expected": {
+                    "prompt": "",
+                    "tests": "def check(f):\n    assert f() == 1\n",
+                    "entry_point": "f",
+                },
+            }
+        ]
+        apply_graders(results, prompts, enable_code_exec=True)
+        assert results[0].quality.passed is True
+        # Caller's expected dict must not be mutated with the private flag.
+        assert "_enabled" not in prompts[0]["expected"]
+
+
+class TestQualitySerialization:
+    def test_prompt_result_round_trips_quality(self):
+        q = QualityResult(
+            grader="numeric", passed=True, score=1.0, detail="extracted=18"
+        )
+        pr = PromptResult(
+            prompt_name="p1",
+            category="gsm8k",
+            output_text="#### 18",
+            status_code=200,
+            grader="numeric",
+            quality=q,
+        )
+        restored = PromptResult.from_dict(pr.to_dict())
+        assert restored.grader == "numeric"
+        assert restored.quality is not None
+        assert restored.quality.passed is True
+        assert restored.quality.score == 1.0
+
+    def test_prompt_result_without_quality_round_trips(self):
+        pr = PromptResult("p1", "factual", "Paris", 200)
+        restored = PromptResult.from_dict(pr.to_dict())
+        assert restored.quality is None
+        assert restored.grader is None
+
+
+class TestScenarioQualitySummary:
+    def _graded(self, name, passed):
+        return PromptResult(
+            name,
+            "gsm8k",
+            "x",
+            200,
+            grader="numeric",
+            quality=QualityResult("numeric", passed, 1.0 if passed else 0.0, ""),
+        )
+
+    def test_counts_passed_over_graded(self):
+        sc = ScenarioResult(
+            scenario_name="baseline",
+            scenario_description="",
+            env_overrides={},
+            prompt_results=[
+                self._graded("a", True),
+                self._graded("b", False),
+                self._graded("c", True),
+                PromptResult("d", "factual", "x", 200),  # ungraded
+            ],
+        )
+        assert sc.quality_summary() == (2, 3)
+
+    def test_no_graded_prompts_returns_zero_total(self):
+        sc = ScenarioResult(
+            scenario_name="baseline",
+            scenario_description="",
+            env_overrides={},
+            prompt_results=[PromptResult("d", "factual", "x", 200)],
+        )
+        assert sc.quality_summary() == (0, 0)

--- a/tests/test_bench_quality_wiring.py
+++ b/tests/test_bench_quality_wiring.py
@@ -127,6 +127,58 @@ class TestApplyGraders:
         assert results[0].quality is not None
         assert results[0].quality.passed is None
 
+    def test_returns_code_exec_excluded_count(self):
+        # apply_graders should *report* the disabled-code_exec count
+        # directly so the runner doesn't have to re-infer it from
+        # ``passed is None`` (which would also match grader exceptions).
+        prompts = [
+            {
+                "name": "p1",
+                "grader": "code_exec",
+                "expected": {
+                    "prompt": "",
+                    "tests": "",
+                    "entry_point": "f",
+                },
+            },
+            {"name": "p2", "grader": "numeric", "expected": {"answer": 1}},
+        ]
+        results = [
+            self._result("p1", "anything"),
+            self._result("p2", "#### 1"),
+        ]
+        stats = apply_graders(results, prompts, enable_code_exec=False)
+        assert stats == {"code_exec_excluded": 1}
+
+    def test_returns_zero_excluded_when_code_exec_enabled(self, monkeypatch):
+        # Stub grade() so we don't actually spawn a subprocess.
+        monkeypatch.setattr(
+            "olmlx.bench.runner.grade",
+            lambda g, o, e: QualityResult(g, True, 1.0, ""),
+        )
+        prompts = [{"name": "p1", "grader": "code_exec", "expected": {}}]
+        results = [self._result("p1", "x")]
+        stats = apply_graders(results, prompts, enable_code_exec=True)
+        assert stats == {"code_exec_excluded": 0}
+
+    def test_grade_exception_caught_and_logged(self, monkeypatch, caplog):
+        # grade() is contracted not to raise, but a future regression
+        # mustn't abort the whole bench run and lose accumulated results.
+        # The fallback preserves the ``r.grader ⇔ r.quality`` invariant.
+        def boom(grader_name, output, expected):
+            raise RuntimeError("simulated grader regression")
+
+        monkeypatch.setattr("olmlx.bench.runner.grade", boom)
+        prompts = [{"name": "p1", "grader": "numeric", "expected": {"answer": 1}}]
+        results = [self._result("p1", "#### 1")]
+        with caplog.at_level("WARNING", logger="olmlx.bench.runner"):
+            apply_graders(results, prompts, enable_code_exec=False)
+        assert results[0].grader == "numeric"
+        assert results[0].quality is not None
+        assert results[0].quality.passed is None
+        assert "simulated grader regression" in results[0].quality.detail
+        assert any("Grader" in rec.getMessage() for rec in caplog.records)
+
     def test_code_exec_enabled_injects_flag(self, monkeypatch):
         # Verifies the injection contract without actually running a
         # subprocess — the real code_exec execution is covered in
@@ -216,6 +268,32 @@ class TestScenarioQualitySummary:
             prompt_results=[PromptResult("d", "factual", "x", 200)],
         )
         assert sc.quality_summary() == (0, 0)
+
+    def test_indeterminate_graded_excluded_from_tally(self):
+        # Prompts that have a grader + a QualityResult but ``passed is
+        # None`` (e.g. ``code_exec`` when ``enable_code_exec`` is false)
+        # must not count toward the denominator — otherwise the reported
+        # pass rate is dragged down by prompts that were never actually
+        # judged.
+        sc = ScenarioResult(
+            scenario_name="baseline",
+            scenario_description="",
+            env_overrides={},
+            prompt_results=[
+                self._graded("a", True),
+                PromptResult(
+                    "b",
+                    "humaneval",
+                    "x",
+                    200,
+                    grader="code_exec",
+                    quality=QualityResult(
+                        "code_exec", None, None, "code_exec disabled"
+                    ),
+                ),
+            ],
+        )
+        assert sc.quality_summary() == (1, 1)
 
 
 class TestRunResultMetadata:

--- a/tests/test_bench_quality_wiring.py
+++ b/tests/test_bench_quality_wiring.py
@@ -39,6 +39,31 @@ class TestBuildPrompts:
         with pytest.raises(ValueError):
             build_prompts("bogus")
 
+    def test_all_set_currently_has_unique_names(self):
+        # Build succeeds today — no collisions. Catches future regressions
+        # at construction rather than letting them mis-grade a saved run.
+        build_prompts("all")
+
+    def test_all_set_raises_on_duplicate_names(self, monkeypatch):
+        import pytest
+
+        from olmlx.bench.prompts import BenchPrompt
+        from olmlx.bench.task_prompts import PROMPT_SETS
+
+        # Synthesize a collision: pick any real graded prompt name and add
+        # a fake throughput probe with the same name. ``build_prompts`` must
+        # reject the union with a clear error rather than silently shipping
+        # the collision into apply_graders.
+        any_graded_name = next(iter(PROMPT_SETS.values()))[0].name
+        dup = BenchPrompt(
+            name=any_graded_name,
+            category="throughput",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        monkeypatch.setattr("olmlx.bench.runner.PROMPTS", (dup,))
+        with pytest.raises(ValueError, match="Duplicate prompt names"):
+            build_prompts("all")
+
 
 class TestApplyGraders:
     def _result(self, name, output, status=200):
@@ -229,6 +254,26 @@ class TestRunResultMetadata:
         run = RunResult.from_dict(legacy)
         assert run.prompt_set is None
         assert run.bench_env == {}
+
+
+class TestBenchEnvCapture:
+    """``bench_env`` should record only experiment-defining variables, not
+    operational knobs — the timeout is a safety rail that doesn't change
+    how to interpret an A/B result."""
+
+    def test_think_is_captured(self, monkeypatch):
+        from olmlx.bench.runner import _capture_bench_env
+
+        monkeypatch.setenv("OLMLX_BENCH_THINK", "true")
+        assert _capture_bench_env() == {"OLMLX_BENCH_THINK": "true"}
+
+    def test_worker_timeout_is_not_captured(self, monkeypatch):
+        from olmlx.bench.runner import _capture_bench_env
+
+        monkeypatch.setenv("OLMLX_BENCH_WORKER_TIMEOUT", "1800")
+        monkeypatch.delenv("OLMLX_BENCH_THINK", raising=False)
+        # Operational knob, intentionally excluded from the experiment record.
+        assert _capture_bench_env() == {}
 
 
 class TestWorkerTimeout:

--- a/tests/test_bench_quality_wiring.py
+++ b/tests/test_bench_quality_wiring.py
@@ -275,6 +275,22 @@ class TestBenchEnvCapture:
         # Operational knob, intentionally excluded from the experiment record.
         assert _capture_bench_env() == {}
 
+    def test_unrecognized_think_is_not_captured(self, monkeypatch):
+        # A typo'd value (e.g. ``"tru"``) falls back to engine default in
+        # the worker. Recording it in bench_env would imply think was
+        # toggled when the run actually used engine default — defeats the
+        # self-describing-A/B purpose.
+        from olmlx.bench.runner import _capture_bench_env
+
+        monkeypatch.setenv("OLMLX_BENCH_THINK", "tru")
+        assert _capture_bench_env() == {}
+
+    def test_recognized_think_is_captured_verbatim(self, monkeypatch):
+        from olmlx.bench.runner import _capture_bench_env
+
+        monkeypatch.setenv("OLMLX_BENCH_THINK", "False")
+        assert _capture_bench_env() == {"OLMLX_BENCH_THINK": "False"}
+
 
 class TestWorkerTimeout:
     """`OLMLX_BENCH_WORKER_TIMEOUT` must never silently disable the kill

--- a/tests/test_bench_quality_wiring.py
+++ b/tests/test_bench_quality_wiring.py
@@ -71,6 +71,36 @@ class TestBuildPrompts:
             "BenchPrompt.to_dict() did not surface grader to apply_graders"
         )
 
+    def test_quality_set_raises_on_within_set_duplicate(self, monkeypatch):
+        # Same collision concern as ``"all"`` but within the graded set:
+        # if two task_prompts entries ever share a name, apply_graders's
+        # by-name dict silently keeps the last one. Synthesize a collision
+        # via PROMPT_SETS monkeypatch and verify build_prompts catches it
+        # for the ``"quality"`` path too — not just ``"all"``.
+        import pytest
+
+        from olmlx.bench.prompts import BenchPrompt
+
+        a = BenchPrompt(
+            name="dup",
+            category="gsm8k",
+            messages=[{"role": "user", "content": "x"}],
+            grader="numeric",
+            expected={"answer": 1},
+        )
+        b = BenchPrompt(
+            name="dup",
+            category="mmlu",
+            messages=[{"role": "user", "content": "y"}],
+            grader="numeric",
+            expected={"answer": 2},
+        )
+        monkeypatch.setattr(
+            "olmlx.bench.task_prompts.PROMPT_SETS", {"set_a": [a], "set_b": [b]}
+        )
+        with pytest.raises(ValueError, match="Duplicate prompt names within quality"):
+            build_prompts("quality")
+
     def test_all_set_raises_on_duplicate_names(self, monkeypatch):
         import pytest
 

--- a/tests/test_bench_quality_wiring.py
+++ b/tests/test_bench_quality_wiring.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from olmlx.bench.prompts import PROMPTS
 from olmlx.bench.results import PromptResult, RunResult, ScenarioResult
-from olmlx.bench.runner import apply_graders, build_prompts
+from olmlx.bench.runner import _worker_timeout, apply_graders, build_prompts
 from olmlx.bench.quality import QualityResult
 from olmlx.bench.task_prompts import PROMPT_SETS
 
@@ -218,3 +218,42 @@ class TestRunResultMetadata:
         run = RunResult.from_dict(legacy)
         assert run.prompt_set is None
         assert run.bench_env == {}
+
+
+class TestWorkerTimeout:
+    """`OLMLX_BENCH_WORKER_TIMEOUT` must never silently disable the kill
+    switch (e.g. via ``inf``) and never silently swallow a typo'd value.
+    """
+
+    def test_unset_returns_default(self, monkeypatch):
+        monkeypatch.delenv("OLMLX_BENCH_WORKER_TIMEOUT", raising=False)
+        assert _worker_timeout() == 600.0
+
+    def test_positive_value_used(self, monkeypatch):
+        monkeypatch.setenv("OLMLX_BENCH_WORKER_TIMEOUT", "1800")
+        assert _worker_timeout() == 1800.0
+
+    def test_inf_rejected(self, monkeypatch, caplog):
+        # `subprocess.run(timeout=inf)` waits forever — must never get there.
+        monkeypatch.setenv("OLMLX_BENCH_WORKER_TIMEOUT", "inf")
+        with caplog.at_level("WARNING", logger="olmlx.bench.runner"):
+            assert _worker_timeout() == 600.0
+        assert any("inf" in rec.getMessage().lower() for rec in caplog.records)
+
+    def test_nan_rejected(self, monkeypatch):
+        monkeypatch.setenv("OLMLX_BENCH_WORKER_TIMEOUT", "nan")
+        assert _worker_timeout() == 600.0
+
+    def test_zero_rejected(self, monkeypatch):
+        monkeypatch.setenv("OLMLX_BENCH_WORKER_TIMEOUT", "0")
+        assert _worker_timeout() == 600.0
+
+    def test_negative_rejected(self, monkeypatch):
+        monkeypatch.setenv("OLMLX_BENCH_WORKER_TIMEOUT", "-5")
+        assert _worker_timeout() == 600.0
+
+    def test_unparseable_warns(self, monkeypatch, caplog):
+        monkeypatch.setenv("OLMLX_BENCH_WORKER_TIMEOUT", "abc")
+        with caplog.at_level("WARNING", logger="olmlx.bench.runner"):
+            assert _worker_timeout() == 600.0
+        assert any("abc" in rec.getMessage() for rec in caplog.records)

--- a/tests/test_bench_quality_wiring.py
+++ b/tests/test_bench_quality_wiring.py
@@ -7,25 +7,31 @@ tested in test_bench_quality.py.
 
 from __future__ import annotations
 
-from olmlx.bench.results import PromptResult, ScenarioResult
+from olmlx.bench.prompts import PROMPTS
+from olmlx.bench.results import PromptResult, RunResult, ScenarioResult
 from olmlx.bench.runner import apply_graders, build_prompts
 from olmlx.bench.quality import QualityResult
+from olmlx.bench.task_prompts import PROMPT_SETS
 
 
 class TestBuildPrompts:
-    def test_throughput_set_has_no_graders(self):
-        prompts = build_prompts("throughput")
-        assert len(prompts) == 7
-        assert all(p.grader is None for p in prompts)
+    def test_throughput_set_matches_canonical_list(self):
+        # Tie the assertion to the source list so adding a throughput probe
+        # in prompts.py doesn't silently require a test edit.
+        assert build_prompts("throughput") == list(PROMPTS)
+        assert all(p.grader is None for p in build_prompts("throughput"))
 
     def test_quality_set_is_all_graded(self):
         prompts = build_prompts("quality")
-        # gsm8k(20) + mmlu(20) + humaneval(10)
-        assert len(prompts) == 50
+        expected_size = sum(len(v) for v in PROMPT_SETS.values())
+        assert len(prompts) == expected_size
         assert all(p.grader is not None for p in prompts)
 
-    def test_all_set_is_union(self):
-        assert len(build_prompts("all")) == 57
+    def test_all_set_is_throughput_plus_quality(self):
+        # Relationship-based: survives any future addition to either set.
+        assert len(build_prompts("all")) == len(build_prompts("throughput")) + len(
+            build_prompts("quality")
+        )
 
     def test_unknown_set_raises(self):
         import pytest
@@ -72,6 +78,10 @@ class TestApplyGraders:
         results = [self._result("p1", "", status=503)]
         prompts = [{"name": "p1", "grader": "numeric", "expected": {"answer": 18}}]
         apply_graders(results, prompts, enable_code_exec=False)
+        # Invariant: r.grader is set iff r.quality is set. A failed request
+        # leaves both as None so consumers don't have to special-case the
+        # "graded prompt but no verdict" combination.
+        assert results[0].grader is None
         assert results[0].quality is None
 
     def test_code_exec_disabled_by_default(self):
@@ -170,3 +180,41 @@ class TestScenarioQualitySummary:
             prompt_results=[PromptResult("d", "factual", "x", 200)],
         )
         assert sc.quality_summary() == (0, 0)
+
+
+class TestRunResultMetadata:
+    """Saved runs must record which prompt set + bench env they ran with so
+    an operator can tell a think run apart from a no-think run, or a
+    throughput run apart from a quality run, from the JSON alone."""
+
+    def _empty_run(self, **kwargs):
+        return RunResult(
+            model="m",
+            timestamp="20260101T000000Z",
+            git_sha=None,
+            scenarios=[],
+            **kwargs,
+        )
+
+    def test_prompt_set_round_trips(self):
+        run = self._empty_run(prompt_set="quality")
+        assert RunResult.from_dict(run.to_dict()).prompt_set == "quality"
+
+    def test_bench_env_round_trips(self):
+        run = self._empty_run(bench_env={"OLMLX_BENCH_THINK": "true"})
+        restored = RunResult.from_dict(run.to_dict())
+        assert restored.bench_env == {"OLMLX_BENCH_THINK": "true"}
+
+    def test_legacy_run_without_new_fields_loads(self):
+        # Old run JSONs (pre-this-PR) have no prompt_set or bench_env.
+        # Loading must default both rather than raise.
+        legacy = {
+            "model": "m",
+            "timestamp": "20260101T000000Z",
+            "git_sha": None,
+            "max_tokens_override": None,
+            "scenarios": [],
+        }
+        run = RunResult.from_dict(legacy)
+        assert run.prompt_set is None
+        assert run.bench_env == {}

--- a/tests/test_bench_quality_wiring.py
+++ b/tests/test_bench_quality_wiring.py
@@ -102,23 +102,34 @@ class TestApplyGraders:
         assert results[0].quality is not None
         assert results[0].quality.passed is None
 
-    def test_code_exec_enabled_injects_flag(self):
-        results = [self._result("p1", "```python\ndef f():\n    return 1\n```")]
-        prompts = [
-            {
-                "name": "p1",
-                "grader": "code_exec",
-                "expected": {
-                    "prompt": "",
-                    "tests": "def check(f):\n    assert f() == 1\n",
-                    "entry_point": "f",
-                },
-            }
-        ]
+    def test_code_exec_enabled_injects_flag(self, monkeypatch):
+        # Verifies the injection contract without actually running a
+        # subprocess — the real code_exec execution is covered in
+        # test_bench_quality.py. Stubs ``grade`` in the runner namespace
+        # to capture what apply_graders hands it.
+        captured: dict = {}
+
+        def fake_grade(grader_name, output, expected):
+            captured["grader"] = grader_name
+            captured["expected"] = expected
+            return QualityResult(grader=grader_name, passed=True, score=1.0, detail="")
+
+        monkeypatch.setattr("olmlx.bench.runner.grade", fake_grade)
+
+        results = [self._result("p1", "irrelevant")]
+        original_expected = {
+            "prompt": "",
+            "tests": "def check(f):\n    assert f() == 1\n",
+            "entry_point": "f",
+        }
+        prompts = [{"name": "p1", "grader": "code_exec", "expected": original_expected}]
         apply_graders(results, prompts, enable_code_exec=True)
-        assert results[0].quality.passed is True
+
+        assert captured["grader"] == "code_exec"
+        assert captured["expected"]["_enabled"] is True
         # Caller's expected dict must not be mutated with the private flag.
-        assert "_enabled" not in prompts[0]["expected"]
+        assert "_enabled" not in original_expected
+        assert results[0].quality.passed is True
 
 
 class TestQualitySerialization:

--- a/tests/test_bench_quality_wiring.py
+++ b/tests/test_bench_quality_wiring.py
@@ -44,6 +44,33 @@ class TestBuildPrompts:
         # at construction rather than letting them mis-grade a saved run.
         build_prompts("all")
 
+    def test_to_dict_carries_grader_fields_into_apply_graders(self):
+        # Integration check: ``build_prompts("quality")`` →
+        # ``BenchPrompt.to_dict()`` → ``apply_graders`` must round-trip
+        # the ``grader`` and ``expected`` fields. If ``to_dict()`` ever
+        # silently dropped either, the quality run would report
+        # ``quality 0/0`` with no error. This test pins the contract.
+        prompts = build_prompts("quality")
+        prompts_data = [p.to_dict() for p in prompts]
+        # Pick the first graded prompt and synthesise a "pass" result.
+        first = prompts[0]
+        assert first.grader is not None
+        result = PromptResult(
+            first.name,
+            first.category,
+            output_text="",  # filled below per grader
+            status_code=200,
+        )
+        # Numeric is the easiest "pass" output to synthesise; if the first
+        # prompt isn't numeric, skip the content check and just confirm the
+        # grader was applied (verdict-shape, not verdict-value).
+        if first.grader == "numeric":
+            result.output_text = f"#### {first.expected['answer']}"
+        apply_graders([result], prompts_data, enable_code_exec=False)
+        assert result.grader == first.grader, (
+            "BenchPrompt.to_dict() did not surface grader to apply_graders"
+        )
+
     def test_all_set_raises_on_duplicate_names(self, monkeypatch):
         import pytest
 
@@ -109,7 +136,18 @@ class TestApplyGraders:
         assert results[0].grader is None
         assert results[0].quality is None
 
-    def test_code_exec_disabled_by_default(self):
+    def test_code_exec_disabled_does_not_call_grade(self, monkeypatch):
+        # Runner enforces the code_exec gate itself; ``grade()`` must not
+        # be invoked at all when ``enable_code_exec=False``. Otherwise a
+        # future change to the grader's internal opt-in flag would silently
+        # let untrusted code execute. Stubs ``grade`` to assert non-call.
+        called = []
+
+        def watch_grade(*args, **kwargs):
+            called.append(args)
+            return QualityResult("code_exec", True, 1.0, "")
+
+        monkeypatch.setattr("olmlx.bench.runner.grade", watch_grade)
         results = [self._result("p1", "```python\ndef f():\n    return 1\n```")]
         prompts = [
             {
@@ -123,9 +161,10 @@ class TestApplyGraders:
             }
         ]
         apply_graders(results, prompts, enable_code_exec=False)
-        # Grader runs but returns ungraded (passed=None) when not enabled.
+        assert called == []
         assert results[0].quality is not None
         assert results[0].quality.passed is None
+        assert results[0].grader == "code_exec"
 
     def test_returns_code_exec_excluded_count(self):
         # apply_graders should *report* the disabled-code_exec count

--- a/tests/test_bench_runner.py
+++ b/tests/test_bench_runner.py
@@ -54,7 +54,9 @@ class TestRunWorker:
         with patch(
             "olmlx.bench.runner.subprocess.run", side_effect=fake_subprocess_run
         ):
-            results = _run_worker("test-model", scenario, prompts_data, None)
+            results = _run_worker(
+                "test-model", scenario, prompts_data, None, worker_timeout=600.0
+            )
 
         assert len(results) == 1
         assert results[0].prompt_name == "factual"
@@ -71,7 +73,7 @@ class TestRunWorker:
             stdout = ""
 
         with patch("olmlx.bench.runner.subprocess.run", return_value=FakeResult()):
-            results = _run_worker("model", scenario, [], None)
+            results = _run_worker("model", scenario, [], None, worker_timeout=600.0)
 
         assert len(results) == 1
         assert results[0].prompt_name == "__worker_error__"
@@ -87,7 +89,7 @@ class TestRunWorker:
             "olmlx.bench.runner.subprocess.run",
             side_effect=subprocess.TimeoutExpired(cmd="test", timeout=600),
         ):
-            results = _run_worker("model", scenario, [], None)
+            results = _run_worker("model", scenario, [], None, worker_timeout=600.0)
 
         assert len(results) == 1
         assert "timed out" in results[0].error.lower()
@@ -116,7 +118,7 @@ class TestRunWorker:
             return FakeResult()
 
         with patch("olmlx.bench.runner.subprocess.run", side_effect=capture_run):
-            _run_worker("model", scenario, [], None)
+            _run_worker("model", scenario, [], None, worker_timeout=600.0)
 
         assert captured_env.get("OLMLX_KV_CACHE_QUANT") == "turboquant:4"
 
@@ -139,7 +141,7 @@ class TestRunWorker:
             return FakeResult()
 
         with patch("olmlx.bench.runner.subprocess.run", side_effect=capture_run):
-            _run_worker("model", scenario, [], max_tokens=64)
+            _run_worker("model", scenario, [], max_tokens=64, worker_timeout=600.0)
 
         assert "--max-tokens" in captured_cmd
         assert "64" in captured_cmd

--- a/tests/test_bench_worker.py
+++ b/tests/test_bench_worker.py
@@ -16,11 +16,24 @@ class TestResolveBenchThink:
     def test_falsy_disables_thinking(self, value):
         assert _resolve_bench_think({"OLMLX_BENCH_THINK": value}) is False
 
-    def test_unset_returns_none(self):
-        assert _resolve_bench_think({}) is None
+    def test_unset_returns_none_silently(self, caplog):
+        with caplog.at_level("WARNING", logger="olmlx.bench.worker"):
+            assert _resolve_bench_think({}) is None
+        # Unset is the engine-default path; no warning should fire.
+        assert caplog.records == []
 
-    def test_empty_returns_none(self):
-        assert _resolve_bench_think({"OLMLX_BENCH_THINK": ""}) is None
+    def test_empty_returns_none_silently(self, caplog):
+        with caplog.at_level("WARNING", logger="olmlx.bench.worker"):
+            assert _resolve_bench_think({"OLMLX_BENCH_THINK": ""}) is None
+        assert caplog.records == []
 
-    def test_unrecognized_returns_none(self):
-        assert _resolve_bench_think({"OLMLX_BENCH_THINK": "maybe"}) is None
+    def test_unrecognized_returns_none_and_warns(self, caplog):
+        # A typo'd value (e.g. ``"enabled"``) must not pass silently — an
+        # A/B with one arm typo'd would otherwise run engine-default on
+        # both arms with no signal anything went wrong.
+        with caplog.at_level("WARNING", logger="olmlx.bench.worker"):
+            assert _resolve_bench_think({"OLMLX_BENCH_THINK": "enabled"}) is None
+        assert any(
+            "OLMLX_BENCH_THINK" in rec.getMessage() and "enabled" in rec.getMessage()
+            for rec in caplog.records
+        )

--- a/tests/test_bench_worker.py
+++ b/tests/test_bench_worker.py
@@ -1,0 +1,26 @@
+"""Tests for the bench worker's thinking toggle."""
+
+from __future__ import annotations
+
+import pytest
+
+from olmlx.bench.worker import _resolve_bench_think
+
+
+class TestResolveBenchThink:
+    @pytest.mark.parametrize("value", ["true", "True", "1", "on", "yes"])
+    def test_truthy_enables_thinking(self, value):
+        assert _resolve_bench_think({"OLMLX_BENCH_THINK": value}) is True
+
+    @pytest.mark.parametrize("value", ["false", "False", "0", "off", "no"])
+    def test_falsy_disables_thinking(self, value):
+        assert _resolve_bench_think({"OLMLX_BENCH_THINK": value}) is False
+
+    def test_unset_returns_none(self):
+        assert _resolve_bench_think({}) is None
+
+    def test_empty_returns_none(self):
+        assert _resolve_bench_think({"OLMLX_BENCH_THINK": ""}) is None
+
+    def test_unrecognized_returns_none(self):
+        assert _resolve_bench_think({"OLMLX_BENCH_THINK": "maybe"}) is None


### PR DESCRIPTION
## What this does

Connects the bench's existing grader modules (`quality.py`, `task_prompts.py`, `goldens.py`) to the runner — and adds a thinking on/off toggle for A/B comparison.

Before: `olmlx bench run` always ran 7 throughput probes with no graders, reporting tok/s only.

After: `olmlx bench run --prompt-set quality --enable-code-exec` runs the 50-prompt graded mini-set (GSM8K-20, MMLU-20, HumanEval-10) and reports `quality x/y (z%)` alongside tok/s.

## Surface

- `olmlx bench run --prompt-set {throughput,quality,all}` — selects which prompts to send. Default `throughput` preserves existing behavior.
- `olmlx bench run --enable-code-exec` — opts in to the HumanEval `code_exec` grader (off by default; runs model code in a resource-limited subprocess, safe only because olmlx is a single-user local tool).
- `OLMLX_BENCH_THINK={true,false}` — env toggle on the bench worker that injects the Ollama `think` field into `/api/chat`, so the same model can be benched with and without thinking from a driver script. Unset → engine default.
- `OLMLX_BENCH_WORKER_TIMEOUT` — extends the 600s per-scenario subprocess kill timeout (graded runs with thinking on can run several minutes).

## Internals

- Grading runs in the parent after the worker returns — the worker still only produces `output_text`, matching the contract documented in `quality.py`.
- `PromptResult` gained `grader` and `quality` fields. Backward-compatible: old run JSONs load with both as `None` (verified on existing runs on disk).
- `ScenarioResult.quality_summary()` returns `(passed, graded_total)` and drives the new `quality x/y (z%)` suffix on the per-scenario summary line.
- `apply_graders()` injects the `_enabled` flag into a **copy** of `expected` before calling `code_exec` so the prompt's `expected` dict is never mutated.
- The runner's prompt-set helper composes `task_prompts.PROMPT_SETS` (gsm8k + mmlu + humaneval); the helper raises on unknown set names.

## Tests

- `tests/test_bench_quality_wiring.py` (14 new) — prompt-set selection, grader application across grader types, code_exec gating + non-mutation, `PromptResult` round-trip with quality, `ScenarioResult.quality_summary` aggregation.
- `tests/test_bench_worker.py` (13 new) — `OLMLX_BENCH_THINK` resolution across truthy/falsy/unset/unrecognized.
- Full bench suite still green: `232 passed`. Ruff clean.

## End-to-end verification

Ran the full think-vs-no-think A/B across six thinking-capable Qwen models on the quality set (`--max-tokens 1024 --enable-code-exec`). Spot-summary:

| Model | Think | No-Think |
|---|---:|---:|
| Qwen3-0.6B-4bit | 23/50 (46%) | 33/50 (66%) |
| Qwen3.5-0.8B-4bit | 29/50 (58%) | 38/50 (76%) |
| Qwen3-4B-4bit | 45/50 (90%) | 50/50 (100%) |
| Qwen3-8B-4bit | 44/50 (88%) | 50/50 (100%) |
| Qwen3.6-35B-A3B-4bit | 42/50 (84%) | 50/50 (100%) |
| Qwen3.6-35B-A3B-6bit | 48/50 (96%) | 50/50 (100%) |

Driver scripts and result logs kept local (`bench-results/quality-think-compare/`, untracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)