### PR TITLE
fix(dflash): remove self.causal guard from sliding attention mask (#317)

### DIFF
--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -350,7 +350,7 @@ class DFlashDraftModel(nn.Module):
             t == "sliding_attention" and not config.attention_causal
             for t in config.layer_types
         ):
-            logger.info(
+            logger.warning(
                 "DFlash draft (%d layers): sliding_attention layers "
                 "with attention_causal=False.  As of gh#317 the "
                 "inference path applies a sliding-causal mask whenever "

--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -31,6 +31,10 @@ from mlx_lm.models.rope_utils import initialize_rope
 
 logger = logging.getLogger(__name__)
 
+# Tracks how many sliding non-causal layers have been instantiated
+# this process lifetime so the warning fires only once per model load.
+_sliding_non_causal_warn_count = 0
+
 
 @dataclass
 class DraftConfig:
@@ -151,13 +155,13 @@ class DFlashAttention(nn.Module):
 
     .. note::
 
-       In steady-state decoding with a full ``RotatingKVCache``,
-       ``ctx_len`` is always ``window`` (the cache holds exactly that
-       many keys), so ``ctx_len + L = window + L > window`` for any
-       proposal length ``L > 0`` — the sliding-causal mask is
-       unconditionally applied.  The ``>`` threshold only matters
-       during the initial cache fill-up phase when the context is
-       still shorter than the window.
+       With a full ``RotatingKVCache`` (``max_size = window - 1``,
+       the ``make_cache()`` convention for sliding layers),
+       ``ctx_len`` is ``window - 1``, so ``ctx_len + L > window``
+       holds for ``L >= 2`` — the mask kicks in at two or more
+       proposal tokens.  In practice DFlash always processes
+       ``block_size >= 2`` tokens per step, so the mask is
+       effectively unconditional in steady state.
     """
 
     def __init__(self, config: DraftConfig, layer_idx: int):
@@ -185,19 +189,22 @@ class DFlashAttention(nn.Module):
             # trained with an older olmlx version.  The mismatch is
             # undetectable at load time because the checkpoint does not
             # record which code version trained it, so warn the
-            # operator.
-            logger.warning(
-                "DFlashAttention layer %d is sliding_attention with "
-                "attention_causal=False.  As of gh#317 the inference "
-                "path applies a sliding-causal mask whenever "
-                "ctx_len + L > sliding_window regardless of the causal "
-                "flag.  Drafts trained with an older olmlx version "
-                "were trained without this mask and may show degraded "
-                "acceptance rates.  Re-train with the latest "
-                "preparation pipeline if acceptance is unexpectedly "
-                "low.",
-                layer_idx,
-            )
+            # operator once per model load.
+            global _sliding_non_causal_warn_count
+            num_warned = _sliding_non_causal_warn_count
+            _sliding_non_causal_warn_count += 1
+            if num_warned == 0:
+                logger.warning(
+                    "DFlash draft contains sliding_attention layers "
+                    "with attention_causal=False.  As of gh#317 the "
+                    "inference path applies a sliding-causal mask "
+                    "whenever ctx_len + L > sliding_window regardless "
+                    "of the causal flag.  Drafts trained with an "
+                    "older olmlx version were trained without this "
+                    "mask and may show degraded acceptance rates.  "
+                    "Re-train with the latest preparation pipeline "
+                    "if acceptance is unexpectedly low."
+                )
 
         self.q_proj = nn.Linear(
             config.hidden_size, self.n_heads * self.head_dim, bias=False

--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -19,6 +19,7 @@ not duplicated in memory.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -27,6 +28,8 @@ import mlx.nn as nn
 from mlx_lm.models.base import create_causal_mask
 from mlx_lm.models.cache import KVCache, RotatingKVCache
 from mlx_lm.models.rope_utils import initialize_rope
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -166,6 +169,35 @@ class DFlashAttention(nn.Module):
         self.is_sliding = config.layer_types[layer_idx] == "sliding_attention"
         self.sliding_window = config.sliding_window if self.is_sliding else None
         self.causal = config.attention_causal
+
+        if self.is_sliding and self.sliding_window is None:
+            raise ValueError(
+                "DFlashAttention layer has is_sliding=True but no "
+                "sliding_window set — a sliding-attention layer "
+                "requires a window size.  This is a DraftConfig bug."
+            )
+        if self.is_sliding and not self.causal:
+            # Locally-trained non-causal sliding drafts were trained
+            # without the sliding-causal mask on these layers.  After
+            # gh#317 Gap 6 the inference path applies the mask
+            # unconditionally — matching upstream z-lab/dflash but
+            # creating a silent train/inference mismatch for any draft
+            # trained with an older olmlx version.  The mismatch is
+            # undetectable at load time because the checkpoint does not
+            # record which code version trained it, so warn the
+            # operator.
+            logger.warning(
+                "DFlashAttention layer %d is sliding_attention with "
+                "attention_causal=False.  As of gh#317 the inference "
+                "path applies a sliding-causal mask whenever "
+                "ctx_len + L > sliding_window regardless of the causal "
+                "flag.  Drafts trained with an older olmlx version "
+                "were trained without this mask and may show degraded "
+                "acceptance rates.  Re-train with the latest "
+                "preparation pipeline if acceptance is unexpectedly "
+                "low.",
+                layer_idx,
+            )
 
         self.q_proj = nn.Linear(
             config.hidden_size, self.n_heads * self.head_dim, bias=False

--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -338,14 +338,14 @@ class DFlashDraftModel(nn.Module):
         self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rope = _build_rope(config)
 
-        # Locally-trained non-causal sliding drafts were trained without
-        # the sliding-causal mask on those layers (old olmlx versions).
-        # After gh#317 Gap 6 inference applies the mask unconditionally
-        # on sliding layers, creating a silent train/inference mismatch.
-        # The checkpoint does not record which code version trained it,
-        # so the mismatch is undetectable at load time — warn every
-        # model construction (logger.warning fires on every reload even
-        # in long-running servers, unlike warnings.warn).
+        # The warning fires for every non-causal sliding draft —
+        # including correctly-trained ones that were prepared with the
+        # patched pipeline.  The checkpoint format does not record which
+        # code version trained it, so we cannot distinguish legacy
+        # (mask-free) training from post-#317 (mask-applied) training.
+        # Newly-trained drafts correctly expect the mask at inference
+        # time and can safely ignore this warning; the heuristic "if
+        # acceptance is unexpectedly low, re-train" still holds.
         if any(
             t == "sliding_attention" and not config.attention_causal
             for t in config.layer_types
@@ -355,10 +355,10 @@ class DFlashDraftModel(nn.Module):
                 "layers with attention_causal=False.  As of gh#317 the "
                 "inference path applies a sliding-causal mask whenever "
                 "ctx_len + L > sliding_window regardless of the causal "
-                "flag.  Drafts trained with an older olmlx version were "
-                "trained without this mask and may show degraded "
-                "acceptance rates.  Re-train with the latest preparation "
-                "pipeline if acceptance is unexpectedly low.",
+                "flag.  Correctly-trained post-#317 drafts expect this "
+                "mask and can safely ignore this warning.  Older drafts "
+                "trained without the mask may show degraded acceptance "
+                "rates — re-train if acceptance is unexpectedly low.",
                 config.num_hidden_layers,
             )
 

--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -124,10 +124,16 @@ class DFlashAttention(nn.Module):
     context-K (offset by the prior cache offset).
 
     When ``config.attention_causal`` is ``False`` (bidirectional), the
-    mask is ``None`` for both full- and sliding-attention layers.
-    Bidirectional sliding layers rely on ``RotatingKVCache`` eviction
-    (enforced by ``make_cache()`` via ``layer_types``) to limit the
-    effective receptive field — no explicit spatial mask is needed.
+    mask is ``None`` for full-attention layers only. Sliding-attention
+    layers always apply a sliding-causal mask (via
+    ``create_causal_mask``) when the combined context + proposal length
+    exceeds the sliding window — matching upstream z-lab/dflash
+    behaviour regardless of the ``causal`` flag. For sequences shorter
+    than the window the mask remains ``None`` so in-window attention is
+    fully bidirectional. The ``RotatingKVCache`` eviction (enforced by
+    ``make_cache()`` via ``layer_types``) works alongside the explicit
+    spatial mask — the mask bounds the attention dot-product to the
+    window while the cache discards keys outside it.
     """
 
     def __init__(self, config: DraftConfig, layer_idx: int):

--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -134,6 +134,27 @@ class DFlashAttention(nn.Module):
     ``make_cache()`` via ``layer_types``) works alongside the explicit
     spatial mask — the mask bounds the attention dot-product to the
     window while the cache discards keys outside it.
+
+    .. note::
+
+       ``create_causal_mask`` enforces *both* the spatial window and
+       causal ordering within the proposal stream.  When the window is
+       exceeded, proposal token ``i`` cannot attend to proposal token
+       ``j > i`` even when ``attention_causal`` is ``False``.  This
+       matches upstream z-lab/dflash and avoids a train/inference
+       mismatch, but a custom draft architecture that was trained with
+       full bidirectionality for proposal tokens would silently degrade
+       under this mask.
+
+    .. note::
+
+       In steady-state decoding with a full ``RotatingKVCache``,
+       ``ctx_len`` is always ``window`` (the cache holds exactly that
+       many keys), so ``ctx_len + L = window + L > window`` for any
+       proposal length ``L > 0`` — the sliding-causal mask is
+       unconditionally applied.  The ``>`` threshold only matters
+       during the initial cache fill-up phase when the context is
+       still shorter than the window.
     """
 
     def __init__(self, config: DraftConfig, layer_idx: int):

--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -350,15 +350,15 @@ class DFlashDraftModel(nn.Module):
             t == "sliding_attention" and not config.attention_causal
             for t in config.layer_types
         ):
-            logger.warning(
-                "DFlash draft (%d layers) contains sliding_attention "
-                "layers with attention_causal=False.  As of gh#317 the "
+            logger.info(
+                "DFlash draft (%d layers): sliding_attention layers "
+                "with attention_causal=False.  As of gh#317 the "
                 "inference path applies a sliding-causal mask whenever "
                 "ctx_len + L > sliding_window regardless of the causal "
-                "flag.  Correctly-trained post-#317 drafts expect this "
-                "mask and can safely ignore this warning.  Older drafts "
-                "trained without the mask may show degraded acceptance "
-                "rates — re-train if acceptance is unexpectedly low.",
+                "flag.  The mask also enforces causal ordering between "
+                "proposal tokens.  Correctly-trained post-#317 drafts "
+                "expect this mask; older drafts trained without the "
+                "mask may show degraded acceptance rates.",
                 config.num_hidden_layers,
             )
 

--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -20,6 +20,7 @@ not duplicated in memory.
 from __future__ import annotations
 
 import logging
+import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -30,10 +31,6 @@ from mlx_lm.models.cache import KVCache, RotatingKVCache
 from mlx_lm.models.rope_utils import initialize_rope
 
 logger = logging.getLogger(__name__)
-
-# Tracks how many sliding non-causal layers have been instantiated
-# this process lifetime so the warning fires only once per model load.
-_sliding_non_causal_warn_count = 0
 
 
 @dataclass
@@ -189,22 +186,21 @@ class DFlashAttention(nn.Module):
             # trained with an older olmlx version.  The mismatch is
             # undetectable at load time because the checkpoint does not
             # record which code version trained it, so warn the
-            # operator once per model load.
-            global _sliding_non_causal_warn_count
-            num_warned = _sliding_non_causal_warn_count
-            _sliding_non_causal_warn_count += 1
-            if num_warned == 0:
-                logger.warning(
-                    "DFlash draft contains sliding_attention layers "
-                    "with attention_causal=False.  As of gh#317 the "
-                    "inference path applies a sliding-causal mask "
-                    "whenever ctx_len + L > sliding_window regardless "
-                    "of the causal flag.  Drafts trained with an "
-                    "older olmlx version were trained without this "
-                    "mask and may show degraded acceptance rates.  "
-                    "Re-train with the latest preparation pipeline "
-                    "if acceptance is unexpectedly low."
-                )
+            # operator once per call-site (warnings.warn deduplicates
+            # by default, resetting between test sessions and on model
+            # reload).
+            warnings.warn(
+                "DFlash draft contains sliding_attention layers "
+                "with attention_causal=False.  As of gh#317 the "
+                "inference path applies a sliding-causal mask "
+                "whenever ctx_len + L > sliding_window regardless "
+                "of the causal flag.  Drafts trained with an "
+                "older olmlx version were trained without this "
+                "mask and may show degraded acceptance rates.  "
+                "Re-train with the latest preparation pipeline "
+                "if acceptance is unexpectedly low.",
+                stacklevel=2,
+            )
 
         self.q_proj = nn.Linear(
             config.hidden_size, self.n_heads * self.head_dim, bias=False
@@ -281,6 +277,10 @@ class DFlashAttention(nn.Module):
 
         ctx_len = keys.shape[2] - L
         mask = "causal" if self.causal else None
+        # The ``or 0`` fallback is dead code after the __init__ guard
+        # (raising ValueError when is_sliding=True without a window),
+        # but kept as belt-and-suspenders in case the guard is ever
+        # bypassed (e.g. direct construction in tests).
         if self.is_sliding and ctx_len + L > (self.sliding_window or 0):
             # Upstream z-lab/dflash always applies a sliding-causal mask on
             # sliding layers regardless of causal mode (see

--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -20,7 +20,6 @@ not duplicated in memory.
 from __future__ import annotations
 
 import logging
-import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -175,31 +174,9 @@ class DFlashAttention(nn.Module):
             raise ValueError(
                 "DFlashAttention layer has is_sliding=True but no "
                 "sliding_window set — a sliding-attention layer "
-                "requires a window size.  This is a DraftConfig bug."
-            )
-        if self.is_sliding and not self.causal:
-            # Locally-trained non-causal sliding drafts were trained
-            # without the sliding-causal mask on these layers.  After
-            # gh#317 Gap 6 the inference path applies the mask
-            # unconditionally — matching upstream z-lab/dflash but
-            # creating a silent train/inference mismatch for any draft
-            # trained with an older olmlx version.  The mismatch is
-            # undetectable at load time because the checkpoint does not
-            # record which code version trained it, so warn the
-            # operator once per call-site (warnings.warn deduplicates
-            # by default, resetting between test sessions and on model
-            # reload).
-            warnings.warn(
-                "DFlash draft contains sliding_attention layers "
-                "with attention_causal=False.  As of gh#317 the "
-                "inference path applies a sliding-causal mask "
-                "whenever ctx_len + L > sliding_window regardless "
-                "of the causal flag.  Drafts trained with an "
-                "older olmlx version were trained without this "
-                "mask and may show degraded acceptance rates.  "
-                "Re-train with the latest preparation pipeline "
-                "if acceptance is unexpectedly low.",
-                stacklevel=2,
+                "requires a window size.  This occurs when "
+                "DFlashAttention is constructed directly without "
+                "DraftConfig validation."
             )
 
         self.q_proj = nn.Linear(
@@ -360,6 +337,30 @@ class DFlashDraftModel(nn.Module):
         ]
         self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rope = _build_rope(config)
+
+        # Locally-trained non-causal sliding drafts were trained without
+        # the sliding-causal mask on those layers (old olmlx versions).
+        # After gh#317 Gap 6 inference applies the mask unconditionally
+        # on sliding layers, creating a silent train/inference mismatch.
+        # The checkpoint does not record which code version trained it,
+        # so the mismatch is undetectable at load time — warn every
+        # model construction (logger.warning fires on every reload even
+        # in long-running servers, unlike warnings.warn).
+        if any(
+            t == "sliding_attention" and not config.attention_causal
+            for t in config.layer_types
+        ):
+            logger.warning(
+                "DFlash draft (%d layers) contains sliding_attention "
+                "layers with attention_causal=False.  As of gh#317 the "
+                "inference path applies a sliding-causal mask whenever "
+                "ctx_len + L > sliding_window regardless of the causal "
+                "flag.  Drafts trained with an older olmlx version were "
+                "trained without this mask and may show degraded "
+                "acceptance rates.  Re-train with the latest preparation "
+                "pipeline if acceptance is unexpectedly low.",
+                config.num_hidden_layers,
+            )
 
         # Populated by ``bind()``. We use ``object.__setattr__`` there to
         # bypass mlx's ``Module.__setattr__`` — assigning an

--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -215,7 +215,13 @@ class DFlashAttention(nn.Module):
 
         ctx_len = keys.shape[2] - L
         mask = "causal" if self.causal else None
-        if self.is_sliding and self.causal and ctx_len + L > (self.sliding_window or 0):
+        if self.is_sliding and ctx_len + L > (self.sliding_window or 0):
+            # Upstream z-lab/dflash always applies a sliding-causal mask on
+            # sliding layers regardless of causal mode (see
+            # dflash/model_mlx.py:110-114). The spatial window constrains
+            # which positions a token can interact with independently of the
+            # causal directionality; matching this avoids a train/inference
+            # mismatch for sliding-attention draft architectures.
             mask = create_causal_mask(
                 L, offset=ctx_len, window_size=self.sliding_window
             )

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -31,7 +31,11 @@ from olmlx.engine.gdn_rollback import (
 )
 from mlx_lm.models.rope_utils import initialize_rope
 
-from olmlx.engine.dflash.draft_model import DFlashAttention, DFlashDraftModel, DraftConfig
+from olmlx.engine.dflash.draft_model import (
+    DFlashAttention,
+    DFlashDraftModel,
+    DraftConfig,
+)
 from olmlx.engine.speculative_stream import speculative_stream_generate
 
 
@@ -483,7 +487,7 @@ class TestSlidingAttentionMask:
         cache_non_causal: KVCache | RotatingKVCache = KVCache()
 
         x_ctx = mx.random.normal((1, 3, hidden_size))  # S=3
-        x = mx.random.normal((1, 2, hidden_size))       # L=2, S+L=5 > 4
+        x = mx.random.normal((1, 2, hidden_size))  # L=2, S+L=5 > 4
 
         out_causal = attn_causal(x, x_ctx, rope, cache_causal)
         out_non_causal = attn_non_causal(x, x_ctx, rope, cache_non_causal)
@@ -515,7 +519,7 @@ class TestSlidingAttentionMask:
         cache_non_causal: KVCache | RotatingKVCache = KVCache()
 
         x_ctx = mx.random.normal((1, 1, hidden_size))  # S=1
-        x = mx.random.normal((1, 2, hidden_size))       # L=2, S+L=3 <= 4
+        x = mx.random.normal((1, 2, hidden_size))  # L=2, S+L=3 <= 4
 
         out_causal = attn_causal(x, x_ctx, rope, cache_causal)
         out_non_causal = attn_non_causal(x, x_ctx, rope, cache_non_causal)

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -663,6 +663,82 @@ class TestSlidingAttentionMask:
             mx.eval(out_c, out_nc)
             assert mx.allclose(out_c, out_nc, atol=1e-5)
 
+    def test_warns_on_sliding_non_causal_draft(self, caplog):
+        """DFlashDraftModel emits a warning when any layer is sliding
+        with attention_causal=False, informing operators that
+        locally-trained non-causal sliding drafts may regress.
+        """
+        cfg = DraftConfig(
+            hidden_size=16,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=8,
+            intermediate_size=32,
+            vocab_size=64,
+            rms_norm_eps=1e-6,
+            rope_theta=10000.0,
+            max_position_embeddings=2048,
+            block_size=4,
+            num_target_layers=1,
+            target_layer_ids=[0],
+            mask_token_id=0,
+            layer_types=("sliding_attention", "sliding_attention"),
+            sliding_window=4,
+            attention_causal=False,
+        )
+        with caplog.at_level("WARNING", logger="olmlx.engine.dflash.draft_model"):
+            _ = DFlashDraftModel(cfg)
+        assert "sliding_attention" in caplog.text
+        assert "attention_causal=False" in caplog.text
+
+    def test_no_warning_when_sliding_causal(self, caplog):
+        cfg = DraftConfig(
+            hidden_size=16,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=8,
+            intermediate_size=32,
+            vocab_size=64,
+            rms_norm_eps=1e-6,
+            rope_theta=10000.0,
+            max_position_embeddings=2048,
+            block_size=4,
+            num_target_layers=1,
+            target_layer_ids=[0],
+            mask_token_id=0,
+            layer_types=("sliding_attention", "sliding_attention"),
+            sliding_window=4,
+            attention_causal=True,
+        )
+        with caplog.at_level("WARNING", logger="olmlx.engine.dflash.draft_model"):
+            _ = DFlashDraftModel(cfg)
+        assert "sliding_attention" not in caplog.text
+
+    def test_no_warning_when_full_attention(self, caplog):
+        cfg = DraftConfig(
+            hidden_size=16,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=8,
+            intermediate_size=32,
+            vocab_size=64,
+            rms_norm_eps=1e-6,
+            rope_theta=10000.0,
+            max_position_embeddings=2048,
+            block_size=4,
+            num_target_layers=1,
+            target_layer_ids=[0],
+            mask_token_id=0,
+            layer_types=("full_attention", "full_attention"),
+            attention_causal=False,
+        )
+        with caplog.at_level("WARNING", logger="olmlx.engine.dflash.draft_model"):
+            _ = DFlashDraftModel(cfg)
+        assert "sliding_attention" not in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # DFlashDraftModel.bind()

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -565,13 +565,16 @@ class TestSlidingAttentionMask:
 
     def test_at_window_boundary_no_sliding_mask(self):
         """ctx_len + L == sliding_window falls on the <= side — no
-        sliding-causal mask is applied. This is intentional: the oldest
-        cached key sits at the edge of what ``RotatingKVCache`` will
-        evict next step, and the zero-token proposal bump keeps the
-        effective span within the window for the current step. A
-        ``>``-only threshold matches the upstream z-lab/dflash
-        behaviour of only applying the explicit spatial mask when the
-        combined sequence strictly *exceeds* the window capacity.
+        sliding-causal mask is applied.  This test uses a fresh
+        ``KVCache`` (simulating the initial fill-up phase) where the
+        cache has not yet accumulated ``window`` keys, so
+        ``ctx_len + L`` can land exactly at the window boundary.  In
+        steady-state decoding with a full ``RotatingKVCache`` the
+        boundary is unreachable (``ctx_len`` is always ``window``), so
+        the ``>`` threshold only matters during the initial cache
+        fill-up.  Matching upstream z-lab/dflash, the spatial mask is
+        only applied when the combined sequence strictly *exceeds* the
+        window.
         """
         window = 4
         hidden_size = 16
@@ -599,6 +602,59 @@ class TestSlidingAttentionMask:
 
         # No sliding mask applied — causal gets "causal", non-causal gets None.
         assert not mx.allclose(out_causal, out_non_causal, atol=1e-5)
+
+    def test_sliding_mask_with_rotating_cache_steady_state(self):
+        """With a pre-filled ``RotatingKVCache`` (the production path),
+        the sliding-causal mask is unconditionally applied because
+        ``ctx_len`` is always ``window`` and any proposal creates
+        ``ctx_len + L > window``.  Causal and non-causal sliding layers
+        produce identical output.
+        """
+        window = 4
+        hidden_size = 16
+        attn_causal = self._make_attn(
+            attention_causal=True, hidden_size=hidden_size, sliding_window=window
+        )
+        attn_non_causal = self._make_attn(
+            attention_causal=False, hidden_size=hidden_size, sliding_window=window
+        )
+        attn_non_causal.update(attn_causal.parameters())
+
+        rope = initialize_rope(
+            hidden_size // 2, 10000.0, traditional=False, max_position_embeddings=2048
+        )
+        # RotatingKVCache mirrors make_cache() for sliding layers.
+        cache_causal: KVCache | RotatingKVCache = RotatingKVCache(
+            max_size=max(window - 1, 1), keep=0
+        )
+        cache_non_causal: KVCache | RotatingKVCache = RotatingKVCache(
+            max_size=max(window - 1, 1), keep=0
+        )
+
+        # Fill the cache with window tokens (two steps to simulate
+        # steady-state decoding after initial fill-up).
+        x_ctx = mx.random.normal((1, 2, hidden_size))
+        x = mx.random.normal((1, 1, hidden_size))
+        mx.eval(
+            attn_causal(x, x_ctx, rope, cache_causal),
+            attn_non_causal(x, x_ctx, rope, cache_non_causal),
+        )
+        x_ctx2 = mx.random.normal((1, 2, hidden_size))
+        x2 = mx.random.normal((1, 1, hidden_size))
+        mx.eval(
+            attn_causal(x2, x_ctx2, rope, cache_causal),
+            attn_non_causal(x2, x_ctx2, rope, cache_non_causal),
+        )
+
+        # Now ctx_len == window (cache is full). Any L > 0 triggers the
+        # sliding-causal mask.
+        x_ctx3 = mx.random.normal((1, 1, hidden_size))
+        x3 = mx.random.normal((1, 2, hidden_size))
+        out_causal = attn_causal(x3, x_ctx3, rope, cache_causal)
+        out_non_causal = attn_non_causal(x3, x_ctx3, rope, cache_non_causal)
+        mx.eval(out_causal, out_non_causal)
+
+        assert mx.allclose(out_causal, out_non_causal, atol=1e-5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -611,9 +611,18 @@ class TestSlidingAttentionMask:
         )
 
     def test_sliding_mask_with_rotating_cache_steady_state(self):
-        """Production path: with a pre-filled ``RotatingKVCache`` and
-        multstep decoding, verify the sliding-causal mask produces
-        identical outputs for causal and non-causal sliding layers.
+        """Production path: with a pre-filled ``RotatingKVCache`` (the
+        cache type ``make_cache()`` creates for sliding layers), verify
+        the sliding-causal mask produces identical outputs for causal
+        and non-causal sliding layers when ``ctx_len + L > window``.
+
+        With ``RotatingKVCache(max_size=window-1)`` the cache holds at
+        most ``window-1`` keys, so ``ctx_len + L > window`` for any
+        ``L >= 2``.  DFlash always processes ``block_size >= 2`` tokens
+        per step, so the mask is effectively unconditional in steady
+        state.  The ``L=1`` edge case where ``ctx_len + L == window``
+        is an academic corner that never occurs in real DFlash
+        inference.
         """
         window = 4
         hidden_size = 16
@@ -629,15 +638,12 @@ class TestSlidingAttentionMask:
             hidden_size // 2, 10000.0, traditional=False, max_position_embeddings=2048
         )
 
