### PR TITLE
fix(inference): honour per-request keep_alive in _inference_ref expiry refresh (#338)

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1094,7 +1094,7 @@ async def _inference_locked(
 
 
 @contextlib.contextmanager
-def _inference_ref(lm: LoadedModel, keep_alive: str | None = None):
+def _inference_ref(lm: LoadedModel, keep_alive: int | str | None = None):
     """Track active inference on a model to prevent expiry during use.
 
     Note: there is a small window between ``ensure_loaded()`` (which returns
@@ -1122,6 +1122,12 @@ def _inference_ref(lm: LoadedModel, keep_alive: str | None = None):
             lm.active_refs -= 1
         # Refresh expiry so the model doesn't expire immediately after inference.
         # Honour per-request keep_alive when available (fix #338).
+        # Falls back to settings.default_keep_alive when no per-request value
+        # is given.  The else branch (ka is None → expires_at = None, i.e.
+        # never expire) mirrors ensure_loaded's refresh path for already-loaded
+        # models (both paths have the same pre-existing limitation: per-model
+        # keep_alive from models.json is not checked during refresh — only at
+        # initial load time).
         ka = parse_keep_alive(
             keep_alive if keep_alive is not None else settings.default_keep_alive
         )
@@ -1863,11 +1869,15 @@ async def generate_completion(
 
     if stream:
         return _prepend_meta(
-            _stream_completion(lm, prompt, mt, gen_kwargs, stats, images, keep_alive=keep_alive),
+            _stream_completion(
+                lm, prompt, mt, gen_kwargs, stats, images, keep_alive=keep_alive
+            ),
             {"thinking_expected": thinking_expected},
         )
     else:
-        result = await _full_completion(lm, prompt, mt, gen_kwargs, stats, images, keep_alive=keep_alive)
+        result = await _full_completion(
+            lm, prompt, mt, gen_kwargs, stats, images, keep_alive=keep_alive
+        )
         result["thinking_expected"] = thinking_expected
         return result
 

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1094,7 +1094,7 @@ async def _inference_locked(
 
 
 @contextlib.contextmanager
-def _inference_ref(lm: LoadedModel):
+def _inference_ref(lm: LoadedModel, keep_alive: str | None = None):
     """Track active inference on a model to prevent expiry during use.
 
     Note: there is a small window between ``ensure_loaded()`` (which returns
@@ -1108,6 +1108,10 @@ def _inference_ref(lm: LoadedModel):
     Bug #118: Python ``+=`` on int is not atomic. Concurrent async tasks can
     race on ``active_refs``. Use the model's ``_active_refs_lock`` to protect
     increments and decrements.
+
+    Bug #338: *keep_alive* overrides the global default for expiry refresh.
+    When a request passes a specific keep_alive, that value is honoured after
+    inference instead of being silently replaced with the global default.
     """
     with lm._active_refs_lock:
         lm.active_refs += 1
@@ -1116,10 +1120,15 @@ def _inference_ref(lm: LoadedModel):
     finally:
         with lm._active_refs_lock:
             lm.active_refs -= 1
-        # Refresh expiry so the model doesn't expire immediately after inference
-        ka = parse_keep_alive(settings.default_keep_alive)
+        # Refresh expiry so the model doesn't expire immediately after inference.
+        # Honour per-request keep_alive when available (fix #338).
+        ka = parse_keep_alive(
+            keep_alive if keep_alive is not None else settings.default_keep_alive
+        )
         if ka is not None:
             lm.expires_at = time.time() + ka
+        else:
+            lm.expires_at = None
 
 
 def _build_generate_kwargs(options: dict | None, is_vlm: bool = False) -> dict:
@@ -1854,11 +1863,11 @@ async def generate_completion(
 
     if stream:
         return _prepend_meta(
-            _stream_completion(lm, prompt, mt, gen_kwargs, stats, images),
+            _stream_completion(lm, prompt, mt, gen_kwargs, stats, images, keep_alive=keep_alive),
             {"thinking_expected": thinking_expected},
         )
     else:
-        result = await _full_completion(lm, prompt, mt, gen_kwargs, stats, images)
+        result = await _full_completion(lm, prompt, mt, gen_kwargs, stats, images, keep_alive=keep_alive)
         result["thinking_expected"] = thinking_expected
         return result
 
@@ -2387,6 +2396,7 @@ async def _stream_completion(
     use_prompt_cache: bool = False,
     prompt_tokens: list[int] | None = None,
     cache_id: str = "",
+    keep_alive: str | None = None,
 ) -> AsyncGenerator[dict, None]:
     # Use explicit acquire/release instead of `async with` to prevent
     # CancelledError from releasing the lock before cleanup completes.
@@ -2553,7 +2563,7 @@ async def _stream_completion(
         )
         timed_out = False
 
-        with _inference_ref(lm), Timer() as total_timer:
+        with _inference_ref(lm, keep_alive=keep_alive), Timer() as total_timer:
             with Timer() as eval_timer:
                 inf_start = time.monotonic()
                 token = None
@@ -2716,13 +2726,14 @@ async def _full_completion(
     use_prompt_cache: bool = False,
     prompt_tokens: list[int] | None = None,
     cache_id: str = "",
+    keep_alive: str | None = None,
 ) -> dict:
     # inference_timeout is not enforced for non-streaming: the GPU thread
     # cannot be safely cancelled (releasing the lock while Metal is still
     # running causes concurrent command buffer access).  Streaming handles
     # this via CancellableStream.cancel() + drain_and_join().
     async with _inference_locked(lm.inference_queue_timeout, sync_mode=lm.sync_mode):
-        with _inference_ref(lm):
+        with _inference_ref(lm, keep_alive=keep_alive):
             # Cache setup must happen under the inference lock so two
             # concurrent requests can't race to read/mutate the same store
             # entry.  The gate at the call site has already excluded VLM
@@ -3210,6 +3221,7 @@ async def generate_chat(
                 use_prompt_cache=use_prompt_cache,
                 prompt_tokens=prompt_tokens,
                 cache_id=cache_id,
+                keep_alive=keep_alive,
             ),
             {"thinking_expected": thinking_expected},
         )
@@ -3225,6 +3237,7 @@ async def generate_chat(
             use_prompt_cache=use_prompt_cache,
             prompt_tokens=prompt_tokens,
             cache_id=cache_id,
+            keep_alive=keep_alive,
         )
         # Mirror the streaming meta chunk so non-streaming routers can gate
         # orphan `</think>` handling on the same signal (issue #307).
@@ -3292,7 +3305,7 @@ async def generate_embeddings(
     lm = await manager.ensure_loaded(model_name, keep_alive)
 
     async with _inference_locked(lm.inference_queue_timeout, sync_mode=lm.sync_mode):
-        with _inference_ref(lm):
+        with _inference_ref(lm, keep_alive=keep_alive):
             embeddings = []
 
             tokenizer = lm.text_tokenizer

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -723,3 +723,153 @@ class TestKVCacheMemorySafetyFactor:
         """Zero tokens should still return 0."""
         model = MagicMock()
         assert estimate_kv_cache_bytes(model, 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# Bug #338: _inference_ref expiry refresh ignores per-request keep_alive
+# ---------------------------------------------------------------------------
+class TestInferenceRefKeepAlive:
+    """_inference_ref must honour per-request keep_alive (fix #338)."""
+
+    # The multi-threaded test above (test_concurrent_inference_ref_no_race)
+    # patches parse_keep_alive concurrently in 10 threads.  unittest.mock.patch
+    # is not thread-safe for the same target — a thread may restore another
+    # thread's mock as the "original", leaking the mock into subsequent tests.
+    # Work around by restoring the real function before each test.
+    @staticmethod
+    def setup_method() -> None:
+        import olmlx.engine.model_manager as _mm
+
+        _inf_mod.parse_keep_alive = _mm.parse_keep_alive  # type: ignore[attr-defined]
+
+    def test_uses_per_request_keep_alive(self):
+        """_inference_ref(keep_alive='1s') should set expiry to ~1 second."""
+        real_lm = LoadedModel(
+            name="test",
+            hf_path="test/test",
+            model=MagicMock(),
+            tokenizer=MagicMock(),
+        )
+        with _inference_ref(real_lm, keep_alive="1s"):
+            pass
+
+        assert real_lm.expires_at is not None
+        assert real_lm.expires_at <= time.time() + 2, (
+            f"expires_at should be ~1s from now, got {real_lm.expires_at - time.time():.1f}s"
+        )
+
+    def test_uses_zero_keep_alive(self):
+        """_inference_ref(keep_alive='0') should set expiry to now."""
+        real_lm = LoadedModel(
+            name="test",
+            hf_path="test/test",
+            model=MagicMock(),
+            tokenizer=MagicMock(),
+        )
+        with _inference_ref(real_lm, keep_alive="0"):
+            pass
+
+        assert real_lm.expires_at is not None
+        assert real_lm.expires_at <= time.time() + 1, (
+            f"expires_at should be ~0s from now, got {real_lm.expires_at - time.time():.1f}s"
+        )
+
+    def test_never_expire_keep_alive(self):
+        """_inference_ref(keep_alive='-1') should set expires_at to None."""
+        real_lm = LoadedModel(
+            name="test",
+            hf_path="test/test",
+            model=MagicMock(),
+            tokenizer=MagicMock(),
+        )
+        real_lm.expires_at = time.time() + 300
+        with _inference_ref(real_lm, keep_alive="-1"):
+            pass
+
+        assert real_lm.expires_at is None, (
+            f"expires_at should be None for keep_alive=-1, got {real_lm.expires_at}"
+        )
+
+    def test_falls_back_to_default_keep_alive(self):
+        """_inference_ref() without keep_alive should use settings.default_keep_alive."""
+        real_lm = LoadedModel(
+            name="test",
+            hf_path="test/test",
+            model=MagicMock(),
+            tokenizer=MagicMock(),
+        )
+        with patch.object(
+            _inf_mod.settings, "default_keep_alive", "2m"
+        ):
+            with _inference_ref(real_lm):
+                pass
+
+        assert real_lm.expires_at is not None
+        assert 110 <= (real_lm.expires_at - time.time()) <= 130, (
+            f"expires_at should be ~120s (2m) from now, "
+            f"got {real_lm.expires_at - time.time():.1f}s"
+        )
+
+    def test_none_setting_default_regression(self):
+        """When keep_alive is None and settings is also None, no refresh happens.
+
+        This is the pre-fix behaviour for the default path (unchanged).
+        """
+        real_lm = LoadedModel(
+            name="test",
+            hf_path="test/test",
+            model=MagicMock(),
+            tokenizer=MagicMock(),
+        )
+        with patch.object(_inf_mod.settings, "default_keep_alive", "0"):
+            with _inference_ref(real_lm):
+                pass
+
+        assert real_lm.expires_at is not None
+        assert real_lm.expires_at <= time.time() + 1, (
+            f"expires_at should be ~0s from now, got {real_lm.expires_at - time.time():.1f}s"
+        )
+
+    def test_speculative_refresh_does_not_overwrite_never(self):
+        """When keep_alive='-1', _inference_ref should not overwrite with default.
+
+        Regression test: before #338, _inference_ref would clobber expires_at=None
+        with the global default even when the request asked for -1.
+        """
+        real_lm = LoadedModel(
+            name="test",
+            hf_path="test/test",
+            model=MagicMock(),
+            tokenizer=MagicMock(),
+        )
+        real_lm.expires_at = None
+
+        with patch.object(
+            _inf_mod.settings, "default_keep_alive", "5m"
+        ):
+            with _inference_ref(real_lm, keep_alive="-1"):
+                pass
+
+        assert real_lm.expires_at is None, (
+            "keep_alive='-1' must keep expires_at=None even when default_keep_alive=5m"
+        )
+
+    def test_request_keep_alive_overrides_default(self):
+        """Per-request keep_alive='1s' must override settings.default_keep_alive='5m'"""
+        real_lm = LoadedModel(
+            name="test",
+            hf_path="test/test",
+            model=MagicMock(),
+            tokenizer=MagicMock(),
+        )
+        with patch.object(
+            _inf_mod.settings, "default_keep_alive", "5m"
+        ):
+            with _inference_ref(real_lm, keep_alive="1s"):
+                pass
+
+        assert real_lm.expires_at is not None
+        assert real_lm.expires_at <= time.time() + 2, (
+            f"Per-request keep_alive='1s' must win over default '5m', "
+            f"got {real_lm.expires_at - time.time():.1f}s"
+        )

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -798,9 +798,7 @@ class TestInferenceRefKeepAlive:
             model=MagicMock(),
             tokenizer=MagicMock(),
         )
-        with patch.object(
-            _inf_mod.settings, "default_keep_alive", "2m"
-        ):
+        with patch.object(_inf_mod.settings, "default_keep_alive", "2m"):
             with _inference_ref(real_lm):
                 pass
 
@@ -811,9 +809,9 @@ class TestInferenceRefKeepAlive:
         )
 
     def test_none_setting_default_regression(self):
-        """When keep_alive is None and settings is also None, no refresh happens.
+        """_inference_ref() with no per-request keep_alive falls back to settings.default_keep_alive.
 
-        This is the pre-fix behaviour for the default path (unchanged).
+        Patches default to "0" so expiry is set to approximately now.
         """
         real_lm = LoadedModel(
             name="test",
@@ -844,9 +842,7 @@ class TestInferenceRefKeepAlive:
         )
         real_lm.expires_at = None
 
-        with patch.object(
-            _inf_mod.settings, "default_keep_alive", "5m"
-        ):
+        with patch.object(_inf_mod.settings, "default_keep_alive", "5m"):
             with _inference_ref(real_lm, keep_alive="-1"):
                 pass
 
@@ -862,9 +858,7 @@ class TestInferenceRefKeepAlive:
             model=MagicMock(),
             tokenizer=MagicMock(),
         )
-        with patch.object(
-            _inf_mod.settings, "default_keep_alive", "5m"
-        ):
+        with patch.object(_inf_mod.settings, "default_keep_alive", "5m"):
             with _inference_ref(real_lm, keep_alive="1s"):
                 pass
 


### PR DESCRIPTION
## Summary

Fixes #338: `keep_alive` sent on a chat/generate request was ignored by `_inference_ref`'s expiry refresh — the request value never actually controlled when the model unloads.

## Root cause

`_inference_ref()` in `olmlx/engine/inference.py` always refreshed `lm.expires_at` using `settings.default_keep_alive` (`"5m"`), ignoring the per-request `keep_alive` value that had been passed through `ensure_loaded()`.

## Changes

- **`olmlx/engine/inference.py`**: `_inference_ref` now accepts `keep_alive: str | None = None` and uses it (falling back to `settings.default_keep_alive` when none provided). Added `else: lm.expires_at = None` branch for consistency with `ensure_loaded`. `_stream_completion` and `_full_completion` gain a `keep_alive` kwarg. `generate_chat`, `generate_completion`, and `generate_embeddings` pass their existing `keep_alive` parameter through.
- **`tests/test_inference_bugs.py`**: Added `TestInferenceRefKeepAlive` with 7 tests covering per-request `1s`/`0`/`-1`, fallback to default, request overriding default, and the regression where `-1` was clobbered.

## Verification

Full test suite: 2966 passed, 0 failures.