### PR TITLE
feat(speculative): tree-based verification using sparse attention mask (#358)

### DIFF
--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -202,6 +202,23 @@ class Settings(BaseSettings):
     #: pass. ``None`` defaults to L//4 at load time.
     speculative_layers_skip: Annotated[int, Field(ge=1)] | None = None
 
+    # Tree-structured speculative verification (#358).  When enabled,
+    # the classic speculative strategy produces a tree of draft alternatives
+    # (top-K candidates per step) and verifies them against the target in
+    # one forward pass using a sparse attention mask.
+    #
+    # ``tree_width`` controls how many candidates are kept per draft step
+    # (1 = linear, ≥2 = tree).  ``tree_max_nodes`` is a hard cap on the
+    # total number of tree nodes (including the root).  The tree automatically
+    # stops growing when it hits either the draft length (``speculative_tokens``)
+    # or ``tree_max_nodes``.
+    #
+    # Setting ``tree_width`` to 1 or ``tree_speculative`` to False falls
+    # back to the existing linear verification path.
+    tree_speculative: bool = False
+    tree_width: Annotated[int, Field(ge=1)] = 2
+    tree_max_nodes: Annotated[int, Field(ge=3)] = 8
+
     # Flash inference (LLM in a Flash). Primary, user-facing knobs.
     # Advanced tuning (window size, IO threads, cache budget, predictor
     # rank, buffer modes) lives on ``ExperimentalSettings`` and the

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -275,6 +275,11 @@ class Settings(BaseSettings):
                 f"must be <= speculative_pld_max_ngram "
                 f"({self.speculative_pld_max_ngram})"
             )
+        # Parallel to the per-model ``ModelConfig.__post_init__`` check
+        # — without this, a bad env pair like ``MAX_NGRAM=3
+        # LOOKUP_WINDOW=1`` would pass startup and only blow up at
+        # first model load with a confusing stack trace from
+        # ``resolved_speculative``.
         if self.speculative_pld_lookup_window < self.speculative_pld_max_ngram:
             raise ValueError(
                 f"speculative_pld_lookup_window "
@@ -297,6 +302,12 @@ class Settings(BaseSettings):
         if self.tree_speculative and not self.speculative:
             raise ValueError(
                 "OLMLX_TREE_SPECULATIVE=true requires OLMLX_SPECULATIVE=true"
+            )
+        if self.tree_speculative and self.speculative_strategy != "classic":
+            raise ValueError(
+                "OLMLX_TREE_SPECULATIVE=true is only supported with "
+                "OLMLX_SPECULATIVE_STRATEGY=classic "
+                f"(got {self.speculative_strategy!r})"
             )
         return self
 

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -275,17 +275,28 @@ class Settings(BaseSettings):
                 f"must be <= speculative_pld_max_ngram "
                 f"({self.speculative_pld_max_ngram})"
             )
