### PR TITLE
feat: self-speculative decoding (LayerSkip-style)

### DIFF
--- a/olmlx/bench/scenarios.py
+++ b/olmlx/bench/scenarios.py
@@ -233,6 +233,27 @@ SCENARIOS: list[Scenario] = [
         should_skip=_requires_speculative_draft,
     ),
     Scenario(
+        name="self-speculative",
+        description=(
+            "Self-speculative decoding (LayerSkip — no external draft "
+            "model; uses the target's own early layers as draft)"
+        ),
+        env_overrides={
+            "OLMLX_SPECULATIVE": "true",
+            "OLMLX_SPECULATIVE_STRATEGY": "self_speculative",
+        },
+    ),
+    Scenario(
+        name="flash+self-speculative",
+        description="Flash inference + self-speculative decoding",
+        env_overrides={
+            "OLMLX_FLASH": "true",
+            "OLMLX_SPECULATIVE": "true",
+            "OLMLX_SPECULATIVE_STRATEGY": "self_speculative",
+        },
+        should_skip=_requires_flash,
+    ),
+    Scenario(
         name="flash+prefetch",
         description="Flash inference + speculative neuron prefetch",
         env_overrides={"OLMLX_FLASH": "true", "OLMLX_FLASH_PREFETCH": "true"},

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -1041,6 +1041,18 @@ def _audit_speculative_config(
             # per-model override, so the global setting is still
             # logically unused for that model.
             global_draft_used = True
+        if enabled and draft and strategy == "self_speculative":
+            # ``self_speculative`` uses the target's own layers as
+            # draft — an external draft model set in the config is
+            # silently ignored by ``_load_self_speculative_decoder``.
+            # Warn so the operator knows the draft model setting has
+            # no effect while this strategy is active.
+            logger.warning(
+                "speculative_draft_model is set for %r but "
+                "strategy='self_speculative' uses the target's own "
+                "layers — the draft model will be ignored.",
+                name,
+            )
         if enabled:
             # Resolve the full experimental config (global defaults
             # merged with per-model overrides) for ``flash`` and via

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -604,6 +604,7 @@ def _apply_serve_overrides(args) -> None:
     spec_strategy = getattr(args, "speculative_strategy", None)
     spec_draft = getattr(args, "speculative_draft_model", None)
     spec_tokens = getattr(args, "speculative_tokens", None)
+    spec_layers_skip = getattr(args, "speculative_layers_skip", None)
     if spec is not None:
         _settings.speculative = spec
     if spec_strategy is not None:
@@ -612,6 +613,8 @@ def _apply_serve_overrides(args) -> None:
         _settings.speculative_draft_model = spec_draft
     if spec_tokens is not None:
         _settings.speculative_tokens = spec_tokens
+    if spec_layers_skip is not None:
+        _settings.speculative_layers_skip = spec_layers_skip
 
     kvq = getattr(args, "kv_cache_quant", None)
     if kvq is not None:
@@ -745,8 +748,8 @@ def _apply_serve_overrides(args) -> None:
             "with Flash-MoE. Once Flash-MoE is prepared and loads, this "
             "will raise a ValueError at load time (dflash requires "
             "hidden-state capture that does not generalize to MoE "
-            "routing): %s. Use speculative_strategy='classic' or set "
-            "speculative=false.",
+            "routing): %s. Use speculative_strategy='classic', "
+            "'self_speculative', or set speculative=false.",
             ", ".join(dflash_moe_actionable),
         )
     if bad:
@@ -1021,7 +1024,7 @@ def _audit_speculative_config(
                 exc_info=True,
             )
             continue
-        if enabled and not draft:
+        if enabled and not draft and strategy != "self_speculative":
             bad.append(name)
         elif not enabled and mc.speculative_draft_model:
             # Use the raw per-model field rather than the resolved
@@ -2818,15 +2821,17 @@ def build_parser() -> argparse.ArgumentParser:
     serve_p.add_argument(
         "--speculative-strategy",
         dest="speculative_strategy",
-        choices=("classic", "dflash", "eagle", "pld"),
+        choices=("classic", "dflash", "eagle", "pld", "self_speculative"),
         default=None,
         help=(
             "Speculative decoding strategy: 'classic' (standalone draft LM), "
             "'dflash' (block-diffusion draft conditioned on target hidden "
             "states), 'eagle' (autoregressive draft head conditioned on "
-            "target last-layer hidden, arxiv 2401.15077), or 'pld' "
+            "target last-layer hidden, arxiv 2401.15077), 'pld' "
             "(prompt-lookup decoding — n-gram lookup in the prompt+generated "
-            "history, no draft model required). Default: classic."
+            "history, no draft model required), or 'self_speculative' "
+            "(LayerSkip-style — uses target's own early layers as draft; "
+            "no external draft model required). Default: classic."
         ),
     )
     serve_p.add_argument(
@@ -2846,6 +2851,17 @@ def build_parser() -> argparse.ArgumentParser:
             "for classic, 10 for PLD). For DFlash this is the block size "
             "(excluding the pending token); for PLD it's the max draft "
             "length (actual draft is bounded by the longest n-gram match)."
+        ),
+    )
+    serve_p.add_argument(
+        "--speculative-layers-skip",
+        dest="speculative_layers_skip",
+        type=_positive_int,
+        default=None,
+        help=(
+            "Number of layers skipped during self_speculative draft "
+            "(default: L//4, where L is the total number of layers). "
+            "Only applies to strategy='self_speculative'."
         ),
     )
     serve_p.add_argument(

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -167,14 +167,20 @@ class Settings(BaseSettings):
     #   carries an ``eagle_config`` block.
     # - ``pld``: prompt-lookup decoding. No draft model — the "draft" comes
     #   from n-gram lookup in the prompt+generated history. Free acceptance
-    #   on code edits, repeated context, and JSON/structured replies. Only
-    #   speculative strategy that composes with Flash-MoE.
+    #   on code edits, repeated context, and JSON/structured replies.
+    # - ``self_speculative``: LayerSkip-style decoding — uses the target's
+    #   own early layers (0..L-skip-1) as an autoregressive draft, then
+    #   verifies with all L layers in one forward pass. No external draft
+    #   model required. Works under Flash and Flash-MoE.
+    #   Configured with ``speculative_layers_skip`` (default: L//4).
+    # Both ``pld`` and ``self_speculative`` compose with Flash-MoE.
     # ``speculative_tokens`` is reused as DFlash's ``block_size``, EAGLE's
-    # per-verify draft-token count, and PLD's max draft length. ``None``
-    # means "use the strategy default": 4 for classic, 10 for PLD, the
-    # draft model's pre-trained ``block_size`` for DFlash and EAGLE.
+    # per-verify draft-token count, PLD's max draft length, and
+    # self_speculative's draft token count. ``None`` means "use the
+    # strategy default": 4 for classic and self_speculative, 10 for PLD,
+    # the draft model's pre-trained ``block_size`` for DFlash and EAGLE.
     speculative: bool = False
-    speculative_strategy: Literal["classic", "dflash", "eagle", "pld"] = "classic"
+    speculative_strategy: Literal["classic", "dflash", "eagle", "pld", "self_speculative"] = "classic"
     speculative_draft_model: Annotated[str, Field(min_length=1)] | None = None
     speculative_tokens: Annotated[int, Field(gt=0)] | None = None
     #: PLD-only knobs (ignored by other strategies). N-gram sizes for the
@@ -190,6 +196,9 @@ class Settings(BaseSettings):
     #: max_ngram=3); raise it if you need matches against an older
     #: prefix, lower it if you're seeing scan-time regressions.
     speculative_pld_lookup_window: Annotated[int, Field(gt=0)] = 8192
+    #: Self-speculative knob — number of layers skipped during the draft
+    #: pass. ``None`` defaults to L//4 at load time.
+    speculative_layers_skip: Annotated[int, Field(ge=1)] | None = None
 
     # Flash inference (LLM in a Flash). Primary, user-facing knobs.
     # Advanced tuning (window size, IO threads, cache budget, predictor

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -180,7 +180,9 @@ class Settings(BaseSettings):
     # strategy default": 4 for classic and self_speculative, 10 for PLD,
     # the draft model's pre-trained ``block_size`` for DFlash and EAGLE.
     speculative: bool = False
-    speculative_strategy: Literal["classic", "dflash", "eagle", "pld", "self_speculative"] = "classic"
+    speculative_strategy: Literal[
+        "classic", "dflash", "eagle", "pld", "self_speculative"
+    ] = "classic"
     speculative_draft_model: Annotated[str, Field(min_length=1)] | None = None
     speculative_tokens: Annotated[int, Field(gt=0)] | None = None
     #: PLD-only knobs (ignored by other strategies). N-gram sizes for the

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2942,6 +2942,46 @@ class ModelManager:
             lookup_window=spec_config.pld_lookup_window,
         )
 
