### PR TITLE
fix: derive manifest on demand for models without manifest.json

### DIFF
--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -1462,6 +1462,7 @@ class ModelManager:
                             if _manifest_path.exists():
                                 try:
                                     import json
+
                                     _model_size = json.loads(
                                         _manifest_path.read_text()
                                     ).get("size", 0)
@@ -3061,10 +3062,7 @@ class ModelManager:
             load_path = str(local_dir)
             # Backfill manifest.json when missing so show() and list_local()
             # don't need to derive metadata on every access.
-            if (
-                local_dir.exists()
-                and not (local_dir / "manifest.json").exists()
-            ):
+            if local_dir.exists() and not (local_dir / "manifest.json").exists():
                 from olmlx.models.store import _derive_manifest
 
                 # Find the Ollama short name for this hf_path, falling back

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -25,7 +25,7 @@ from olmlx.engine.template_caps import TemplateCaps, detect_caps
 if TYPE_CHECKING:
     from olmlx.models.store import ModelStore
 
-from olmlx.models.store import _strip_ollama_tag
+from olmlx.models.store import _dir_size, _strip_ollama_tag
 
 logger = logging.getLogger(__name__)
 
@@ -1451,6 +1451,13 @@ class ModelManager:
                     # close it. Non-Flash models leave this at None.
                     _weight_store = getattr(model, "_weight_store", None)
 
+                    # Compute on-disk size for the model directory.
+                    _model_size = 0
+                    if self.store is not None:
+                        _local_dir = self.store.local_path(hf_path)
+                        if _local_dir.exists():
+                            _model_size = await asyncio.to_thread(_dir_size, _local_dir)
+
                     # _find_spectral_dir may trigger multi-minute calibration.
                     # Run it in a thread so it does not block the event loop.
                     _spectral_dir = await asyncio.to_thread(
@@ -1469,6 +1476,7 @@ class ModelManager:
                         weight_store=_weight_store,
                         template_caps=caps,
                         expires_at=expires,
+                        size_bytes=_model_size,
                         kv_cache_quant=kv_cache_quant,
                         spectral_calibration_dir=_spectral_dir,
                         default_options=dict(model_config.options),
@@ -3037,6 +3045,20 @@ class ModelManager:
         if self.store is not None:
             local_dir = self.store.ensure_downloaded(hf_path)
             load_path = str(local_dir)
+            # Backfill manifest.json when missing so show() and list_local()
+            # don't need to derive metadata on every access.
+            if (
+                local_dir.exists()
+                and not (local_dir / "manifest.json").exists()
+            ):
+                from olmlx.models.store import _derive_manifest
+
+                manifest = _derive_manifest(
+                    local_dir,
+                    self.registry.normalize_name(hf_path),
+                    hf_path,
+                )
+                manifest.save(local_dir / "manifest.json")
 
         # Check for flash-MoE-prepared model
         if self._is_flash_moe_enabled(flash_moe_config):

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -1451,12 +1451,26 @@ class ModelManager:
                     # close it. Non-Flash models leave this at None.
                     _weight_store = getattr(model, "_weight_store", None)
 
-                    # Compute on-disk size for the model directory.
+                    # Read on-disk size from the manifest (backfilled by
+                    # _load_model), falling back to _dir_size for
+                    # pre-existing manifests that may lack the field.
                     _model_size = 0
                     if self.store is not None:
                         _local_dir = self.store.local_path(hf_path)
                         if _local_dir.exists():
-                            _model_size = await asyncio.to_thread(_dir_size, _local_dir)
+                            _manifest_path = _local_dir / "manifest.json"
+                            if _manifest_path.exists():
+                                try:
+                                    import json
+                                    _model_size = json.loads(
+                                        _manifest_path.read_text()
+                                    ).get("size", 0)
+                                except Exception:
+                                    pass
+                            if _model_size == 0:
+                                _model_size = await asyncio.to_thread(
+                                    _dir_size, _local_dir
+                                )
 
                     # _find_spectral_dir may trigger multi-minute calibration.
                     # Run it in a thread so it does not block the event loop.
@@ -3053,9 +3067,17 @@ class ModelManager:
             ):
                 from olmlx.models.store import _derive_manifest
 
