### PR TITLE
fix: derive model metadata from disk when manifest.json is missing (#340)

### DIFF
--- a/olmlx/models/store.py
+++ b/olmlx/models/store.py
@@ -82,27 +82,46 @@ def _dir_size(path: Path) -> int:
     return total
 
 
+def _read_hf_path_sidecar(model_dir: Path) -> str | None:
+    """Read the .hf_path sidecar written by ensure_downloaded, if present.
+
+    The sidecar exists for dirs we created via /api/pull or model load — it
+    carries the exact HF repo id so _derive_manifest doesn't have to reverse
+    the lossy _safe_dir_name encoding for orgs whose names contain '_'.
+    """
+    sidecar = model_dir / ".hf_path"
+    if not sidecar.exists():
+        return None
+    try:
+        text = sidecar.read_text().strip()
+    except OSError:
+        return None
+    return text or None
+
+
+def _write_hf_path_sidecar(model_dir: Path, hf_path: str) -> None:
+    sidecar = model_dir / ".hf_path"
+    try:
+        sidecar.write_text(hf_path)
+    except OSError:
+        logger.warning("Failed to write hf_path sidecar to %s", sidecar)
+
+
 def _derive_manifest(
     model_dir: Path,
     *,
-    name: str | None = None,
-    hf_path: str | None = None,
+    name: str,
+    hf_path: str,
 ) -> ModelManifest:
     """Synthesize a ModelManifest from on-disk files when manifest.json is absent.
 
     Covers model dirs created outside of /api/pull — mlx-lm's own download
     path, manual moves, etc. — which have config.json + weights but no
-    manifest.json (issue #340).
+    manifest.json (issue #340).  Caller resolves name/hf_path so the result
+    is deterministic across endpoints (see ModelStore._canonicalize_dir).
     """
     meta = _extract_metadata(model_dir)
     size = _dir_size(model_dir)
-    if hf_path is None:
-        # Dir naming convention is _safe_dir_name(hf_path) — for the typical
-        # "org/repo" shape this is "org_repo", so reverse the first underscore.
-        d = model_dir.name
-        hf_path = d.replace("_", "/", 1) if "_" in d else d
-    if name is None:
-        name = hf_path if ":" in hf_path else f"{hf_path}:latest"
     mtime = model_dir.stat().st_mtime
     modified_at = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
     return ModelManifest(
@@ -136,6 +155,29 @@ class ModelStore:
         return (local / "config.json").exists() and not (
             local / ".downloading"
         ).exists()
+
+    def _canonicalize_dir(self, model_dir: Path) -> tuple[str, str]:
+        """Return the canonical (manifest_name, hf_path) for a model dir.
+
+        Resolution order for hf_path: .hf_path sidecar (authoritative for
+        dirs we created) → reverse the dir-name encoding (lossy fallback
+        for orgs whose names contain '_').  manifest_name prefers the
+        registry's normalized alias for this hf_path, so digests are stable
+        across /api/show, /api/tags, and /api/ps regardless of how the
+        caller spelled the model.
+        """
+        hf_path = _read_hf_path_sidecar(model_dir)
+        if hf_path is None:
+            d = model_dir.name
+            hf_path = d.replace("_", "/", 1) if "_" in d else d
+        canonical_name: str | None = None
+        for cfg_name, cfg in self.registry.list_models().items():
+            if cfg.hf_path == hf_path:
+                canonical_name = self.registry.normalize_name(cfg_name)
+                break
+        if canonical_name is None:
+            canonical_name = hf_path if ":" in hf_path else f"{hf_path}:latest"
+        return canonical_name, hf_path
 
     def _resolve_model_dir(self, name: str) -> Path | None:
         """Resolve a model name to its local directory, trying HF-path-based naming first.
@@ -201,6 +243,9 @@ class ModelStore:
             # resume on retry.  The .downloading marker keeps is_downloaded()
             # safe either way.
             snapshot_download(repo_id=hf_path, local_dir=str(local_dir))
+            # Persist the exact hf_path so future _derive_manifest calls
+            # don't have to reverse the lossy dir-name encoding (issue #340).
+            _write_hf_path_sidecar(local_dir, hf_path)
             try:
                 marker.unlink(missing_ok=True)
             except OSError:
@@ -286,23 +331,34 @@ class ModelStore:
 
             yield {"status": "success"}
 
+    def _derive_and_cache(self, model_dir: Path) -> ModelManifest:
+        """Build a ModelManifest from disk and persist it as manifest.json.
+
+        Caching to disk caps the _dir_size walk to one per model per
+        install (subsequent calls hit the manifest.json fast path).  Write
+        failures are tolerated — the manifest is still returned for this
+        call, the walk just repeats next time.
+        """
+        name, hf_path = self._canonicalize_dir(model_dir)
+        manifest = _derive_manifest(model_dir, name=name, hf_path=hf_path)
+        try:
+            manifest.save(model_dir / "manifest.json")
+        except OSError:
+            logger.warning(
+                "Failed to cache derived manifest at %s", model_dir / "manifest.json"
+            )
+        return manifest
+
     def list_local(self) -> list[ModelManifest]:
         """List all locally stored models.
 
         Dirs without manifest.json but with config.json are still surfaced
-        with metadata derived from disk (issue #340).
+        with metadata derived from disk and cached as manifest.json on
+        first sight (issue #340).
         """
         models = []
         if not self.models_dir.exists():
             return models
-        # Map safe-dir-name → (normalized name, hf_path) so derived manifests
-        # for known models inherit their registry-canonical name/hf_path.
-        by_dir: dict[str, tuple[str, str]] = {}
-        for cfg_name, cfg in self.registry.list_models().items():
-            by_dir.setdefault(
-                _safe_dir_name(cfg.hf_path),
-                (self.registry.normalize_name(cfg_name), cfg.hf_path),
-            )
         for d in self.models_dir.iterdir():
             if not d.is_dir():
                 continue
@@ -318,11 +374,8 @@ class ModelStore:
                     )
             if not (d / "config.json").exists():
                 continue
-            entry = by_dir.get(d.name)
-            name = entry[0] if entry else None
-            hf_path = entry[1] if entry else None
             try:
-                models.append(_derive_manifest(d, name=name, hf_path=hf_path))
+                models.append(self._derive_and_cache(d))
             except Exception:
                 logger.warning("Failed to derive manifest for %s", d)
         return models
@@ -339,10 +392,7 @@ class ModelStore:
                 logger.warning(
                     "Failed to load manifest %s; deriving from disk", manifest_path
                 )
-        resolved = self.registry.resolve(name)
-        hf_path = resolved.hf_path if resolved is not None else None
-        derived_name = self.registry.normalize_name(name) if "/" not in name else None
-        return _derive_manifest(model_dir, name=derived_name, hf_path=hf_path)
+        return self._derive_and_cache(model_dir)
 
     def delete(self, name: str) -> bool:
         import shutil

--- a/olmlx/models/store.py
+++ b/olmlx/models/store.py
@@ -82,6 +82,42 @@ def _dir_size(path: Path) -> int:
     return total
 
 
+def _derive_manifest(
+    model_dir: Path,
+    *,
+    name: str | None = None,
+    hf_path: str | None = None,
+) -> ModelManifest:
+    """Synthesize a ModelManifest from on-disk files when manifest.json is absent.
+
+    Covers model dirs created outside of /api/pull — mlx-lm's own download
+    path, manual moves, etc. — which have config.json + weights but no
+    manifest.json (issue #340).
+    """
+    meta = _extract_metadata(model_dir)
+    size = _dir_size(model_dir)
+    if hf_path is None:
+        # Dir naming convention is _safe_dir_name(hf_path) — for the typical
+        # "org/repo" shape this is "org_repo", so reverse the first underscore.
+        d = model_dir.name
+        hf_path = d.replace("_", "/", 1) if "_" in d else d
+    if name is None:
+        name = hf_path if ":" in hf_path else f"{hf_path}:latest"
+    mtime = model_dir.stat().st_mtime
+    modified_at = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
+    return ModelManifest(
+        name=name,
+        hf_path=hf_path,
+        size=size,
+        modified_at=modified_at,
+        digest=ModelManifest.compute_digest(name),
+        format="mlx",
+        family=meta["family"],
+        parameter_size=meta["parameter_size"],
+        quantization_level=meta["quantization_level"],
+    )
+
+
 class ModelStore:
     def __init__(self, registry: ModelRegistry):
         self.registry = registry
@@ -102,18 +138,27 @@ class ModelStore:
         ).exists()
 
     def _resolve_model_dir(self, name: str) -> Path | None:
-        """Resolve a model name to its local directory, trying HF-path-based naming first."""
+        """Resolve a model name to its local directory, trying HF-path-based naming first.
+
+        A directory qualifies if it has either manifest.json (created by
+        /api/pull) or config.json (created by mlx-lm download paths or
+        manual moves — issue #340).
+        """
+
+        def _is_model_dir(d: Path) -> bool:
+            return (d / "manifest.json").exists() or (d / "config.json").exists()
+
         resolved = self.registry.resolve(name)
         hf_path = resolved.hf_path if resolved is not None else None
         if hf_path is not None:
             d = self.local_path(hf_path)
-            if (d / "manifest.json").exists():
+            if _is_model_dir(d):
                 return d
         # Fall back to old name-based directories
         normalized = self.registry.normalize_name(name)
         for candidate in [_safe_dir_name(normalized), _safe_dir_name(name)]:
             d = self.models_dir / candidate
-            if (d / "manifest.json").exists():
+            if _is_model_dir(d):
                 return d
         return None
 
@@ -242,25 +287,62 @@ class ModelStore:
             yield {"status": "success"}
 
     def list_local(self) -> list[ModelManifest]:
-        """List all locally stored models."""
+        """List all locally stored models.
+
+        Dirs without manifest.json but with config.json are still surfaced
+        with metadata derived from disk (issue #340).
+        """
         models = []
         if not self.models_dir.exists():
             return models
+        # Map safe-dir-name → (normalized name, hf_path) so derived manifests
+        # for known models inherit their registry-canonical name/hf_path.
+        by_dir: dict[str, tuple[str, str]] = {}
+        for cfg_name, cfg in self.registry.list_models().items():
+            by_dir.setdefault(
+                _safe_dir_name(cfg.hf_path),
+                (self.registry.normalize_name(cfg_name), cfg.hf_path),
+            )
         for d in self.models_dir.iterdir():
-            if d.is_dir():
-                manifest_path = d / "manifest.json"
-                if manifest_path.exists():
-                    try:
-                        models.append(ModelManifest.load(manifest_path))
-                    except Exception:
-                        logger.warning("Failed to load manifest: %s", manifest_path)
+            if not d.is_dir():
+                continue
+            manifest_path = d / "manifest.json"
+            if manifest_path.exists():
+                try:
+                    models.append(ModelManifest.load(manifest_path))
+                    continue
+                except Exception:
+                    logger.warning(
+                        "Failed to load manifest %s; deriving from disk",
+                        manifest_path,
+                    )
+            if not (d / "config.json").exists():
+                continue
+            entry = by_dir.get(d.name)
+            name = entry[0] if entry else None
+            hf_path = entry[1] if entry else None
+            try:
+                models.append(_derive_manifest(d, name=name, hf_path=hf_path))
+            except Exception:
+                logger.warning("Failed to derive manifest for %s", d)
         return models
 
     def show(self, name: str) -> ModelManifest | None:
         model_dir = self._resolve_model_dir(name)
-        if model_dir is not None:
-            return ModelManifest.load(model_dir / "manifest.json")
-        return None
+        if model_dir is None:
+            return None
+        manifest_path = model_dir / "manifest.json"
+        if manifest_path.exists():
+            try:
+                return ModelManifest.load(manifest_path)
+            except Exception:
+                logger.warning(
+                    "Failed to load manifest %s; deriving from disk", manifest_path
+                )
+        resolved = self.registry.resolve(name)
+        hf_path = resolved.hf_path if resolved is not None else None
+        derived_name = self.registry.normalize_name(name) if "/" not in name else None
+        return _derive_manifest(model_dir, name=derived_name, hf_path=hf_path)
 
     def delete(self, name: str) -> bool:
         import shutil

--- a/olmlx/routers/status.py
+++ b/olmlx/routers/status.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Request
@@ -37,8 +38,10 @@ async def ps(request: Request):
             expires = datetime.fromtimestamp(lm.expires_at, tz=timezone.utc).isoformat()
         # Pull disk-side metadata (family, quantization, digest, on-disk size)
         # from the store — derived from manifest.json when present, or from
-        # config.json + dir contents otherwise (issue #340).
-        manifest = store.show(lm.name)
+        # config.json + dir contents otherwise (issue #340).  The first
+        # derive call walks the model dir (one-time cost; result is cached
+        # to manifest.json), so run it off the event loop.
+        manifest = await asyncio.to_thread(store.show, lm.name)
         if manifest is not None:
             details = ModelDetails(
                 format=manifest.format,

--- a/olmlx/routers/status.py
+++ b/olmlx/routers/status.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import PlainTextResponse
 
 from olmlx import __version__
+from olmlx.schemas.models import ModelDetails
 from olmlx.schemas.status import PsResponse, RunningModel, VersionResponse
 
 router = APIRouter()
@@ -27,17 +28,37 @@ async def version():
 @router.get("/api/ps")
 async def ps(request: Request):
     manager = request.app.state.model_manager
+    store = request.app.state.model_store
     loaded = manager.get_loaded()
     models = []
     for lm in loaded:
         expires = ""
         if lm.expires_at is not None:
             expires = datetime.fromtimestamp(lm.expires_at, tz=timezone.utc).isoformat()
+        # Pull disk-side metadata (family, quantization, digest, on-disk size)
+        # from the store — derived from manifest.json when present, or from
+        # config.json + dir contents otherwise (issue #340).
+        manifest = store.show(lm.name)
+        if manifest is not None:
+            details = ModelDetails(
+                format=manifest.format,
+                family=manifest.family,
+                parameter_size=manifest.parameter_size,
+                quantization_level=manifest.quantization_level,
+            )
+            digest = manifest.digest
+            disk_size = manifest.size or lm.size_bytes
+        else:
+            details = ModelDetails()
+            digest = ""
+            disk_size = lm.size_bytes
         models.append(
             RunningModel(
                 name=lm.name,
                 model=lm.hf_path,
-                size=lm.size_bytes,
+                size=disk_size,
+                digest=digest,
+                details=details,
                 expires_at=expires,
                 size_vram=lm.size_bytes,
                 active_refs=lm.active_refs,

--- a/tests/test_routers_models.py
+++ b/tests/test_routers_models.py
@@ -41,3 +41,28 @@ class TestModelsRouter:
         data = resp.json()
         assert "details" in data
         assert data["details"]["family"] == "qwen"
+
+    @pytest.mark.asyncio
+    async def test_show_found_without_manifest(self, app_client):
+        """Issue #340: /api/show works on dirs that lack manifest.json."""
+        import json
+
+        store = app_client._transport.app.state.model_store
+        local_dir = store.local_path("mlx-community/Qwen3-4B-4bit")
+        local_dir.mkdir(parents=True, exist_ok=True)
+        (local_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "qwen3",
+                    "quantization": {"bits": 4, "group_size": 64},
+                }
+            )
+        )
+
+        resp = await app_client.post(
+            "/api/show", json={"model": "mlx-community/Qwen3-4B-4bit"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["details"]["family"] == "qwen3"
+        assert data["details"]["quantization_level"] == "4-bit"

--- a/tests/test_routers_status.py
+++ b/tests/test_routers_status.py
@@ -42,6 +42,35 @@ class TestStatusRouter:
         assert data["models"][0]["name"] == "qwen3:latest"
 
     @pytest.mark.asyncio
+    async def test_ps_populates_details_without_manifest(self, app_client):
+        """Issue #340: /api/ps fills details from config.json when manifest.json is missing."""
+        import json
+
+        store = app_client._transport.app.state.model_store
+        # The mock loaded model is "qwen3:latest" → "Qwen/Qwen3-8B-MLX".
+        local_dir = store.local_path("Qwen/Qwen3-8B-MLX")
+        local_dir.mkdir(parents=True, exist_ok=True)
+        (local_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "qwen3",
+                    "quantization": {"bits": 4, "group_size": 64},
+                }
+            )
+        )
+        (local_dir / "model.safetensors").write_bytes(b"\x00" * 512)
+
+        resp = await app_client.get("/api/ps")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["models"]) == 1
+        model = data["models"][0]
+        assert model["details"]["family"] == "qwen3"
+        assert model["details"]["quantization_level"] == "4-bit"
+        assert model["size"] >= 512
+        assert model["digest"] != ""
+
+    @pytest.mark.asyncio
     async def test_ps_with_expiry(self, app_client):
         import time
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -157,6 +157,54 @@ class TestModelStore:
         assert result is not None
         assert result.name == "test:latest"
 
+    def test_show_found_without_manifest(self, mock_store, tmp_path):
+        """Issue #340: show derives metadata from config.json when manifest.json is missing.
+
+        Reproduces dirs populated by mlx-lm download paths or manual moves,
+        which lack manifest.json but have config.json + weights.
+        """
+        local_dir = mock_store.local_path("mlx-community/Qwen3-4B-4bit")
+        local_dir.mkdir(parents=True)
+        (local_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "qwen3",
+                    "hidden_size": 2560,
+                    "num_hidden_layers": 36,
+                    "quantization": {"bits": 4, "group_size": 64},
+                }
+            )
+        )
+        (local_dir / "model.safetensors").write_bytes(b"\x00" * 1024)
+
+        result = mock_store.show("mlx-community/Qwen3-4B-4bit")
+        assert result is not None
+        assert result.hf_path == "mlx-community/Qwen3-4B-4bit"
+        assert result.family == "qwen3"
+        assert result.quantization_level == "4-bit"
+        assert result.size >= 1024
+        assert result.digest != ""
+
+    def test_list_local_includes_dirs_without_manifest(self, mock_store, tmp_path):
+        """Issue #340: list_local surfaces models that lack manifest.json."""
+        local_dir = mock_store.local_path("mlx-community/Qwen3-4B-4bit")
+        local_dir.mkdir(parents=True)
+        (local_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "qwen3",
+                    "quantization": {"bits": 4, "group_size": 64},
+                }
+            )
+        )
+        (local_dir / "model.safetensors").write_bytes(b"\x00" * 256)
+
+        results = mock_store.list_local()
+        assert len(results) == 1
+        assert results[0].hf_path == "mlx-community/Qwen3-4B-4bit"
+        assert results[0].family == "qwen3"
+        assert results[0].quantization_level == "4-bit"
+
     def test_delete_not_found(self, mock_store):
         assert mock_store.delete("nonexistent") is False
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -185,6 +185,49 @@ class TestModelStore:
         assert result.size >= 1024
         assert result.digest != ""
 