+    def _load_self_speculative_decoder(
+        self,
+        target_model: Any,
+        spec_config: SpeculativeConfig,
+    ) -> Any:
+        """Create a SelfSpeculativeDecoder using the target's own early layers.
+
+        No external draft model is loaded. ``spec_config.layers_skip``
+        determines how many layers the draft skips (defaulting to
+        ``L // 4`` when ``None``).
+        """
+        from olmlx.engine.gdn_rollback import get_model_layers
+        from olmlx.engine.self_speculative import SelfSpeculativeDecoder
+
+        num_tokens = spec_config.num_tokens if spec_config.num_tokens is not None else 4
+
+        total_layers = len(get_model_layers(target_model))
+        if spec_config.layers_skip is not None:
+            layers_skip = spec_config.layers_skip
+        else:
+            layers_skip = max(total_layers // 4, 1)
+        num_early_layers = total_layers - layers_skip
+        if num_early_layers < 1:
+            num_early_layers = 1
+            layers_skip = total_layers - 1
+
+        logger.info(
+            "Self-speculative: draft uses %d/%d layers (skip=%d, λ=%d)",
+            num_early_layers,
+            total_layers,
+            layers_skip,
+            num_tokens,
+        )
+
+        return SelfSpeculativeDecoder(
+            target_model=target_model,
+            num_early_layers=num_early_layers,
+            num_speculative_tokens=num_tokens,
+        )
+
     def _is_flash_enabled(self, flash_config: ResolvedFlashConfig) -> bool:
         return flash_config.enabled
 
@@ -3248,8 +3288,9 @@ class ModelManager:
                     raise ValueError(
                         f"speculative_strategy={spec_config.strategy!r} is "
                         "not supported on Flash-MoE targets. Use "
-                        "speculative_strategy='classic' or remove the "
-                        "speculative settings."
+                        "speculative_strategy='classic' or "
+                        "'self_speculative', or remove the speculative "
+                        "settings."
                     )
                 if flash_config.flash_speculative:
                     raise ValueError(
@@ -3273,6 +3314,10 @@ class ModelManager:
                     if spec_config.strategy == "pld":
                         decoder = self._load_pld_decoder(
                             model, spec_config, is_vlm=is_vlm
+                        )
+                    elif spec_config.strategy == "self_speculative":
+                        decoder = self._load_self_speculative_decoder(
+                            model, spec_config
                         )
                     else:
                         decoder = self._load_speculative_decoder(
@@ -3355,8 +3400,9 @@ class ModelManager:
                     raise ValueError(
                         f"speculative_strategy={spec_config.strategy!r} is not "
                         "supported on VLM targets. Use "
-                        "speculative_strategy='classic' or remove the "
-                        "speculative settings."
+                        "speculative_strategy='classic' or "
+                        "'self_speculative', or remove the speculative "
+                        "settings."
                     )
                 if flash_config.flash_speculative:
                     raise ValueError(
@@ -3369,6 +3415,11 @@ class ModelManager:
                     if spec_config.strategy == "pld":
                         decoder = self._load_pld_decoder(
                             model, spec_config, is_vlm=True
+                        )
+                    elif spec_config.strategy == "self_speculative":
+                        spec_target = getattr(model, "language_model", model)
+                        decoder = self._load_self_speculative_decoder(
+                            spec_target, spec_config
                         )
                     else:
                         decoder = self._load_speculative_decoder(
@@ -3405,6 +3456,8 @@ class ModelManager:
                 decoder = self._load_eagle_decoder(model, spec_config)
             elif spec_config.strategy == "pld":
                 decoder = self._load_pld_decoder(model, spec_config)
+            elif spec_config.strategy == "self_speculative":
+                decoder = self._load_self_speculative_decoder(model, spec_config)
             else:
                 decoder = self._load_speculative_decoder(model, hf_path, spec_config)
             return model, tokenizer, is_vlm, caps, decoder

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -14,9 +14,9 @@ import logging
 
 from olmlx.config import FlashMoeConfig, SyncMode, settings
 
-SpeculativeStrategy = Literal["classic", "dflash", "eagle", "pld"]
+SpeculativeStrategy = Literal["classic", "dflash", "eagle", "pld", "self_speculative"]
 _VALID_SPECULATIVE_STRATEGIES: frozenset[str] = frozenset(
-    ("classic", "dflash", "eagle", "pld")
+    ("classic", "dflash", "eagle", "pld", "self_speculative")
 )
 
 logger = logging.getLogger(__name__)
@@ -262,8 +262,9 @@ class SpeculativeConfig(NamedTuple):
 
     enabled: bool
     draft_model: str | None
-    #: ``None`` means "use the strategy default" — 4 for classic speculative
-    #: decoding, the draft model's pre-trained ``block_size`` for DFlash.
+    #: ``None`` means "use the strategy default" — 4 for classic and
+    #: self_speculative, the draft model's pre-trained ``block_size``
+    #: for DFlash and EAGLE.
     num_tokens: int | None
     strategy: SpeculativeStrategy = "classic"
     #: PLD-only n-gram tuning. ``None`` means "use the global
@@ -273,6 +274,9 @@ class SpeculativeConfig(NamedTuple):
     pld_max_ngram: int | None = None
     pld_min_ngram: int | None = None
     pld_lookup_window: int | None = None
+    #: Number of layers to skip during self_speculative draft. ``None``
+    #: means "use the strategy default" — L//4 at load time.
+    layers_skip: int | None = None
 
 
 @dataclass
@@ -303,6 +307,7 @@ class ModelConfig:
     speculative_pld_max_ngram: int | None = None
     speculative_pld_min_ngram: int | None = None
     speculative_pld_lookup_window: int | None = None
+    speculative_layers_skip: int | None = None
     #: KV cache quantization method and bits (e.g. "turboquant:4").
     #: ``None`` means inherit the global ``Settings.kv_cache_quant`` value.
     kv_cache_quant: str | None = None
@@ -401,6 +406,15 @@ class ModelConfig:
                 f"'speculative_pld_max_ngram' "
                 f"({self.speculative_pld_max_ngram})"
             )
+        if self.speculative_layers_skip is not None and (
+            isinstance(self.speculative_layers_skip, bool)
+            or not isinstance(self.speculative_layers_skip, int)
+            or self.speculative_layers_skip < 1
+        ):
+            raise ValueError(
+                f"'speculative_layers_skip' must be a positive integer or "
+                f"None, got {self.speculative_layers_skip!r}"
+            )
         # Flash primary-knob bounds match the Settings field constraints.
         # Kept here so direct ModelConfig() construction (tests,
         # programmatic callers) hits the same validation as from_entry().
@@ -497,13 +511,14 @@ class ModelConfig:
         """Resolve speculative config: per-model overrides global settings.
 
         Returns a ``SpeculativeConfig(enabled, draft_model, num_tokens,
-        strategy, pld_max_ngram, pld_min_ngram, pld_lookup_window)``.
+        strategy, pld_max_ngram, pld_min_ngram, pld_lookup_window,
+        layers_skip)``.
         When ``enabled`` is ``False`` the draft slot is forced to
         ``None`` even if a global ``speculative_draft_model`` is
         configured — callers should never see a non-None draft for a
-        disabled model. The token count and PLD knobs are always
-        returned so callers that flip ``enabled`` at runtime keep a
-        sensible default.
+        disabled model. The token count, PLD knobs, and layers_skip are
+        always returned so callers that flip ``enabled`` at runtime keep
+        a sensible default.
         """
         from olmlx.config import settings
 
@@ -535,6 +550,11 @@ class ModelConfig:
             if self.speculative_pld_lookup_window is not None
             else settings.speculative_pld_lookup_window
         )
+        layers_skip = (
+            self.speculative_layers_skip
+            if self.speculative_layers_skip is not None
+            else settings.speculative_layers_skip
+        )
         # Cross-field checks: per-model overrides combined with global
         # values may produce inverted/under-sized pairs that pass each
         # layer's local validation. ``Settings`` and
@@ -562,13 +582,14 @@ class ModelConfig:
                 )
         if not enabled:
             return SpeculativeConfig(
-                False,
-                None,
-                tokens,
-                strategy,
-                pld_max_ngram,
-                pld_min_ngram,
-                pld_lookup_window,
+                enabled=False,
+                draft_model=None,
+                num_tokens=tokens,
+                strategy=strategy,
+                pld_max_ngram=pld_max_ngram,
+                pld_min_ngram=pld_min_ngram,
+                pld_lookup_window=pld_lookup_window,
+                layers_skip=layers_skip,
             )
         draft = (
             self.speculative_draft_model
@@ -576,13 +597,14 @@ class ModelConfig:
             else settings.speculative_draft_model
         )
         return SpeculativeConfig(
-            True,
-            draft,
-            tokens,
-            strategy,
-            pld_max_ngram,
-            pld_min_ngram,
-            pld_lookup_window,
+            enabled=True,
+            draft_model=draft,
+            num_tokens=tokens,
+            strategy=strategy,
+            pld_max_ngram=pld_max_ngram,
+            pld_min_ngram=pld_min_ngram,
+            pld_lookup_window=pld_lookup_window,
+            layers_skip=layers_skip,
         )
 
     def resolved_kv_cache_quant(self) -> str | None:
@@ -786,6 +808,19 @@ class ModelConfig:
             speculative_pld_min_ngram = entry.get("speculative_pld_min_ngram")
             speculative_pld_lookup_window = entry.get("speculative_pld_lookup_window")
 
+            speculative_layers_skip_raw = entry.get("speculative_layers_skip")
+            if speculative_layers_skip_raw is not None:
+                if (
+                    isinstance(speculative_layers_skip_raw, bool)
+                    or not isinstance(speculative_layers_skip_raw, int)
+                    or speculative_layers_skip_raw < 1
+                ):
+                    raise ValueError(
+                        f"'speculative_layers_skip' must be a positive integer, "
+                        f"got {speculative_layers_skip_raw!r}"
+                    )
+            speculative_layers_skip = speculative_layers_skip_raw
+
             # Flash primary-knob fields: type/bounds checks live in
             # ``ModelConfig.__post_init__`` (which fires from the
             # ``cls(...)`` call below). Pull raw values verbatim and let
@@ -851,6 +886,7 @@ class ModelConfig:
                 speculative_pld_max_ngram=speculative_pld_max_ngram,
                 speculative_pld_min_ngram=speculative_pld_min_ngram,
                 speculative_pld_lookup_window=speculative_pld_lookup_window,
+                speculative_layers_skip=speculative_layers_skip,
                 kv_cache_quant=kv_cache_quant_raw,
                 weight_quant=weight_quant_raw,
                 flash=flash,
@@ -887,6 +923,7 @@ class ModelConfig:
             and self.speculative_pld_max_ngram is None
             and self.speculative_pld_min_ngram is None
             and self.speculative_pld_lookup_window is None
+            and self.speculative_layers_skip is None
             and self.kv_cache_quant is None
             and self.weight_quant is None
             and self.flash is None
@@ -932,6 +969,8 @@ class ModelConfig:
             result["speculative_pld_min_ngram"] = self.speculative_pld_min_ngram
         if self.speculative_pld_lookup_window is not None:
             result["speculative_pld_lookup_window"] = self.speculative_pld_lookup_window
+        if self.speculative_layers_skip is not None:
+            result["speculative_layers_skip"] = self.speculative_layers_skip
         if self.kv_cache_quant is not None:
             result["kv_cache_quant"] = self.kv_cache_quant
         if self.weight_quant is not None:

--- a/olmlx/engine/self_speculative/__init__.py
+++ b/olmlx/engine/self_speculative/__init__.py
@@ -1,0 +1,3 @@
+from olmlx.engine.self_speculative.decoder import SelfSpeculativeDecoder
+
+__all__ = ["SelfSpeculativeDecoder"]

--- a/olmlx/engine/self_speculative/decoder.py
+++ b/olmlx/engine/self_speculative/decoder.py
@@ -1,0 +1,326 @@
+"""Self-speculative decoding (LayerSkip-style).
+
+Uses the target model's own early layers as an autoregressive draft.
+No external draft model required. Works under Flash and Flash-MoE.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+import mlx.core as mx
+import mlx.nn as nn
+
+try:
+    from mlx_lm.models.cache import make_prompt_cache, trim_prompt_cache
+except ImportError:  # pragma: no cover — mlx-lm is always available at runtime
+    make_prompt_cache = None
+    trim_prompt_cache = None
+
+from olmlx.engine.gdn_rollback import get_model_layers
+
+logger = logging.getLogger(__name__)
+
+
+def _find_module(model: Any, paths: tuple[tuple[str, ...], ...]) -> Any | None:
+    for path in paths:
+        obj: Any = model
+        for attr in path:
+            obj = getattr(obj, attr, None)
+            if obj is None:
+                break
+        if obj is not None:
+            return obj
+    return None
+
+
+_EMBED_PATHS: tuple[tuple[str, ...], ...] = (
+    ("embed_tokens",),
+    ("model", "embed_tokens"),
+    ("language_model", "model", "embed_tokens"),
+    ("language_model", "embed_tokens"),
+)
+
+_NORM_PATHS: tuple[tuple[str, ...], ...] = (
+    ("norm",),
+    ("model", "norm"),
+    ("language_model", "model", "norm"),
+    ("language_model", "norm"),
+)
+
+_LM_HEAD_PATHS: tuple[tuple[str, ...], ...] = (
+    ("lm_head",),
+    ("language_model", "lm_head"),
+    ("model", "lm_head"),
+    ("language_model", "model", "lm_head"),
+)
+
+
+def _logits(out: Any) -> mx.array:
+    return cast(mx.array, getattr(out, "logits", out))
+
+
+def _eval_cache(cache: list) -> None:
+    """Materialise KV cache state without evaluating logits (mirrors
+    the version in speculative.py)."""
+    arrs: list[mx.array] = []
+    for c in cache:
+        k = getattr(c, "keys", None)
+        v = getattr(c, "values", None)
+        if isinstance(k, mx.array):
+            arrs.append(k)
+        elif isinstance(k, (list, tuple)):
+            arrs.extend(a for a in k if isinstance(a, mx.array))
+        if isinstance(v, mx.array):
+            arrs.append(v)
+        elif isinstance(v, (list, tuple)):
+            arrs.extend(a for a in v if isinstance(a, mx.array))
+        if k is None and v is None:
+            state = getattr(c, "state", None)
+            if isinstance(state, (list, tuple)):
+                arrs.extend(a for a in state if isinstance(a, mx.array))
+        for attr in ("_key_dequant", "_value_dequant"):
+            buf = getattr(c, attr, None)
+            if isinstance(buf, mx.array):
+                arrs.append(buf)
+    if arrs:
+        mx.eval(*arrs)
+
+
+def _prefill_last_logit(model: Any, prompt: mx.array, cache: list) -> mx.array:
+    """Return the logit for the last prompt position (mirrors speculative.py).
+
+    Two-pass split: prefix fills cache (logits discarded), last token
+    produces a [1, 1, vocab] logit.
+    """
+    if prompt.shape[1] <= 1:
+        return _logits(model(prompt, cache=cache))[0, -1, :]
+    prefix, last = prompt[:, :-1], prompt[:, -1:]
+    model(prefix, cache=cache)
+    _eval_cache(cache)
+    return _logits(model(last, cache=cache))[0, 0, :]
+
+
+def verify_draft_greedy(
+    draft_tokens: list[int],
+    target_logits: mx.array,
+) -> list[int]:
+    """Verify draft tokens against target logits (greedy)."""
+    n = len(draft_tokens)
+    target_choices = mx.argmax(target_logits, axis=-1)
+    mx.eval(target_choices)
+    accepted: list[int] = []
+    for i in range(n):
+        target_token = int(target_choices[i].item())
+        if draft_tokens[i] == target_token:
+            accepted.append(draft_tokens[i])
+        else:
+            accepted.append(target_token)
+            return accepted
+    accepted.append(int(target_choices[n].item()))
+    return accepted
+
+
+class SelfSpeculativeDecoder:
+    """Self-speculative decoding using the target's own early layers.
+
+    The first ``num_early_layers`` of the target serve as the draft
+    model: they generate λ candidate tokens autoregressively through a
+    shared KV cache.  The full target (all layers) then verifies all
+    candidates in a single forward pass.
+
+    Works under Flash and Flash-MoE because no hidden-state hooks or
+    target patching are involved — just running the model's own layers.
+    """
+
+    def __init__(
+        self,
+        target_model: nn.Module,
+        num_early_layers: int,
+        num_speculative_tokens: int = 4,
+        acceptance_rate_ema: float = 0.9,
+    ):
+        if make_prompt_cache is None or trim_prompt_cache is None:
+            raise RuntimeError(
+                "mlx_lm.models.cache is unavailable; self-speculative "
+                "decoding requires it for KV-cache management."
+            )
+        if num_speculative_tokens < 1:
+            raise ValueError(
+                f"num_speculative_tokens must be >= 1; got {num_speculative_tokens}"
+            )
+
+        self._target = target_model
+
+        layers = get_model_layers(target_model)
+        self._total_layers = len(layers)
+        if num_early_layers < 1 or num_early_layers >= self._total_layers:
+            raise ValueError(
+                f"num_early_layers ({num_early_layers}) must be in "
+                f"[1, {self._total_layers - 1}] for a target with "
+                f"{self._total_layers} layers"
+            )
+        self._N = num_early_layers
+        self._layers = layers
+
+        # Discover embed, norm, lm_head via path probing
+        self._embed = _find_module(target_model, _EMBED_PATHS)
+        if self._embed is None:
+            raise ValueError(
+                f"Cannot find embed_tokens on model {type(target_model).__name__}"
+            )
+        self._norm = _find_module(target_model, _NORM_PATHS)
+        if self._norm is None:
+            raise ValueError(
+                f"Cannot find norm on model {type(target_model).__name__}"
+            )
+        self._lm_head = _find_module(target_model, _LM_HEAD_PATHS)
+        if self._lm_head is None:
+            # Tied-embeddings fallback
+            as_linear = getattr(self._embed, "as_linear", None)
+            if callable(as_linear):
+                self._lm_head = as_linear
+            else:
+                raise ValueError(
+                    f"Cannot find lm_head on model {type(target_model).__name__}"
+                )
+
+        self._lambda = num_speculative_tokens
+        self._alpha = 0.5
+        self._alpha_ema = acceptance_rate_ema
+
+        # Per-request state (populated by prefill)
+        self._cache: list | None = None
+        self._last_logit: mx.array | None = None
+        self._pending_token: int | None = None
+        self._prompt_len: int = 0
+
+        # Stats (reset on prefill)
+        self._stats_steps: int = 0
+        self._stats_proposed: int = 0
+        self._stats_accepted_draft: int = 0
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """No-op — no GDN patches or external resources to release."""
+
+    def reset(self) -> None:
+        self._cache = None
+        self._last_logit = None
+        self._pending_token = None
+        self._prompt_len = 0
+        self._stats_steps = 0
+        self._stats_proposed = 0
+        self._stats_accepted_draft = 0
+
+    def stats_summary(self) -> dict[str, Any]:
+        steps = self._stats_steps
+        proposed = self._stats_proposed
+        accepted_draft = self._stats_accepted_draft
+        acceptance_rate = accepted_draft / proposed if proposed else 0.0
+        avg_tokens_per_step = (accepted_draft + steps) / steps if steps else 0.0
+        return {
+            "steps": steps,
+            "proposed": proposed,
+            "accepted_draft": accepted_draft,
+            "acceptance_rate": acceptance_rate,
+            "avg_tokens_per_step": avg_tokens_per_step,
+            "ema_acceptance_rate": self._alpha,
+            "lambda": self._lambda,
+        }
+
+    # ------------------------------------------------------------------
+    # Protocol: prefill / step
+    # ------------------------------------------------------------------
+
+    def prefill(self, prompt: mx.array) -> int:
+        """Process the prompt through the full model, populating KV cache.
+
+        Returns the first generated token.
+        """
+        self.reset()
+
+        self._cache = make_prompt_cache(self._target)
+
+        # Reset cached RoPE state on VLM targets (mlx-vlm 0.4.4)
+        for attr in ("_position_ids", "_rope_deltas"):
+            if hasattr(self._target, attr):
+                setattr(self._target, attr, None)
+
+        self._last_logit = _prefill_last_logit(self._target, prompt, self._cache)
+        mx.eval(self._last_logit)
+
+        self._prompt_len = prompt.shape[1]
+        first_token = int(mx.argmax(self._last_logit).item())
+        self._pending_token = first_token
+        return first_token
+
+    def step(self) -> tuple[list[int], int]:
+        """One self-speculative decoding step.
+
+        Must call ``prefill()`` first.
+        Returns (accepted_tokens, num_draft_generated).
+        """
+        assert self._cache is not None, "Call prefill() before step()"
+        assert self._pending_token is not None, "Call prefill() before step()"
+
+        pending = self._pending_token
+        draft_tokens: list[int] = []
+
+        # --- Draft: autoregressive through early layers 0..N-1 ---
+        next_token = pending
+        for _ in range(self._lambda):
+            inp = mx.array([[next_token]])
+            h = self._embed(inp)
+            for i in range(self._N):
+                h = self._layers[i](h, cache=self._cache[i])
+            h = self._norm(h)
+            logits = self._lm_head(h)
+            next_logits = logits[:, -1, :]
+            mx.eval(next_logits)
+            next_token = int(mx.argmax(next_logits, axis=-1).item())
+            draft_tokens.append(next_token)
+
+        # --- Pre-verify: trim early-layer caches back to prompt_len ---
+        # The draft advanced cache[0..N-1] by lambda entries; discard
+        # them so the verify pass can append uniformly across all layers.
+        for i in range(self._N):
+            trim_prompt_cache([self._cache[i]], self._lambda)
+
+        # --- Verify: full model on [pending, D_1, ..., D_lambda] ---
+        all_tokens = mx.array([[pending] + draft_tokens])
+        target_out = _logits(self._target(all_tokens, cache=self._cache))
+        mx.eval(target_out)
+        verification_logits = target_out[0]  # (lambda+1, vocab)
+
+        # --- Accept/reject ---
+        accepted = verify_draft_greedy(draft_tokens, verification_logits)
+        num_accepted = len(accepted)
+
+        # --- Trim caches to accepted prefix ---
+        trim_count = max(self._lambda + 1 - num_accepted, 0)
+        if trim_count > 0:
+            trim_prompt_cache(self._cache, trim_count)
+
+        # --- Update state ---
+        self._prompt_len += num_accepted
+        self._last_logit = verification_logits[num_accepted - 1]
+        mx.eval(self._last_logit)
+        self._pending_token = int(mx.argmax(self._last_logit).item())
+
+        # --- Update acceptance-rate EMA and stats ---
+        num_accepted_draft = min(num_accepted - 1, self._lambda)
+        acceptance = num_accepted_draft / max(self._lambda, 1)
+        self._alpha = (
+            self._alpha_ema * self._alpha
+            + (1 - self._alpha_ema) * acceptance
+        )
+        self._stats_steps += 1
+        self._stats_proposed += self._lambda
+        self._stats_accepted_draft += num_accepted_draft
+
+        return accepted, self._lambda

--- a/olmlx/engine/self_speculative/decoder.py
+++ b/olmlx/engine/self_speculative/decoder.py
@@ -172,9 +172,7 @@ class SelfSpeculativeDecoder:
             )
         self._norm = _find_module(target_model, _NORM_PATHS)
         if self._norm is None:
-            raise ValueError(
-                f"Cannot find norm on model {type(target_model).__name__}"
-            )
+            raise ValueError(f"Cannot find norm on model {type(target_model).__name__}")
         self._lm_head = _find_module(target_model, _LM_HEAD_PATHS)
         if self._lm_head is None:
             # Tied-embeddings fallback
@@ -315,10 +313,7 @@ class SelfSpeculativeDecoder:
         # --- Update acceptance-rate EMA and stats ---
         num_accepted_draft = min(num_accepted - 1, self._lambda)
         acceptance = num_accepted_draft / max(self._lambda, 1)
-        self._alpha = (
-            self._alpha_ema * self._alpha
-            + (1 - self._alpha_ema) * acceptance
-        )
+        self._alpha = self._alpha_ema * self._alpha + (1 - self._alpha_ema) * acceptance
         self._stats_steps += 1
         self._stats_proposed += self._lambda
         self._stats_accepted_draft += num_accepted_draft

--- a/olmlx/engine/self_speculative/decoder.py
+++ b/olmlx/engine/self_speculative/decoder.py
@@ -18,7 +18,8 @@ except ImportError:  # pragma: no cover — mlx-lm is always available at runtim
     make_prompt_cache = None
     trim_prompt_cache = None
 
-from olmlx.engine.gdn_rollback import get_model_layers
+from olmlx.engine.gdn_rollback import find_gdn_class, get_model_layers
+from olmlx.engine.speculative import verify_draft_greedy
 
 logger = logging.getLogger(__name__)
 
@@ -102,26 +103,6 @@ def _prefill_last_logit(model: Any, prompt: mx.array, cache: list) -> mx.array:
     return _logits(model(last, cache=cache))[0, 0, :]
 
 
-def verify_draft_greedy(
-    draft_tokens: list[int],
-    target_logits: mx.array,
-) -> list[int]:
-    """Verify draft tokens against target logits (greedy)."""
-    n = len(draft_tokens)
-    target_choices = mx.argmax(target_logits, axis=-1)
-    mx.eval(target_choices)
-    accepted: list[int] = []
-    for i in range(n):
-        target_token = int(target_choices[i].item())
-        if draft_tokens[i] == target_token:
-            accepted.append(draft_tokens[i])
-        else:
-            accepted.append(target_token)
-            return accepted
-    accepted.append(int(target_choices[n].item()))
-    return accepted
-
-
 class SelfSpeculativeDecoder:
     """Self-speculative decoding using the target's own early layers.
 
@@ -132,6 +113,19 @@ class SelfSpeculativeDecoder:
 
     Works under Flash and Flash-MoE because no hidden-state hooks or
     target patching are involved — just running the model's own layers.
+
+    Limitations
+    -----------
+    * Hybrid linear-attention targets (Qwen3.5/3.6, Qwen3-Coder-Next)
+      with ``GatedDeltaNet`` layers are **not supported** — their
+      ``ArraysCache`` RNN-style state cannot be rolled back after the
+      autoregressive draft without ``GDNStateCapture`` (planned for a
+      follow-up PR).
+    * Sliding-window attention targets with ``RotatingKVCache`` /
+      ``ChunkedKVCache`` in early layers are **not supported** — the
+      per-step trim between draft and verify fails on non-trimmable
+      caches (the same models gated off from cross-request prompt caching
+      in issue #343).
     """
 
     def __init__(
@@ -183,6 +177,45 @@ class SelfSpeculativeDecoder:
                 raise ValueError(
                     f"Cannot find lm_head on model {type(target_model).__name__}"
                 )
+
+        # --- Guard: hybrid linear-attention targets (GatedDeltaNet) ---
+        # The autoregressive draft pass advances ``ArraysCache`` RNN-state
+        # for any GDN layers among the first N.  ``trim_prompt_cache`` is
+        # a no-op on these, so the state diverges after partial acceptance
+        # and corrupts every subsequent step.  Full GDN rollback
+        # (``GDNStateCapture`` + ``rollback_autoregressive``) is planned
+        # for a follow-up PR.
+        gdn_cls = find_gdn_class(target_model)
+        if gdn_cls is not None:
+            raise NotImplementedError(
+                f"self_speculative is not yet supported on hybrid "
+                f"linear-attention targets ({gdn_cls.__module__}.{gdn_cls.__name__} "
+                "detected). The autoregressive draft mutates GatedDeltaNet "
+                "recurrent state which cannot be rolled back with "
+                "trim_prompt_cache. Planned for a follow-up PR."
+            )
+
+        # --- Guard: non-trimmable caches in early layers ---
+        # Probe the first early-layer cache to see if ``trim()`` is
+        # supported.  RotatingKVCache / ChunkedKVCache in Gemma 4 /
+        # gpt-oss models fail ``trim_prompt_cache`` (issue #343) — the
+        # per-step discard of draft entries would either raise or
+        # silently corrupt offsets.
+        probe_cache = make_prompt_cache(target_model)
+        early_non_trimmable = False
+        for i in range(min(self._N, len(probe_cache))):
+            if not hasattr(probe_cache[i], "trim") or not callable(
+                getattr(probe_cache[i], "trim", None)
+            ):
+                early_non_trimmable = True
+                break
+        if early_non_trimmable:
+            raise NotImplementedError(
+                "self_speculative is not supported on models with "
+                "non-trimmable KV caches in early layers (e.g. "
+                "RotatingKVCache/ChunkedKVCache). The per-step cache "
+                "trim between draft and verify cannot be performed."
+            )
 
         self._lambda = num_speculative_tokens
         self._alpha = 0.5
@@ -262,6 +295,15 @@ class SelfSpeculativeDecoder:
 
         Must call ``prefill()`` first.
         Returns (accepted_tokens, num_draft_generated).
+
+        Cache-length invariant
+        ----------------------
+        After each ``step()``, ``self._cache`` contains exactly
+        ``self._prompt_len`` entries across all layers (the original
+        prompt plus every accepted token).  The pending token is *not*
+        in the cache — it is fed as the first token of the verify batch
+        in the next step.  This matches the ``SpeculativeDecoder``
+        invariant.
         """
         assert self._cache is not None, "Call prefill() before step()"
         assert self._pending_token is not None, "Call prefill() before step()"
@@ -286,10 +328,14 @@ class SelfSpeculativeDecoder:
         # --- Pre-verify: trim early-layer caches back to prompt_len ---
         # The draft advanced cache[0..N-1] by lambda entries; discard
         # them so the verify pass can append uniformly across all layers.
+        # Late layers (N..L-1) were never advanced — they're still at
+        # prompt_len, so trimming them is a no-op (but we only trim
+        # early layers anyway).
         for i in range(self._N):
             trim_prompt_cache([self._cache[i]], self._lambda)
 
         # --- Verify: full model on [pending, D_1, ..., D_lambda] ---
+        # The verify feed is λ+1 tokens.  All layers append uniformly.
         all_tokens = mx.array([[pending] + draft_tokens])
         target_out = _logits(self._target(all_tokens, cache=self._cache))
         mx.eval(target_out)
@@ -300,9 +346,16 @@ class SelfSpeculativeDecoder:
         num_accepted = len(accepted)
 
         # --- Trim caches to accepted prefix ---
+        # After verify the cache grew by λ+1 entries (for all layers).
+        # We keep ``num_accepted`` of those entries; trim the rest.
+        # ``num_accepted`` is always >= 1 (greedy accept guarantees at
+        # least one token).
         trim_count = max(self._lambda + 1 - num_accepted, 0)
         if trim_count > 0:
             trim_prompt_cache(self._cache, trim_count)
+        # Post-trim cache length = old_prompt_len + num_accepted.
+        # ``_prompt_len`` is updated to the same value below so the
+        # invariant holds.
 
         # --- Update state ---
         self._prompt_len += num_accepted

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -357,9 +357,6 @@ class TestSpeculativeConfig:
         monkeypatch.setattr("olmlx.config.settings.speculative_tokens", 8)
 
         mc = ModelConfig(hf_path="Qwen/Qwen3-32B")
-        # Field-by-field check rather than full-tuple equality so the
-        # PLD knobs (added later) don't bind the assertion to specific
-        # defaults — those have their own tests below.
         resolved = mc.resolved_speculative()
         assert resolved.enabled is True
         assert resolved.draft_model == "Qwen/Qwen3-0.6B"


### PR DESCRIPTION
Closes #359

### Summary
Self-speculative decoding uses the target model's own early layers as a zero-cost draft — no external draft model needed. The draft runs layers 0..N-1 autoregressively, then the full model verifies in one forward pass.

### Key design
- LayerSkip-style: $N$ early layers serve as draft, all $L$ layers verify
- KV cache shared between draft and verify passes
- Early-layer cache entries are discarded between draft and verify (cheap, $N$ is small)
- No hidden-state hooks or target patching → works under Flash, Flash-MoE, and VLM

### New files
- `olmlx/engine/self_speculative/__init__.py`
- `olmlx/engine/self_speculative/decoder.py` — `SelfSpeculativeDecoder` implementing the `prefill`/`step`/`reset` protocol

### Modified files
- `olmlx/config.py` — `"self_speculative"` added to `speculative_strategy` Literal, new `speculative_layers_skip` setting
- `olmlx/engine/registry.py` — `SpeculativeConfig` gains `layers_skip`, full config surface wired through
- `olmlx/engine/model_manager.py` — `_load_self_speculative_decoder`, dispatch branches, Flash-MoE/VLM unblocked
- `olmlx/cli.py` — `--speculative-strategy self_speculative`, `--speculative-layers-skip N`, audit exemption
- `olmlx/bench/scenarios.py` — `self-speculative` and `flash+self-speculative` scenarios
- `tests/test_config.py` — updated to use attribute access on expanded `SpeculativeConfig`

### Verification
- 2988 tests pass
- ruff clean
- pyright 0 errors