+                # Find the Ollama short name for this hf_path, falling back
+                # to the hf_path itself if no registry entry maps to it.
+                manifest_name = self.registry.normalize_name(hf_path)
+                for short_name, mc in self.registry.list_models().items():
+                    if mc.hf_path == hf_path:
+                        manifest_name = short_name
+                        break
+
                 manifest = _derive_manifest(
                     local_dir,
-                    self.registry.normalize_name(hf_path),
+                    manifest_name,
                     hf_path,
                 )
                 manifest.save(local_dir / "manifest.json")

--- a/olmlx/models/store.py
+++ b/olmlx/models/store.py
@@ -291,6 +291,13 @@ class ModelStore:
         models = []
         if not self.models_dir.exists():
             return models
+        # Build a reverse map: safe_dir_name → (short_name, hf_path) from the
+        # registry so we can match unknown model directories to their Ollama name.
+        dir_to_info: dict[str, tuple[str, str]] = {}
+        for short_name, cfg in self.registry.list_models().items():
+            safe = _safe_dir_name(cfg.hf_path)
+            if safe not in dir_to_info:
+                dir_to_info[safe] = (short_name, cfg.hf_path)
         for d in self.models_dir.iterdir():
             if d.is_dir():
                 manifest_path = d / "manifest.json"
@@ -304,13 +311,18 @@ class ModelStore:
                 config_path = d / "config.json"
                 if config_path.exists():
                     try:
-                        # Extract name and hf_path from directory name heuristics.
-                        # The dir name is _safe_dir_name(hf_path), so we try to
-                        # reverse it by finding the matching HF path in the registry.
-                        dir_name = d.name
-                        hf_path = dir_name.replace("_", "/", 1) if "_" in dir_name else dir_name
-                        # Use the normalized short name if we can resolve it
-                        manifest = _derive_manifest(d, hf_path, hf_path)
+                        info = dir_to_info.get(d.name)
+                        if info is not None:
+                            short_name, hf_path = info
+                        else:
+                            # Unknown model — reverse the safe_dir_name heuristic
+                            hf_path = (
+                                d.name.replace("_", "/", 1)
+                                if "_" in d.name
+                                else d.name
+                            )
+                            short_name = hf_path
+                        manifest = _derive_manifest(d, short_name, hf_path)
                         manifest.save(manifest_path)
                         models.append(manifest)
                     except Exception:

--- a/olmlx/models/store.py
+++ b/olmlx/models/store.py
@@ -318,9 +318,7 @@ class ModelStore:
                         else:
                             # Unknown model — reverse the safe_dir_name heuristic
                             hf_path = (
-                                d.name.replace("_", "/", 1)
-                                if "_" in d.name
-                                else d.name
+                                d.name.replace("_", "/", 1) if "_" in d.name else d.name
                             )
                             short_name = hf_path
                         manifest = _derive_manifest(d, short_name, hf_path)

--- a/olmlx/models/store.py
+++ b/olmlx/models/store.py
@@ -82,6 +82,40 @@ def _dir_size(path: Path) -> int:
     return total
 
 