+    def test_derive_uses_hf_path_sidecar(self, mock_store, tmp_path):
+        """Sidecar wins over the lossy dir-name reverse for orgs with '_' in name."""
+        # Pick an hf_path whose _safe_dir_name → reverse round-trip would lie.
+        hf_path = "my_org/MyModel"
+        local_dir = mock_store.local_path(hf_path)
+        local_dir.mkdir(parents=True)
+        (local_dir / "config.json").write_text(json.dumps({"model_type": "test"}))
+        (local_dir / ".hf_path").write_text(hf_path)
+
+        result = mock_store.show(hf_path)
+        assert result is not None
+        # Without the sidecar, the dir "my_org_MyModel" reverses to "my/org_MyModel".
+        assert result.hf_path == hf_path
+
+    def test_show_and_list_digests_agree_without_manifest(self, mock_store, tmp_path):
+        """Issue #351 review: digest must match between /api/show and /api/tags."""
+        local_dir = mock_store.local_path("Qwen/Qwen3-8B-MLX")
+        local_dir.mkdir(parents=True)
+        (local_dir / "config.json").write_text(json.dumps({"model_type": "qwen3"}))
+
+        show_via_alias = mock_store.show("qwen3")
+        # show() cached manifest.json on the first call; remove it so the
+        # second show() also re-derives and we're comparing derive paths.
+        (local_dir / "manifest.json").unlink()
+        show_via_hf = mock_store.show("Qwen/Qwen3-8B-MLX")
+        (local_dir / "manifest.json").unlink()
+        listed = [
+            m for m in mock_store.list_local() if m.hf_path == "Qwen/Qwen3-8B-MLX"
+        ]
+        assert len(listed) == 1
+        assert show_via_alias.digest == show_via_hf.digest == listed[0].digest
+        assert show_via_alias.name == "qwen3:latest"
+
+    def test_derive_caches_manifest_to_disk(self, mock_store, tmp_path):
+        """First derive walks the dir; subsequent calls hit manifest.json."""
+        local_dir = mock_store.local_path("org/model")
+        local_dir.mkdir(parents=True)
+        (local_dir / "config.json").write_text(json.dumps({"model_type": "test"}))
+        manifest_path = local_dir / "manifest.json"
+        assert not manifest_path.exists()
+        mock_store.show("org/model")
+        assert manifest_path.exists()
+
     def test_list_local_includes_dirs_without_manifest(self, mock_store, tmp_path):
         """Issue #340: list_local surfaces models that lack manifest.json."""
         local_dir = mock_store.local_path("mlx-community/Qwen3-4B-4bit")


### PR DESCRIPTION
## Summary

- `/api/show` 404'd and `/api/ps` returned empty `family`/`quantization_level`/`digest`/`size` for any model directory created outside of `/api/pull` (mlx-lm's own download path, manual moves). Affected ~half of model dirs on a typical install.
- `ModelStore._resolve_model_dir` now treats `config.json` as sufficient proof of a model dir (manifest.json remains preferred). A new `_derive_manifest()` helper synthesizes a `ModelManifest` from `config.json` + dir size + dir mtime when `manifest.json` is absent. `show()` and `list_local()` fall back to it.
- `/api/ps` looks up each loaded model via `store.show()` to populate `details.family`/`parameter_size`/`quantization_level`, `digest`, and on-disk `size` (`size_vram` still tracks the loaded bytes).

Fixes #340.

## Test plan

- [x] `uv run pytest tests/` — 2974 passed, 4 skipped
- [x] `uv run ruff check` + `ruff format --check` on touched files
- [ ] Manual: hit `/api/show` and `/api/ps` against a real install with a mlx-lm-downloaded dir (no `manifest.json`) and confirm family/quant/digest/size now populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)