### PR TITLE
fix(eagle): use buffer-based GDNStateCapture API after extraction refactor

### DIFF
--- a/olmlx/engine/eagle/decoder.py
+++ b/olmlx/engine/eagle/decoder.py
@@ -46,6 +46,7 @@ from olmlx.engine.dflash.decoder import (
 from olmlx.engine.gdn_rollback import (
     _HAS_GDN,
     find_gdn_class as _find_gdn_class,
+    GDNBuffer as _GDNBuffer,
     GDNStateCapture as _GDNStateCapture,
     get_model_layers as _get_layers,
 )
@@ -161,8 +162,11 @@ class EagleDecoder:
         # GDN state capture for non-trim-able targets. Created in
         # ``prefill`` only when the target cache is non-trim-able
         # (Qwen3.5/3.6 hybrid linear-attention case). ``None`` for
-        # standard-attention targets that take the trim path.
+        # standard-attention targets that take the trim path. The
+        # capture owns the class-level monkey-patch; the buffer holds
+        # the per-step snapshots that ``rollback_single`` replays.
         self._capture: _GDNStateCapture | None = None
+        self._capture_buffer: _GDNBuffer | None = None
         self._target_can_trim: bool = True
 
         # Stats (reset on prefill).
@@ -190,6 +194,7 @@ class EagleDecoder:
                 self._capture.close()
             finally:
                 self._capture = None
+                self._capture_buffer = None
         if self._patched:
             try:
                 _unpatch_model(self._target)
@@ -328,8 +333,15 @@ class EagleDecoder:
                 # GDN state, which subsequent rollbacks may need to replay
                 # against. ``_GDNStateCapture.__init__`` acquires
                 # ``_GDN_PATCH_LOCK``; ``reset()`` releases it via
-                # ``capture.close()``.
-                self._capture = _GDNStateCapture(self._target)
+                # ``capture.close()``. ``for_model`` locates the GDN class,
+                # constructs the capture and a buffer pre-populated with
+                # the target's GDN modules in forward-pass order, then
+                # registers the buffer as active so subsequent forwards
+                # snapshot into it.
+                self._capture, self._capture_buffer = _GDNStateCapture.for_model(
+                    self._target
+                )
+                self._capture.use_buffer(self._capture_buffer)
 
             # Run the target on the prompt and capture its last-layer hidden.
             # Two-pass: prefix fills the KV cache without materialising the
@@ -468,11 +480,11 @@ class EagleDecoder:
         # *should* follow seed_token (i.e. should match draft[0]),
         # logits[1] should match draft[1], etc.
         # Clear the GDN capture's per-step state so this verify's
-        # snapshots don't pile on top of last step's. ``rollback``
-        # replays positionally over ``self._capture._gdn_inputs``, so
-        # leftover entries would be applied to the wrong layer.
-        if self._capture is not None:
-            self._capture.clear()
+        # snapshots don't pile on top of last step's. ``rollback_single``
+        # replays positionally over the buffer, so leftover entries
+        # would be applied to the wrong layer.
+        if self._capture_buffer is not None:
+            self._capture_buffer.clear()
         # Reset the hidden-capture slot to ``None`` before the verify
         # forward. Without this, a silent hook failure on step 2+ would
         # leave last step's hidden in place and the ``is None`` guard
@@ -525,21 +537,22 @@ class EagleDecoder:
                 # Hybrid linear-attention path. ``_capture`` was created
                 # in prefill; same control-flow invariant guards as
                 # DFlash's ``step``.
-                if self._capture is None:
+                if self._capture is None or self._capture_buffer is None:
                     raise RuntimeError(
                         "EagleDecoder internal invariant violated: target "
                         "cache is non-trim-able but no GDN capture was "
                         "installed. This is an olmlx bug."
                     )
-                # ``rollback(cache, accepted, trim)`` internally slices
-                # the captured GDN inputs to ``q[:, :accepted + 1]``
-                # — i.e. the first ``accepted + 1`` positions of *this
-                # step's* capture. The capture is populated by the
-                # verify forward over ``verify_input = [seed_token,
-                # *draft_tokens]`` (length ``block_size + 1``), so its
-                # position 0 is the seed_token regardless of whether
-                # the seed came from prefill (step 1) or from the
-                # previous step's accepted tail (step 2+).
+                # ``rollback_single(buffer, cache, accepted, trim)``
+                # internally slices the captured GDN inputs to
+                # ``q[:, :accepted + 1]`` — i.e. the first
+                # ``accepted + 1`` positions of *this step's* capture.
+                # The capture is populated by the verify forward over
+                # ``verify_input = [seed_token, *draft_tokens]``
+                # (length ``block_size + 1``), so its position 0 is the
+                # seed_token regardless of whether the seed came from
+                # prefill (step 1) or from the previous step's accepted
+                # tail (step 2+).
                 #
                 # We want to keep ``num_accepted`` positions of this
                 # step's verify in the cache. Passing
@@ -551,7 +564,12 @@ class EagleDecoder:
                 # arithmetic for the same reason — its verify input
                 # is ``[pending, MASK*bs]`` where ``pending`` plays
                 # the same position-0 role as our ``seed_token``.
-                self._capture.rollback(self._target_cache, num_accepted - 1, trim)
+                self._capture.rollback_single(
+                    self._capture_buffer,
+                    self._target_cache,
+                    accepted=num_accepted - 1,
+                    trim=trim,
+                )
         # Draft cache trim — the draft is always a standard-attention
         # transformer with trim-able KVCache, so this path is the same
         # regardless of target architecture.

--- a/tests/test_eagle.py
+++ b/tests/test_eagle.py
@@ -722,22 +722,30 @@ class TestEagleDecoderGDNPath:
 
         # Stub ``_GDNStateCapture`` so we don't actually need a real
         # ``GatedDeltaNet`` class on the target. Mirrors only the
-        # methods the decoder calls (``__init__``, ``clear``, ``close``,
-        # ``rollback``).
+        # methods the decoder calls: ``for_model`` (returns the
+        # capture/buffer pair), ``use_buffer``, ``close``, and
+        # ``rollback_single``; the buffer side exposes ``clear``.
         captured_calls = {"init": 0, "clear": 0, "close": 0, "rollback": []}
 
-        class _FakeCapture:
-            def __init__(self, model):
-                captured_calls["init"] += 1
-                self._model = model
-
+        class _FakeBuffer:
             def clear(self):
                 captured_calls["clear"] += 1
+
+        class _FakeCapture:
+            @classmethod
+            def for_model(cls, model):
+                captured_calls["init"] += 1
+                inst = cls()
+                inst._model = model
+                return inst, _FakeBuffer()
+
+            def use_buffer(self, _buf):
+                pass
 
             def close(self):
                 captured_calls["close"] += 1
 
-            def rollback(self, cache, accepted, trim):
+            def rollback_single(self, _buffer, _cache, accepted, trim):
                 captured_calls["rollback"].append((accepted, trim))
 
         monkeypatch.setattr(decoder_mod, "_GDNStateCapture", _FakeCapture)
@@ -755,13 +763,14 @@ class TestEagleDecoderGDNPath:
         decoder.prefill(mx.array([[1, 2, 3]], dtype=mx.int32))
         assert captured_calls["init"] == 1
         assert decoder._capture is not None
+        assert decoder._capture_buffer is not None
         assert decoder._target_can_trim is False
 
     def test_step_calls_rollback_on_non_trimmable_cache(self, monkeypatch):
         # Same setup as above; verify that ``step()`` invokes
-        # ``capture.clear()`` before the verify forward and
-        # ``capture.rollback(...)`` instead of ``trim_prompt_cache``
-        # for the target cache.
+        # ``buffer.clear()`` before the verify forward and
+        # ``capture.rollback_single(...)`` instead of
+        # ``trim_prompt_cache`` for the target cache.
         from olmlx.engine.eagle import decoder as decoder_mod
 
         monkeypatch.setattr(decoder_mod, "can_trim_prompt_cache", lambda _: False)
@@ -787,17 +796,22 @@ class TestEagleDecoderGDNPath:
 
         captured_calls = {"clear": 0, "close": 0, "rollback": []}
 
-        class _FakeCapture:
-            def __init__(self, model):
-                pass
-
+        class _FakeBuffer:
             def clear(self):
                 captured_calls["clear"] += 1
+
+        class _FakeCapture:
+            @classmethod
+            def for_model(cls, _model):
+                return cls(), _FakeBuffer()
+
+            def use_buffer(self, _buf):
+                pass
 
             def close(self):
                 captured_calls["close"] += 1
 
-            def rollback(self, cache, accepted, trim):
+            def rollback_single(self, _buffer, _cache, accepted, trim):
                 captured_calls["rollback"].append((accepted, trim))
 
         monkeypatch.setattr(decoder_mod, "_GDNStateCapture", _FakeCapture)
@@ -817,7 +831,7 @@ class TestEagleDecoderGDNPath:
         decoder, _, _ = _make_decoder(block_size=2)
         decoder.prefill(mx.array([[1, 2, 3]], dtype=mx.int32))
         accepted, _ = decoder.step()
-        # capture.clear must run before verify
+        # buffer.clear must run before verify
         assert captured_calls["clear"] == 1
         # rollback must run after verify. With the
         # ``verify_draft_greedy`` patch above we deterministically
@@ -836,8 +850,8 @@ class TestEagleDecoderGDNPath:
         # draft trim; settle for "no double-trim of target": the
         # number of target_trim_calls equals the number of draft
         # trims (== 1 if any draft trim happened).
-        # Rather than a brittle equality, just confirm capture.rollback
-        # ran — the path is exercised.
+        # Rather than a brittle equality, just confirm
+        # capture.rollback_single ran — the path is exercised.
         decoder.reset()
         # close should fire on reset
         assert captured_calls["close"] == 1


### PR DESCRIPTION
## Summary
- `EagleDecoder` was using the pre-refactor `GDNStateCapture` API (`_GDNStateCapture(model)`, `capture.clear()`, `capture.rollback(cache, accepted, trim)`) — none of these exist on the post-refactor class in `gdn_rollback.py`. A hybrid linear-attention target (Qwen3.5/3.6) running EAGLE would crash on the first partial-acceptance verify.
- Fix mirrors DFlash: `_GDNStateCapture.for_model(target)` to get capture + buffer, `use_buffer(buffer)` to register, `buffer.clear()` per step, `capture.rollback_single(buffer, cache, accepted, trim)` on rejection.
- Test stubs updated to expose the real API (`for_model`/`use_buffer`/`rollback_single`) so future drift surfaces as a stub mismatch instead of going unnoticed.

The bug was masked because every existing `TestEagleDecoderGDNPath` case monkey-patches `_GDNStateCapture` with a fake mirroring the *old* API. Hybrid-target EAGLE has no real-API coverage in the unit suite — that gap remains, but the stub now at least models the right method names.

Surfaced while triaging #360 (GDN rollback amortization on high-acceptance requests) — separate issue, but #360 work would have hit this crash immediately.

## Test plan
- [x] `uv run pytest tests/test_eagle.py tests/test_gdn_rollback.py tests/test_dflash.py tests/test_speculative.py tests/test_speculative_hybrid.py` — 130 passed
- [x] `uv run ruff check` + `uv run ruff format --check`
- [ ] Run EAGLE against a real Qwen3.5/3.6 target end-to-end (no local checkpoint handy — would still hit the ~5% acceptance ceiling documented in CLAUDE.md, but rollback path would no longer crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)