+def _derive_manifest(local_dir: Path, name: str, hf_path: str) -> ModelManifest:
+    """Dynamically build a ModelManifest from on-disk files.
+
+    Reads ``config.json`` and ``quantize_config.json`` for metadata,
+    computes directory size, and generates a digest.  Used as a fallback
+    when ``manifest.json`` is missing (e.g. models downloaded via mlx-lm
+    rather than ``/api/pull``).
+
+    When *local_dir* does not exist on disk, returns a manifest with
+    size=0 and an empty modified_at.
+    """
+    meta = _extract_metadata(local_dir)
+    size = _dir_size(local_dir) if local_dir.exists() else 0
+    modified_at = ""
+    if local_dir.exists():
+        try:
+            modified_at = datetime.fromtimestamp(
+                local_dir.stat().st_mtime, tz=timezone.utc
+            ).isoformat()
+        except OSError:
+            pass
+    return ModelManifest(
+        name=name,
+        hf_path=hf_path,
+        size=size,
+        modified_at=modified_at,
+        digest=ModelManifest.compute_digest(name),
+        format="mlx",
+        family=meta["family"],
+        parameter_size=meta["parameter_size"],
+        quantization_level=meta["quantization_level"],
+    )
+
+
 class ModelStore:
     def __init__(self, registry: ModelRegistry):
         self.registry = registry
@@ -101,20 +135,31 @@ class ModelStore:
             local / ".downloading"
         ).exists()
 
-    def _resolve_model_dir(self, name: str) -> Path | None:
-        """Resolve a model name to its local directory, trying HF-path-based naming first."""
+    def _resolve_model_dir(self, name: str) -> tuple[Path, bool] | None:
+        """Resolve a model name to its local directory.
+
+        Returns ``(path, has_manifest)`` where *has_manifest* is ``True``
+        when a ``manifest.json`` exists, ``False`` when only ``config.json``
+        was found (model is downloaded but no manifest was written yet).
+
+        Returns ``None`` when the model cannot be found at all.
+        """
         resolved = self.registry.resolve(name)
         hf_path = resolved.hf_path if resolved is not None else None
         if hf_path is not None:
             d = self.local_path(hf_path)
             if (d / "manifest.json").exists():
-                return d
+                return (d, True)
+            if (d / "config.json").exists():
+                return (d, False)
         # Fall back to old name-based directories
         normalized = self.registry.normalize_name(name)
         for candidate in [_safe_dir_name(normalized), _safe_dir_name(name)]:
             d = self.models_dir / candidate
             if (d / "manifest.json").exists():
-                return d
+                return (d, True)
+            if (d / "config.json").exists():
+                return (d, False)
         return None
 
     def _pull_lock(self, hf_path: str) -> asyncio.Lock:
@@ -242,7 +287,7 @@ class ModelStore:
             yield {"status": "success"}
 
     def list_local(self) -> list[ModelManifest]:
-        """List all locally stored models."""
+        """List all locally stored models, deriving manifests for directories that lack one."""
         models = []
         if not self.models_dir.exists():
             return models
@@ -252,22 +297,47 @@ class ModelStore:
                 if manifest_path.exists():
                     try:
                         models.append(ModelManifest.load(manifest_path))
+                        continue
                     except Exception:
                         logger.warning("Failed to load manifest: %s", manifest_path)
+                # No valid manifest — try to derive one from config.json
+                config_path = d / "config.json"
+                if config_path.exists():
+                    try:
+                        # Extract name and hf_path from directory name heuristics.
+                        # The dir name is _safe_dir_name(hf_path), so we try to
+                        # reverse it by finding the matching HF path in the registry.
+                        dir_name = d.name
+                        hf_path = dir_name.replace("_", "/", 1) if "_" in dir_name else dir_name
+                        # Use the normalized short name if we can resolve it
+                        manifest = _derive_manifest(d, hf_path, hf_path)
+                        manifest.save(manifest_path)
+                        models.append(manifest)
+                    except Exception:
+                        logger.debug("Failed to derive manifest for %s", d)
         return models
 
     def show(self, name: str) -> ModelManifest | None:
-        model_dir = self._resolve_model_dir(name)
-        if model_dir is not None:
+        resolved = self._resolve_model_dir(name)
+        if resolved is None:
+            return None
+        model_dir, has_manifest = resolved
+        if has_manifest:
             return ModelManifest.load(model_dir / "manifest.json")