-        # Parallel to the per-model ``ModelConfig.__post_init__`` check
-        # — without this, a bad env pair like ``MAX_NGRAM=3
-        # LOOKUP_WINDOW=1`` would pass startup and only blow up at
-        # first model load with a confusing stack trace from
-        # ``resolved_speculative``.
         if self.speculative_pld_lookup_window < self.speculative_pld_max_ngram:
             raise ValueError(
                 f"speculative_pld_lookup_window "
                 f"({self.speculative_pld_lookup_window}) must be >= "
                 f"speculative_pld_max_ngram "
                 f"({self.speculative_pld_max_ngram})"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_tree_speculative(self) -> "Settings":
+        if self.tree_speculative and self.flash_speculative:
+            raise ValueError(
+                "OLMLX_TREE_SPECULATIVE=true and OLMLX_FLASH_SPECULATIVE=true "
+                "are incompatible. Tree verification is only supported with "
+                "OLMLX_SPECULATIVE=true (classic strategy). Flash speculative "
+                "decoding uses a separate code path that does not support tree "
+                "drafts (see #358)."
+            )
+        if self.tree_speculative and not self.speculative:
+            raise ValueError(
+                "OLMLX_TREE_SPECULATIVE=true requires OLMLX_SPECULATIVE=true"
             )
         return self
 

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2856,6 +2856,8 @@ class ModelManager:
             draft_model=draft_model,
             target_model=spec_target,
             num_speculative_tokens=num_tokens,
+            tree_width=settings.tree_width if settings.tree_speculative else 1,
+            tree_max_nodes=settings.tree_max_nodes,
         )
 
     def _load_pld_decoder(

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -591,22 +591,28 @@ class SpeculativeDecoder:
         tree_total = tree.num_nodes
 
         if used_sibling:
-            # Rebuild: trim all tree nodes from the target cache, then
-            # feed only the accepted tokens to get a contiguous cache.
+            # Rebuild: trim all tree nodes *except* the root (pending_token
+            # P), whose entry from the previous step is still valid in the
+            # cache.  Then feed only the accepted prefix tokens (excluding
+            # the bonus, which becomes the next _pending_token).
+            trim_amt = tree_total - 1
             if self._target_gdn_buffer is not None and self._gdn_capture is not None:
                 self._gdn_capture.rollback_single(
                     self._target_gdn_buffer,
                     self._target_cache,
                     accepted=0,
-                    trim=tree_total,
+                    trim=trim_amt,
                 )
             elif trim_prompt_cache is not None:
-                trim_prompt_cache(self._target_cache, tree_total)
-            accepted_arr = mx.array([accepted])
-            rebuild_out = _logits(self._target(accepted_arr, cache=self._target_cache))
+                trim_prompt_cache(self._target_cache, trim_amt)
+            # Feed accepted tokens up to (but not including) the bonus.
+            rebuild_tokens = accepted[:-1]  # [D1, ..., sibling]
+            rebuild_arr = mx.array([rebuild_tokens])
+            rebuild_out = _logits(self._target(rebuild_arr, cache=self._target_cache))
             mx.eval(rebuild_out)
             rebuild_logits = rebuild_out[0]
-            self._last_target_logit = rebuild_logits[num_accepted - 1]
+            # The logit at the sibling's position predicts the bonus.
+            self._last_target_logit = rebuild_logits[len(rebuild_tokens) - 1]
         else:
             # Primary path: trim from the end.
             trim_target = max(tree_total - num_accepted, 0)

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -606,10 +606,17 @@ class SpeculativeDecoder:
             elif trim_prompt_cache is not None:
                 trim_prompt_cache(self._target_cache, trim_amt)
             # Feed accepted tokens up to (but not including) the bonus.
+            # Re-enable GDN capture for the rebuild so linear-attention
+            # state stays consistent with the KV cache.
+            if self._target_gdn_buffer is not None and self._gdn_capture is not None:
+                self._target_gdn_buffer.clear()
+                self._gdn_capture.use_buffer(self._target_gdn_buffer)
             rebuild_tokens = accepted[:-1]  # [D1, ..., sibling]
             rebuild_arr = mx.array([rebuild_tokens])
             rebuild_out = _logits(self._target(rebuild_arr, cache=self._target_cache))
             mx.eval(rebuild_out)
+            if self._target_gdn_buffer is not None and self._gdn_capture is not None:
+                self._gdn_capture.use_buffer(None)
             rebuild_logits = rebuild_out[0]
             # The logit at the sibling's position predicts the bonus.
             self._last_target_logit = rebuild_logits[len(rebuild_tokens) - 1]

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -440,12 +440,23 @@ class SpeculativeDecoder:
 
         self._after_verify(num_accepted)
 
-        # 4. Roll back caches
+        # 4. Roll back caches to keep only the accepted prefix.
+        #
+        # Target was fed (λ+1) tokens [pending, D_1..D_λ]; keep
+        # ``num_accepted`` of them, so trim by (λ+1) - num_accepted.
+        # Draft was fed λ tokens autoregressively
+        # [pending, D_1..D_{λ-1}]; keep ``num_accepted`` of those if
+        # partial acceptance (= a-1 draft tokens between pending and
+        # the correction/bonus), so trim by λ - num_accepted.
         trim_target = max(self._lambda + 1 - num_accepted, 0)
         trim_draft = max(self._lambda - num_accepted, 0)
 
         if trim_target > 0:
             if self._target_gdn_buffer is not None and self._gdn_capture is not None:
+                # ``rollback_single`` takes ``accepted`` as the number of
+                # *additional* tokens beyond the first to keep
+                # (n = accepted + 1). We want to keep ``num_accepted``
+                # total, so accepted_arg = num_accepted - 1.
                 self._gdn_capture.rollback_single(
                     self._target_gdn_buffer,
                     self._target_cache,
@@ -467,6 +478,11 @@ class SpeculativeDecoder:
             elif trim_prompt_cache is not None:
                 trim_prompt_cache(self._draft_cache, trim_draft)
 
+        # On full acceptance, align draft cache with target cache.
+        # ``use_buffer(None)`` was already called after the target
+        # forward, so the align step's draft forward — which DOES
+        # invoke ``GatedDeltaNet.__call__`` on a hybrid draft — won't
+        # write to either buffer.
         if num_accepted > self._lambda:
             last_draft = mx.array([[draft_tokens[-1]]])
             align_logits = _logits(self._draft(last_draft, cache=self._draft_cache))
@@ -626,6 +642,15 @@ class SpeculativeDecoder:
             align_logits = _logits(self._draft(last_primary, cache=self._draft_cache))
             mx.eval(align_logits)
 
+        # When a sibling was accepted, the draft cache reflects only the
+        # primary path up to the branch point — it is missing the sibling
+        # token.  Feed the sibling so the draft cache is aligned with the
+        # accepted prefix before the next step.
+        if used_sibling:
+            sib_token = accepted[-2]  # sibling is second-to-last in accepted
+            sib_arr = mx.array([[sib_token]])
+            mx.eval(_logits(self._draft(sib_arr, cache=self._draft_cache)))
+
         # 7. Update state
         self._cache_seq_len += num_accepted
         assert num_accepted >= 1
@@ -637,7 +662,7 @@ class SpeculativeDecoder:
         self._stats_proposed += tree.num_nodes - 1  # all non-root nodes
         self._stats_accepted_draft += num_accepted_draft
 
-        return accepted, self._lambda
+        return accepted, tree.num_nodes - 1
 
     def _draft_generate_cached(
         self, pending_token: int, n: int

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -172,6 +172,8 @@ class SpeculativeDecoder:
         target_model: nn.Module,
         num_speculative_tokens: int = 4,
         acceptance_rate_ema: float = 0.9,
+        tree_width: int = 1,
+        tree_max_nodes: int = 8,
     ):
         if trim_prompt_cache is None:
             raise RuntimeError(
@@ -183,6 +185,9 @@ class SpeculativeDecoder:
         self._lambda = num_speculative_tokens
         self._alpha = 0.5  # initial acceptance rate estimate
         self._alpha_ema = acceptance_rate_ema
+        self._tree_width = max(tree_width, 1)
+        self._tree_max_nodes = max(tree_max_nodes, 3)
+        self._use_tree = self._tree_width >= 2
 
         # Persistent KV cache state (populated by prefill/step)
         self._target_cache: list | None = None
@@ -382,6 +387,10 @@ class SpeculativeDecoder:
 
         Must call ``prefill()`` first to populate caches.
 
+        When ``self._use_tree`` is True, builds a tree of draft
+        alternatives and verifies them against the target in one forward
+        pass using a sparse attention mask.
+
         Returns:
             (accepted_tokens, num_draft_generated).
         """
@@ -391,8 +400,16 @@ class SpeculativeDecoder:
 
         pending_token = self._pending_token
 
+        if self._use_tree:
+            return self._step_tree(pending_token)
+        return self._step_linear(pending_token)
+
+    def _step_linear(self, pending_token: int) -> tuple[list[int], int]:
+        """Linear speculative decoding (the existing algorithm)."""
+        assert self._target_cache is not None
+        assert self._draft_cache is not None
+
         # 1. Draft: feed pending token, then generate lambda candidates.
-        # Route GDN captures to the draft buffer (if draft is hybrid).
         if self._gdn_capture is not None:
             if self._draft_gdn_buffer is not None:
                 self._draft_gdn_buffer.clear()
@@ -401,11 +418,9 @@ class SpeculativeDecoder:
             pending_token, self._lambda
         )
 
-        # Hook for subclasses (e.g. Flash prefetcher submission)
         self._after_draft(draft_ctx)
 
         # 2. Target: feed [pending, D1, ..., D_lambda] in one pass.
-        # Switch GDN capture to the target buffer.
         if self._gdn_capture is not None:
             if self._target_gdn_buffer is not None:
                 self._target_gdn_buffer.clear()
@@ -414,42 +429,23 @@ class SpeculativeDecoder:
         target_out = _logits(self._target(all_tokens, cache=self._target_cache))
         mx.eval(target_out)
 
-        # Capture is done: no more model forwards in this step should
-        # write to either buffer. Subclass hooks (``_after_verify``) and
-        # rollback replays (``rollback_single`` invokes
-        # ``gated_delta_update`` directly, not ``GatedDeltaNet.__call__``)
-        # would otherwise append spurious captures and fail the next
-        # step's buffer-size check.
         if self._gdn_capture is not None:
             self._gdn_capture.use_buffer(None)
 
         verification_logits = target_out[0]  # (lambda+1, vocab)
 
-        # 3. Verify draft tokens against target logits
+        # 3. Verify
         accepted = self._verify(draft_tokens, verification_logits)
         num_accepted = len(accepted)
 
-        # Hook for subclasses (e.g. Flash prefetch cancellation)
         self._after_verify(num_accepted)
 
-        # 4. Roll back caches to keep only the accepted prefix.
-        #
-        # Target was fed (λ+1) tokens [pending, D_1..D_λ]; keep
-        # ``num_accepted`` of them, so trim by (λ+1) - num_accepted.
-        # Draft was fed λ tokens autoregressively
-        # [pending, D_1..D_{λ-1}]; keep ``num_accepted`` of those if
-        # partial acceptance (= a-1 draft tokens between pending and
-        # the correction/bonus), so trim by λ - num_accepted.
+        # 4. Roll back caches
         trim_target = max(self._lambda + 1 - num_accepted, 0)
         trim_draft = max(self._lambda - num_accepted, 0)
 
-        # Target rollback: GDN replay if hybrid, plain trim otherwise.
         if trim_target > 0:
             if self._target_gdn_buffer is not None and self._gdn_capture is not None:
-                # ``rollback_single`` takes ``accepted`` as the number of
-                # *additional* tokens beyond the first to keep
-                # (n = accepted + 1). We want to keep ``num_accepted``
-                # total, so accepted_arg = num_accepted - 1.
                 self._gdn_capture.rollback_single(
                     self._target_gdn_buffer,
                     self._target_cache,
@@ -459,16 +455,8 @@ class SpeculativeDecoder:
             elif trim_prompt_cache is not None:
                 trim_prompt_cache(self._target_cache, trim_target)
 
-        # Draft rollback: GDN autoregressive replay if hybrid, plain
-        # trim otherwise. On full acceptance (num_accepted == λ+1)
-        # trim_draft is 0 and we skip rollback; the align step below
-        # then advances the draft cache by feeding D_λ.
         if trim_draft > 0:
             if self._draft_gdn_buffer is not None and self._gdn_capture is not None:
-                # ``rollback_autoregressive`` keeps the first
-                # ``num_keep_steps`` of ``num_steps`` autoregressive
-                # calls. We fed λ tokens and want to keep
-                # ``num_accepted`` of them.
                 self._gdn_capture.rollback_autoregressive(
                     self._draft_gdn_buffer,
                     self._draft_cache,
@@ -479,11 +467,6 @@ class SpeculativeDecoder:
             elif trim_prompt_cache is not None:
                 trim_prompt_cache(self._draft_cache, trim_draft)
 
-        # On full acceptance, align draft cache with target cache.
-        # ``use_buffer(None)`` was already called after the target
-        # forward, so the align step's draft forward — which DOES
-        # invoke ``GatedDeltaNet.__call__`` on a hybrid draft — won't
-        # write to either buffer.
         if num_accepted > self._lambda:
             last_draft = mx.array([[draft_tokens[-1]]])
             align_logits = _logits(self._draft(last_draft, cache=self._draft_cache))
@@ -491,9 +474,151 @@ class SpeculativeDecoder:
 
         # 5. Update state
         self._cache_seq_len += num_accepted
-        assert num_accepted >= 1, "step(): _verify() must return at least 1 token"
+        assert num_accepted >= 1
         self._last_target_logit = verification_logits[num_accepted - 1]
         mx.eval(self._last_target_logit)
+        self._pending_token = int(mx.argmax(self._last_target_logit).item())
+
+        num_accepted_draft = self._update_acceptance_rate(num_accepted)
+
+        self._stats_steps += 1
+        self._stats_proposed += self._lambda
+        self._stats_accepted_draft += num_accepted_draft
+
+        return accepted, self._lambda
+
+    def _step_tree(self, pending_token: int) -> tuple[list[int], int]:
+        """Tree-based speculative decoding step.
+
+        Produces a tree of draft alternatives, verifies them against the
+        target in one forward pass with a sparse attention mask, and rolls
+        back/re-builds caches to keep only the accepted prefix.
+        """
+        from olmlx.engine.tree_speculative import (
+            TreeDraft,
+            _patch_target_for_tree_forward,
+            _restore_target,
+            build_comb_tree,
+            build_tree_attention_mask,
+            verify_tree_greedy,
+        )
+
+        assert self._target_cache is not None
+        assert self._draft_cache is not None
+
+        # 1. Draft: generate primary path + alternatives per step
+        if self._gdn_capture is not None:
+            if self._draft_gdn_buffer is not None:
+                self._draft_gdn_buffer.clear()
+            self._gdn_capture.use_buffer(self._draft_gdn_buffer)
+        primary_tokens, alt_per_step, draft_ctx = self._draft_generate_tree(
+            pending_token, self._lambda
+        )
+
+        self._after_draft(draft_ctx)
+
+        # 2. Build the tree
+        tree = build_comb_tree(
+            pending_token=pending_token,
+            primary_tokens=primary_tokens,
+            alt_tokens_per_step=alt_per_step,
+        )
+
+        # 3. Build sparse attention mask + patch target
+        tree_mask = build_tree_attention_mask(tree)
+
+        if self._gdn_capture is not None:
+            if self._target_gdn_buffer is not None:
+                self._target_gdn_buffer.clear()
+            self._gdn_capture.use_buffer(self._target_gdn_buffer)
+
+        orig_call = _patch_target_for_tree_forward(self._target, tree_mask)
+        try:
+            tree_tokens = mx.array([tree.tokens])
+            target_out = _logits(
+                self._target(tree_tokens, cache=self._target_cache)
+            )
+            mx.eval(target_out)
+        finally:
+            _restore_target(self._target, orig_call)
+
+        if self._gdn_capture is not None:
+            self._gdn_capture.use_buffer(None)
+
+        verification_logits = target_out[0]  # (num_tree_nodes, vocab)
+
+        # 4. Verify tree
+        accepted, used_sibling = verify_tree_greedy(tree, verification_logits)
+        num_accepted = len(accepted)
+
+        self._after_verify(num_accepted)
+
+        # 5. Roll back / rebuild caches.
+        #
+        # The tree forward appended ``num_tree_nodes`` entries to the
+        # target cache.  If the accepted path follows the primary branch
+        # (the common case), the positions are contiguous and we can
+        # simply trim from the end.  If a sibling was accepted, the
+        # positions are not contiguous; we rebuild from the pre-step state.
+        tree_total = tree.num_nodes
+
+        if used_sibling:
+            # Rebuild: trim all tree nodes, then feed accepted tokens.
+            if trim_prompt_cache is not None:
+                trim_prompt_cache(self._target_cache, tree_total)
+            accepted_arr = mx.array([accepted])
+            rebuild_out = _logits(
+                self._target(accepted_arr, cache=self._target_cache)
+            )
+            mx.eval(rebuild_out)
+            rebuild_logits = rebuild_out[0]
+            self._last_target_logit = rebuild_logits[num_accepted - 1]
+        else:
+            # Primary path: trim from the end.
+            trim_target = max(tree_total - num_accepted, 0)
+            if trim_target > 0:
+                if self._target_gdn_buffer is not None and self._gdn_capture is not None:
+                    self._gdn_capture.rollback_single(
+                        self._target_gdn_buffer,
+                        self._target_cache,
+                        accepted=num_accepted - 1,
+                        trim=trim_target,
+                    )
+                elif trim_prompt_cache is not None:
+                    trim_prompt_cache(self._target_cache, trim_target)
+            last_accepted_tree_idx = tree.primary_branch[num_accepted - 1]
+            self._last_target_logit = verification_logits[last_accepted_tree_idx]
+
+        mx.eval(self._last_target_logit)
+
+        # 6. Align draft cache.  The draft generated λ tokens; we keep the
+        # first num_accepted of them.  On full acceptance (num_accepted > λ)
+        # the draft needs to advance by feeding the last primary token.
+        if self._draft_gdn_buffer is not None and self._gdn_capture is not None:
+            # GDN rollback: replay draft state.
+            num_keep_steps = min(num_accepted, self._lambda)
+            trim_draft_steps = self._lambda - num_keep_steps
+            if trim_draft_steps > 0:
+                self._gdn_capture.rollback_autoregressive(
+                    self._draft_gdn_buffer,
+                    self._draft_cache,
+                    num_steps=self._lambda,
+                    num_keep_steps=num_keep_steps,
+                    trim=trim_draft_steps,
+                )
+        else:
+            trim_draft = max(self._lambda - num_accepted, 0)
+            if trim_draft > 0 and trim_prompt_cache is not None:
+                trim_prompt_cache(self._draft_cache, trim_draft)
+
+        if num_accepted > self._lambda:
+            last_primary = mx.array([[primary_tokens[-1]]])
+            align_logits = _logits(self._draft(last_primary, cache=self._draft_cache))
+            mx.eval(align_logits)
+
+        # 7. Update state
+        self._cache_seq_len += num_accepted
+        assert num_accepted >= 1
         self._pending_token = int(mx.argmax(self._last_target_logit).item())
 
         num_accepted_draft = self._update_acceptance_rate(num_accepted)
@@ -527,6 +652,38 @@ class SpeculativeDecoder:
             tokens.append(next_token)
 
         return tokens, []
+
+    def _draft_generate_tree(
+        self, pending_token: int, n: int
+    ) -> tuple[list[int], list[list[int]], list[mx.array]]:
+        """Generate *n* primary tokens + top-K alternatives per step.
+
+        Only called when ``self._use_tree`` is True.  Returns the primary
+        path tokens and, for each step, the top-K candidate tokens (the
+        first is the primary, the rest are siblings).
+
+        Returns:
+            (primary_tokens, alt_tokens_per_step, context).
+        """
+        assert self._draft_cache is not None
+        from olmlx.engine.tree_speculative import extract_top_k_from_logits
+
+        k = self._tree_width
+        next_token = pending_token
+        primary_tokens: list[int] = []
+        alt_tokens_per_step: list[list[int]] = []
+
+        for _ in range(n):
+            inp = mx.array([[next_token]])
+            logits = _logits(self._draft(inp, cache=self._draft_cache))
+            next_logits = logits[:, -1, :]
+            candidates = extract_top_k_from_logits(next_logits, k)
+            primary = candidates[0]
+            primary_tokens.append(primary)
+            alt_tokens_per_step.append(candidates[1:])  # siblings (may be empty)
+            next_token = primary
+
+        return primary_tokens, alt_tokens_per_step, []
 
     def _after_draft(self, draft_ctx: list[mx.array]) -> None:
         """Hook called after draft generation. Override for prefetch submission."""

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -509,6 +509,13 @@ class SpeculativeDecoder:
         Produces a tree of draft alternatives, verifies them against the
         target in one forward pass with a sparse attention mask, and rolls
         back/re-builds caches to keep only the accepted prefix.
+
+        Known limitation: tree nodes are fed as a flat sequence, so sibling
+        nodes inherit sequential RoPE positions from their flat indices rather
+        than their tree depth.  This causes siblings at depth *d* to receive
+        positional encodings intended for later positions, which may degrade
+        acceptance rates.  A future PR should inject per-node position IDs
+        based on ``tree.depths``.
         """
         from olmlx.engine.tree_speculative import (
             _patch_target_for_tree_forward,
@@ -540,15 +547,22 @@ class SpeculativeDecoder:
             max_nodes=self._tree_max_nodes,
         )
 
-        # 3. Build sparse attention mask + patch target
+        # 3. Build sparse attention mask + patch target.
+        # The tree mask only covers the tree nodes; the KV cache already
+        # holds the prompt + previous generation tokens at positions
+        # [0, cache_len).  Every tree node must attend to the full cached
+        # prefix, so we pad the mask with zeros on the key-length axis.
         tree_mask = build_tree_attention_mask(tree)
+        cache_len = self._target_cache[0].offset
+        prefix_mask = mx.zeros((1, 1, tree.num_nodes, cache_len), dtype=mx.float32)
+        full_mask = mx.concatenate([prefix_mask, tree_mask], axis=-1)
 
         if self._gdn_capture is not None:
             if self._target_gdn_buffer is not None:
                 self._target_gdn_buffer.clear()
             self._gdn_capture.use_buffer(self._target_gdn_buffer)
 
-        orig_call = _patch_target_for_tree_forward(self._target, tree_mask)
+        orig_call = _patch_target_for_tree_forward(self._target, full_mask)
         try:
             tree_tokens = mx.array([tree.tokens])
             target_out = _logits(self._target(tree_tokens, cache=self._target_cache))

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -535,9 +535,7 @@ class SpeculativeDecoder:
         orig_call = _patch_target_for_tree_forward(self._target, tree_mask)
         try:
             tree_tokens = mx.array([tree.tokens])
-            target_out = _logits(
-                self._target(tree_tokens, cache=self._target_cache)
-            )
+            target_out = _logits(self._target(tree_tokens, cache=self._target_cache))
             mx.eval(target_out)
         finally:
             _restore_target(self._target, orig_call)
@@ -565,7 +563,6 @@ class SpeculativeDecoder:
         if used_sibling:
             # Rebuild: trim all tree nodes from the target cache, then
             # feed only the accepted tokens to get a contiguous cache.
-            tree_total = tree.num_nodes
             if self._target_gdn_buffer is not None and self._gdn_capture is not None:
                 self._gdn_capture.rollback_single(
                     self._target_gdn_buffer,
@@ -576,9 +573,7 @@ class SpeculativeDecoder:
             elif trim_prompt_cache is not None:
                 trim_prompt_cache(self._target_cache, tree_total)
             accepted_arr = mx.array([accepted])
-            rebuild_out = _logits(
-                self._target(accepted_arr, cache=self._target_cache)
-            )
+            rebuild_out = _logits(self._target(accepted_arr, cache=self._target_cache))
             mx.eval(rebuild_out)
             rebuild_logits = rebuild_out[0]
             self._last_target_logit = rebuild_logits[num_accepted - 1]
@@ -586,7 +581,10 @@ class SpeculativeDecoder:
             # Primary path: trim from the end.
             trim_target = max(tree_total - num_accepted, 0)
             if trim_target > 0:
-                if self._target_gdn_buffer is not None and self._gdn_capture is not None:
+                if (
+                    self._target_gdn_buffer is not None
+                    and self._gdn_capture is not None
+                ):
                     self._gdn_capture.rollback_single(
                         self._target_gdn_buffer,
                         self._target_cache,

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -495,7 +495,6 @@ class SpeculativeDecoder:
         back/re-builds caches to keep only the accepted prefix.
         """
         from olmlx.engine.tree_speculative import (
-            TreeDraft,
             _patch_target_for_tree_forward,
             _restore_target,
             build_comb_tree,
@@ -517,11 +516,12 @@ class SpeculativeDecoder:
 
         self._after_draft(draft_ctx)
 
-        # 2. Build the tree
+        # 2. Build the tree, respecting the max-nodes cap.
         tree = build_comb_tree(
             pending_token=pending_token,
             primary_tokens=primary_tokens,
             alt_tokens_per_step=alt_per_step,
+            max_nodes=self._tree_max_nodes,
         )
 
         # 3. Build sparse attention mask + patch target
@@ -563,8 +563,17 @@ class SpeculativeDecoder:
         tree_total = tree.num_nodes
 
         if used_sibling:
-            # Rebuild: trim all tree nodes, then feed accepted tokens.
-            if trim_prompt_cache is not None:
+            # Rebuild: trim all tree nodes from the target cache, then
+            # feed only the accepted tokens to get a contiguous cache.
+            tree_total = tree.num_nodes
+            if self._target_gdn_buffer is not None and self._gdn_capture is not None:
+                self._gdn_capture.rollback_single(
+                    self._target_gdn_buffer,
+                    self._target_cache,
+                    accepted=0,
+                    trim=tree_total,
+                )
+            elif trim_prompt_cache is not None:
                 trim_prompt_cache(self._target_cache, tree_total)
             accepted_arr = mx.array([accepted])
             rebuild_out = _logits(
@@ -591,12 +600,15 @@ class SpeculativeDecoder:
 
         mx.eval(self._last_target_logit)
 
-        # 6. Align draft cache.  The draft generated λ tokens; we keep the
-        # first num_accepted of them.  On full acceptance (num_accepted > λ)
-        # the draft needs to advance by feeding the last primary token.
+        # 6. Align draft cache.  The draft generated λ primary-path tokens
+        # autoregressively.  When a sibling was accepted the accepted path
+        # includes the sibling + bonus but the draft only ran the primary;
+        # we keep only the prefix of primary steps that are still valid.
+        num_draft_keep = (num_accepted - 2) if used_sibling else num_accepted
+        num_draft_keep = max(num_draft_keep, 0)
+
         if self._draft_gdn_buffer is not None and self._gdn_capture is not None:
-            # GDN rollback: replay draft state.
-            num_keep_steps = min(num_accepted, self._lambda)
+            num_keep_steps = min(num_draft_keep, self._lambda)
             trim_draft_steps = self._lambda - num_keep_steps
             if trim_draft_steps > 0:
                 self._gdn_capture.rollback_autoregressive(
@@ -607,11 +619,11 @@ class SpeculativeDecoder:
                     trim=trim_draft_steps,
                 )
         else:
-            trim_draft = max(self._lambda - num_accepted, 0)
+            trim_draft = max(self._lambda - num_draft_keep, 0)
             if trim_draft > 0 and trim_prompt_cache is not None:
                 trim_prompt_cache(self._draft_cache, trim_draft)
 
-        if num_accepted > self._lambda:
+        if num_accepted > self._lambda and not used_sibling:
             last_primary = mx.array([[primary_tokens[-1]]])
             align_logits = _logits(self._draft(last_primary, cache=self._draft_cache))
             mx.eval(align_logits)
@@ -624,7 +636,7 @@ class SpeculativeDecoder:
         num_accepted_draft = self._update_acceptance_rate(num_accepted)
 
         self._stats_steps += 1
-        self._stats_proposed += self._lambda
+        self._stats_proposed += tree.num_nodes - 1  # all non-root nodes
         self._stats_accepted_draft += num_accepted_draft
 
         return accepted, self._lambda

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -490,7 +490,7 @@ class SpeculativeDecoder:
 
         # 5. Update state
         self._cache_seq_len += num_accepted
-        assert num_accepted >= 1
+        assert num_accepted >= 1, "step(): _verify() must return at least 1 token"
         self._last_target_logit = verification_logits[num_accepted - 1]
         mx.eval(self._last_target_logit)
         self._pending_token = int(mx.argmax(self._last_target_logit).item())
@@ -667,7 +667,7 @@ class SpeculativeDecoder:
 
         # 7. Update state
         self._cache_seq_len += num_accepted
-        assert num_accepted >= 1
+        assert num_accepted >= 1, "step(): _verify() must return at least 1 token"
         self._pending_token = int(mx.argmax(self._last_target_logit).item())
 
         num_accepted_draft = self._update_acceptance_rate(num_accepted)

--- a/olmlx/engine/tree_speculative.py
+++ b/olmlx/engine/tree_speculative.py
@@ -441,4 +441,5 @@ def extract_top_k_from_logits(
     sort_idx = mx.argsort(-top_vals, axis=-1)
     sorted_indices = mx.take(part_idx, sort_idx, axis=-1)
     mx.eval(sorted_indices)
-    return sorted_indices.flatten().tolist()
+    flat = sorted_indices.flatten()
+    return [int(flat[i].item()) for i in range(k)]

--- a/olmlx/engine/tree_speculative.py
+++ b/olmlx/engine/tree_speculative.py
@@ -441,5 +441,4 @@ def extract_top_k_from_logits(
     sort_idx = mx.argsort(-top_vals, axis=-1)
     sorted_indices = mx.take(part_idx, sort_idx, axis=-1)
     mx.eval(sorted_indices)
-    flat = sorted_indices.flatten()
-    return [int(flat[i].item()) for i in range(k)]
+    return sorted_indices.flatten().tolist()

--- a/olmlx/engine/tree_speculative.py
+++ b/olmlx/engine/tree_speculative.py
@@ -389,9 +389,9 @@ def _patch_target_for_tree_forward(
             "for this architecture."
         )
 
-    orig_call = inner.__call__
+    orig_call = type(inner).__call__
 
-    def _tree_call(inputs: mx.array, cache: Any = None) -> Any:
+    def _tree_call(self_: Any, inputs: mx.array, cache: Any = None) -> Any:
         h = embed_fn(inputs)
         if cache is None:
             cache = [None] * len(layers)
@@ -399,18 +399,18 @@ def _patch_target_for_tree_forward(
             h = layer(h, tree_mask, c)
         return norm_fn(h)
 
-    inner.__call__ = _tree_call
+    type(inner).__call__ = _tree_call  # type: ignore[method-assign]
     return orig_call
 
 
 def _restore_target(target: Any, orig_call: Any) -> None:
-    """Restore the model's original ``__call__`` after tree forward."""
+    """Restore the model's original __call__ after tree forward."""
     inner = target
     if hasattr(target, "language_model") and target.language_model is not None:
         inner = target.language_model
     elif hasattr(target, "model") and target.model is not None:
         inner = target.model
-    inner.__call__ = orig_call
+    type(inner).__call__ = orig_call  # type: ignore[method-assign]
 
 
 def extract_top_k_from_logits(

--- a/olmlx/engine/tree_speculative.py
+++ b/olmlx/engine/tree_speculative.py
@@ -111,6 +111,7 @@ def build_comb_tree(
     pending_token: int,
     primary_tokens: list[int],
     alt_tokens_per_step: list[list[int]],
+    max_nodes: int = 16,
 ) -> TreeDraft:
     """Build a tree where the primary path has sibling alternatives at
     each draft level.
@@ -159,17 +160,21 @@ def build_comb_tree(
         depths.append(i + 1)
         primary_branch.append(len(tokens) - 1)
 
-    # Phase 2: siblings — one group per level, after the primary path
+    # Phase 2: siblings — one group per level, after the primary path.
+    # Stop early when the tree would exceed max_nodes.
     for level in range(n_levels):
         alts = alt_tokens_per_step[level]
         if not alts:
             continue
         parent_idx = level  # parent is the primary node at the SAME depth
         for alt_tok in alts:
+            if len(tokens) >= max_nodes:
+                break
             tokens.append(alt_tok)
             parent_indices.append(parent_idx)
             depths.append(level + 1)
-            # NOT added to primary_branch
+        if len(tokens) >= max_nodes:
+            break
 
     return TreeDraft(
         tokens=tokens,
@@ -261,24 +266,19 @@ def verify_tree_greedy(
     """Verify a tree of draft tokens against target logits (greedy).
 
     Walks the primary path first.  At each step, if the target's argmax
-    at the node's position matches the draft token, the token is accepted
-    and we continue.  On a mismatch at the primary path, we scan sibling
-    nodes at the same depth — if any sibling matches, we accept it plus
-    the target's bonus token at the sibling's position and return.
+    at the node's parent position matches the draft token, the token is
+    accepted and we continue.  On a mismatch at the primary path, we scan
+    sibling nodes at the same depth — if any sibling matches, we accept it
+    plus the target's bonus token at the sibling's position and return.
 
     All draft tokens accepted → take the bonus token from the primary
     path's final position.
 
-    Args:
-        tree: A ``TreeDraft`` of draft alternatives.
-        target_logits: ``(num_tree_nodes, vocab)`` target model logits
-            for every tree position, in pre-order.
-
-    Returns:
-        ``(accepted_tokens, used_sibling)`` where *used_sibling* is True
-        iff a sibling node (not on the primary path) was accepted.  This
-        signals the caller that the cache entries for the accepted path
-        are not contiguous and may require a rebuild.
+    The sibling scan assumes all siblings at depth *d* share the same
+    parent as the primary node at depth *d* (true for ``build_comb_tree``,
+    but not guaranteed for ``build_full_tree``).  If ``build_full_tree``
+    is wired in, the sibling loop must additionally validate that the
+    sibling's parent is on the currently accepted prefix path.
     """
     n_logits = target_logits.shape[0]
     n_nodes = tree.num_nodes

--- a/olmlx/engine/tree_speculative.py
+++ b/olmlx/engine/tree_speculative.py
@@ -1,0 +1,423 @@
+"""Tree-structured speculative verification.
+
+Builds a tree of draft alternatives and verifies them against the target
+model in a single forward pass using a sparse attention mask.
+
+The tree is organised as a flat pre-order sequence where each position
+can only attend to its ancestors (via the mask), so sibling branches are
+isolated from each other while sharing the common prefix context.
+
+Reference: issue #358.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+# Sentinel: a large negative value used in additive attention masks to
+# block attention between positions that are not in an ancestor
+# relationship.
+_MASK_BLOCK = -1e9
+
+
+@dataclass
+class TreeDraft:
+    """A tree of draft token alternatives for speculative verification.
+
+    The tree is stored in pre-order (parent before children).  Position 0
+    is always the root (the pending/seed token).  ``parent_indices[i]``
+    gives the flat index of the parent of node *i*; -1 for the root.
+
+    ``primary_branch`` records the indices that form the main (most-likely)
+    path from root to leaf, used as the starting point during verification
+    before falling back to siblings.
+    """
+
+    tokens: list[int]
+    parent_indices: list[int]
+    primary_branch: list[int] = field(default_factory=list)
+    # depth of each node (root=0); populated by build_comb_tree
+    depths: list[int] = field(default_factory=list)
+
+    @property
+    def num_nodes(self) -> int:
+        return len(self.tokens)
+
+    @property
+    def num_draft_levels(self) -> int:
+        """Number of draft levels (excluding root)."""
+        if not self.tokens:
+            return 0
+        return max(self.depths) if self.depths else 0
+
+    def get_ancestors(self, node_idx: int) -> list[int]:
+        """Return the ancestor indices of *node_idx* (including itself)."""
+        path = [node_idx]
+        p = self.parent_indices[node_idx]
+        while p >= 0:
+            path.append(p)
+            p = self.parent_indices[p]
+        path.reverse()
+        return path
+
+
+def build_tree_attention_mask(
+    tree: TreeDraft,
+    dtype: mx.Dtype = mx.float32,
+) -> mx.array:
+    """Build an additive attention mask for a tree-structured sequence.
+
+    Returns a mask of shape ``(1, 1, n, n)`` where *n* is the number of
+    tree nodes.  Values are 0.0 (allowed to attend) or ``_MASK_BLOCK``
+    (blocked).  Position *i* can attend to position *j* iff *j* is an
+    ancestor of *i* (or *j == i* for self-attention).
+
+    The mask shape ``(batch=1, n_heads=1, query_len, key_len)``
+    broadcasts correctly with ``mx.fast.scaled_dot_product_attention``.
+    """
+    n = tree.num_nodes
+
+    # Build the mask as a plain Python/numpy structure first (MLX arrays
+    # are immutable — we can't scatter individual entries efficiently with
+    # the older ArrayAt API that lacks .set()).
+    import numpy as np
+
+    mask_np = np.full((n, n), _MASK_BLOCK, dtype=np.float32)
+    for i in range(n):
+        mask_np[i, i] = 0.0
+        p = tree.parent_indices[i]
+        while p >= 0:
+            mask_np[i, p] = 0.0
+            p = tree.parent_indices[p]
+
+    mask = mx.array(mask_np, dtype=dtype)
+    return mask.reshape(1, 1, n, n)
+
+
+def _build_causal_mask(seq_len: int, dtype: mx.Dtype = mx.float32) -> mx.array:
+    """Build a standard causal attention mask of shape (1, 1, n, n)."""
+    mask = mx.full((seq_len, seq_len), _MASK_BLOCK, dtype=dtype)
+    mask = mx.triu(mask, k=1)
+    return mask.reshape(1, 1, seq_len, seq_len)
+
+
+def build_comb_tree(
+    pending_token: int,
+    primary_tokens: list[int],
+    alt_tokens_per_step: list[list[int]],
+) -> TreeDraft:
+    """Build a tree where the primary path has sibling alternatives at
+    each draft level.
+
+    Tree structure (example w=2, λ=3)::
+
+        Root (pending)
+        ├── D1⁰ ── D2⁰ ── D3⁰     (primary path)
+        ├── D1¹                     (sibling at level 1, leaf)
+        ├── D2¹                     (sibling at level 2, leaf)
+        └── D3¹                     (sibling at level 3, leaf)
+
+    Sibling nodes are leaves: they have no children in the tree.
+    Their "children" are the bonus tokens produced by the target's
+    verification forward.
+
+    Args:
+        pending_token: The seed token (root).
+        primary_tokens: Main draft path ``[D1, D2, ..., Dλ]``.
+        alt_tokens_per_step: For each level 0..λ-1, the alternative
+            tokens that should appear as siblings.  ``len(alt_tokens_per_step)``
+            must equal ``len(primary_tokens)``.  An empty list at a level
+            means no siblings for that level.
+
+    Returns:
+        A ``TreeDraft`` in pre-order with the root at index 0.
+    """
+    n_levels = len(primary_tokens)
+    if len(alt_tokens_per_step) != n_levels:
+        raise ValueError(
+            f"alt_tokens_per_step length ({len(alt_tokens_per_step)}) must "
+            f"match primary_tokens length ({n_levels})"
+        )
+
+    # Phase 1: primary path
+    #   indices 0..n_levels (root + primary)
+    tokens: list[int] = [pending_token]
+    parent_indices: list[int] = [-1]  # root
+    depths: list[int] = [0]
+    primary_branch: list[int] = [0]  # root is part of the primary branch
+
+    for i, tok in enumerate(primary_tokens):
+        parent_idx = i  # parent is the previous node
+        tokens.append(tok)
+        parent_indices.append(parent_idx)
+        depths.append(i + 1)
+        primary_branch.append(len(tokens) - 1)
+
+    # Phase 2: siblings — one group per level, after the primary path
+    for level in range(n_levels):
+        alts = alt_tokens_per_step[level]
+        if not alts:
+            continue
+        parent_idx = level  # parent is the primary node at the SAME depth
+        for alt_tok in alts:
+            tokens.append(alt_tok)
+            parent_indices.append(parent_idx)
+            depths.append(level + 1)
+            # NOT added to primary_branch
+
+    return TreeDraft(
+        tokens=tokens,
+        parent_indices=parent_indices,
+        primary_branch=primary_branch,
+        depths=depths,
+    )
+
+
+def build_full_tree(
+    pending_token: int,
+    draft_tokens_by_step: list[list[tuple[int, int]]],
+    max_nodes: int = 16,
+) -> TreeDraft:
+    """Build a full K-ary tree from draft alternatives at each level.
+
+    Each level's alternatives list has ``(token_id, parent_index)`` pairs.
+    Parent indices refer to the *previous* level's position in the flat
+    sequence.  Built breadth-first so that each level's nodes are
+    contiguous (important for the final positional layout).
+
+    The tree is pruned to at most *max_nodes* nodes (including the root).
+
+    Args:
+        pending_token: The seed token (root).
+        draft_tokens_by_step: For each depth 1..D, a list of
+            ``(token_id, parent_pos_in_prev_level)`` pairs where the
+            parent position is 0-based within the previous level.
+        max_nodes: Hard limit on total nodes.
+
+    Returns:
+        A ``TreeDraft`` where each node has exactly one parent and the
+        primary branch follows the first child at each level.
+    """
+    # Level 0: root
+    tokens: list[int] = [pending_token]
+    parent_indices: list[int] = [-1]
+    depths: list[int] = [0]
+    primary_branch: list[int] = [0]
+
+    level_start_indices: list[int] = [0]  # start index of each level
+    # Number of nodes at each level so far (populated incrementally)
+    level_sizes: list[int] = [1]
+
+    for depth_idx, level_entries in enumerate(draft_tokens_by_step):
+        if len(tokens) >= max_nodes:
+            break
+        depth = depth_idx + 1
+        prev_start = level_start_indices[depth_idx]
+        prev_size = level_sizes[depth_idx]
+        level_start_indices.append(len(tokens))
+        level_node_count = 0
+
+        # Determine which parent gets the primary continuation
+        primary_parent_offset = 0  # first parent at this level → primary child
+
+        for parent_offset, (tok, _parent_rel_idx) in enumerate(level_entries):
+            if len(tokens) >= max_nodes:
+                break
+            parent_abs_idx = prev_start + _parent_rel_idx
+            if parent_abs_idx < prev_start or parent_abs_idx >= prev_start + prev_size:
+                raise ValueError(
+                    f"Parent index {_parent_rel_idx} at depth {depth} is out of "
+                    f"bounds [0, {prev_size})"
+                )
+            tokens.append(tok)
+            parent_indices.append(parent_abs_idx)
+            depths.append(depth)
+            level_node_count += 1
+
+            # First child of the first parent is the primary branch
+            if parent_offset == 0 and _parent_rel_idx == primary_parent_offset:
+                primary_branch.append(len(tokens) - 1)
+
+        level_sizes.append(level_node_count)
+
+    return TreeDraft(
+        tokens=tokens,
+        parent_indices=parent_indices,
+        primary_branch=primary_branch,
+        depths=depths,
+    )
+
+
+def verify_tree_greedy(
+    tree: TreeDraft,
+    target_logits: mx.array,
+) -> tuple[list[int], bool]:
+    """Verify a tree of draft tokens against target logits (greedy).
+
+    Walks the primary path first.  At each step, if the target's argmax
+    at the node's position matches the draft token, the token is accepted
+    and we continue.  On a mismatch at the primary path, we scan sibling
+    nodes at the same depth — if any sibling matches, we accept it plus
+    the target's bonus token at the sibling's position and return.
+
+    All draft tokens accepted → take the bonus token from the primary
+    path's final position.
+
+    Args:
+        tree: A ``TreeDraft`` of draft alternatives.
+        target_logits: ``(num_tree_nodes, vocab)`` target model logits
+            for every tree position, in pre-order.
+
+    Returns:
+        ``(accepted_tokens, used_sibling)`` where *used_sibling* is True
+        iff a sibling node (not on the primary path) was accepted.  This
+        signals the caller that the cache entries for the accepted path
+        are not contiguous and may require a rebuild.
+    """
+    n_logits = target_logits.shape[0]
+    n_nodes = tree.num_nodes
+    if n_logits != n_nodes:
+        # Should never happen if the caller fed the correct tree tokens
+        # to the target, but guard defensively.
+        raise ValueError(
+            f"target_logits has {n_logits} positions but tree has {n_nodes} nodes"
+        )
+
+    target_choices = mx.argmax(target_logits, axis=-1)
+    mx.eval(target_choices)
+
+    # Index the nodes by depth for fast sibling lookup.
+    nodes_by_depth: dict[int, list[int]] = {}
+    for i, d in enumerate(tree.depths):
+        nodes_by_depth.setdefault(d, []).append(i)
+
+    accepted: list[int] = []
+
+    # Walk the primary branch.
+    # Each node's acceptance is checked against the *parent* position's
+    # logit: the logit at position p predicts what comes after position p
+    # (the token that should occupy position p's child).
+    for depth in range(1, tree.num_draft_levels + 1):
+        if depth >= len(tree.primary_branch):
+            break
+        node_idx = tree.primary_branch[depth]
+        parent_idx = tree.parent_indices[node_idx]
+        draft_token = tree.tokens[node_idx]
+        # target_choices[parent_idx] is "what comes after parent"
+        target_token = int(target_choices[parent_idx].item())
+
+        if draft_token == target_token:
+            accepted.append(draft_token)
+        else:
+            # Primary mismatch — try siblings at the same depth.
+            siblings = nodes_by_depth.get(depth, [])
+            for sib_idx in siblings:
+                if sib_idx == node_idx:
+                    continue
+                sib_parent = tree.parent_indices[sib_idx]
+                sib_token = tree.tokens[sib_idx]
+                if sib_token == int(target_choices[sib_parent].item()):
+                    accepted.append(sib_token)
+                    # Bonus: what comes after the sibling (target_choices[sib_idx]
+                    # is the prediction at the sibling's own position).
+                    accepted.append(
+                        int(target_choices[sib_idx].item())
+                    )
+                    return accepted, True
+
+            # No sibling matched — accept target's choice at the
+            # rejected position and return.
+            accepted.append(target_token)
+            return accepted, False
+
+    # All primary tokens matched — add bonus token.
+    # The bonus is the prediction at the last primary node's position.
+    primary_last_idx = tree.primary_branch[-1]
+    accepted.append(int(target_choices[primary_last_idx].item()))
+    return accepted, False
+
+
+def _patch_target_for_tree_forward(
+    target: Any,
+    tree_mask: mx.array,
+) -> Any:
+    """Temporarily patch a model to use a sparse tree attention mask.
+
+    Replaces the model's ``__call__`` with a version that passes
+    *tree_mask* to each attention layer instead of creating a causal
+    mask.  Returns the original ``__call__`` so the caller can restore it.
+
+    Supports Qwen3-family models (``embed_tokens`` / ``layers`` / ``norm``
+    pattern) and wrappers whose ``language_model`` exposes the same
+    pattern.  For other architectures the patch may raise — add a new
+    branch in the dispatch inside the patched function.
+
+    The caller MUST restore the original ``__call__`` after the forward
+    pass.  Failure to restore will leak the tree mask into subsequent
+    generations.
+    """
+    # Resolve the inner module that actually runs the transformer layers.
+    inner = target
+    if hasattr(target, "language_model") and target.language_model is not None:
+        inner = target.language_model
+
+    # Detect model structure.
+    layers = getattr(inner, "layers", None)
+    norm_fn = getattr(inner, "norm", None)
+    embed_fn = getattr(inner, "embed_tokens", None)
+
+    if layers is None or norm_fn is None or embed_fn is None:
+        raise NotImplementedError(
+            f"Target model {type(target).__name__} does not expose "
+            "embed_tokens/layers/norm; tree mask injection not supported "
+            "for this architecture."
+        )
+
+    orig_call = inner.__call__
+
+    def _tree_call(inputs: mx.array, cache: Any = None) -> Any:
+        h = embed_fn(inputs)
+        if cache is None:
+            cache = [None] * len(layers)
+        for layer, c in zip(layers, cache):
+            h = layer(h, tree_mask, c)
+        return norm_fn(h)
+
+    inner.__call__ = _tree_call
+    return orig_call
+
+
+def _restore_target(target: Any, orig_call: Any) -> None:
+    """Restore the model's original ``__call__`` after tree forward."""
+    inner = target
+    if hasattr(target, "language_model") and target.language_model is not None:
+        inner = target.language_model
+    inner.__call__ = orig_call
+
+
+def extract_top_k_from_logits(
+    logits: mx.array,
+    k: int,
+) -> list[int]:
+    """Extract the top-K token IDs from a logit vector.
+
+    Args:
+        logits: ``(vocab,)`` or ``(batch, vocab)`` logits.
+        k: Number of candidates to return.
+
+    Returns:
+        Token IDs of the top-K candidates, sorted by descending score.
+    """
+    if k <= 1:
+        return [int(mx.argmax(logits, axis=-1).item())]
+    # argsort ascending → negate logits for descending
+    sorted_idx = mx.argsort(-logits, axis=-1)[..., :k]
+    mx.eval(sorted_idx)
+    flat = sorted_idx.flatten()
+    return [int(flat[i].item()) for i in range(k)]

--- a/olmlx/engine/tree_speculative.py
+++ b/olmlx/engine/tree_speculative.py
@@ -146,15 +146,17 @@ def build_comb_tree(
             f"match primary_tokens length ({n_levels})"
         )
 
-    # Phase 1: primary path
-    #   indices 0..n_levels (root + primary)
+    # Phase 1: primary path — indices 0..n_levels (root + primary).
+    # Stop building the primary path early if it would exceed max_nodes.
     tokens: list[int] = [pending_token]
-    parent_indices: list[int] = [-1]  # root
+    parent_indices: list[int] = [-1]
     depths: list[int] = [0]
-    primary_branch: list[int] = [0]  # root is part of the primary branch
+    primary_branch: list[int] = [0]
 
-    for i, tok in enumerate(primary_tokens):
-        parent_idx = i  # parent is the previous node
+    n_primary = min(n_levels, max_nodes - 1)  # -1 for the already-added root
+    for i in range(n_primary):
+        tok = primary_tokens[i]
+        parent_idx = i
         tokens.append(tok)
         parent_indices.append(parent_idx)
         depths.append(i + 1)
@@ -316,19 +318,23 @@ def verify_tree_greedy(
             accepted.append(draft_token)
         else:
             # Primary mismatch — try siblings at the same depth.
+            # The sibling scan assumes all siblings at depth *d* share
+            # the same parent as the primary node (true for comb trees,
+            # not guaranteed for full trees).  Validate explicitly.
             siblings = nodes_by_depth.get(depth, [])
+            primary_parent = parent_idx
             for sib_idx in siblings:
                 if sib_idx == node_idx:
                     continue
                 sib_parent = tree.parent_indices[sib_idx]
+                if sib_parent != primary_parent:
+                    continue  # skip siblings from other branches
                 sib_token = tree.tokens[sib_idx]
                 if sib_token == int(target_choices[sib_parent].item()):
                     accepted.append(sib_token)
                     # Bonus: what comes after the sibling (target_choices[sib_idx]
                     # is the prediction at the sibling's own position).
-                    accepted.append(
-                        int(target_choices[sib_idx].item())
-                    )
+                    accepted.append(int(target_choices[sib_idx].item()))
                     return accepted, True
 
             # No sibling matched — accept target's choice at the
@@ -349,14 +355,16 @@ def _patch_target_for_tree_forward(
 ) -> Any:
     """Temporarily patch a model to use a sparse tree attention mask.
 
-    Replaces the model's ``__call__`` with a version that passes
-    *tree_mask* to each attention layer instead of creating a causal
-    mask.  Returns the original ``__call__`` so the caller can restore it.
+    Replaces the inner transformer's ``__call__`` with a version that
+    passes *tree_mask* to each attention layer instead of creating a
+    causal mask.  Returns the original ``__call__`` so the caller can
+    restore it.
 
-    Supports Qwen3-family models (``embed_tokens`` / ``layers`` / ``norm``
-    pattern) and wrappers whose ``language_model`` exposes the same
-    pattern.  For other architectures the patch may raise — add a new
-    branch in the dispatch inside the patched function.
+    Supports Qwen3-family models via two common patterns:
+    - Text models (``Qwen3ForCausalLM``): the inner transformer lives at
+      ``target.model``; ``target.lm_head`` is applied by the outer wrapper.
+    - VLM models: the inner transformer lives at
+      ``target.language_model``.
 
     The caller MUST restore the original ``__call__`` after the forward
     pass.  Failure to restore will leak the tree mask into subsequent
@@ -366,6 +374,8 @@ def _patch_target_for_tree_forward(
     inner = target
     if hasattr(target, "language_model") and target.language_model is not None:
         inner = target.language_model
+    elif hasattr(target, "model") and target.model is not None:
+        inner = target.model
 
     # Detect model structure.
     layers = getattr(inner, "layers", None)
@@ -398,6 +408,8 @@ def _restore_target(target: Any, orig_call: Any) -> None:
     inner = target
     if hasattr(target, "language_model") and target.language_model is not None:
         inner = target.language_model
+    elif hasattr(target, "model") and target.model is not None:
+        inner = target.model
     inner.__call__ = orig_call
 
 
@@ -406,6 +418,8 @@ def extract_top_k_from_logits(
     k: int,
 ) -> list[int]:
     """Extract the top-K token IDs from a logit vector.
+
+    Uses ``mx.argpartition`` for k ≪ vocab_size (avoids a full sort).
 
     Args:
         logits: ``(vocab,)`` or ``(batch, vocab)`` logits.
@@ -416,8 +430,16 @@ def extract_top_k_from_logits(
     """
     if k <= 1:
         return [int(mx.argmax(logits, axis=-1).item())]
-    # argsort ascending → negate logits for descending
-    sorted_idx = mx.argsort(-logits, axis=-1)[..., :k]
-    mx.eval(sorted_idx)
-    flat = sorted_idx.flatten()
+
+    vocab = logits.shape[-1]
+    # argpartition places the smallest kth elements before index kth.
+    # We want the largest k, so negate and partition on (k - 1).
+    kth = min(k - 1, vocab - 1)
+    part_idx = mx.argpartition(-logits, kth=kth, axis=-1)[..., :k]
+    # part_idx is not sorted — pull the top-k values and argsort them.
+    top_vals = mx.take(logits, part_idx, axis=-1)
+    sort_idx = mx.argsort(-top_vals, axis=-1)
+    sorted_indices = mx.take(part_idx, sort_idx, axis=-1)
+    mx.eval(sorted_indices)
+    flat = sorted_indices.flatten()
     return [int(flat[i].item()) for i in range(k)]

--- a/tests/test_tree_speculative.py
+++ b/tests/test_tree_speculative.py
@@ -1,0 +1,369 @@
+"""Tests for tree-structured speculative verification (engine/tree_speculative.py)."""
+
+import mlx.core as mx
+import pytest
+
+from olmlx.engine.tree_speculative import (
+    TreeDraft,
+    build_comb_tree,
+    build_full_tree,
+    build_tree_attention_mask,
+    extract_top_k_from_logits,
+    verify_tree_greedy,
+)
+
+
+class TestBuildCombTree:
+    def test_basic_structure(self):
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20, 30],
+            alt_tokens_per_step=[[11], [21], [31]],
+        )
+        # 1 root + 3 primary + 3 siblings = 7
+        assert tree.num_nodes == 7
+        assert tree.tokens == [1, 10, 20, 30, 11, 21, 31]
+        assert tree.parent_indices == [-1, 0, 1, 2, 0, 1, 2]
+        assert tree.depths == [0, 1, 2, 3, 1, 2, 3]
+        assert tree.primary_branch == [0, 1, 2, 3]
+        assert tree.num_draft_levels == 3
+
+    def test_empty_alternatives(self):
+        tree = build_comb_tree(
+            pending_token=5,
+            primary_tokens=[10, 20],
+            alt_tokens_per_step=[[], []],
+        )
+        # Root + 2 primary = 3 (no siblings)
+        assert tree.num_nodes == 3
+        assert tree.tokens == [5, 10, 20]
+
+    def test_mixed_alternatives(self):
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20, 30],
+            alt_tokens_per_step=[[11, 12], [], [31]],
+        )
+        # Root + 3 primary + 2 (level 1) + 0 (level 2) + 1 (level 3) = 7
+        assert tree.num_nodes == 7
+        assert tree.parent_indices == [-1, 0, 1, 2, 0, 0, 2]
+
+    def test_length_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            build_comb_tree(
+                pending_token=1,
+                primary_tokens=[10, 20],
+                alt_tokens_per_step=[[11]],  # too short
+            )
+
+    def test_ancestor_path(self):
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20, 30],
+            alt_tokens_per_step=[[11], [21], [31]],
+        )
+        # D3 primary is at index 3
+        ancestors = tree.get_ancestors(3)
+        assert ancestors == [0, 1, 2, 3]  # root, D1, D2, D3
+
+        # Sibling at level 1 (index 4)
+        ancestors_4 = tree.get_ancestors(4)
+        assert ancestors_4 == [0, 4]  # root, D1_sib
+
+        # Sibling at level 2 (index 5)
+        ancestors_5 = tree.get_ancestors(5)
+        assert ancestors_5 == [0, 1, 5]  # root, D1, D2_sib
+
+
+class TestBuildFullTree:
+    def test_simple_tree(self):
+        tree = build_full_tree(
+            pending_token=100,
+            draft_tokens_by_step=[
+                [(10, 0), (11, 0)],  # depth 1: 2 children of root
+                [(20, 0), (21, 1)],  # depth 2: child of 10, child of 11
+            ],
+            max_nodes=16,
+        )
+        # depth 0: 1 node (root)
+        # depth 1: 2 nodes
+        # depth 2: 2 nodes
+        # total: 5
+        assert tree.num_nodes == 5
+
+    def test_max_nodes_prune(self):
+        tree = build_full_tree(
+            pending_token=1,
+            draft_tokens_by_step=[
+                [(10, 0), (11, 0), (12, 0)],
+                [(20, 0), (21, 0)],
+            ],
+            max_nodes=4,
+        )
+        # depth 0: 1
+        # depth 1: 3 (total 4 → hit max_nodes)
+        # depth 2: 0 (pruned)
+        assert tree.num_nodes == 4
+        assert tree.num_draft_levels == 1
+
+
+class TestAttentionMask:
+    def test_mask_shape(self):
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20, 30],
+            alt_tokens_per_step=[[11], [21], [31]],
+        )
+        mask = build_tree_attention_mask(tree)
+        assert mask.shape == (1, 1, 7, 7)
+
+    def test_root_only_sees_itself(self):
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20],
+            alt_tokens_per_step=[[], []],
+        )
+        mask = build_tree_attention_mask(tree)
+        mask_2d = mask[0, 0]
+        n = tree.num_nodes  # 3
+
+        # Root (pos 0) can attend to itself only
+        assert mask_2d[0, 0].item() == 0.0
+        for j in range(1, n):
+            assert mask_2d[0, j].item() < -1e8, f"root should not see pos {j}"
+
+    def test_primary_path_causal(self):
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20, 30],
+            alt_tokens_per_step=[[], [], []],
+        )
+        mask = build_tree_attention_mask(tree)
+        mask_2d = mask[0, 0]
+        n = 4  # root + 3 primary
+
+        # Position 1 (D1) sees root + itself
+        for j in range(n):
+            if j <= 1:
+                assert mask_2d[1, j].item() == 0.0, f"D1 should see pos {j}"
+            else:
+                assert mask_2d[1, j].item() < -1e8
+
+        # Position 2 (D2) sees root + D1 + itself
+        for j in range(n):
+            if j <= 2:
+                assert mask_2d[2, j].item() == 0.0, f"D2 should see pos {j}"
+            else:
+                assert mask_2d[2, j].item() < -1e8
+
+    def test_sibling_isolation(self):
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20],
+            alt_tokens_per_step=[[11], [21]],
+        )
+        mask = build_tree_attention_mask(tree)
+        mask_2d = mask[0, 0]
+        n = tree.num_nodes  # 5
+        # D1_sib is at index 3 (after primary path)
+        # It should see root (0) and itself (3), NOT D1 (1) or D2 (2)
+
+        # Root: ok
+        assert mask_2d[3, 0].item() == 0.0
+        # Itself: ok
+        assert mask_2d[3, 3].item() == 0.0
+        # D1: should NOT see
+        assert mask_2d[3, 1].item() < -1e8, "D1_sib should NOT see D1"
+        # D2: should NOT see
+        assert mask_2d[3, 2].item() < -1e8, "D1_sib should NOT see D2"
+        # D2_sib (index 4): should NOT see
+        assert mask_2d[3, 4].item() < -1e8
+
+        # D2_sib is at index 4. It should see root (0) and D1 (1), NOT D2 (2)
+        assert mask_2d[4, 0].item() == 0.0
+        assert mask_2d[4, 1].item() == 0.0, "D2_sib should see D1"
+        assert mask_2d[4, 2].item() < -1e8, "D2_sib should NOT see D2"
+        assert mask_2d[4, 3].item() < -1e8, "D2_sib should NOT see D1_sib"
+        assert mask_2d[4, 4].item() == 0.0
+
+
+class TestVerifyTreeGreedy:
+    def test_full_primary_acceptance(self):
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20, 30],
+            alt_tokens_per_step=[[11], [21], [31]],
+        )
+        vocab_size = 50
+        # Set logits: target_choices[0]=10, [1]=20, [2]=30, [3]=42(bonus)
+        logits = mx.zeros((tree.num_nodes, vocab_size))
+        logits = logits.at[0, 10].add(100.0)
+        logits = logits.at[1, 20].add(100.0)
+        logits = logits.at[2, 30].add(100.0)
+        logits = logits.at[3, 42].add(100.0)
+
+        accepted, used_sibling = verify_tree_greedy(tree, logits)
+        assert accepted == [10, 20, 30, 42]
+        assert not used_sibling
+
+    def test_primary_rejection_at_position_2(self):
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20, 30],
+            alt_tokens_per_step=[[11], [21], [31]],
+        )
+        vocab_size = 50
+        logits = mx.zeros((tree.num_nodes, vocab_size))
+        logits = logits.at[0, 10].add(100.0)  # D1 matches
+        logits = logits.at[1, 15].add(100.0)  # D2: target picks 15 (mismatch!)
+
+        accepted, used_sibling = verify_tree_greedy(tree, logits)
+        assert accepted == [10, 15]
+        assert not used_sibling
+
+    def test_sibling_match_at_position_2(self):
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20, 30],
+            alt_tokens_per_step=[[11], [21], [31]],
+        )
+        vocab_size = 50
+        logits = mx.zeros((tree.num_nodes, vocab_size))
+        logits = logits.at[0, 10].add(100.0)  # D1 matches
+        logits = logits.at[1, 15].add(50.0)   # D2 mismatches
+        logits = logits.at[1, 21].add(100.0)  # D2_sib matches at parent pos 1
+
+        accepted, used_sibling = verify_tree_greedy(tree, logits)
+        assert used_sibling
+        assert accepted[0] == 10  # D1
+        assert accepted[1] == 21  # D2_sib
+        # bonus from target_choices[sib_idx] = target_choices[5] = 0
+        assert len(accepted) == 3
+
+    def test_sibling_match_bonus(self):
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20, 30],
+            alt_tokens_per_step=[[11], [21], [31]],
+        )
+        vocab_size = 50
+        logits = mx.zeros((tree.num_nodes, vocab_size))
+        logits = logits.at[0, 10].add(100.0)  # D1 matches
+        logits = logits.at[1, 15].add(50.0)   # D2 mismatches
+        logits = logits.at[1, 21].add(100.0)  # D2_sib matches
+        # Bonus: target_choices[5] (sibling position 5)
+        logits = logits.at[5, 42].add(100.0)  # bonus token for sibling
+
+        accepted, used_sibling = verify_tree_greedy(tree, logits)
+        assert used_sibling
+        assert accepted == [10, 21, 42]
+
+    def test_sibling_at_position_1(self):
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20, 30],
+            alt_tokens_per_step=[[11], [21], [31]],
+        )
+        vocab_size = 50
+        logits = mx.zeros((tree.num_nodes, vocab_size))
+        # D1: target_choices[0]=15 (mismatch!)
+        logits = logits.at[0, 15].add(50.0)
+        # D1_sib: target_choices[0]=11 (larger → match!)
+        logits = logits.at[0, 11].add(100.0)
+        # Bonus for sibling: target_choices[4] (D1_sib's position = 4)
+        logits = logits.at[4, 42].add(100.0)
+
+        accepted, used_sibling = verify_tree_greedy(tree, logits)
+        assert used_sibling
+        assert accepted == [11, 42]
+
+    def test_logit_count_mismatch_raises(self):
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20],
+            alt_tokens_per_step=[[], []],
+        )
+        logits = mx.zeros((1, 50))  # wrong size
+        with pytest.raises(ValueError):
+            verify_tree_greedy(tree, logits)
+
+
+class TestExtractTopK:
+    def test_k_1_returns_argmax(self):
+        logits = mx.array([0.1, 0.5, 0.3, 0.9, 0.05])
+        result = extract_top_k_from_logits(logits, 1)
+        assert result == [3]
+
+    def test_k_3_returns_top_3(self):
+        logits = mx.array([0.1, 0.5, 0.3, 0.02, 0.9, 0.05])
+        result = extract_top_k_from_logits(logits, 3)
+        assert result[0] == 4  # 0.9
+        assert result[1] == 1  # 0.5
+        assert result[2] == 2  # 0.3
+
+    def test_2d_logits(self):
+        logits = mx.array([[0.1, 0.5, 0.3, 0.9]])
+        result = extract_top_k_from_logits(logits, 2)
+        assert result[0] == 3  # 0.9
+        assert result[1] == 1  # 0.5
+
+
+class TestTreeWidth1Degenerate:
+    """When tree_width=1, the tree is a single path (degenerate tree).
+    verify_tree_greedy should produce the same result as verify_draft_greedy."""
+
+    def test_matches_verify_draft_greedy(self):
+        from olmlx.engine.speculative import verify_draft_greedy
+
+        # Build a tree with width=1 (no siblings): just the primary path
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20, 30, 40],
+            alt_tokens_per_step=[[], [], [], []],
+        )
+        # tree has 5 nodes: root + 4 primary
+        # Tree verify checks using parent positions (target_choices[parent_idx])
+        # Linear verify checks using consecutive positions (target_choices[i])
+
+        vocab_size = 50
+        logits = mx.zeros((tree.num_nodes, vocab_size))
+        # In tree: D1 uses target_choices[0], D2 uses target_choices[1], etc.
+        # In linear: D1 uses target_choices[0], D2 uses target_choices[1], etc.
+        # These match because positions are consecutive in a single-path tree.
+        logits = logits.at[0, 10].add(100.0)
+        logits = logits.at[1, 20].add(100.0)
+        logits = logits.at[2, 30].add(100.0)
+        logits = logits.at[3, 15].add(100.0)  # D4 mismatch → accept 15
+        # Bonus irrelevant here (no full acceptance)
+
+        tree_accepted, _ = verify_tree_greedy(tree, logits)
+
+        # Linear equivalent
+        lin_logits = logits[: len(tree.primary_branch), :]  # 5 positions
+        lin_accepted = verify_draft_greedy([10, 20, 30, 40], lin_logits)
+
+        assert tree_accepted == lin_accepted, (
+            f"tree: {tree_accepted}, linear: {lin_accepted}"
+        )
+
+    def test_full_acceptance_matches(self):
+        from olmlx.engine.speculative import verify_draft_greedy
+
+        tree = build_comb_tree(
+            pending_token=1,
+            primary_tokens=[10, 20],
+            alt_tokens_per_step=[[], []],
+        )
+        vocab_size = 50
+        logits = mx.zeros((tree.num_nodes, vocab_size))
+        logits = logits.at[0, 10].add(100.0)  # D1
+        logits = logits.at[1, 20].add(100.0)  # D2
+        logits = logits.at[2, 42].add(100.0)  # bonus
+
+        tree_accepted, _ = verify_tree_greedy(tree, logits)
+        lin_logits = logits[:3, :]
+        lin_accepted = verify_draft_greedy([10, 20], lin_logits)
+
+        assert tree_accepted == lin_accepted, (
+            f"tree: {tree_accepted}, linear: {lin_accepted}"
+        )

--- a/tests/test_tree_speculative.py
+++ b/tests/test_tree_speculative.py
@@ -4,7 +4,6 @@ import mlx.core as mx
 import pytest
 
 from olmlx.engine.tree_speculative import (
-    TreeDraft,
     build_comb_tree,
     build_full_tree,
     build_tree_attention_mask,
@@ -164,7 +163,6 @@ class TestAttentionMask:
         )
         mask = build_tree_attention_mask(tree)
         mask_2d = mask[0, 0]
-        n = tree.num_nodes  # 5
         # D1_sib is at index 3 (after primary path)
         # It should see root (0) and itself (3), NOT D1 (1) or D2 (2)
 

--- a/tests/test_tree_speculative.py
+++ b/tests/test_tree_speculative.py
@@ -228,7 +228,7 @@ class TestVerifyTreeGreedy:
         vocab_size = 50
         logits = mx.zeros((tree.num_nodes, vocab_size))
         logits = logits.at[0, 10].add(100.0)  # D1 matches
-        logits = logits.at[1, 15].add(50.0)   # D2 mismatches
+        logits = logits.at[1, 15].add(50.0)  # D2 mismatches
         logits = logits.at[1, 21].add(100.0)  # D2_sib matches at parent pos 1
 
         accepted, used_sibling = verify_tree_greedy(tree, logits)
@@ -247,7 +247,7 @@ class TestVerifyTreeGreedy:
         vocab_size = 50
         logits = mx.zeros((tree.num_nodes, vocab_size))
         logits = logits.at[0, 10].add(100.0)  # D1 matches
-        logits = logits.at[1, 15].add(50.0)   # D2 mismatches
+        logits = logits.at[1, 15].add(50.0)  # D2 mismatches
         logits = logits.at[1, 21].add(100.0)  # D2_sib matches
         # Bonus: target_choices[5] (sibling position 5)
         logits = logits.at[5, 42].add(100.0)  # bonus token for sibling


### PR DESCRIPTION
## Summary

Implements tree-structured speculative verification for the classic strategy. The draft model produces top-K candidates per step, which are arranged into a tree with sibling alternatives at each draft level. The target verifies all alternatives in a single forward pass using a sparse attention mask where each node attends only to its ancestors.

## Changes

### New: `olmlx/engine/tree_speculative.py`
- `TreeDraft` — dataclass representing a tree of draft alternatives
- `build_comb_tree()` — primary path + K-1 sibling alternatives per level
- `build_tree_attention_mask()` — sparse additive mask (ancestor-only attention)
- `verify_tree_greedy()` — tree-walking verification with sibling fallback
- `_patch_target_for_tree_forward()` / `_restore_target()` — mask injection for Qwen3-family models
- `extract_top_k_from_logits()` — top-K candidate extraction

### Modified: `olmlx/engine/speculative.py`
- `SpeculativeDecoder.__init__` — `tree_width`, `tree_max_nodes` params
- `step()` — dispatches to `_step_linear` (unchanged) or `_step_tree` (new)
- `_step_tree()` — tree build → mask → patched target forward → tree verify → cache rollback/rebuild
- `_draft_generate_tree()` — primary + top-K alternatives per step

### Modified: `olmlx/config.py`
- `tree_speculative`, `tree_width`, `tree_max_nodes` settings

### New: `tests/test_tree_speculative.py`
22 tests: tree building, mask construction, full acceptance, primary rejection, sibling match, bonus token, property tests against `verify_draft_greedy`

## Configuration

```bash
OLMLX_SPECULATIVE=true
OLMLX_TREE_SPECULATIVE=true
OLMLX_TREE_WIDTH=2
OLMLX_TREE_MAX_NODES=8
```

Setting `OLMLX_TREE_WIDTH=1` falls back to the existing linear verification.

Closes #358