-        # L=2 and L=4 steps over a full RotatingKVCache: both lengths
-        # exceed the window (ctx_len >= window - 1 → ctx_len + L > window
-        # for L >= 2).  Use identical fresh caches for both side-by-side
-        # comparisons so the L=1 intermediate doesn't shift the cache.
-        for L, expect_same in ((2, True), (4, True)):
+        for L in (2, 4):
             cc, cnc = self._new_rotating_caches(window)
             cache_causal: KVCache | RotatingKVCache = cc
             cache_non_causal: KVCache | RotatingKVCache = cnc
-            # Fill to steady state.
+            # Fill to steady state with shared tensors so both caches
+            # have identical history.
             x_ctx_a = mx.random.normal((1, 2, hidden_size))
             x_a = mx.random.normal((1, 1, hidden_size))
             mx.eval(
@@ -656,49 +662,6 @@ class TestSlidingAttentionMask:
             out_nc = attn_non_causal(x_prop, x_ctx, rope, cache_non_causal)
             mx.eval(out_c, out_nc)
             assert mx.allclose(out_c, out_nc, atol=1e-5)
-
-        # L=1: with ctx_len == window-1, ctx_len + 1 == window — no
-        # sliding mask triggered.  Causal flag controls.
-        cc, cnc = self._new_rotating_caches(window)
-        cache_causal2: KVCache | RotatingKVCache = cc
-        cache_non_causal2: KVCache | RotatingKVCache = cnc
-        x_ctx_a = mx.random.normal((1, 2, hidden_size))
-        mx.eval(
-            attn_causal(
-                mx.random.normal((1, 1, hidden_size)), x_ctx_a, rope, cache_causal2
-            ),
-            attn_non_causal(
-                mx.random.normal((1, 1, hidden_size)), x_ctx_a, rope, cache_non_causal2
-            ),
-        )
-        mx.eval(
-            attn_causal(
-                mx.random.normal((1, 1, hidden_size)),
-                mx.random.normal((1, 2, hidden_size)),
-                rope,
-                cache_causal2,
-            ),
-            attn_non_causal(
-                mx.random.normal((1, 1, hidden_size)),
-                mx.random.normal((1, 2, hidden_size)),
-                rope,
-                cache_non_causal2,
-            ),
-        )
-        out_c1 = attn_causal(
-            mx.random.normal((1, 1, hidden_size)),
-            mx.random.normal((1, 1, hidden_size)),
-            rope,
-            cache_causal2,
-        )
-        out_nc1 = attn_non_causal(
-            mx.random.normal((1, 1, hidden_size)),
-            mx.random.normal((1, 1, hidden_size)),
-            rope,
-            cache_non_causal2,
-        )
-        mx.eval(out_c1, out_nc1)
-        assert not mx.allclose(out_c1, out_nc1, atol=1e-5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -570,7 +570,8 @@ class TestSlidingAttentionMask:
         cache has not yet accumulated ``window`` keys, so
         ``ctx_len + L`` can land exactly at the window boundary.  In
         steady-state decoding with a full ``RotatingKVCache`` the
-        boundary is unreachable (``ctx_len`` is always ``window``), so
+        boundary is unreachable (``ctx_len`` is always ``window - 1``
+        because ``max_size = window - 1``), so
         the ``>`` threshold only matters during the initial cache
         fill-up.  Matching upstream z-lab/dflash, the spatial mask is
         only applied when the combined sequence strictly *exceeds* the

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -669,9 +669,9 @@ class TestSlidingAttentionMask:
             mx.eval(out_c, out_nc)
             assert mx.allclose(out_c, out_nc, atol=1e-5)
 
-    def test_logs_info_on_sliding_non_causal_draft(self, caplog):
-        """DFlashDraftModel logs at INFO when any layer is sliding
-        with attention_causal=False, informing operators that
+    def test_warns_on_sliding_non_causal_draft(self, caplog):
+        """DFlashDraftModel warns when any layer is sliding with
+        attention_causal=False, informing operators that
         locally-trained non-causal sliding drafts may regress.
         """
         cfg = DraftConfig(
@@ -693,12 +693,12 @@ class TestSlidingAttentionMask:
             sliding_window=4,
             attention_causal=False,
         )
-        with caplog.at_level("INFO", logger="olmlx.engine.dflash.draft_model"):
+        with caplog.at_level("WARNING", logger="olmlx.engine.dflash.draft_model"):
             _ = DFlashDraftModel(cfg)
         assert "sliding_attention" in caplog.text
         assert "attention_causal=False" in caplog.text
 
-    def test_no_log_when_sliding_causal(self, caplog):
+    def test_no_warning_when_sliding_causal(self, caplog):
         cfg = DraftConfig(
             hidden_size=16,
             num_hidden_layers=2,
@@ -718,11 +718,39 @@ class TestSlidingAttentionMask:
             sliding_window=4,
             attention_causal=True,
         )
-        with caplog.at_level("INFO", logger="olmlx.engine.dflash.draft_model"):
+        with caplog.at_level("WARNING", logger="olmlx.engine.dflash.draft_model"):
             _ = DFlashDraftModel(cfg)
         assert "sliding_attention" not in caplog.text
 
-    def test_no_log_when_full_attention(self, caplog):
+    def test_sliding_without_window_raises_valueerror(self):
+        """DFlashAttention.__init__ raises ValueError when is_sliding=True
+        but sliding_window is None.  DraftConfig has its own validation,
+        so the only way to reach this guard is by mutating the config
+        after construction — but the guard provides defense-in-depth for
+        direct construction paths."""
+        cfg = DraftConfig(
+            hidden_size=16,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=8,
+            intermediate_size=32,
+            vocab_size=64,
+            rms_norm_eps=1e-6,
+            rope_theta=10000.0,
+            max_position_embeddings=2048,
+            block_size=4,
+            num_target_layers=1,
+            target_layer_ids=[0],
+            mask_token_id=0,
+            layer_types=("sliding_attention",),
+            sliding_window=4,
+        )
+        cfg.sliding_window = None
+        with pytest.raises(ValueError, match="sliding-attention layer"):
+            DFlashAttention(cfg, layer_idx=0)
+
+    def test_no_warning_when_full_attention(self, caplog):
         cfg = DraftConfig(
             hidden_size=16,
             num_hidden_layers=2,
@@ -741,7 +769,7 @@ class TestSlidingAttentionMask:
             layer_types=("full_attention", "full_attention"),
             attention_causal=False,
         )
-        with caplog.at_level("INFO", logger="olmlx.engine.dflash.draft_model"):
+        with caplog.at_level("WARNING", logger="olmlx.engine.dflash.draft_model"):
             _ = DFlashDraftModel(cfg)
         assert "sliding_attention" not in caplog.text
 

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -29,7 +29,9 @@ from olmlx.engine.gdn_rollback import (
     _order_matches,
     find_gdn_class as _find_gdn_class,
 )
-from olmlx.engine.dflash.draft_model import DFlashDraftModel, DraftConfig
+from mlx_lm.models.rope_utils import initialize_rope
+
+from olmlx.engine.dflash.draft_model import DFlashAttention, DFlashDraftModel, DraftConfig
 from olmlx.engine.speculative_stream import speculative_stream_generate
 
 
@@ -410,6 +412,117 @@ class TestDraftConfig:
                 target_layer_ids=[0, 1],  # length 2 != num_target_layers 3
                 mask_token_id=0,
             )
+
+
+# ---------------------------------------------------------------------------
+# Sliding attention mask (regression for gh#317 Gap 6)
+# ---------------------------------------------------------------------------
+
+
+class TestSlidingAttentionMask:
+    """When ``ctx_len + L > sliding_window``, the sliding-causal mask is
+    applied regardless of ``attention_causal`` — matching upstream
+    z-lab/dflash behaviour. When within the window, ``attention_causal``
+    still controls mask presence.
+    """
+
+    @staticmethod
+    def _make_sliding_attn(
+        attention_causal: bool,
+        *,
+        hidden_size: int = 16,
+        sliding_window: int = 4,
+        seed: int = 42,
+    ) -> DFlashAttention:
+        cfg = DraftConfig(
+            hidden_size=hidden_size,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            head_dim=hidden_size // 2,
+            intermediate_size=hidden_size * 2,
+            vocab_size=64,
+            rms_norm_eps=1e-6,
+            rope_theta=10000.0,
+            max_position_embeddings=2048,
+            block_size=4,
+            num_target_layers=1,
+            target_layer_ids=[0],
+            mask_token_id=0,
+            layer_types=("sliding_attention",),
+            sliding_window=sliding_window,
+            attention_causal=attention_causal,
+        )
+        mx.random.seed(seed)
+        return DFlashAttention(cfg, layer_idx=0)
+
+    def test_sliding_mask_applied_when_window_exceeded(self):
+        """Causal and non-causal sliding layers produce identical output
+        when ctx_len + L > window because both get the same
+        sliding-causal mask.
+        """
+        window = 4
+        hidden_size = 16
+        attn_causal = self._make_sliding_attn(
+            attention_causal=True, hidden_size=hidden_size, sliding_window=window
+        )
+        attn_non_causal = self._make_sliding_attn(
+            attention_causal=False, hidden_size=hidden_size, sliding_window=window
+        )
+        # Copy weights so both layers have identical parameters.
+        for src_param, dst_param in zip(
+            attn_causal.parameters().values(), attn_non_causal.parameters().values()
+        ):
+            dst_param.update(src_param)
+
+        rope = initialize_rope(
+            hidden_size // 2, 10000.0, traditional=False, max_position_embeddings=2048
+        )
+        # Both get the same cache type (KVCache) to isolate mask differences.
+        cache_causal: KVCache | RotatingKVCache = KVCache()
+        cache_non_causal: KVCache | RotatingKVCache = KVCache()
+
+        x_ctx = mx.random.normal((1, 3, hidden_size))  # S=3
+        x = mx.random.normal((1, 2, hidden_size))       # L=2, S+L=5 > 4
+
+        out_causal = attn_causal(x, x_ctx, rope, cache_causal)
+        out_non_causal = attn_non_causal(x, x_ctx, rope, cache_non_causal)
+        mx.eval(out_causal, out_non_causal)
+
+        assert mx.allclose(out_causal, out_non_causal, atol=1e-5)
+
+    def test_no_sliding_mask_when_within_window(self):
+        """When ctx_len + L <= window, attention_causal still controls
+        the mask — non-causal gets None, causal gets "causal".
+        """
+        window = 4
+        hidden_size = 16
+        attn_causal = self._make_sliding_attn(
+            attention_causal=True, hidden_size=hidden_size, sliding_window=window
+        )
+        attn_non_causal = self._make_sliding_attn(
+            attention_causal=False, hidden_size=hidden_size, sliding_window=window
+        )
+        for src_param, dst_param in zip(
+            attn_causal.parameters().values(), attn_non_causal.parameters().values()
+        ):
+            dst_param.update(src_param)
+
+        rope = initialize_rope(
+            hidden_size // 2, 10000.0, traditional=False, max_position_embeddings=2048
+        )
+        cache_causal: KVCache | RotatingKVCache = KVCache()
+        cache_non_causal: KVCache | RotatingKVCache = KVCache()
+
+        x_ctx = mx.random.normal((1, 1, hidden_size))  # S=1
+        x = mx.random.normal((1, 2, hidden_size))       # L=2, S+L=3 <= 4
+
+        out_causal = attn_causal(x, x_ctx, rope, cache_causal)
+        out_non_causal = attn_non_causal(x, x_ctx, rope, cache_non_causal)
+        mx.eval(out_causal, out_non_causal)
+
+        # Causal mask restricts attention vs no mask — outputs should differ.
+        assert not mx.allclose(out_causal, out_non_causal, atol=1e-5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -603,12 +603,17 @@ class TestSlidingAttentionMask:
         # No sliding mask applied — causal gets "causal", non-causal gets None.
         assert not mx.allclose(out_causal, out_non_causal, atol=1e-5)
 
+    @staticmethod
+    def _new_rotating_caches(window: int):
+        return (
+            RotatingKVCache(max_size=max(window - 1, 1), keep=0),
+            RotatingKVCache(max_size=max(window - 1, 1), keep=0),
+        )
+
     def test_sliding_mask_with_rotating_cache_steady_state(self):
-        """With a pre-filled ``RotatingKVCache`` (the production path),
-        the sliding-causal mask is unconditionally applied because
-        ``ctx_len`` is always ``window`` and any proposal creates
-        ``ctx_len + L > window``.  Causal and non-causal sliding layers
-        produce identical output.
+        """Production path: with a pre-filled ``RotatingKVCache`` and
+        multstep decoding, verify the sliding-causal mask produces
+        identical outputs for causal and non-causal sliding layers.
         """
         window = 4
         hidden_size = 16
@@ -623,38 +628,77 @@ class TestSlidingAttentionMask:
         rope = initialize_rope(
             hidden_size // 2, 10000.0, traditional=False, max_position_embeddings=2048
         )
-        # RotatingKVCache mirrors make_cache() for sliding layers.
-        cache_causal: KVCache | RotatingKVCache = RotatingKVCache(
-            max_size=max(window - 1, 1), keep=0
-        )
-        cache_non_causal: KVCache | RotatingKVCache = RotatingKVCache(
-            max_size=max(window - 1, 1), keep=0
-        )
 
-        # Fill the cache with window tokens (two steps to simulate
-        # steady-state decoding after initial fill-up).
-        x_ctx = mx.random.normal((1, 2, hidden_size))
-        x = mx.random.normal((1, 1, hidden_size))
+        # L=2 and L=4 steps over a full RotatingKVCache: both lengths
+        # exceed the window (ctx_len >= window - 1 → ctx_len + L > window
+        # for L >= 2).  Use identical fresh caches for both side-by-side
+        # comparisons so the L=1 intermediate doesn't shift the cache.
+        for L, expect_same in ((2, True), (4, True)):
+            cc, cnc = self._new_rotating_caches(window)
+            cache_causal: KVCache | RotatingKVCache = cc
+            cache_non_causal: KVCache | RotatingKVCache = cnc
+            # Fill to steady state.
+            x_ctx_a = mx.random.normal((1, 2, hidden_size))
+            x_a = mx.random.normal((1, 1, hidden_size))
+            mx.eval(
+                attn_causal(x_a, x_ctx_a, rope, cache_causal),
+                attn_non_causal(x_a, x_ctx_a, rope, cache_non_causal),
+            )
+            x_ctx_b = mx.random.normal((1, 2, hidden_size))
+            x_b = mx.random.normal((1, 1, hidden_size))
+            mx.eval(
+                attn_causal(x_b, x_ctx_b, rope, cache_causal),
+                attn_non_causal(x_b, x_ctx_b, rope, cache_non_causal),
+            )
+            x_ctx = mx.random.normal((1, 1, hidden_size))
+            x_prop = mx.random.normal((1, L, hidden_size))
+            out_c = attn_causal(x_prop, x_ctx, rope, cache_causal)
+            out_nc = attn_non_causal(x_prop, x_ctx, rope, cache_non_causal)
+            mx.eval(out_c, out_nc)
+            assert mx.allclose(out_c, out_nc, atol=1e-5)
+
+        # L=1: with ctx_len == window-1, ctx_len + 1 == window — no
+        # sliding mask triggered.  Causal flag controls.
+        cc, cnc = self._new_rotating_caches(window)
+        cache_causal2: KVCache | RotatingKVCache = cc
+        cache_non_causal2: KVCache | RotatingKVCache = cnc
+        x_ctx_a = mx.random.normal((1, 2, hidden_size))
         mx.eval(
-            attn_causal(x, x_ctx, rope, cache_causal),
-            attn_non_causal(x, x_ctx, rope, cache_non_causal),
+            attn_causal(
+                mx.random.normal((1, 1, hidden_size)), x_ctx_a, rope, cache_causal2
+            ),
+            attn_non_causal(
+                mx.random.normal((1, 1, hidden_size)), x_ctx_a, rope, cache_non_causal2
+            ),
         )
-        x_ctx2 = mx.random.normal((1, 2, hidden_size))
-        x2 = mx.random.normal((1, 1, hidden_size))
         mx.eval(
-            attn_causal(x2, x_ctx2, rope, cache_causal),
-            attn_non_causal(x2, x_ctx2, rope, cache_non_causal),
+            attn_causal(
+                mx.random.normal((1, 1, hidden_size)),
+                mx.random.normal((1, 2, hidden_size)),
+                rope,
+                cache_causal2,
+            ),
+            attn_non_causal(
+                mx.random.normal((1, 1, hidden_size)),
+                mx.random.normal((1, 2, hidden_size)),
+                rope,
+                cache_non_causal2,
+            ),
         )
-
-        # Now ctx_len == window (cache is full). Any L > 0 triggers the
-        # sliding-causal mask.
-        x_ctx3 = mx.random.normal((1, 1, hidden_size))
-        x3 = mx.random.normal((1, 2, hidden_size))
-        out_causal = attn_causal(x3, x_ctx3, rope, cache_causal)
-        out_non_causal = attn_non_causal(x3, x_ctx3, rope, cache_non_causal)
-        mx.eval(out_causal, out_non_causal)
-
-        assert mx.allclose(out_causal, out_non_causal, atol=1e-5)
+        out_c1 = attn_causal(
+            mx.random.normal((1, 1, hidden_size)),
+            mx.random.normal((1, 1, hidden_size)),
+            rope,
+            cache_causal2,
+        )
+        out_nc1 = attn_non_causal(
+            mx.random.normal((1, 1, hidden_size)),
+            mx.random.normal((1, 1, hidden_size)),
+            rope,
+            cache_non_causal2,
+        )
+        mx.eval(out_c1, out_nc1)
+        assert not mx.allclose(out_c1, out_nc1, atol=1e-5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -431,11 +431,12 @@ class TestSlidingAttentionMask:
     """
 
     @staticmethod
-    def _make_sliding_attn(
+    def _make_attn(
         attention_causal: bool,
         *,
         hidden_size: int = 16,
         sliding_window: int = 4,
+        layer_types: tuple = ("sliding_attention",),
         seed: int = 42,
     ) -> DFlashAttention:
         cfg = DraftConfig(
@@ -453,7 +454,7 @@ class TestSlidingAttentionMask:
             num_target_layers=1,
             target_layer_ids=[0],
             mask_token_id=0,
-            layer_types=("sliding_attention",),
+            layer_types=layer_types,
             sliding_window=sliding_window,
             attention_causal=attention_causal,
         )
@@ -467,17 +468,17 @@ class TestSlidingAttentionMask:
         """
         window = 4
         hidden_size = 16
-        attn_causal = self._make_sliding_attn(
+        attn_causal = self._make_attn(
             attention_causal=True, hidden_size=hidden_size, sliding_window=window
         )
-        attn_non_causal = self._make_sliding_attn(
+        attn_non_causal = self._make_attn(
             attention_causal=False, hidden_size=hidden_size, sliding_window=window
         )
         # Copy weights so both layers have identical parameters.
-        for src_param, dst_param in zip(
-            attn_causal.parameters().values(), attn_non_causal.parameters().values()
-        ):
-            dst_param.update(src_param)
+        # Use ``nn.Module.update()``, not dict-value mutation —
+        # ``parameters()`` returns a freshly-built dict whose
+        # values are disconnected from the module.
+        attn_non_causal.update(attn_causal.parameters())
 
         rope = initialize_rope(
             hidden_size // 2, 10000.0, traditional=False, max_position_embeddings=2048
@@ -501,16 +502,13 @@ class TestSlidingAttentionMask:
         """
         window = 4
         hidden_size = 16
-        attn_causal = self._make_sliding_attn(
+        attn_causal = self._make_attn(
             attention_causal=True, hidden_size=hidden_size, sliding_window=window
         )
-        attn_non_causal = self._make_sliding_attn(
+        attn_non_causal = self._make_attn(
             attention_causal=False, hidden_size=hidden_size, sliding_window=window
         )
-        for src_param, dst_param in zip(
-            attn_causal.parameters().values(), attn_non_causal.parameters().values()
-        ):
-            dst_param.update(src_param)
+        attn_non_causal.update(attn_causal.parameters())
 
         rope = initialize_rope(
             hidden_size // 2, 10000.0, traditional=False, max_position_embeddings=2048
@@ -526,6 +524,80 @@ class TestSlidingAttentionMask:
         mx.eval(out_causal, out_non_causal)
 
         # Causal mask restricts attention vs no mask — outputs should differ.
+        assert not mx.allclose(out_causal, out_non_causal, atol=1e-5)
+
+    def test_full_attention_layers_unaffected(self):
+        """Full-attention layers are not touched by the sliding-mask
+        change — the ``self.is_sliding`` guard still short-circuits.
+        Causal and non-causal full-attention layers should produce
+        different outputs (causal mask vs no mask) regardless of
+        sequence length.
+        """
+        hidden_size = 16
+        attn_causal = self._make_attn(
+            attention_causal=True,
+            hidden_size=hidden_size,
+            layer_types=("full_attention",),
+        )
+        attn_non_causal = self._make_attn(
+            attention_causal=False,
+            hidden_size=hidden_size,
+            layer_types=("full_attention",),
+        )
+        attn_non_causal.update(attn_causal.parameters())
+
+        rope = initialize_rope(
+            hidden_size // 2, 10000.0, traditional=False, max_position_embeddings=2048
+        )
+        cache_causal: KVCache | RotatingKVCache = KVCache()
+        cache_non_causal: KVCache | RotatingKVCache = KVCache()
+
+        # Long sequence (would trigger sliding mask if this were sliding).
+        x_ctx = mx.random.normal((1, 6, hidden_size))  # S=6
+        x = mx.random.normal((1, 2, hidden_size))  # L=2
+
+        out_causal = attn_causal(x, x_ctx, rope, cache_causal)
+        out_non_causal = attn_non_causal(x, x_ctx, rope, cache_non_causal)
+        mx.eval(out_causal, out_non_causal)
+
+        # Full-attention: causal gets mask, non-causal does not.
+        assert not mx.allclose(out_causal, out_non_causal, atol=1e-5)
+
+    def test_at_window_boundary_no_sliding_mask(self):
+        """ctx_len + L == sliding_window falls on the <= side — no
+        sliding-causal mask is applied. This is intentional: the oldest
+        cached key sits at the edge of what ``RotatingKVCache`` will
+        evict next step, and the zero-token proposal bump keeps the
+        effective span within the window for the current step. A
+        ``>``-only threshold matches the upstream z-lab/dflash
+        behaviour of only applying the explicit spatial mask when the
+        combined sequence strictly *exceeds* the window capacity.
+        """
+        window = 4
+        hidden_size = 16
+        attn_causal = self._make_attn(
+            attention_causal=True, hidden_size=hidden_size, sliding_window=window
+        )
+        attn_non_causal = self._make_attn(
+            attention_causal=False, hidden_size=hidden_size, sliding_window=window
+        )
+        attn_non_causal.update(attn_causal.parameters())
+
+        rope = initialize_rope(
+            hidden_size // 2, 10000.0, traditional=False, max_position_embeddings=2048
+        )
+        cache_causal: KVCache | RotatingKVCache = KVCache()
+        cache_non_causal: KVCache | RotatingKVCache = KVCache()
+
+        # S+L == 4 exactly (window), not >.
+        x_ctx = mx.random.normal((1, 2, hidden_size))  # S=2
+        x = mx.random.normal((1, 2, hidden_size))  # L=2, S+L=4 == window
+
+        out_causal = attn_causal(x, x_ctx, rope, cache_causal)
+        out_non_causal = attn_non_causal(x, x_ctx, rope, cache_non_causal)
+        mx.eval(out_causal, out_non_causal)
+
+        # No sliding mask applied — causal gets "causal", non-causal gets None.
         assert not mx.allclose(out_causal, out_non_causal, atol=1e-5)
 
 

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -657,6 +657,11 @@ class TestSlidingAttentionMask:
                 attn_causal(x_b, x_ctx_b, rope, cache_causal),
                 attn_non_causal(x_b, x_ctx_b, rope, cache_non_causal),
             )
+            # RotatingKVCache offset is the monotonic write counter; after
+            # two passes of 2 ctx keys each, offset >= max_size means the
+            # ring buffer is full (= window - 1 keys resident).
+            assert cache_causal.offset >= window - 1
+            assert cache_non_causal.offset >= window - 1
             x_ctx = mx.random.normal((1, 1, hidden_size))
             x_prop = mx.random.normal((1, L, hidden_size))
             out_c = attn_causal(x_prop, x_ctx, rope, cache_causal)
@@ -664,8 +669,8 @@ class TestSlidingAttentionMask:
             mx.eval(out_c, out_nc)
             assert mx.allclose(out_c, out_nc, atol=1e-5)
 
-    def test_warns_on_sliding_non_causal_draft(self, caplog):
-        """DFlashDraftModel emits a warning when any layer is sliding
+    def test_logs_info_on_sliding_non_causal_draft(self, caplog):
+        """DFlashDraftModel logs at INFO when any layer is sliding
         with attention_causal=False, informing operators that
         locally-trained non-causal sliding drafts may regress.
         """
@@ -688,12 +693,12 @@ class TestSlidingAttentionMask:
             sliding_window=4,
             attention_causal=False,
         )
-        with caplog.at_level("WARNING", logger="olmlx.engine.dflash.draft_model"):
+        with caplog.at_level("INFO", logger="olmlx.engine.dflash.draft_model"):
             _ = DFlashDraftModel(cfg)
         assert "sliding_attention" in caplog.text
         assert "attention_causal=False" in caplog.text
 
-    def test_no_warning_when_sliding_causal(self, caplog):
+    def test_no_log_when_sliding_causal(self, caplog):
         cfg = DraftConfig(
             hidden_size=16,
             num_hidden_layers=2,
@@ -713,11 +718,11 @@ class TestSlidingAttentionMask:
             sliding_window=4,
             attention_causal=True,
         )
-        with caplog.at_level("WARNING", logger="olmlx.engine.dflash.draft_model"):
+        with caplog.at_level("INFO", logger="olmlx.engine.dflash.draft_model"):
             _ = DFlashDraftModel(cfg)
         assert "sliding_attention" not in caplog.text
 
-    def test_no_warning_when_full_attention(self, caplog):
+    def test_no_log_when_full_attention(self, caplog):
         cfg = DraftConfig(
             hidden_size=16,
             num_hidden_layers=2,
@@ -736,7 +741,7 @@ class TestSlidingAttentionMask:
             layer_types=("full_attention", "full_attention"),
             attention_causal=False,
         )
-        with caplog.at_level("WARNING", logger="olmlx.engine.dflash.draft_model"):
+        with caplog.at_level("INFO", logger="olmlx.engine.dflash.draft_model"):
             _ = DFlashDraftModel(cfg)
         assert "sliding_attention" not in caplog.text
 


### PR DESCRIPTION
The upstream z-lab/dflash reference always applies a sliding-causal mask on sliding layers regardless of causal mode. Removing the `self.causal` condition fixes a train/inference mismatch for sliding-attention draft architectures (e.g. Gemma 4-style).

$Summary of gap status from #317:
- **Gaps 1-4**: Already implemented in the codebase
- **Gap 5**: Documented structural limitation (multi-window training)
- **Gap 6**: Fixed in this PR — \[![...Closes #317](http://example.com)...\]

\
Closes #317.