-        return None
+        # Derive manifest on demand and backfill so subsequent calls are fast.
+        normalized = self.registry.normalize_name(name)
+        resolved_cfg = self.registry.resolve(name)
+        hf_path = resolved_cfg.hf_path if resolved_cfg is not None else name
+        manifest = _derive_manifest(model_dir, normalized, hf_path)
+        manifest.save(model_dir / "manifest.json")
+        return manifest
 
     def delete(self, name: str) -> bool:
         import shutil
 
-        model_dir = self._resolve_model_dir(name)
-        if model_dir is not None:
-            shutil.rmtree(model_dir)
+        resolved = self._resolve_model_dir(name)
+        if resolved is not None:
+            shutil.rmtree(resolved[0])
             return True
         return False
 

--- a/olmlx/models/store.py
+++ b/olmlx/models/store.py
@@ -310,6 +310,7 @@ class ModelStore:
                 # No valid manifest — try to derive one from config.json
                 config_path = d / "config.json"
                 if config_path.exists():
+                    manifest: ModelManifest | None = None
                     try:
                         info = dir_to_info.get(d.name)
                         if info is not None:
@@ -324,9 +325,11 @@ class ModelStore:
                             short_name = hf_path
                         manifest = _derive_manifest(d, short_name, hf_path)
                         manifest.save(manifest_path)
-                        models.append(manifest)
                     except Exception:
                         logger.debug("Failed to derive manifest for %s", d)
+                    # Include the model even if save failed (disk full, etc.)
+                    if manifest is not None:
+                        models.append(manifest)
         return models
 
     def show(self, name: str) -> ModelManifest | None:

--- a/olmlx/routers/status.py
+++ b/olmlx/routers/status.py
@@ -5,7 +5,6 @@ from fastapi import APIRouter, Request
 from fastapi.responses import PlainTextResponse
 
 from olmlx import __version__
-from olmlx.models.store import _dir_size, _extract_metadata
 from olmlx.schemas.models import ModelDetails
 from olmlx.schemas.status import PsResponse, RunningModel, VersionResponse
 
@@ -38,23 +37,25 @@ async def ps(request: Request):
         if lm.expires_at is not None:
             expires = datetime.fromtimestamp(lm.expires_at, tz=timezone.utc).isoformat()
 
-        # Resolve on-disk model metadata for details and size.
+        # Read metadata from the manifest (backfilled at load time) to avoid
+        # expensive _dir_size / _extract_metadata calls on the event loop.
         size = lm.size_bytes
         meta = {"family": "", "parameter_size": "", "quantization_level": ""}
         digest = ""
         if store is not None:
             local_dir = store.local_path(lm.hf_path)
-            if local_dir.exists():
-                if size == 0:
-                    size = _dir_size(local_dir)
-                meta = _extract_metadata(local_dir)
-                manifest_path = local_dir / "manifest.json"
-                if manifest_path.exists():
-                    try:
-                        manifest = json.loads(manifest_path.read_text())
-                        digest = manifest.get("digest", "")
-                    except Exception:
-                        pass
+            manifest_path = local_dir / "manifest.json"
+            if manifest_path.exists():
+                try:
+                    m = json.loads(manifest_path.read_text())
+                    if size == 0:
+                        size = m.get("size", 0)
+                    digest = m.get("digest", "")
+                    meta["family"] = m.get("family", "")
+                    meta["parameter_size"] = m.get("parameter_size", "")
+                    meta["quantization_level"] = m.get("quantization_level", "")
+                except Exception:
+                    pass
 
         models.append(
             RunningModel(

--- a/olmlx/routers/status.py
+++ b/olmlx/routers/status.py
@@ -1,6 +1,5 @@
 import json
 from datetime import datetime, timezone
-from pathlib import Path
 
 from fastapi import APIRouter, Request
 from fastapi.responses import PlainTextResponse

--- a/olmlx/routers/status.py
+++ b/olmlx/routers/status.py
@@ -1,9 +1,13 @@
+import json
 from datetime import datetime, timezone
+from pathlib import Path
 
 from fastapi import APIRouter, Request
 from fastapi.responses import PlainTextResponse
 
 from olmlx import __version__
+from olmlx.models.store import _dir_size, _extract_metadata
+from olmlx.schemas.models import ModelDetails
 from olmlx.schemas.status import PsResponse, RunningModel, VersionResponse
 
 router = APIRouter()
@@ -27,19 +31,46 @@ async def version():
 @router.get("/api/ps")
 async def ps(request: Request):
     manager = request.app.state.model_manager
+    store = request.app.state.model_store
     loaded = manager.get_loaded()
     models = []
     for lm in loaded:
         expires = ""
         if lm.expires_at is not None:
             expires = datetime.fromtimestamp(lm.expires_at, tz=timezone.utc).isoformat()
+
+        # Resolve on-disk model metadata for details and size.
+        size = lm.size_bytes
+        meta = {"family": "", "parameter_size": "", "quantization_level": ""}
+        digest = ""
+        if store is not None:
+            local_dir = store.local_path(lm.hf_path)
+            if local_dir.exists():
+                if size == 0:
+                    size = _dir_size(local_dir)
+                meta = _extract_metadata(local_dir)
+                manifest_path = local_dir / "manifest.json"
+                if manifest_path.exists():
+                    try:
+                        manifest = json.loads(manifest_path.read_text())
+                        digest = manifest.get("digest", "")
+                    except Exception:
+                        pass
+
         models.append(
             RunningModel(
                 name=lm.name,
                 model=lm.hf_path,
-                size=lm.size_bytes,
+                size=size,
+                digest=digest,
+                details=ModelDetails(
+                    format="mlx",
+                    family=meta["family"],
+                    parameter_size=meta["parameter_size"],
+                    quantization_level=meta["quantization_level"],
+                ),
                 expires_at=expires,
-                size_vram=lm.size_bytes,
+                size_vram=size,
                 active_refs=lm.active_refs,
             )
         )

--- a/tests/test_routers_status.py
+++ b/tests/test_routers_status.py
@@ -1,5 +1,8 @@
 """Tests for olmlx.routers.status."""
 
+import json
+import time
+
 import pytest
 
 from olmlx import __version__
@@ -43,11 +46,50 @@ class TestStatusRouter:
 
     @pytest.mark.asyncio
     async def test_ps_with_expiry(self, app_client):
-        import time
-
         manager = app_client._transport.app.state.model_manager
         lm = manager._loaded["qwen3:latest"]
         lm.expires_at = time.time() + 300
         resp = await app_client.get("/api/ps")
         data = resp.json()
         assert data["models"][0]["expires_at"] != ""
+
+    @pytest.mark.asyncio
+    async def test_ps_populates_details_from_config(self, app_client, tmp_path):
+        """ps populates details.family etc. from config.json on disk."""
+        lm = app_client._transport.app.state.model_manager._loaded["qwen3:latest"]
+        # Create the model directory with a config.json
+        store = app_client._transport.app.state.model_store
+        local_dir = store.local_path(lm.hf_path)
+        local_dir.mkdir(parents=True, exist_ok=True)
+        config = {
+            "model_type": "llama",
+            "hidden_size": 4096,
+            "num_hidden_layers": 32,
+            "quantization": {"bits": 4},
+        }
+        (local_dir / "config.json").write_text(json.dumps(config))
+
+        resp = await app_client.get("/api/ps")
+        assert resp.status_code == 200
+        data = resp.json()
+        model = data["models"][0]
+        assert model["details"]["family"] == "llama"
+        assert model["details"]["parameter_size"] != ""
+        assert model["details"]["quantization_level"] == "4-bit"
+        assert model["details"]["format"] == "mlx"
+
+    @pytest.mark.asyncio
+    async def test_ps_populates_size_and_vram(self, app_client, tmp_path):
+        """ps populates size and size_vram from disk when lm.size_bytes is 0."""
+        lm = app_client._transport.app.state.model_manager._loaded["qwen3:latest"]
+        store = app_client._transport.app.state.model_store
+        local_dir = store.local_path(lm.hf_path)
+        local_dir.mkdir(parents=True, exist_ok=True)
+        (local_dir / "weights.safetensors").write_bytes(b"\x00" * 1024)
+        (local_dir / "config.json").write_text(json.dumps({"model_type": "test"}))
+
+        resp = await app_client.get("/api/ps")
+        data = resp.json()
+        model = data["models"][0]
+        assert model["size"] == 1024 + len(json.dumps({"model_type": "test"}))
+        assert model["size_vram"] == model["size"]

--- a/tests/test_routers_status.py
+++ b/tests/test_routers_status.py
@@ -55,41 +55,58 @@ class TestStatusRouter:
 
     @pytest.mark.asyncio
     async def test_ps_populates_details_from_config(self, app_client, tmp_path):
-        """ps populates details.family etc. from config.json on disk."""
+        """ps populates details from manifest rather than config.json."""
         lm = app_client._transport.app.state.model_manager._loaded["qwen3:latest"]
-        # Create the model directory with a config.json
         store = app_client._transport.app.state.model_store
         local_dir = store.local_path(lm.hf_path)
         local_dir.mkdir(parents=True, exist_ok=True)
-        config = {
-            "model_type": "llama",
-            "hidden_size": 4096,
-            "num_hidden_layers": 32,
-            "quantization": {"bits": 4},
+        # Write a manifest with the metadata (mimics backfilling at load time)
+        manifest = {
+            "name": lm.name,
+            "hf_path": lm.hf_path,
+            "size": 0,
+            "digest": "sha256:abc123",
+            "format": "mlx",
+            "family": "llama",
+            "parameter_size": "8B",
+            "quantization_level": "4-bit",
         }
-        (local_dir / "config.json").write_text(json.dumps(config))
+        (local_dir / "manifest.json").write_text(json.dumps(manifest))
 
         resp = await app_client.get("/api/ps")
         assert resp.status_code == 200
         data = resp.json()
         model = data["models"][0]
         assert model["details"]["family"] == "llama"
-        assert model["details"]["parameter_size"] != ""
+        assert model["details"]["parameter_size"] == "8B"
         assert model["details"]["quantization_level"] == "4-bit"
         assert model["details"]["format"] == "mlx"
+        assert model["digest"] == "sha256:abc123"
 
     @pytest.mark.asyncio
     async def test_ps_populates_size_and_vram(self, app_client, tmp_path):
-        """ps populates size and size_vram from disk when lm.size_bytes is 0."""
+        """ps populates size and size_vram from the manifest when lm.size_bytes is 0."""
         lm = app_client._transport.app.state.model_manager._loaded["qwen3:latest"]
         store = app_client._transport.app.state.model_store
         local_dir = store.local_path(lm.hf_path)
         local_dir.mkdir(parents=True, exist_ok=True)
-        (local_dir / "weights.safetensors").write_bytes(b"\x00" * 1024)
+        # Write a manifest with the size pre-computed (as _load_model does)
+        manifest = {
+            "name": lm.name,
+            "hf_path": lm.hf_path,
+            "size": 4096,
+            "digest": "",
+            "format": "mlx",
+            "family": "test",
+            "parameter_size": "",
+            "quantization_level": "",
+        }
+        (local_dir / "manifest.json").write_text(json.dumps(manifest))
         (local_dir / "config.json").write_text(json.dumps({"model_type": "test"}))
 
         resp = await app_client.get("/api/ps")
         data = resp.json()
         model = data["models"][0]
-        assert model["size"] == 1024 + len(json.dumps({"model_type": "test"}))
+        assert model["size"] == 4096
         assert model["size_vram"] == model["size"]
+        assert model["details"]["family"] == "test"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -478,3 +478,136 @@ class TestEnsureDownloaded:
 
         assert call_count == 1
         assert all(r == mock_store.local_path("Qwen/Qwen3-8B-MLX") for r in results)
+
+
+class TestDeriveManifest:
+    def test_derive_manifest_no_config(self, tmp_path):
+        """_derive_manifest works even without config.json (returns empty metadata)."""
+        from olmlx.models.store import _derive_manifest
+
+        manifest = _derive_manifest(tmp_path, "test:latest", "test/model")
+        assert manifest.name == "test:latest"
+        assert manifest.hf_path == "test/model"
+        assert manifest.family == ""
+        assert manifest.parameter_size == ""
+        assert manifest.quantization_level == ""
+        assert manifest.format == "mlx"
+        assert manifest.digest != ""
+
+    def test_derive_manifest_with_config(self, tmp_path):
+        """_derive_manifest reads metadata from config.json."""
+        from olmlx.models.store import _derive_manifest
+
+        config = {
+            "model_type": "qwen2",
+            "hidden_size": 4096,
+            "num_hidden_layers": 32,
+            "quantization": {"bits": 4},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        manifest = _derive_manifest(tmp_path, "test:latest", "test/model")
+        assert manifest.family == "qwen2"
+        assert manifest.quantization_level == "4-bit"
+        assert manifest.size > 0  # at least the config.json bytes
+
+
+class TestShowWithoutManifest:
+    def test_show_derives_manifest_when_missing(self, mock_store, tmp_path):
+        """show() returns derived manifest when manifest.json is absent."""
+        # Create a model dir with config.json but no manifest.json
+        local_dir = mock_store.local_path("test/model")
+        local_dir.mkdir(parents=True)
+        config = {
+            "model_type": "llama",
+            "hidden_size": 2048,
+            "num_hidden_layers": 16,
+        }
+        (local_dir / "config.json").write_text(json.dumps(config))
+        # Register the mapping so resolve works
+        from olmlx.engine.registry import ModelConfig
+
+        mock_store.registry._mappings["test:latest"] = ModelConfig(hf_path="test/model")
+
+        result = mock_store.show("test")
+        assert result is not None
+        assert result.name == "test:latest"
+        assert result.family == "llama"
+        # After calling show(), manifest.json should be backfilled
+        assert (local_dir / "manifest.json").exists()
+
+    def test_show_backfilled_manifest_is_valid(self, mock_store, tmp_path):
+        """After backfill, subsequent show() calls load from manifest."""
+        local_dir = mock_store.local_path("test/model")
+        local_dir.mkdir(parents=True)
+        config = {"model_type": "llama"}
+        (local_dir / "config.json").write_text(json.dumps(config))
+        from olmlx.engine.registry import ModelConfig
+
+        mock_store.registry._mappings["test:latest"] = ModelConfig(hf_path="test/model")
+
+        # First call derives and backfills
+        result1 = mock_store.show("test")
+        # Second call loads from backfilled manifest
+        result2 = mock_store.show("test")
+        assert result1 is not None
+        assert result2 is not None
+        assert result1.name == result2.name
+        assert result1.family == result2.family
+
+
+class TestResolveModelDir:
+    def test_resolve_returns_none_for_unknown(self, mock_store):
+        assert mock_store._resolve_model_dir("nonexistent") is None
+
+    def test_resolve_returns_path_with_manifest_flag(self, mock_store, tmp_path):
+        """_resolve_model_dir returns (path, True) when manifest.json exists."""
+        local_dir = mock_store.local_path("test/model")
+        local_dir.mkdir(parents=True)
+        (local_dir / "config.json").write_text("{}")
+        (local_dir / "manifest.json").write_text(
+            json.dumps({"name": "test:latest", "hf_path": "test/model"})
+        )
+        from olmlx.engine.registry import ModelConfig
+        mock_store.registry._mappings["test:latest"] = ModelConfig(hf_path="test/model")
+
+        result = mock_store._resolve_model_dir("test")
+        assert result is not None
+        path, has_manifest = result
+        assert path == local_dir
+        assert has_manifest is True
+
+    def test_resolve_returns_path_without_manifest(self, mock_store, tmp_path):
+        """_resolve_model_dir returns (path, False) when only config.json exists."""
+        local_dir = mock_store.local_path("test/model")
+        local_dir.mkdir(parents=True)
+        (local_dir / "config.json").write_text("{}")
+        from olmlx.engine.registry import ModelConfig
+        mock_store.registry._mappings["test:latest"] = ModelConfig(hf_path="test/model")
+
+        result = mock_store._resolve_model_dir("test")
+        assert result is not None
+        path, has_manifest = result
+        assert path == local_dir
+        assert has_manifest is False
+
+
+class TestListLocalWithoutManifest:
+    def test_list_local_includes_dirs_without_manifest(self, mock_store, tmp_path):
+        """list_local() includes model directories that lack manifest.json."""
+        local_dir = mock_store.local_path("test/model")
+        local_dir.mkdir(parents=True)
+        config = {"model_type": "llama", "hidden_size": 2048, "num_hidden_layers": 16}
+        (local_dir / "config.json").write_text(json.dumps(config))
+
+        results = mock_store.list_local()
+        assert len(results) == 1
+        assert results[0].family == "llama"
+        # Manifest should have been backfilled
+        assert (local_dir / "manifest.json").exists()
+
+    def test_list_local_skips_dirs_without_config(self, mock_store, tmp_path):
+        """list_local() skips directories that have neither manifest.json nor config.json."""
+        empty_dir = tmp_path / "models" / "empty_dir"
+        empty_dir.mkdir(parents=True)
+        results = mock_store.list_local()
+        assert len(results) == 0

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -568,6 +568,7 @@ class TestResolveModelDir:
             json.dumps({"name": "test:latest", "hf_path": "test/model"})
         )
         from olmlx.engine.registry import ModelConfig
+
         mock_store.registry._mappings["test:latest"] = ModelConfig(hf_path="test/model")
 
         result = mock_store._resolve_model_dir("test")
@@ -582,6 +583,7 @@ class TestResolveModelDir:
         local_dir.mkdir(parents=True)
         (local_dir / "config.json").write_text("{}")
         from olmlx.engine.registry import ModelConfig
+
         mock_store.registry._mappings["test:latest"] = ModelConfig(hf_path="test/model")
 
         result = mock_store._resolve_model_dir("test")


### PR DESCRIPTION
Models downloaded via mlx-lm (as opposed to `/api/pull`) lacked `manifest.json`, causing `/api/show` to 404 and `/api/ps` to return empty metadata.

### Changes

**`olmlx/models/store.py`**:
- Added `_derive_manifest()` — dynamically builds a `ModelManifest` from `config.json`, directory size, and mtime.
- `_resolve_model_dir()` now returns `(path, has_manifest)` tuple; falls back to directories with `config.json` when `manifest.json` is absent.
- `show()` derives and backfills a manifest when `manifest.json` is missing.
- `list_local()` includes model directories that have `config.json` but no `manifest.json`.

**`olmlx/engine/model_manager.py`**:
- `_load_model()` backfills `manifest.json` at model load time so first-use inference populates metadata.
- `ensure_loaded()` now sets `LoadedModel.size_bytes` from disk (previously always 0).

**`olmlx/routers/status.py`**:
- `/api/ps` populates `details` (`family`, `parameter_size`, `quantization_level`, `format`), `digest`, and computes `size`/`size_vram` from disk when not already set.

### Tests
11 new tests covering all fallback paths. 2755 tests pass.