### PR TITLE
feat: Whisper transcription endpoint /v1/audio/transcriptions (#366)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ olmlx/
 ├── routers/
 │   ├── anthropic.py    # /v1/messages — Anthropic Messages API (Claude Code)
 │   ├── openai.py       # /v1/chat/completions, /v1/completions, /v1/models, /v1/embeddings
+│   ├── audio.py        # /v1/audio/transcriptions — OpenAI Whisper STT (mlx-whisper)
 │   ├── chat.py         # /api/chat (Ollama)
 │   ├── generate.py     # /api/generate (Ollama)
 │   ├── models.py       # /api/tags, /api/show, /api/ps (Ollama)
@@ -84,6 +85,7 @@ olmlx/
 ├── schemas/
 │   ├── anthropic.py    # Anthropic API request/response models
 │   ├── openai.py       # OpenAI API request/response models
+│   ├── audio.py        # Audio transcription response models
 │   ├── common.py       # Shared schema types
 │   ├── chat.py         # Ollama chat schemas
 │   ├── generate.py     # Ollama generate schemas
@@ -143,6 +145,7 @@ olmlx/
   - **Path B — Draft-informed**: During speculative decoding, captures the draft model's hidden states (pre-lm_head, via `draft.model()` + `draft.lm_head()`) and submits bulk prefetch for all target layers before verification. Maps draft positions to target layers by depth ratio so early/deep layers get appropriate signals. Deduplicates predictor calls when multiple layers share the same draft position.
   - **Prefetcher** (`prefetch.py`): Owns a dedicated `ThreadPoolExecutor` (default 16 threads) separate from the weight store's I/O pool. Prediction runs synchronously on the calling thread (MLX `mx.eval` deadlocks under concurrent multi-thread use); only I/O is async. `PrefetchStats` tracks submitted/hits/misses/failures. Lifecycle: prefetcher must be closed before weight store on model unload (prefetcher tasks submit into the weight store's pool).
   - Config: `OLMLX_FLASH_PREFETCH=true`. Tuning: `OLMLX_EXPERIMENTAL_FLASH_PREFETCH_CONFIDENCE_THRESHOLD` (default 0.3), `_MIN_NEURONS` (64), `_MAX_NEURONS`, `_IO_THREADS` (16).
+- **Audio transcription** (`routers/audio.py`): OpenAI-compatible `POST /v1/audio/transcriptions` backed by `mlx-whisper`. Multipart upload (`file` + `model`, optional `language`/`prompt`/`response_format`/`temperature`/`timestamp_granularities[]`) is streamed to a temp file under `OLMLX_AUDIO_MAX_BYTES` (default 100 MB; 413 on overflow). Whisper models are a first-class `ModelManager` kind: `_detect_model_kind` returns `"whisper"` (via `model_type == "whisper"` or the presence of mlx whisper dims `n_mels`/`n_audio_state` — mlx-community repos ship a non-HF `config.json`), `_load_model` loads them with `mlx_whisper.load_models.load_model`, and `LoadedModel.is_whisper` guards the LLM-only prompt-cache probe and KV-quant/spectral paths. `engine/inference.py::generate_transcription` acquires the inference lock + active-ref, injects the managed model into `mlx_whisper.transcribe.ModelHolder` (the module-level singleton — race-free under the serialized lock; obtained via `importlib.import_module` because the package shadows the submodule name) so `transcribe()` reuses it instead of loading its own, and runs the synchronous transcribe in a worker thread. Response formats: `json` (`{text}`), `verbose_json` (`{task, language, duration, text, segments[]}`), `text`, `srt`, `vtt` (srt/vtt rendered from segments by helpers in `routers/audio.py`). The `ForceJSONMiddleware` (which rewrites non-JSON bodies to `application/json` for Ollama `curl -d` compatibility) explicitly skips `multipart/form-data` so the upload's content-type/boundary survives. **Requires ffmpeg on PATH** (mlx-whisper decodes via ffmpeg); a missing/failed decode surfaces as HTTP 400. Convenience names `whisper-turbo`/`whisper-large` are seeded into `DEFAULT_MODELS`; direct HF paths auto-register as usual. Streaming transcription and diarization are out of scope.
 
 ## Development
 

--- a/docs/superpowers/plans/2026-05-28-whisper-transcription-endpoint.md
+++ b/docs/superpowers/plans/2026-05-28-whisper-transcription-endpoint.md
@@ -1,0 +1,1103 @@
+# Whisper Transcription Endpoint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an OpenAI-compatible `POST /v1/audio/transcriptions` route backed by `mlx-whisper`, with whisper models managed through the existing `ModelManager`.
+
+**Architecture:** A new `routers/audio.py` accepts a multipart upload, streams it to a temp file under a size cap, and calls a new `generate_transcription()` in `engine/inference.py`. That function loads the whisper model via `ModelManager` (new `"whisper"` model kind in `model_manager.py`), injects it into `mlx_whisper`'s module-level `ModelHolder`, and runs `mlx_whisper.transcribe()` in a worker thread under the inference lock. Results are serialized to `json`/`verbose_json`/`text`/`srt`/`vtt`.
+
+**Tech Stack:** Python, FastAPI, mlx-whisper (0.4.3), pydantic-settings, pytest. ffmpeg is a runtime requirement.
+
+---
+
+## File Structure
+
+- **Create** `olmlx/routers/audio.py` — the endpoint, multipart handling, size cap, format serialization, srt/vtt helpers.
+- **Create** `olmlx/schemas/audio.py` — `TranscriptionResponse`, `TranscriptionSegment`, `VerboseTranscriptionResponse`.
+- **Modify** `olmlx/config.py` — add `audio_max_bytes` setting.
+- **Modify** `olmlx/engine/model_manager.py` — `"whisper"` kind detection, whisper load branch, `is_whisper` flag, probe/kv-quant guards.
+- **Modify** `olmlx/engine/inference.py` — add `generate_transcription()`.
+- **Modify** `olmlx/app.py` — register `audio.router`.
+- **Modify** `olmlx/cli.py` — seed whisper names in `DEFAULT_MODELS`.
+- **Modify** `CLAUDE.md` — audio-transcription design bullet.
+- **Create** `tests/test_routers_audio.py`, `tests/test_audio_formats.py`; **extend** `tests/test_model_manager.py`, `tests/test_config.py`, `tests/test_inference.py` (or a new `tests/test_inference_transcription.py`), `tests/test_cli.py`.
+
+Note: `pyproject.toml`/`uv.lock` already have `mlx-whisper` (added during spec phase). Run `uv sync --no-editable` if the dep is not yet installed in your environment.
+
+---
+
+## Task 1: Config — `audio_max_bytes`
+
+**Files:**
+- Modify: `olmlx/config.py`
+- Test: `tests/test_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_config.py`:
+
+```python
+def test_audio_max_bytes_default():
+    from olmlx.config import Settings
+
+    s = Settings()
+    assert s.audio_max_bytes == 100 * 1024 * 1024
+
+
+def test_audio_max_bytes_env_override(monkeypatch):
+    monkeypatch.setenv("OLMLX_AUDIO_MAX_BYTES", "1048576")
+    from olmlx.config import Settings
+
+    s = Settings()
+    assert s.audio_max_bytes == 1048576
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_config.py::test_audio_max_bytes_default -v`
+Expected: FAIL — `AttributeError: 'Settings' object has no attribute 'audio_max_bytes'`
+
+- [ ] **Step 3: Implement**
+
+In `olmlx/config.py`, inside the `Settings` class, add a field near the other numeric limits (e.g. after `prompt_cache_*` fields). Use the `Field` import already present in the file:
+
+```python
+    audio_max_bytes: int = Field(
+        100 * 1024 * 1024,
+        gt=0,
+        description="Max upload size for /v1/audio/transcriptions (OLMLX_AUDIO_MAX_BYTES).",
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_config.py -k audio_max_bytes -v`
+Expected: PASS (both tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/config.py tests/test_config.py
+git commit -m "feat(config): add OLMLX_AUDIO_MAX_BYTES setting (#366)"
+```
+
+---
+
+## Task 2: Whisper model-kind detection
+
+**Files:**
+- Modify: `olmlx/engine/model_manager.py:1654` (inside `_detect_model_kind`)
+- Test: `tests/test_model_manager.py` (class `TestDetectModelKind`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_model_manager.py` inside `class TestDetectModelKind`:
+
+```python
+    def test_whisper_by_model_type(self, tmp_path, registry, mock_store):
+        config_path = self._make_config(tmp_path, {"model_type": "whisper"})
+        manager = self._make_manager(registry, mock_store)
+        with patch("huggingface_hub.hf_hub_download", return_value=config_path):
+            kind = manager._detect_model_kind("test/whisper")
+        assert kind == "whisper"
+
+    def test_whisper_by_dims_without_model_type(self, tmp_path, registry, mock_store):
+        # mlx-community whisper repos ship a non-HF config.json with dims and
+        # no usable model_type (load_model pops it).
+        config_path = self._make_config(
+            tmp_path,
+            {
+                "n_mels": 80,
+                "n_audio_ctx": 1500,
+                "n_audio_state": 384,
+                "n_audio_head": 6,
+                "n_audio_layer": 4,
+                "n_vocab": 51865,
+                "n_text_ctx": 448,
+                "n_text_state": 384,
+                "n_text_head": 6,
+                "n_text_layer": 4,
+            },
+        )
+        manager = self._make_manager(registry, mock_store)
+        with patch("huggingface_hub.hf_hub_download", return_value=config_path):
+            kind = manager._detect_model_kind("test/whisper-mlx")
+        assert kind == "whisper"
+
+    def test_llama_not_whisper(self, tmp_path, registry, mock_store):
+        config_path = self._make_config(tmp_path, {"model_type": "llama"})
+        manager = self._make_manager(registry, mock_store)
+        with patch("huggingface_hub.hf_hub_download", return_value=config_path):
+            kind = manager._detect_model_kind("test/model")
+        assert kind == "text"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_model_manager.py::TestDetectModelKind -k whisper -v`
+Expected: FAIL — the dims test returns `"unknown"`, the model_type test returns `"unknown"`.
+
+- [ ] **Step 3: Implement**
+
+In `olmlx/engine/model_manager.py`, locate (currently line 1654):
+
+```python
+        model_type = config.get("model_type", "").lower()
+        if not model_type:
+            return "unknown"
+```
+
+Replace those three lines with:
+
+```python
+        model_type = config.get("model_type", "").lower()
+
+        # Whisper STT (issue #366). Check before the empty-model_type return:
+        # mlx-community whisper repos ship a non-HF config.json carrying
+        # mlx_whisper.whisper.ModelDimensions fields, and load_model pops
+        # "model_type", so model_type is often absent. The dims keys are the
+        # robust discriminator; the model_type check covers HF-style configs.
+        if model_type == "whisper" or (
+            "n_mels" in config and "n_audio_state" in config
+        ):
+            return "whisper"
+
+        if not model_type:
+            return "unknown"
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/test_model_manager.py::TestDetectModelKind -v`
+Expected: PASS (all, including the new three and the pre-existing ones)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/model_manager.py tests/test_model_manager.py
+git commit -m "feat(engine): detect whisper model kind (#366)"
+```
+
+---
+
+## Task 3: Load whisper models through ModelManager
+
+**Files:**
+- Modify: `olmlx/engine/model_manager.py` — `LoadedModel.is_whisper` field (~line 740), `_load_model` whisper branch (~line 3098), `_probe_cache_capabilities` guard (~line 2008), kv-quant/spectral guard in `ensure_loaded` (~line 1203 / ~1457).
+- Test: `tests/test_model_manager.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new class to `tests/test_model_manager.py`:
+
+```python
+class TestWhisperLoad:
+    def test_load_model_whisper_branch(self, tmp_path, registry, mock_store):
+        manager = ModelManager(registry, mock_store)
+        fake_whisper = MagicMock()
+        with (
+            patch.object(
+                manager, "_detect_model_kind", return_value="whisper"
+            ),
+            patch(
+                "mlx_whisper.load_models.load_model", return_value=fake_whisper
+            ) as mock_load,
+        ):
+            model, tok, is_vlm, caps, spec = manager._load_model("test/whisper")
+        assert model is fake_whisper
+        assert tok is None
+        assert is_vlm is False
+        assert spec is None
+        mock_load.assert_called_once()
+
+    def test_probe_cache_skipped_for_whisper(self, registry, mock_store):
+        from olmlx.engine.model_manager import LoadedModel
+
+        manager = ModelManager(registry, mock_store)
+        lm = LoadedModel(
+            name="whisper:latest",
+            hf_path="test/whisper",
+            model=MagicMock(),
+            tokenizer=None,
+            is_whisper=True,
+        )
+        # Defaults that the probe would normally overwrite.
+        lm.supports_cache_trim = True
+        lm.supports_cache_persistence = False
+        with patch(
+            "mlx_lm.models.cache.make_prompt_cache"
+        ) as mock_make:
+            manager._probe_cache_capabilities(lm)
+        mock_make.assert_not_called()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_model_manager.py::TestWhisperLoad -v`
+Expected: FAIL — `LoadedModel` has no `is_whisper`; `_load_model` has no whisper branch.
+
+- [ ] **Step 3a: Add the `is_whisper` field**
+
+In `olmlx/engine/model_manager.py`, in the `LoadedModel` dataclass, add after `is_flash_moe: bool = False` (near line 740):
+
+```python
+    is_whisper: bool = False
+```
+
+- [ ] **Step 3b: Add the whisper load branch**
+
+In `_load_model`, locate (currently line 3098):
+
+```python
+        kind = self._detect_model_kind(hf_path)
+        logger.info("Detected model kind for %s: %s", hf_path, kind)
+```
+
+Immediately after the `logger.info(...)` line, insert:
+
+```python
+        if kind == "whisper":
+            # Whisper STT (issue #366). Load via mlx-whisper's loader and
+            # return no tokenizer/caps/speculative — the transcription path
+            # drives mlx_whisper.transcribe() directly.
+            import mlx.core as mx
+            import mlx_whisper.load_models as whisper_loader
+
+            model = whisper_loader.load_model(load_path, dtype=mx.float16)
+            return model, None, False, TemplateCaps(), None
+```
+
+(`TemplateCaps` is already imported in this module — confirm via `grep -n "TemplateCaps" olmlx/engine/model_manager.py`; it is used by other branches.)
+
+- [ ] **Step 3c: Guard `_probe_cache_capabilities`**
+
+In `_probe_cache_capabilities` (line ~2008), add at the very top of the method body, before the `try: from mlx_lm.models.cache import make_prompt_cache`:
+
+```python
+        if lm.is_whisper:
+            # Whisper has no LLM-style prompt cache; nothing to probe.
+            return
+```
+
+- [ ] **Step 3d: Guard kv-quant/spectral resolution for whisper**
+
+In `ensure_loaded`, the kv-quant value is resolved at line ~1203:
+
+```python
+                kv_cache_quant = model_config.resolved_kv_cache_quant()
+```
+
+This value flows into `_find_spectral_dir` (line ~1457) and the `LoadedModel(kv_cache_quant=...)` kwarg. Whisper models must not trigger spectral calibration. The model kind is known via `_detect_model_kind`. Add a guard immediately after the `kv_cache_quant = ...` line:
+
+```python
+                # Whisper models (issue #366) have no LLM KV cache — never
+                # apply KV-cache quantization / spectral calibration to them.
+                if self._detect_model_kind(hf_path) == "whisper":
+                    kv_cache_quant = None
+```
+
+Then set `is_whisper=True` on the constructed `LoadedModel`. Find the `LoadedModel(` constructor call (line ~1462) and add a kwarg alongside `is_flash_moe=is_flash_moe,`:
+
+```python
+                        is_whisper=(self._detect_model_kind(hf_path) == "whisper"),
+```
+
+Note: `_detect_model_kind` reads a cached local `config.json` after download, so the extra calls here are cheap local file reads. If you prefer to avoid the double call, capture `_kind = self._detect_model_kind(hf_path)` once near the kv-quant guard and reuse it for both the guard and the `is_whisper` kwarg.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/test_model_manager.py::TestWhisperLoad -v`
+Expected: PASS (both)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/model_manager.py tests/test_model_manager.py
+git commit -m "feat(engine): load whisper models via ModelManager (#366)"
+```
+
+---
+
+## Task 4: SRT/VTT/timestamp formatters
+
+**Files:**
+- Create: `olmlx/routers/audio.py` (formatter helpers first; the route is added in Task 7)
+- Test: `tests/test_audio_formats.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_audio_formats.py`:
+
+```python
+"""Tests for srt/vtt formatting helpers in olmlx.routers.audio."""
+
+from olmlx.routers.audio import _format_timestamp, srt_from_segments, vtt_from_segments
+
+SEGMENTS = [
+    {"start": 0.0, "end": 2.5, "text": " Hello world"},
+    {"start": 2.5, "end": 3661.0, "text": " Second line"},
+]
+
+
+def test_format_timestamp_srt():
+    assert _format_timestamp(0.0, decimal=",") == "00:00:00,000"
+    assert _format_timestamp(3661.5, decimal=",") == "01:01:01,500"
+
+
+def test_format_timestamp_vtt():
+    assert _format_timestamp(3661.5, decimal=".") == "01:01:01.500"
+
+
+def test_srt_from_segments():
+    out = srt_from_segments(SEGMENTS)
+    lines = out.splitlines()
+    assert lines[0] == "1"
+    assert lines[1] == "00:00:00,000 --> 00:00:02,500"
+    assert lines[2] == "Hello world"
+    assert lines[3] == ""
+    assert lines[4] == "2"
+    assert lines[5] == "00:00:02,500 --> 01:01:01,000"
+    assert lines[6] == "Second line"
+
+
+def test_vtt_from_segments():
+    out = vtt_from_segments(SEGMENTS)
+    lines = out.splitlines()
+    assert lines[0] == "WEBVTT"
+    assert lines[1] == ""
+    assert lines[2] == "00:00:00.000 --> 00:00:02.500"
+    assert lines[3] == "Hello world"
+
+
+def test_empty_segments():
+    assert srt_from_segments([]) == ""
+    assert vtt_from_segments([]) == "WEBVTT\n"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_audio_formats.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'olmlx.routers.audio'`
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `olmlx/routers/audio.py` with (route added later in Task 7):
+
+```python
+"""OpenAI-compatible audio transcription route (/v1/audio/transcriptions).
+
+Backed by mlx-whisper. Whisper models are managed through ModelManager;
+see engine/inference.py::generate_transcription and CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+
+def _format_timestamp(seconds: float, *, decimal: str) -> str:
+    """Format seconds as HH:MM:SS<decimal>mmm (decimal "," for SRT, "." for VTT)."""
+    if seconds < 0:
+        seconds = 0.0
+    millis = round(seconds * 1000.0)
+    hours, millis = divmod(millis, 3_600_000)
+    minutes, millis = divmod(millis, 60_000)
+    secs, millis = divmod(millis, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}{decimal}{millis:03d}"
+
+
+def srt_from_segments(segments: list[dict]) -> str:
+    """Render whisper segments as SubRip (.srt) text."""
+    blocks = []
+    for i, seg in enumerate(segments, start=1):
+        start = _format_timestamp(float(seg["start"]), decimal=",")
+        end = _format_timestamp(float(seg["end"]), decimal=",")
+        text = str(seg.get("text", "")).strip()
+        blocks.append(f"{i}\n{start} --> {end}\n{text}\n")
+    return "\n".join(blocks)
+
+
+def vtt_from_segments(segments: list[dict]) -> str:
+    """Render whisper segments as WebVTT (.vtt) text."""
+    lines = ["WEBVTT", ""]
+    for seg in segments:
+        start = _format_timestamp(float(seg["start"]), decimal=".")
+        end = _format_timestamp(float(seg["end"]), decimal=".")
+        text = str(seg.get("text", "")).strip()
+        lines.append(f"{start} --> {end}")
+        lines.append(text)
+        lines.append("")
+    return "\n".join(lines)
+```
+
+Note on the empty-VTT assertion: `"\n".join(["WEBVTT", ""])` == `"WEBVTT\n"`, matching the test. For non-empty SRT, `"\n".join` of blocks each ending in `\n` yields a blank line between blocks; the `test_srt_from_segments` assertions account for this.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/test_audio_formats.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/routers/audio.py tests/test_audio_formats.py
+git commit -m "feat(audio): srt/vtt segment formatters (#366)"
+```
+
+---
+
+## Task 5: Schemas
+
+**Files:**
+- Create: `olmlx/schemas/audio.py`
+- Test: covered by Task 7 router tests (no standalone schema test needed — these are plain response models)
+
+- [ ] **Step 1: Implement the schemas**
+
+Create `olmlx/schemas/audio.py`:
+
+```python
+"""Response schemas for /v1/audio/transcriptions."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class TranscriptionResponse(BaseModel):
+    """Default `response_format=json` body."""
+
+    text: str
+
+
+class TranscriptionSegment(BaseModel):
+    """One whisper segment. Tolerant of extra keys mlx-whisper may add."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: int = 0
+    seek: int = 0
+    start: float = 0.0
+    end: float = 0.0
+    text: str = ""
+    tokens: list[int] = []
+    temperature: float = 0.0
+    avg_logprob: float = 0.0
+    compression_ratio: float = 0.0
+    no_speech_prob: float = 0.0
+
+
+class VerboseTranscriptionResponse(BaseModel):
+    """`response_format=verbose_json` body (OpenAI-compatible shape)."""
+
+    task: str = "transcribe"
+    language: str = ""
+    duration: float = 0.0
+    text: str = ""
+    segments: list[TranscriptionSegment] = []
+```
+
+- [ ] **Step 2: Verify it imports**
+
+Run: `uv run python -c "from olmlx.schemas.audio import VerboseTranscriptionResponse, TranscriptionResponse, TranscriptionSegment; print('ok')"`
+Expected: prints `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add olmlx/schemas/audio.py
+git commit -m "feat(audio): transcription response schemas (#366)"
+```
+
+---
+
+## Task 6: `generate_transcription` engine function
+
+**Files:**
+- Modify: `olmlx/engine/inference.py` (add function near `generate_embeddings`, ~line 3181)
+- Test: Create `tests/test_inference_transcription.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_inference_transcription.py`:
+
+```python
+"""Tests for generate_transcription."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from olmlx.engine.inference import generate_transcription
+
+
+@pytest.mark.asyncio
+async def test_generate_transcription_injects_and_calls(mock_manager):
+    lm = mock_manager._loaded["qwen3:latest"]
+    lm.is_whisper = True
+    mock_manager.ensure_loaded = AsyncMock(return_value=lm)
+
+    result = {"text": "hello", "segments": [], "language": "en"}
+
+    import mlx_whisper.transcribe as wt
+
+    # Reset holder so we can assert injection happened.
+    wt.ModelHolder.model = None
+    wt.ModelHolder.model_path = None
+
+    with patch("mlx_whisper.transcribe.transcribe", return_value=result) as mock_tx:
+        out = await generate_transcription(
+            mock_manager,
+            "whisper-turbo",
+            "/tmp/clip.wav",
+            language="en",
+            prompt="hi",
+            temperature=0.0,
+            word_timestamps=False,
+        )
+
+    assert out == result
+    # Our managed model was injected into the holder.
+    assert wt.ModelHolder.model is lm.model
+    mock_tx.assert_called_once()
+    _, kwargs = mock_tx.call_args
+    assert kwargs["initial_prompt"] == "hi"
+    assert kwargs["language"] == "en"
+
+
+@pytest.mark.asyncio
+async def test_generate_transcription_ffmpeg_missing(mock_manager):
+    lm = mock_manager._loaded["qwen3:latest"]
+    lm.is_whisper = True
+    mock_manager.ensure_loaded = AsyncMock(return_value=lm)
+
+    with patch(
+        "mlx_whisper.transcribe.transcribe",
+        side_effect=FileNotFoundError("ffmpeg"),
+    ):
+        with pytest.raises(ValueError, match="ffmpeg"):
+            await generate_transcription(
+                mock_manager, "whisper-turbo", "/tmp/clip.wav"
+            )
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_inference_transcription.py -v`
+Expected: FAIL — `ImportError: cannot import name 'generate_transcription'`
+
+- [ ] **Step 3: Implement**
+
+In `olmlx/engine/inference.py`, add after `generate_embeddings` (after its `return embeddings`, ~line 3253):
+
+```python
+async def generate_transcription(
+    manager: ModelManager,
+    model_name: str,
+    audio_path: str,
+    *,
+    language: str | None = None,
+    prompt: str | None = None,
+    temperature: float = 0.0,
+    word_timestamps: bool = False,
+    keep_alive: str | None = None,
+) -> dict:
+    """Transcribe an audio file with a whisper model managed by ModelManager.
+
+    Loads (or reuses) the whisper model via ``ensure_loaded``, injects it into
+    mlx_whisper's module-level ``ModelHolder`` so ``transcribe()`` reuses the
+    managed model instead of loading its own, and runs the (synchronous)
+    transcription in a worker thread. Returns the raw mlx-whisper result dict
+    (``text``, ``segments``, ``language``). Issue #366.
+    """
+    import mlx_whisper.transcribe as whisper_transcribe
+
+    lm = await manager.ensure_loaded(model_name, keep_alive)
+
+    # Resolve the on-disk path used as path_or_hf_repo so the ModelHolder
+    # cache key matches what we inject.
+    if manager.store is not None:
+        load_path = str(manager.store.local_path(lm.hf_path))
+    else:
+        load_path = lm.hf_path
+
+    async with _inference_locked(lm.inference_queue_timeout, sync_mode=lm.sync_mode):
+        with _inference_ref(lm):
+            # Inject the managed model so transcribe() reuses it. Safe because
+            # _inference_locked serializes inference (no ModelHolder race).
+            whisper_transcribe.ModelHolder.model = lm.model
+            whisper_transcribe.ModelHolder.model_path = load_path
+
+            def _run() -> dict:
+                try:
+                    return whisper_transcribe.transcribe(
+                        audio_path,
+                        path_or_hf_repo=load_path,
+                        language=language,
+                        initial_prompt=prompt,
+                        temperature=temperature,
+                        word_timestamps=word_timestamps,
+                    )
+                except FileNotFoundError as exc:
+                    raise ValueError(
+                        "Audio decoding failed: ffmpeg was not found on PATH. "
+                        "Install ffmpeg (e.g. `brew install ffmpeg`) to use "
+                        "/v1/audio/transcriptions."
+                    ) from exc
+                except RuntimeError as exc:
+                    # mlx_whisper.audio.load_audio raises RuntimeError on a
+                    # failed ffmpeg decode (bad/corrupt/unsupported file).
+                    raise ValueError(f"Audio decoding failed: {exc}") from exc
+
+            return await asyncio.to_thread(_run)
+```
+
+Confirm `asyncio` is already imported at the top of `inference.py` (it is — `_inference_lock = asyncio.Lock()` exists). Confirm `_inference_locked` and `_inference_ref` names: `grep -n "_inference_locked\|def _inference_ref\|_inference_ref(" olmlx/engine/inference.py` (used by `generate_embeddings`).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/test_inference_transcription.py -v`
+Expected: PASS (both)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/inference.py tests/test_inference_transcription.py
+git commit -m "feat(engine): generate_transcription via mlx-whisper (#366)"
+```
+
+---
+
+## Task 7: The route + app registration
+
+**Files:**
+- Modify: `olmlx/routers/audio.py` (add router + endpoint to the formatter module from Task 4)
+- Modify: `olmlx/app.py:21` (import) and `olmlx/app.py:311` (include)
+- Test: Create `tests/test_routers_audio.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_routers_audio.py`:
+
+```python
+"""Tests for olmlx.routers.audio (/v1/audio/transcriptions)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+RESULT = {
+    "text": "Hello world",
+    "language": "en",
+    "segments": [
+        {
+            "id": 0,
+            "seek": 0,
+            "start": 0.0,
+            "end": 2.5,
+            "text": " Hello world",
+            "tokens": [1, 2],
+            "temperature": 0.0,
+            "avg_logprob": -0.1,
+            "compression_ratio": 1.0,
+            "no_speech_prob": 0.01,
+        }
+    ],
+}
+
+
+def _file():
+    return {"file": ("clip.wav", b"RIFFfakewavdata", "audio/wav")}
+
+
+@pytest.mark.asyncio
+async def test_transcription_json(app_client):
+    with patch(
+        "olmlx.routers.audio.generate_transcription",
+        new_callable=AsyncMock,
+        return_value=RESULT,
+    ):
+        resp = await app_client.post(
+            "/v1/audio/transcriptions",
+            files=_file(),
+            data={"model": "whisper-turbo"},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"text": "Hello world"}
+
+
+@pytest.mark.asyncio
+async def test_transcription_verbose_json(app_client):
+    with patch(
+        "olmlx.routers.audio.generate_transcription",
+        new_callable=AsyncMock,
+        return_value=RESULT,
+    ):
+        resp = await app_client.post(
+            "/v1/audio/transcriptions",
+            files=_file(),
+            data={"model": "whisper-turbo", "response_format": "verbose_json"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["task"] == "transcribe"
+    assert body["language"] == "en"
+    assert body["text"] == "Hello world"
+    assert body["duration"] == 2.5
+    assert len(body["segments"]) == 1
+    assert body["segments"][0]["text"] == " Hello world"
+
+
+@pytest.mark.asyncio
+async def test_transcription_text(app_client):
+    with patch(
+        "olmlx.routers.audio.generate_transcription",
+        new_callable=AsyncMock,
+        return_value=RESULT,
+    ):
+        resp = await app_client.post(
+            "/v1/audio/transcriptions",
+            files=_file(),
+            data={"model": "whisper-turbo", "response_format": "text"},
+        )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/plain")
+    assert resp.text == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_transcription_srt(app_client):
+    with patch(
+        "olmlx.routers.audio.generate_transcription",
+        new_callable=AsyncMock,
+        return_value=RESULT,
+    ):
+        resp = await app_client.post(
+            "/v1/audio/transcriptions",
+            files=_file(),
+            data={"model": "whisper-turbo", "response_format": "srt"},
+        )
+    assert resp.status_code == 200
+    assert "00:00:00,000 --> 00:00:02,500" in resp.text
+    assert "Hello world" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_transcription_unknown_format(app_client):
+    resp = await app_client.post(
+        "/v1/audio/transcriptions",
+        files=_file(),
+        data={"model": "whisper-turbo", "response_format": "bogus"},
+    )
+    assert resp.status_code == 400
+    assert "response_format" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_transcription_too_large(app_client, monkeypatch):
+    monkeypatch.setattr("olmlx.routers.audio.settings.audio_max_bytes", 4)
+    resp = await app_client.post(
+        "/v1/audio/transcriptions",
+        files={"file": ("clip.wav", b"way too many bytes", "audio/wav")},
+        data={"model": "whisper-turbo"},
+    )
+    assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_transcription_word_timestamps(app_client):
+    with patch(
+        "olmlx.routers.audio.generate_transcription",
+        new_callable=AsyncMock,
+        return_value=RESULT,
+    ) as mock_tx:
+        resp = await app_client.post(
+            "/v1/audio/transcriptions",
+            files=_file(),
+            data={
+                "model": "whisper-turbo",
+                "timestamp_granularities[]": "word",
+            },
+        )
+    assert resp.status_code == 200
+    _, kwargs = mock_tx.call_args
+    assert kwargs["word_timestamps"] is True
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_routers_audio.py -v`
+Expected: FAIL — route not registered (404) / import errors.
+
+- [ ] **Step 3a: Add the route to `olmlx/routers/audio.py`**
+
+Append to `olmlx/routers/audio.py` (which currently holds only the formatter helpers and the module docstring/imports). Add these imports at the top of the file (below the existing `from __future__ import annotations`):
+
+```python
+import os
+import tempfile
+
+from fastapi import APIRouter, File, Form, Request, UploadFile
+from fastapi.responses import PlainTextResponse
+
+from olmlx.config import settings
+from olmlx.engine.inference import generate_transcription
+from olmlx.schemas.audio import (
+    TranscriptionResponse,
+    TranscriptionSegment,
+    VerboseTranscriptionResponse,
+)
+
+router = APIRouter()
+
+_VALID_FORMATS = {"json", "verbose_json", "text", "srt", "vtt"}
+```
+
+Then append the endpoint at the end of the file:
+
+```python
+@router.post("/v1/audio/transcriptions")
+async def create_transcription(
+    request: Request,
+    file: UploadFile = File(...),
+    model: str = Form(...),
+    language: str | None = Form(None),
+    prompt: str | None = Form(None),
+    response_format: str = Form("json"),
+    temperature: float = Form(0.0),
+    timestamp_granularities: list[str] | None = Form(
+        None, alias="timestamp_granularities[]"
+    ),
+):
+    if response_format not in _VALID_FORMATS:
+        raise ValueError(
+            f"Unsupported response_format '{response_format}'. "
+            f"Must be one of: {', '.join(sorted(_VALID_FORMATS))}."
+        )
+
+    word_timestamps = bool(
+        timestamp_granularities and "word" in timestamp_granularities
+    )
+
+    manager = request.app.state.model_manager
+    max_bytes = settings.audio_max_bytes
+
+    # Stream the upload to a temp file under the size cap.
+    suffix = os.path.splitext(file.filename or "")[1] or ".wav"
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=suffix)
+    received = 0
+    try:
+        with os.fdopen(tmp_fd, "wb") as tmp:
+            while True:
+                chunk = await file.read(1024 * 1024)
+                if not chunk:
+                    break
+                received += len(chunk)
+                if received > max_bytes:
+                    return PlainTextResponse(
+                        f"Audio file exceeds the limit of {max_bytes} bytes "
+                        f"(OLMLX_AUDIO_MAX_BYTES).",
+                        status_code=413,
+                    )
+                tmp.write(chunk)
+
+        result = await generate_transcription(
+            manager,
+            model,
+            tmp_path,
+            language=language,
+            prompt=prompt,
+            temperature=temperature,
+            word_timestamps=word_timestamps,
+        )
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+    text = result.get("text", "")
+    segments = result.get("segments", []) or []
+
+    if response_format == "text":
+        return PlainTextResponse(text)
+    if response_format == "srt":
+        return PlainTextResponse(srt_from_segments(segments))
+    if response_format == "vtt":
+        return PlainTextResponse(vtt_from_segments(segments))
+    if response_format == "verbose_json":
+        duration = float(segments[-1]["end"]) if segments else 0.0
+        return VerboseTranscriptionResponse(
+            language=result.get("language", "") or "",
+            duration=duration,
+            text=text,
+            segments=[TranscriptionSegment(**s) for s in segments],
+        )
+    # default: json
+    return TranscriptionResponse(text=text)
+```
+
+Note: returning a 413 `PlainTextResponse` from inside the handler short-circuits cleanly because the `finally` still unlinks the temp file. The `srt_from_segments`/`vtt_from_segments` helpers are defined earlier in this same module (Task 4).
+
+- [ ] **Step 3b: Register the router in `olmlx/app.py`**
+
+Edit the import block at `olmlx/app.py:21`:
+
+```python
+from olmlx.routers import (
+    anthropic,
+    audio,
+    blobs,
+    chat,
+    embed,
+    generate,
+    manage,
+    models,
+    openai,
+    status,
+)
+```
+
+And add the include after `app.include_router(openai.router)` (line 311):
+
+```python
+    app.include_router(audio.router)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/test_routers_audio.py -v`
+Expected: PASS (all 7)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/routers/audio.py olmlx/app.py tests/test_routers_audio.py
+git commit -m "feat(audio): /v1/audio/transcriptions route (#366)"
+```
+
+---
+
+## Task 8: Default whisper model names
+
+**Files:**
+- Modify: `olmlx/cli.py:30` (`DEFAULT_MODELS`)
+- Test: `tests/test_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_cli.py`:
+
+```python
+def test_default_models_include_whisper():
+    from olmlx.cli import DEFAULT_MODELS
+
+    assert DEFAULT_MODELS["whisper-turbo:latest"] == (
+        "mlx-community/whisper-large-v3-turbo"
+    )
+    assert "whisper-large:latest" in DEFAULT_MODELS
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_cli.py::test_default_models_include_whisper -v`
+Expected: FAIL — KeyError.
+
+- [ ] **Step 3: Implement**
+
+In `olmlx/cli.py`, extend `DEFAULT_MODELS` (line 30):
+
+```python
+DEFAULT_MODELS = {
+    "llama3.2:latest": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+    "mistral:7b": "mlx-community/Mistral-7B-Instruct-v0.3-4bit",
+    "qwen2.5:3b": "mlx-community/Qwen2.5-3B-Instruct-4bit",
+    "gemma2:2b": "mlx-community/gemma-2-2b-it-4bit",
+    "whisper-turbo:latest": "mlx-community/whisper-large-v3-turbo",
+    "whisper-large:latest": "mlx-community/whisper-large-v3-mlx",
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/test_cli.py::test_default_models_include_whisper -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/cli.py tests/test_cli.py
+git commit -m "feat(cli): seed default whisper model names (#366)"
+```
+
+---
+
+## Task 9: Docs
+
+**Files:**
+- Modify: `CLAUDE.md` (add a Key Design Decisions bullet; add `routers/audio.py` and `schemas/audio.py` to the structure tree)
+
+- [ ] **Step 1: Add the design bullet**
+
+In `CLAUDE.md`, under "## Key Design Decisions", add a new bullet:
+
+```markdown
+- **Audio transcription** (`routers/audio.py`): OpenAI-compatible `POST /v1/audio/transcriptions` backed by `mlx-whisper`. Multipart upload (`file` + `model`, optional `language`/`prompt`/`response_format`/`temperature`/`timestamp_granularities[]`) is streamed to a temp file under `OLMLX_AUDIO_MAX_BYTES` (default 100 MB; 413 on overflow). Whisper models are a first-class `ModelManager` kind: `_detect_model_kind` returns `"whisper"` (via `model_type == "whisper"` or the presence of mlx whisper dims `n_mels`/`n_audio_state` — mlx-community repos ship a non-HF `config.json`), `_load_model` loads them with `mlx_whisper.load_models.load_model`, and `LoadedModel.is_whisper` guards the LLM-only prompt-cache probe and KV-quant/spectral paths. `engine/inference.py::generate_transcription` acquires the inference lock + active-ref, injects the managed model into `mlx_whisper.transcribe.ModelHolder` (the module-level singleton — race-free under the serialized lock) so `transcribe()` reuses it instead of loading its own, and runs the synchronous transcribe in a worker thread. Response formats: `json` (`{text}`), `verbose_json` (`{task, language, duration, text, segments[]}`), `text`, `srt`, `vtt` (srt/vtt rendered from segments by helpers in `routers/audio.py`). **Requires ffmpeg on PATH** (mlx-whisper decodes via ffmpeg); a missing/failed decode surfaces as HTTP 400. Convenience names `whisper-turbo`/`whisper-large` are seeded into `DEFAULT_MODELS`; direct HF paths auto-register as usual. Streaming transcription and diarization are out of scope.
+```
+
+Also add to the structure tree under `routers/` and `schemas/`:
+
+```markdown
+│   ├── audio.py        # /v1/audio/transcriptions — OpenAI Whisper STT (mlx-whisper)
+```
+```markdown
+│   ├── audio.py        # Audio transcription response models
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document /v1/audio/transcriptions (#366)"
+```
+
+---
+
+## Task 10: Full verification
+
+- [ ] **Step 1: Run the full new-test set**
+
+Run:
+```bash
+uv run pytest tests/test_config.py tests/test_model_manager.py \
+  tests/test_audio_formats.py tests/test_inference_transcription.py \
+  tests/test_routers_audio.py tests/test_cli.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step 2: Run the whole suite to check for regressions**
+
+Run: `uv run pytest -q`
+Expected: no new failures vs. baseline (pre-existing skips/xfails unchanged).
+
+- [ ] **Step 3: Lint & format (required before push — user preference)**
+
+Run:
+```bash
+uv run ruff check olmlx tests
+uv run ruff format olmlx tests
+```
+Expected: clean (or only formatting changes applied). Re-run `ruff check` after format. Commit any formatting changes:
+
+```bash
+git add -A && git commit -m "style: ruff format (#366)" || echo "nothing to format"
+```
+
+- [ ] **Step 4: Smoke-import the app**
+
+Run: `uv run python -c "from olmlx.app import create_app; create_app(); print('app ok')"`
+Expected: prints `app ok` (route registration imports cleanly).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** route (T7), multipart upload (T7), formats json/verbose_json/text/srt/vtt (T4+T7), model selection via ModelManager (T2+T3), whisper engine path in model_manager.py (T2+T3), configurable max bytes (T1+T7), schemas (T5), engine inference (T6), aliases (T8), ffmpeg requirement + error (T6), docs (T9). All spec sections map to a task.
+- **Type consistency:** `generate_transcription` signature matches between T6 definition and T7 call site and T6 tests (`language`, `prompt`, `temperature`, `word_timestamps`, `keep_alive`). `srt_from_segments`/`vtt_from_segments`/`_format_timestamp` names match between T4 and T7. `is_whisper` field name consistent across T3 and T6.
+- **Placeholders:** none — every code step shows full code.

--- a/docs/superpowers/specs/2026-05-28-whisper-transcription-endpoint-design.md
+++ b/docs/superpowers/specs/2026-05-28-whisper-transcription-endpoint-design.md
@@ -1,0 +1,167 @@
+# Whisper transcription endpoint (`/v1/audio/transcriptions`) — design
+
+Issue: #366
+
+## Goal
+
+Add an OpenAI-compatible speech-to-text route so `client.audio.transcriptions.create(file=..., model=...)`
+works against olmlx. `mlx-whisper` does the heavy lifting; whisper models are loaded and managed
+through the existing `ModelManager` alongside LLMs.
+
+## Acceptance criteria (from the issue)
+
+- OpenAI SDK `client.audio.transcriptions.create(file=..., model=...)` works against olmlx.
+- Format coverage: `json`, `verbose_json`, `srt` (also `text`, `vtt`).
+- File-size cap configurable via `OLMLX_AUDIO_MAX_BYTES`.
+
+## Out of scope
+
+- Streaming transcription.
+- Diarization.
+- Timestamp granularity beyond what `mlx-whisper` provides natively (we expose `word`/`segment`
+  granularity, both native to mlx-whisper, but nothing finer).
+
+## Dependency & runtime
+
+- Add `mlx-whisper` to `pyproject.toml` (installed: `0.4.3`).
+- **ffmpeg is a runtime requirement** — `mlx_whisper.audio.load_audio` shells out to ffmpeg to
+  decode arbitrary audio containers. We write the upload to a temp file and pass the path to
+  `transcribe()`. If ffmpeg is missing, surface a clear `ValueError` (→ HTTP 400) instructing the
+  operator to install ffmpeg, rather than leaking a raw `FileNotFoundError`/subprocess error.
+
+## Architecture
+
+### `engine/model_manager.py` — whisper model kind
+
+- `_detect_model_kind` gains a `"whisper"` result. Discriminator, checked **early** (right after
+  `config` is loaded and `model_type` computed, before the VLM-keys block):
+  - `model_type == "whisper"`, **or**
+  - whisper dimension keys present: `"n_mels" in config and "n_audio_state" in config`.
+  - The dims check is the robust one: mlx-community whisper repos ship a non-HF `config.json`
+    containing `mlx_whisper.whisper.ModelDimensions` fields (`n_mels`, `n_audio_ctx`,
+    `n_audio_state`, …) and `load_model` pops `model_type`, so `model_type` may be absent.
+- `_load_model` gains a whisper branch (placed before the VLM/text dispatch):
+  `model = mlx_whisper.load_models.load_model(load_path, dtype=mx.float16)`, returns
+  `(model, None, False, TemplateCaps(), None)` — no tokenizer, no caps, no speculative decoder.
+  `float16` matches `transcribe()`'s default `fp16=True`.
+- `LoadedModel` gains `is_whisper: bool = False`.
+- `_probe_cache_capabilities` early-returns when `lm.is_whisper` (one-shot STT has no prompt cache).
+- The kv-quant / spectral-calibration resolution in `ensure_loaded` is skipped for whisper (guard on
+  the detected kind / a whisper flag) — `make_prompt_cache` and quant factories assume an LLM layer
+  stack and don't apply to a `Whisper` module.
+- Keep-alive, LRU eviction, memory check, and `active_refs` all work unchanged — whisper models are
+  registered in `self._loaded` like any other model and appear in `/api/ps`.
+
+### `engine/inference.py` — `generate_transcription`
+
+```
+async def generate_transcription(
+    manager, model_name, audio_path, *,
+    language=None, prompt=None, temperature=0.0,
+    response_format="json", word_timestamps=False, keep_alive=None,
+) -> dict
+```
+
+- `lm = await manager.ensure_loaded(model_name, keep_alive)`.
+- `async with _inference_locked(lm.inference_queue_timeout, sync_mode=lm.sync_mode):` then
+  `with _inference_ref(lm):` — same guard pattern as `generate_embeddings`.
+- Inside the lock, inject the managed model into `mlx_whisper.transcribe.ModelHolder` by setting
+  `ModelHolder.model = lm.model` and `ModelHolder.model_path = <load_path>` so `transcribe()` reuses
+  it instead of loading its own copy. The injection is race-free because `_inference_locked`
+  serializes inference.
+- Run `mlx_whisper.transcribe(audio_path, path_or_hf_repo=<load_path>, language=..., initial_prompt=prompt,
+  temperature=..., word_timestamps=...)` via `asyncio.to_thread` — it is synchronous and can be slow
+  on long audio, so it must not block the event loop.
+- Return the raw result dict (`text`, `segments`, `language`).
+
+Note: the load path used as `path_or_hf_repo` must match what the model was loaded from so the
+`ModelHolder.model_path` guard (`model_path != cls.model_path`) sees a hit. We resolve it from the
+store the same way `_load_model` does (or store it on `LoadedModel`); simplest is to reuse
+`manager`'s store to resolve `lm.hf_path` to the local dir.
+
+### `routers/audio.py` (new)
+
+- `POST /v1/audio/transcriptions`, multipart via FastAPI `UploadFile` + `Form(...)`.
+- Form fields:
+  - `file: UploadFile` (required)
+  - `model: str = Form(...)` (required)
+  - `language: str | None = Form(None)`
+  - `prompt: str | None = Form(None)` → `initial_prompt`
+  - `response_format: str = Form("json")`
+  - `temperature: float = Form(0.0)`
+  - `timestamp_granularities[]` → accept the bracketed OpenAI field name; enable `word_timestamps`
+    when `word` is present (segment granularity is the default and always available).
+- Stream the upload to a `tempfile` enforcing `settings.audio_max_bytes`; on overflow delete the temp
+  file and return HTTP 413. Clean up the temp file in a `finally`.
+- Validate `response_format` ∈ {`json`, `verbose_json`, `text`, `srt`, `vtt`}; otherwise `ValueError`.
+- Call `generate_transcription(...)`, then serialize per format:
+  - `json` → `TranscriptionResponse {text}` (JSON)
+  - `verbose_json` → `VerboseTranscriptionResponse {task:"transcribe", language, duration, text, segments[]}`
+  - `text` → `PlainTextResponse(result["text"])`
+  - `srt` → `PlainTextResponse(srt_from_segments(result["segments"]))`
+  - `vtt` → `PlainTextResponse(vtt_from_segments(result["segments"]))`
+- Errors raise `ValueError` (→ 400 via the app-level handler), consistent with other routers.
+
+### `schemas/audio.py` (new)
+
+- `TranscriptionResponse { text: str }`
+- `TranscriptionSegment { id, seek, start, end, text, tokens, temperature, avg_logprob,
+  compression_ratio, no_speech_prob }` (mirrors mlx-whisper segment dict; tolerant of extras).
+- `VerboseTranscriptionResponse { task: "transcribe", language: str, duration: float, text: str,
+  segments: list[TranscriptionSegment] }`
+- Request shape is handled by `Form(...)` params in the router (a multipart upload can't cleanly be a
+  single Pydantic body alongside the file), so no request model here.
+
+### `config.py`
+
+- `audio_max_bytes: int = Field(100 * 1024 * 1024, gt=0)` → `OLMLX_AUDIO_MAX_BYTES`. Default 100 MB.
+
+### `app.py`
+
+- `app.include_router(audio.router)` alongside `openai.router`.
+
+### Registry aliases
+
+- Seed convenience names in `cli.py`'s `DEFAULT_MODELS` dict (the existing mechanism `ensure_config()`
+  uses to write the initial `~/.olmlx/models.json`), so a fresh install resolves `model="whisper-turbo"`
+  without manual registration:
+  - `whisper-turbo:latest` → `mlx-community/whisper-large-v3-turbo`
+  - `whisper-large:latest` → `mlx-community/whisper-large-v3-mlx`
+- These are plain name→HF-path mappings, identical in form to the existing `DEFAULT_MODELS` LLM
+  entries; they only land on first run when no `models.json` exists yet (matching current behaviour
+  for the seeded LLMs).
+- Direct HF paths (e.g. `mlx-community/whisper-large-v3-turbo`) continue to auto-register on first use
+  regardless, so existing installs with a populated `models.json` still work by passing the HF path.
+
+## SRT/VTT formatting
+
+Small pure helpers converting `segments` (each has `start`, `end` in seconds and `text`) to SubRip /
+WebVTT. Timestamp format: SRT `HH:MM:SS,mmm`, VTT `HH:MM:SS.mmm`, VTT prefixed with a `WEBVTT` header.
+These are pure functions, unit-tested against a fixed segment list.
+
+## Error handling
+
+- Unknown `response_format` → `ValueError` → 400.
+- Upload exceeds `audio_max_bytes` → 413.
+- ffmpeg missing / decode failure → `ValueError` with a clear "install ffmpeg" message → 400.
+- Unknown/unloadable model → existing `ModelManager` errors (400/503/504) bubble through unchanged.
+
+## Testing (TDD)
+
+1. `_detect_model_kind` returns `"whisper"` for (a) `model_type:"whisper"` config and (b) a
+   dims-only mlx config; returns non-whisper for an LLM config.
+2. `srt_from_segments` / `vtt_from_segments` produce correct timestamps and framing from a fixed
+   segment list.
+3. Router rejects an over-cap upload with 413.
+4. Router happy path for `json`, `verbose_json`, `text`, `srt` with `generate_transcription` mocked
+   to return a fixed result dict — assert body shape / content-type per format.
+5. Unknown `response_format` → 400.
+6. ffmpeg-missing path surfaces a clear 400 (simulate by making the decode raise).
+
+Model-loading and real transcription are not unit-tested against real weights (no audio fixture in
+CI); the engine path is covered by the kind-detection test plus a mocked router test.
+
+## Docs
+
+- New CLAUDE.md "Audio transcription" bullet under Key Design Decisions describing the route, the
+  ModelHolder-injection integration, the ffmpeg requirement, and `OLMLX_AUDIO_MAX_BYTES`.

--- a/olmlx/app.py
+++ b/olmlx/app.py
@@ -20,6 +20,7 @@ from olmlx.engine.registry import ModelRegistry
 from olmlx.models.store import ModelStore
 from olmlx.routers import (
     anthropic,
+    audio,
     blobs,
     chat,
     embed,
@@ -136,7 +137,7 @@ class ForceJSONMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         if request.method in ("POST", "PUT", "PATCH"):
             content_type = request.headers.get("content-type", "")
-            if "json" not in content_type:
+            if "json" not in content_type and "multipart/form-data" not in content_type:
                 scope = request.scope
                 headers = dict(scope["headers"])
                 headers[b"content-type"] = b"application/json"
@@ -309,6 +310,7 @@ def create_app() -> FastAPI:
     app.include_router(embed.router)
     app.include_router(blobs.router)
     app.include_router(openai.router)
+    app.include_router(audio.router)
     app.include_router(anthropic.router)
 
     return app

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -32,6 +32,8 @@ DEFAULT_MODELS = {
     "mistral:7b": "mlx-community/Mistral-7B-Instruct-v0.3-4bit",
     "qwen2.5:3b": "mlx-community/Qwen2.5-3B-Instruct-4bit",
     "gemma2:2b": "mlx-community/gemma-2-2b-it-4bit",
+    "whisper-turbo:latest": "mlx-community/whisper-large-v3-turbo",
+    "whisper-large:latest": "mlx-community/whisper-large-v3-mlx",
 }
 
 

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -101,11 +101,13 @@ class Settings(BaseSettings):
     prompt_cache_disk: bool = False
     prompt_cache_disk_path: Path = Path.home() / ".olmlx" / "cache" / "kv"
     prompt_cache_disk_max_gb: Annotated[float, Field(gt=0)] = 10.0
-    audio_max_bytes: int = Field(
-        100 * 1024 * 1024,
-        gt=0,
-        description="Max upload size for /v1/audio/transcriptions (OLMLX_AUDIO_MAX_BYTES).",
-    )
+    audio_max_bytes: Annotated[
+        int,
+        Field(
+            gt=0,
+            description="Max upload size for /v1/audio/transcriptions (OLMLX_AUDIO_MAX_BYTES).",
+        ),
+    ] = 100 * 1024 * 1024
     inference_queue_timeout: Annotated[float, Field(gt=0)] | None = 300.0
     inference_timeout: Annotated[float, Field(gt=0)] | None = None
     sync_mode: SyncMode = "full"

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -101,6 +101,11 @@ class Settings(BaseSettings):
     prompt_cache_disk: bool = False
     prompt_cache_disk_path: Path = Path.home() / ".olmlx" / "cache" / "kv"
     prompt_cache_disk_max_gb: Annotated[float, Field(gt=0)] = 10.0
+    audio_max_bytes: int = Field(
+        100 * 1024 * 1024,
+        gt=0,
+        description="Max upload size for /v1/audio/transcriptions (OLMLX_AUDIO_MAX_BYTES).",
+    )
     inference_queue_timeout: Annotated[float, Field(gt=0)] | None = 300.0
     inference_timeout: Annotated[float, Field(gt=0)] | None = None
     sync_mode: SyncMode = "full"

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -3701,3 +3701,71 @@ async def generate_embeddings(
                     exc_info=True,
                 )
             return embeddings
+
+
+async def generate_transcription(
+    manager: ModelManager,
+    model_name: str,
+    audio_path: str,
+    *,
+    language: str | None = None,
+    prompt: str | None = None,
+    temperature: float = 0.0,
+    word_timestamps: bool = False,
+    keep_alive: str | None = None,
+) -> dict:
+    """Transcribe an audio file with a whisper model managed by ModelManager.
+
+    Loads (or reuses) the whisper model via ``ensure_loaded``, injects it into
+    mlx_whisper's module-level ``ModelHolder`` so ``transcribe()`` reuses the
+    managed model instead of loading its own, and runs the (synchronous)
+    transcription in a worker thread. Returns the raw mlx-whisper result dict
+    (``text``, ``segments``, ``language``). Issue #366.
+    """
+    import importlib
+
+    # NOTE: ``import mlx_whisper.transcribe as ...`` binds to the *function*
+    # ``transcribe``, not the submodule — mlx_whisper's __init__ does
+    # ``from .transcribe import transcribe`` which shadows the submodule name on
+    # the package. Fetch the genuine submodule object (the one unittest.mock's
+    # patch() targets) via importlib so ModelHolder injection lands correctly.
+    whisper_transcribe = importlib.import_module("mlx_whisper.transcribe")
+
+    lm = await manager.ensure_loaded(model_name, keep_alive)
+
+    # Resolve the on-disk path used as path_or_hf_repo so the ModelHolder
+    # cache key matches what we inject.
+    if manager.store is not None:
+        load_path = str(manager.store.local_path(lm.hf_path))
+    else:
+        load_path = lm.hf_path
+
+    async with _inference_locked(lm.inference_queue_timeout, sync_mode=lm.sync_mode):
+        with _inference_ref(lm):
+            # Inject the managed model so transcribe() reuses it. Safe because
+            # _inference_locked serializes inference (no ModelHolder race).
+            whisper_transcribe.ModelHolder.model = lm.model
+            whisper_transcribe.ModelHolder.model_path = load_path
+
+            def _run() -> dict:
+                try:
+                    return whisper_transcribe.transcribe(
+                        audio_path,
+                        path_or_hf_repo=load_path,
+                        language=language,
+                        initial_prompt=prompt,
+                        temperature=temperature,
+                        word_timestamps=word_timestamps,
+                    )
+                except FileNotFoundError as exc:
+                    raise ValueError(
+                        "Audio decoding failed: ffmpeg was not found on PATH. "
+                        "Install ffmpeg (e.g. `brew install ffmpeg`) to use "
+                        "/v1/audio/transcriptions."
+                    ) from exc
+                except RuntimeError as exc:
+                    # mlx_whisper.audio.load_audio raises RuntimeError on a
+                    # failed ffmpeg decode (bad/corrupt/unsupported file).
+                    raise ValueError(f"Audio decoding failed: {exc}") from exc
+
+            return await asyncio.to_thread(_run)

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -3733,6 +3733,17 @@ async def generate_transcription(
 
     lm = await manager.ensure_loaded(model_name, keep_alive)
 
+    # Reject non-whisper models with a clear error (issue #366). Without this,
+    # a text/VLM model name would load fine, get injected into mlx_whisper's
+    # ModelHolder, and produce a cryptic failure inside transcribe(). Raising
+    # ValueError surfaces as HTTP 400 via the app-level handler.
+    if not lm.is_whisper:
+        raise ValueError(
+            f"Model '{model_name}' is not a Whisper model. "
+            "/v1/audio/transcriptions requires a whisper-class model "
+            "(e.g. whisper-turbo or an mlx-community/whisper-* repo)."
+        )
+
     # Resolve the on-disk path used as path_or_hf_repo so the ModelHolder
     # cache key matches what we inject.
     if manager.store is not None:

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -1782,6 +1782,17 @@ class ModelManager:
                 return "unknown"
 
         model_type = config.get("model_type", "").lower()
+
+        # Whisper STT (issue #366). Check before the empty-model_type return:
+        # mlx-community whisper repos ship a non-HF config.json carrying
+        # mlx_whisper.whisper.ModelDimensions fields, and load_model pops
+        # "model_type", so model_type is often absent. The dims keys are the
+        # robust discriminator; the model_type check covers HF-style configs.
+        if model_type == "whisper" or (
+            "n_mels" in config and "n_audio_state" in config
+        ):
+            return "whisper"
+
         if not model_type:
             return "unknown"
 

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -1030,13 +1030,39 @@ class ModelManager:
         # for the wrong vocab. Must use ``lm.text_tokenizer`` (the HF
         # tokenizer, post-VLM-unwrap) to match what
         # ``_install_grammar_processor`` keyed the cache on.
-        try:
-            from olmlx.engine import grammar as _grammar
+        #
+        # Whisper models (issue #366) return ``tokenizer=None``; guard the
+        # grammar drop so it doesn't choke on the missing tokenizer.
+        if not lm.is_whisper:
+            try:
+                from olmlx.engine import grammar as _grammar
 
-            _grammar.drop_for_tokenizer(lm.text_tokenizer)
-        except Exception as exc:
-            logger.exception("Error dropping grammar cache for %s", lm.name)
-            errors.append(exc)
+                _grammar.drop_for_tokenizer(lm.text_tokenizer)
+            except Exception as exc:
+                logger.exception("Error dropping grammar cache for %s", lm.name)
+                errors.append(exc)
+        # Whisper models (issue #366) are injected into mlx_whisper's
+        # module-level ModelHolder by generate_transcription so transcribe()
+        # reuses the managed weights. ModelManager owns that lifetime, so on
+        # close we must drop the holder's strong reference — otherwise the
+        # float16 GPU weights survive eviction/expiry until the next
+        # transcription overwrites them. Guard on identity so closing one
+        # whisper model doesn't clear a different one still referenced.
+        if lm.is_whisper:
+            try:
+                import importlib
+
+                # NOTE: import the submodule via importlib — mlx_whisper's
+                # __init__ rebinds the ``transcribe`` attribute to the
+                # function, shadowing the submodule for ``import ... as``.
+                whisper_transcribe = importlib.import_module("mlx_whisper.transcribe")
+                holder = whisper_transcribe.ModelHolder
+                if holder.model is lm.model:
+                    holder.model = None
+                    holder.model_path = None
+            except Exception as exc:
+                logger.exception("Error clearing whisper ModelHolder for %s", lm.name)
+                errors.append(exc)
         if errors:
             raise ExceptionGroup(f"Errors closing resources for {lm.name}", errors)
 

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -745,6 +745,7 @@ class LoadedModel:
     is_distributed: bool = False
     is_flash: bool = False
     is_flash_moe: bool = False
+    is_whisper: bool = False
     speculative_decoder: Any = None
     weight_store: Any = None
     template_caps: TemplateCaps = field(default_factory=TemplateCaps)
@@ -1257,6 +1258,11 @@ class ModelManager:
                 flash_config = model_config.resolved_flash()
                 kv_cache_quant = model_config.resolved_kv_cache_quant()
                 weight_quant_str = model_config.resolved_weight_quant()
+                # Whisper models (issue #366) have no LLM KV cache — never
+                # apply KV-cache quantization / spectral calibration to them.
+                _model_kind = self._detect_model_kind(hf_path)
+                if _model_kind == "whisper":
+                    kv_cache_quant = None
                 flash_moe_config = model_config.resolved_flash_moe()
 
                 # Pop LRU evictees under the lock; close them outside the lock
@@ -1548,6 +1554,7 @@ class ModelManager:
                         is_distributed=is_distributed,
                         is_flash=is_flash,
                         is_flash_moe=is_flash_moe,
+                        is_whisper=(_model_kind == "whisper"),
                         speculative_decoder=_spec_decoder,
                         weight_store=_weight_store,
                         template_caps=caps,
@@ -2175,6 +2182,9 @@ class ModelManager:
         TurboQuant/Spectral factories would otherwise pull calibration data
         off disk on every model load only to throw the result away.
         """
+        if lm.is_whisper:
+            # Whisper has no LLM-style prompt cache; nothing to probe.
+            return
         try:
             from mlx_lm.models.cache import make_prompt_cache
         except ImportError:
@@ -3506,6 +3516,16 @@ class ModelManager:
 
         kind = self._detect_model_kind(hf_path)
         logger.info("Detected model kind for %s: %s", hf_path, kind)
+
+        if kind == "whisper":
+            # Whisper STT (issue #366). Load via mlx-whisper's loader and
+            # return no tokenizer/caps/speculative — the transcription path
+            # drives mlx_whisper.transcribe() directly.
+            import mlx.core as mx
+            import mlx_whisper.load_models as whisper_loader
+
+            model = whisper_loader.load_model(load_path, dtype=mx.float16)
+            return model, None, False, TemplateCaps(), None
 
         if kind == "vlm":
             # VLM detected — load with mlx-vlm directly

--- a/olmlx/routers/audio.py
+++ b/olmlx/routers/audio.py
@@ -1,0 +1,42 @@
+"""OpenAI-compatible audio transcription route (/v1/audio/transcriptions).
+
+Backed by mlx-whisper. Whisper models are managed through ModelManager;
+see engine/inference.py::generate_transcription and CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+
+def _format_timestamp(seconds: float, *, decimal: str) -> str:
+    """Format seconds as HH:MM:SS<decimal>mmm (decimal "," for SRT, "." for VTT)."""
+    if seconds < 0:
+        seconds = 0.0
+    millis = round(seconds * 1000.0)
+    hours, millis = divmod(millis, 3_600_000)
+    minutes, millis = divmod(millis, 60_000)
+    secs, millis = divmod(millis, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}{decimal}{millis:03d}"
+
+
+def srt_from_segments(segments: list[dict]) -> str:
+    """Render whisper segments as SubRip (.srt) text."""
+    blocks = []
+    for i, seg in enumerate(segments, start=1):
+        start = _format_timestamp(float(seg["start"]), decimal=",")
+        end = _format_timestamp(float(seg["end"]), decimal=",")
+        text = str(seg.get("text", "")).strip()
+        blocks.append(f"{i}\n{start} --> {end}\n{text}\n")
+    return "\n".join(blocks)
+
+
+def vtt_from_segments(segments: list[dict]) -> str:
+    """Render whisper segments as WebVTT (.vtt) text."""
+    lines = ["WEBVTT", ""]
+    for seg in segments:
+        start = _format_timestamp(float(seg["start"]), decimal=".")
+        end = _format_timestamp(float(seg["end"]), decimal=".")
+        text = str(seg.get("text", "")).strip()
+        lines.append(f"{start} --> {end}")
+        lines.append(text)
+        lines.append("")
+    return "\n".join(lines)

--- a/olmlx/routers/audio.py
+++ b/olmlx/routers/audio.py
@@ -6,6 +6,24 @@ see engine/inference.py::generate_transcription and CLAUDE.md.
 
 from __future__ import annotations
 
+import os
+import tempfile
+
+from fastapi import APIRouter, File, Form, Request, UploadFile
+from fastapi.responses import PlainTextResponse
+
+from olmlx.config import settings
+from olmlx.engine.inference import generate_transcription
+from olmlx.schemas.audio import (
+    TranscriptionResponse,
+    TranscriptionSegment,
+    VerboseTranscriptionResponse,
+)
+
+router = APIRouter()
+
+_VALID_FORMATS = {"json", "verbose_json", "text", "srt", "vtt"}
+
 
 def _format_timestamp(seconds: float, *, decimal: str) -> str:
     """Format seconds as HH:MM:SS<decimal>mmm (decimal "," for SRT, "." for VTT)."""
@@ -40,3 +58,82 @@ def vtt_from_segments(segments: list[dict]) -> str:
         lines.append(text)
         lines.append("")
     return "\n".join(lines)
+
+
+@router.post("/v1/audio/transcriptions")
+async def create_transcription(
+    request: Request,
+    file: UploadFile = File(...),
+    model: str = Form(...),
+    language: str | None = Form(None),
+    prompt: str | None = Form(None),
+    response_format: str = Form("json"),
+    temperature: float = Form(0.0),
+    timestamp_granularities: list[str] | None = Form(
+        None, alias="timestamp_granularities[]"
+    ),
+):
+    if response_format not in _VALID_FORMATS:
+        raise ValueError(
+            f"Unsupported response_format '{response_format}'. "
+            f"Must be one of: {', '.join(sorted(_VALID_FORMATS))}."
+        )
+
+    word_timestamps = bool(
+        timestamp_granularities and "word" in timestamp_granularities
+    )
+
+    manager = request.app.state.model_manager
+    max_bytes = settings.audio_max_bytes
+
+    # Stream the upload to a temp file under the size cap.
+    suffix = os.path.splitext(file.filename or "")[1] or ".wav"
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=suffix)
+    received = 0
+    try:
+        with os.fdopen(tmp_fd, "wb") as tmp:
+            while True:
+                chunk = await file.read(1024 * 1024)
+                if not chunk:
+                    break
+                received += len(chunk)
+                if received > max_bytes:
+                    return PlainTextResponse(
+                        f"Audio file exceeds the limit of {max_bytes} bytes "
+                        f"(OLMLX_AUDIO_MAX_BYTES).",
+                        status_code=413,
+                    )
+                tmp.write(chunk)
+
+        result = await generate_transcription(
+            manager,
+            model,
+            tmp_path,
+            language=language,
+            prompt=prompt,
+            temperature=temperature,
+            word_timestamps=word_timestamps,
+        )
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+    text = result.get("text", "")
+    segments = result.get("segments", []) or []
+
+    if response_format == "text":
+        return PlainTextResponse(text)
+    if response_format == "srt":
+        return PlainTextResponse(srt_from_segments(segments))
+    if response_format == "vtt":
+        return PlainTextResponse(vtt_from_segments(segments))
+    if response_format == "verbose_json":
+        duration = float(segments[-1]["end"]) if segments else 0.0
+        return VerboseTranscriptionResponse(
+            language=result.get("language", "") or "",
+            duration=duration,
+            text=text,
+            segments=[TranscriptionSegment(**s) for s in segments],
+        )
+    # default: json
+    return TranscriptionResponse(text=text)

--- a/olmlx/schemas/audio.py
+++ b/olmlx/schemas/audio.py
@@ -1,0 +1,38 @@
+"""Response schemas for /v1/audio/transcriptions."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class TranscriptionResponse(BaseModel):
+    """Default `response_format=json` body."""
+
+    text: str
+
+
+class TranscriptionSegment(BaseModel):
+    """One whisper segment. Tolerant of extra keys mlx-whisper may add."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: int = 0
+    seek: int = 0
+    start: float = 0.0
+    end: float = 0.0
+    text: str = ""
+    tokens: list[int] = []
+    temperature: float = 0.0
+    avg_logprob: float = 0.0
+    compression_ratio: float = 0.0
+    no_speech_prob: float = 0.0
+
+
+class VerboseTranscriptionResponse(BaseModel):
+    """`response_format=verbose_json` body (OpenAI-compatible shape)."""
+
+    task: str = "transcribe"
+    language: str = ""
+    duration: float = 0.0
+    text: str = ""
+    segments: list[TranscriptionSegment] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "mcp>=1.0",
     "rich>=13.0",
     "xgrammar>=0.2.1",
+    "mlx-whisper>=0.4.3",
 ]
 
 [project.scripts]

--- a/tests/test_audio_formats.py
+++ b/tests/test_audio_formats.py
@@ -1,0 +1,43 @@
+"""Tests for srt/vtt formatting helpers in olmlx.routers.audio."""
+
+from olmlx.routers.audio import _format_timestamp, srt_from_segments, vtt_from_segments
+
+SEGMENTS = [
+    {"start": 0.0, "end": 2.5, "text": " Hello world"},
+    {"start": 2.5, "end": 3661.0, "text": " Second line"},
+]
+
+
+def test_format_timestamp_srt():
+    assert _format_timestamp(0.0, decimal=",") == "00:00:00,000"
+    assert _format_timestamp(3661.5, decimal=",") == "01:01:01,500"
+
+
+def test_format_timestamp_vtt():
+    assert _format_timestamp(3661.5, decimal=".") == "01:01:01.500"
+
+
+def test_srt_from_segments():
+    out = srt_from_segments(SEGMENTS)
+    lines = out.splitlines()
+    assert lines[0] == "1"
+    assert lines[1] == "00:00:00,000 --> 00:00:02,500"
+    assert lines[2] == "Hello world"
+    assert lines[3] == ""
+    assert lines[4] == "2"
+    assert lines[5] == "00:00:02,500 --> 01:01:01,000"
+    assert lines[6] == "Second line"
+
+
+def test_vtt_from_segments():
+    out = vtt_from_segments(SEGMENTS)
+    lines = out.splitlines()
+    assert lines[0] == "WEBVTT"
+    assert lines[1] == ""
+    assert lines[2] == "00:00:00.000 --> 00:00:02.500"
+    assert lines[3] == "Hello world"
+
+
+def test_empty_segments():
+    assert srt_from_segments([]) == ""
+    assert vtt_from_segments([]) == "WEBVTT\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,6 +47,15 @@ class TestEnsureConfig:
         assert data == existing
 
 
+def test_default_models_include_whisper():
+    from olmlx.cli import DEFAULT_MODELS
+
+    assert DEFAULT_MODELS["whisper-turbo:latest"] == (
+        "mlx-community/whisper-large-v3-turbo"
+    )
+    assert "whisper-large:latest" in DEFAULT_MODELS
+
+
 class TestBuildPlist:
     def test_plist_structure(self, monkeypatch):
         monkeypatch.setattr("olmlx.cli.shutil.which", lambda _: "/usr/local/bin/olmlx")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -496,3 +496,18 @@ class TestDistributedTensorOnly:
 
     def test_tensor_strategy_accepted(self):
         assert Settings(distributed_strategy="tensor").distributed_strategy == "tensor"
+
+
+def test_audio_max_bytes_default():
+    from olmlx.config import Settings
+
+    s = Settings()
+    assert s.audio_max_bytes == 100 * 1024 * 1024
+
+
+def test_audio_max_bytes_env_override(monkeypatch):
+    monkeypatch.setenv("OLMLX_AUDIO_MAX_BYTES", "1048576")
+    from olmlx.config import Settings
+
+    s = Settings()
+    assert s.audio_max_bytes == 1048576

--- a/tests/test_inference_transcription.py
+++ b/tests/test_inference_transcription.py
@@ -1,0 +1,60 @@
+"""Tests for generate_transcription."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from olmlx.engine.inference import generate_transcription
+
+
+@pytest.mark.asyncio
+async def test_generate_transcription_injects_and_calls(mock_manager):
+    lm = mock_manager._loaded["qwen3:latest"]
+    lm.is_whisper = True
+    mock_manager.ensure_loaded = AsyncMock(return_value=lm)
+
+    result = {"text": "hello", "segments": [], "language": "en"}
+
+    import importlib
+
+    # ``import mlx_whisper.transcribe as wt`` would bind the *function*
+    # ``transcribe`` (the package __init__ shadows the submodule name); use
+    # importlib to get the genuine submodule that holds ModelHolder.
+    wt = importlib.import_module("mlx_whisper.transcribe")
+
+    # Reset holder so we can assert injection happened.
+    wt.ModelHolder.model = None
+    wt.ModelHolder.model_path = None
+
+    with patch("mlx_whisper.transcribe.transcribe", return_value=result) as mock_tx:
+        out = await generate_transcription(
+            mock_manager,
+            "whisper-turbo",
+            "/tmp/clip.wav",
+            language="en",
+            prompt="hi",
+            temperature=0.0,
+            word_timestamps=False,
+        )
+
+    assert out == result
+    # Our managed model was injected into the holder.
+    assert wt.ModelHolder.model is lm.model
+    mock_tx.assert_called_once()
+    _, kwargs = mock_tx.call_args
+    assert kwargs["initial_prompt"] == "hi"
+    assert kwargs["language"] == "en"
+
+
+@pytest.mark.asyncio
+async def test_generate_transcription_ffmpeg_missing(mock_manager):
+    lm = mock_manager._loaded["qwen3:latest"]
+    lm.is_whisper = True
+    mock_manager.ensure_loaded = AsyncMock(return_value=lm)
+
+    with patch(
+        "mlx_whisper.transcribe.transcribe",
+        side_effect=FileNotFoundError("ffmpeg"),
+    ):
+        with pytest.raises(ValueError, match="ffmpeg"):
+            await generate_transcription(mock_manager, "whisper-turbo", "/tmp/clip.wav")

--- a/tests/test_inference_transcription.py
+++ b/tests/test_inference_transcription.py
@@ -58,3 +58,17 @@ async def test_generate_transcription_ffmpeg_missing(mock_manager):
     ):
         with pytest.raises(ValueError, match="ffmpeg"):
             await generate_transcription(mock_manager, "whisper-turbo", "/tmp/clip.wav")
+
+
+@pytest.mark.asyncio
+async def test_generate_transcription_rejects_non_whisper_model(mock_manager):
+    lm = mock_manager._loaded["qwen3:latest"]
+    lm.is_whisper = False  # a text LLM, not a whisper model
+    mock_manager.ensure_loaded = AsyncMock(return_value=lm)
+
+    with patch("mlx_whisper.transcribe.transcribe") as mock_tx:
+        with pytest.raises(ValueError, match="not a Whisper model"):
+            await generate_transcription(mock_manager, "qwen3", "/tmp/clip.wav")
+
+    # Must reject before touching mlx_whisper at all.
+    mock_tx.assert_not_called()

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -5495,3 +5495,49 @@ class TestWhisperLoad:
         with patch("mlx_lm.models.cache.make_prompt_cache") as mock_make:
             manager._probe_cache_capabilities(lm)
         mock_make.assert_not_called()
+
+    def test_close_clears_whisper_model_holder(self, registry, mock_store):
+        import importlib
+
+        from olmlx.engine.model_manager import LoadedModel, ModelManager
+
+        whisper_transcribe = importlib.import_module("mlx_whisper.transcribe")
+        manager = ModelManager(registry, mock_store)
+        sentinel = MagicMock()
+        lm = LoadedModel(
+            name="whisper:latest",
+            hf_path="test/whisper",
+            model=sentinel,
+            tokenizer=None,
+            is_whisper=True,
+        )
+        whisper_transcribe.ModelHolder.model = sentinel
+        whisper_transcribe.ModelHolder.model_path = "test/whisper"
+
+        manager._close_loaded_model(lm)
+
+        assert whisper_transcribe.ModelHolder.model is None
+        assert whisper_transcribe.ModelHolder.model_path is None
+
+    def test_close_preserves_other_whisper_in_holder(self, registry, mock_store):
+        import importlib
+
+        from olmlx.engine.model_manager import LoadedModel, ModelManager
+
+        whisper_transcribe = importlib.import_module("mlx_whisper.transcribe")
+        manager = ModelManager(registry, mock_store)
+        other = MagicMock()
+        lm = LoadedModel(
+            name="whisper:latest",
+            hf_path="test/whisper",
+            model=MagicMock(),
+            tokenizer=None,
+            is_whisper=True,
+        )
+        # Holder references a DIFFERENT model than the one being closed.
+        whisper_transcribe.ModelHolder.model = other
+        whisper_transcribe.ModelHolder.model_path = "other/whisper"
+
+        manager._close_loaded_model(lm)
+
+        assert whisper_transcribe.ModelHolder.model is other

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -822,6 +822,43 @@ class TestDetectModelKind:
                 kind = manager._detect_model_kind("test/qwen2_vl")
         assert kind == "vlm"
 
+    def test_whisper_by_model_type(self, tmp_path, registry, mock_store):
+        config_path = self._make_config(tmp_path, {"model_type": "whisper"})
+        manager = self._make_manager(registry, mock_store)
+        with patch("huggingface_hub.hf_hub_download", return_value=config_path):
+            kind = manager._detect_model_kind("test/whisper")
+        assert kind == "whisper"
+
+    def test_whisper_by_dims_without_model_type(self, tmp_path, registry, mock_store):
+        # mlx-community whisper repos ship a non-HF config.json with dims and
+        # no usable model_type (load_model pops it).
+        config_path = self._make_config(
+            tmp_path,
+            {
+                "n_mels": 80,
+                "n_audio_ctx": 1500,
+                "n_audio_state": 384,
+                "n_audio_head": 6,
+                "n_audio_layer": 4,
+                "n_vocab": 51865,
+                "n_text_ctx": 448,
+                "n_text_state": 384,
+                "n_text_head": 6,
+                "n_text_layer": 4,
+            },
+        )
+        manager = self._make_manager(registry, mock_store)
+        with patch("huggingface_hub.hf_hub_download", return_value=config_path):
+            kind = manager._detect_model_kind("test/whisper-mlx")
+        assert kind == "whisper"
+
+    def test_llama_not_whisper(self, tmp_path, registry, mock_store):
+        config_path = self._make_config(tmp_path, {"model_type": "llama"})
+        manager = self._make_manager(registry, mock_store)
+        with patch("huggingface_hub.hf_hub_download", return_value=config_path):
+            kind = manager._detect_model_kind("test/model")
+        assert kind == "text"
+
 
 class TestProbeCacheCapabilities:
     """Exercise _probe_cache_capabilities, including the probe-failure path

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -5460,3 +5460,38 @@ class TestSpectralAutoCalibrate:
         manager = ModelManager(registry, mock_store)
         with pytest.raises(AssertionError):
             manager._auto_calibrate_spectral("test/model", "turboquant:4")
+
+
+class TestWhisperLoad:
+    def test_load_model_whisper_branch(self, tmp_path, registry, mock_store):
+        manager = ModelManager(registry, mock_store)
+        fake_whisper = MagicMock()
+        with (
+            patch.object(manager, "_detect_model_kind", return_value="whisper"),
+            patch(
+                "mlx_whisper.load_models.load_model", return_value=fake_whisper
+            ) as mock_load,
+        ):
+            model, tok, is_vlm, caps, spec = manager._load_model("test/whisper")
+        assert model is fake_whisper
+        assert tok is None
+        assert is_vlm is False
+        assert spec is None
+        mock_load.assert_called_once()
+
+    def test_probe_cache_skipped_for_whisper(self, registry, mock_store):
+        from olmlx.engine.model_manager import LoadedModel
+
+        manager = ModelManager(registry, mock_store)
+        lm = LoadedModel(
+            name="whisper:latest",
+            hf_path="test/whisper",
+            model=MagicMock(),
+            tokenizer=None,
+            is_whisper=True,
+        )
+        lm.supports_cache_trim = True
+        lm.supports_cache_persistence = False
+        with patch("mlx_lm.models.cache.make_prompt_cache") as mock_make:
+            manager._probe_cache_capabilities(lm)
+        mock_make.assert_not_called()

--- a/tests/test_routers_audio.py
+++ b/tests/test_routers_audio.py
@@ -1,0 +1,142 @@
+"""Tests for olmlx.routers.audio (/v1/audio/transcriptions)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+RESULT = {
+    "text": "Hello world",
+    "language": "en",
+    "segments": [
+        {
+            "id": 0,
+            "seek": 0,
+            "start": 0.0,
+            "end": 2.5,
+            "text": " Hello world",
+            "tokens": [1, 2],
+            "temperature": 0.0,
+            "avg_logprob": -0.1,
+            "compression_ratio": 1.0,
+            "no_speech_prob": 0.01,
+        }
+    ],
+}
+
+
+def _file():
+    return {"file": ("clip.wav", b"RIFFfakewavdata", "audio/wav")}
+
+
+@pytest.mark.asyncio
+async def test_transcription_json(app_client):
+    with patch(
+        "olmlx.routers.audio.generate_transcription",
+        new_callable=AsyncMock,
+        return_value=RESULT,
+    ):
+        resp = await app_client.post(
+            "/v1/audio/transcriptions",
+            files=_file(),
+            data={"model": "whisper-turbo"},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"text": "Hello world"}
+
+
+@pytest.mark.asyncio
+async def test_transcription_verbose_json(app_client):
+    with patch(
+        "olmlx.routers.audio.generate_transcription",
+        new_callable=AsyncMock,
+        return_value=RESULT,
+    ):
+        resp = await app_client.post(
+            "/v1/audio/transcriptions",
+            files=_file(),
+            data={"model": "whisper-turbo", "response_format": "verbose_json"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["task"] == "transcribe"
+    assert body["language"] == "en"
+    assert body["text"] == "Hello world"
+    assert body["duration"] == 2.5
+    assert len(body["segments"]) == 1
+    assert body["segments"][0]["text"] == " Hello world"
+
+
+@pytest.mark.asyncio
+async def test_transcription_text(app_client):
+    with patch(
+        "olmlx.routers.audio.generate_transcription",
+        new_callable=AsyncMock,
+        return_value=RESULT,
+    ):
+        resp = await app_client.post(
+            "/v1/audio/transcriptions",
+            files=_file(),
+            data={"model": "whisper-turbo", "response_format": "text"},
+        )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/plain")
+    assert resp.text == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_transcription_srt(app_client):
+    with patch(
+        "olmlx.routers.audio.generate_transcription",
+        new_callable=AsyncMock,
+        return_value=RESULT,
+    ):
+        resp = await app_client.post(
+            "/v1/audio/transcriptions",
+            files=_file(),
+            data={"model": "whisper-turbo", "response_format": "srt"},
+        )
+    assert resp.status_code == 200
+    assert "00:00:00,000 --> 00:00:02,500" in resp.text
+    assert "Hello world" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_transcription_unknown_format(app_client):
+    resp = await app_client.post(
+        "/v1/audio/transcriptions",
+        files=_file(),
+        data={"model": "whisper-turbo", "response_format": "bogus"},
+    )
+    assert resp.status_code == 400
+    assert "response_format" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_transcription_too_large(app_client, monkeypatch):
+    monkeypatch.setattr("olmlx.routers.audio.settings.audio_max_bytes", 4)
+    resp = await app_client.post(
+        "/v1/audio/transcriptions",
+        files={"file": ("clip.wav", b"way too many bytes", "audio/wav")},
+        data={"model": "whisper-turbo"},
+    )
+    assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_transcription_word_timestamps(app_client):
+    with patch(
+        "olmlx.routers.audio.generate_transcription",
+        new_callable=AsyncMock,
+        return_value=RESULT,
+    ) as mock_tx:
+        resp = await app_client.post(
+            "/v1/audio/transcriptions",
+            files=_file(),
+            data={
+                "model": "whisper-turbo",
+                "timestamp_granularities[]": "word",
+            },
+        )
+    assert resp.status_code == 200
+    _, kwargs = mock_tx.call_args
+    assert kwargs["word_timestamps"] is True

--- a/tests/test_routers_audio.py
+++ b/tests/test_routers_audio.py
@@ -101,6 +101,48 @@ async def test_transcription_srt(app_client):
 
 
 @pytest.mark.asyncio
+async def test_transcription_vtt(app_client):
+    with patch(
+        "olmlx.routers.audio.generate_transcription",
+        new_callable=AsyncMock,
+        return_value=RESULT,
+    ):
+        resp = await app_client.post(
+            "/v1/audio/transcriptions",
+            files=_file(),
+            data={"model": "whisper-turbo", "response_format": "vtt"},
+        )
+    assert resp.status_code == 200
+    assert "WEBVTT" in resp.text
+    assert "00:00:00.000 --> 00:00:02.500" in resp.text
+    assert "Hello world" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_transcription_param_passthrough(app_client):
+    with patch(
+        "olmlx.routers.audio.generate_transcription",
+        new_callable=AsyncMock,
+        return_value=RESULT,
+    ) as mock_tx:
+        resp = await app_client.post(
+            "/v1/audio/transcriptions",
+            files=_file(),
+            data={
+                "model": "whisper-turbo",
+                "language": "fr",
+                "prompt": "context here",
+                "temperature": "0.5",
+            },
+        )
+    assert resp.status_code == 200
+    _, kwargs = mock_tx.call_args
+    assert kwargs["language"] == "fr"
+    assert kwargs["prompt"] == "context here"
+    assert kwargs["temperature"] == 0.5
+
+
+@pytest.mark.asyncio
 async def test_transcription_unknown_format(app_client):
     resp = await app_client.post(
         "/v1/audio/transcriptions",

--- a/uv.lock
+++ b/uv.lock
@@ -1256,6 +1256,34 @@ wheels = [
 ]
 
 [[package]]
+name = "llvmlite"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/0b/b9d1911cfefa61399821dfb37f486d83e0f42630a8d12f7194270c417002/llvmlite-0.47.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:74090f0dcfd6f24ebbef3f21f11e38111c4d7e6919b54c4416e1e357c3446b07", size = 37232770, upload-time = "2026-03-31T18:28:26.765Z" },
+    { url = "https://files.pythonhosted.org/packages/46/27/5799b020e4cdfb25a7c951c06a96397c135efcdc21b78d853bbd9c814c7d/llvmlite-0.47.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca14f02e29134e837982497959a8e2193d6035235de1cb41a9cb2bd6da4eedbb", size = 56275177, upload-time = "2026-03-31T18:28:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/51/48a53fedf01cb1f3f43ef200be17ebf83c8d9a04018d3783c1a226c342c2/llvmlite-0.47.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12a69d4bb05f402f30477e21eeabe81911e7c251cecb192bed82cd83c9db10d8", size = 55128631, upload-time = "2026-03-31T18:28:36.046Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/50/59227d06bdc96e23322713c381af4e77420949d8cd8a042c79e0043096cc/llvmlite-0.47.0-cp311-cp311-win_amd64.whl", hash = "sha256:c37d6eb7aaabfa83ab9c2ff5b5cdb95a5e6830403937b2c588b7490724e05327", size = 38138400, upload-time = "2026-03-31T18:28:40.076Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f", size = 37232769, upload-time = "2026-03-31T18:28:43.735Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/4b/e3f2cd17822cf772a4a51a0a8080b0032e6d37b2dbe8cfb724eac4e31c52/llvmlite-0.47.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5853bf26160857c0c2573415ff4efe01c4c651e59e2c55c2a088740acfee51cd", size = 56275178, upload-time = "2026-03-31T18:28:48.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a3b4a543185305a9bdf3d9759d53646ed96e55e7dfd43f53e7a421b8fbae/llvmlite-0.47.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bcf7fa579e14db59c1a1e113f93ab8a06b56a4be31c7f08264d1d4072d077", size = 55128632, upload-time = "2026-03-31T18:28:52.901Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f5/d281ae0f79378a5a91f308ea9fdb9f9cc068fddd09629edc0725a5a8fde1/llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7", size = 38138692, upload-time = "2026-03-31T18:28:57.147Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6f/4615353e016799f80fa52ccb270a843c413b22361fadda2589b2922fb9b0/llvmlite-0.47.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3c6a735d4e1041808434f9d440faa3d78d9b4af2ee64d05a66f351883b6ceec", size = 37232771, upload-time = "2026-03-31T18:29:01.324Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b8/69f5565f1a280d032525878a86511eebed0645818492feeb169dfb20ae8e/llvmlite-0.47.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2699a74321189e812d476a43d6d7f652f51811e7b5aad9d9bba842a1c7927acb", size = 56275178, upload-time = "2026-03-31T18:29:05.748Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/da/b32cafcb926fb0ce2aa25553bf32cb8764af31438f40e2481df08884c947/llvmlite-0.47.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c6951e2b29930227963e53ee152441f0e14be92e9d4231852102d986c761e40", size = 55128632, upload-time = "2026-03-31T18:29:11.235Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/4898b44e4042c60fafcb1162dfb7014f6f15b1ec19bf29cfea6bf26df90d/llvmlite-0.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2e9adf8698d813a9a5efb2d4370caf344dbc1e145019851fee6a6f319ba760e", size = 38138695, upload-time = "2026-03-31T18:29:15.43Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d4/33c8af00f0bf6f552d74f3a054f648af2c5bc6bece97972f3bfadce4f5ec/llvmlite-0.47.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:de966c626c35c9dff5ae7bf12db25637738d0df83fc370cf793bc94d43d92d14", size = 37232773, upload-time = "2026-03-31T18:29:19.453Z" },
+    { url = "https://files.pythonhosted.org/packages/64/1d/a760e993e0c0ba6db38d46b9f48f6c7dceb8ac838824997fb9e25f97bc04/llvmlite-0.47.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ddbccff2aeaff8670368340a158abefc032fe9b3ccf7d9c496639263d00151aa", size = 56275176, upload-time = "2026-03-31T18:29:24.149Z" },
+    { url = "https://files.pythonhosted.org/packages/84/3b/e679bc3b29127182a7f4aa2d2e9e5bea42adb93fb840484147d59c236299/llvmlite-0.47.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a7b778a2e144fc64468fb9bf509ac1226c9813a00b4d7afea5d988c4e22fca", size = 55128631, upload-time = "2026-03-31T18:29:29.536Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f7/19e2a09c62809c9e63bbd14ce71fb92c6ff7b7b3045741bb00c781efc3c9/llvmlite-0.47.0-cp314-cp314-win_amd64.whl", hash = "sha256:694e3c2cdc472ed2bd8bd4555ca002eec4310961dd58ef791d508f57b5cc4c94", size = 39153826, upload-time = "2026-03-31T18:29:33.681Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a1/581a8c707b5e80efdbbe1dd94527404d33fe50bceb71f39d5a7e11bd57b7/llvmlite-0.47.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:92ec8a169a20b473c1c54d4695e371bde36489fc1efa3688e11e99beba0abf9c", size = 37232772, upload-time = "2026-03-31T18:29:37.952Z" },
+    { url = "https://files.pythonhosted.org/packages/11/03/16090dd6f74ba2b8b922276047f15962fbeea0a75d5601607edb301ba945/llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b", size = 56275178, upload-time = "2026-03-31T18:29:42.58Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/cb/0abf1dd4c5286a95ffe0c1d8c67aec06b515894a0dd2ac97f5e27b82ab0b/llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8", size = 55128632, upload-time = "2026-03-31T18:29:46.939Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/79/d3bbab197e86e0ff4f9c07122895b66a3e0d024247fcff7f12c473cb36d9/llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453", size = 39153839, upload-time = "2026-03-31T18:29:51.004Z" },
+]
+
+[[package]]
 name = "lxml"
 version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1650,6 +1678,34 @@ wheels = [
 ]
 
 [[package]]
+name = "mlx-whisper"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "mlx" },
+    { name = "more-itertools" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "tiktoken" },
+    { name = "torch" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/b7/a35232812a2ccfffcb7614ba96a91338551a660a0e9815cee668bf5743f0/mlx_whisper-0.4.3-py3-none-any.whl", hash = "sha256:6b82b6597a994643a3e5496c7bc229a672e5ca308458455bfe276e76ae024489", size = 890544, upload-time = "2025-08-29T14:56:13.815Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1811,6 +1867,38 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.65.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/b3/650500c2eab4534d98e9166f4298e0f3c69c742afdf24e6eabccd1f16ad8/numba-0.65.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:7020d74b19cdb8cff16506542fdd510756e28c5e7f3bd0b7f574f0f42272fcd9", size = 2680563, upload-time = "2026-04-24T02:02:18.414Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0b/0615dbedb98f5b32a35a53290fbdc6e22306968109278d7e58df82d7a9f6/numba-0.65.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f80ed83774b5173abd6581cd8d2165d1d38e13d2e5c8155c0c0b421784745420", size = 3745018, upload-time = "2026-04-24T02:02:20.252Z" },
+    { url = "https://files.pythonhosted.org/packages/49/aa/4361698f35bf63bff67dfe6c90493731177f48ede954f77b0588731537bc/numba-0.65.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7ed425a43b0a5f9772f2f4e2dd0bbd12eabecae1af0b24efcfd4e053f012aac6", size = 3450962, upload-time = "2026-04-24T02:02:22.449Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9a/af61ec03b3116c161fd7a06b9e8a265729a8718458333e8ffbb06d9a3978/numba-0.65.1-cp311-cp311-win_amd64.whl", hash = "sha256:df40a5028a975b9ea66f6a2a3f7abbdbd541a863070e34ed367aff21141248e4", size = 2747417, upload-time = "2026-04-24T02:02:24.43Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bc/76f8f8c5cf9adee47fdb7bbb03be8900f76f902d451d7477cf12b845e1de/numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:ac3f1e77c352dd0ea9712732c2d8f9ca507717435eec5b5013bf138ac33c4a08", size = 2681371, upload-time = "2026-04-24T02:02:26.105Z" },
+    { url = "https://files.pythonhosted.org/packages/69/47/a415af0283e4db0398104c6d1c11c9861a98dc67a7aa442a7769ed5d6196/numba-0.65.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:52bc6f3ceb8fcaff9b2ae26b4c6b1e9fee39db8d355534c0fe4f39a901246b84", size = 3802467, upload-time = "2026-04-24T02:02:27.712Z" },
+    { url = "https://files.pythonhosted.org/packages/46/36/246f73ec99cfeab2f2cb2ce7d4218766cc36a2da418901223f4f4da9c813/numba-0.65.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90ca10b3463bae0bd70589726fe3c77d01d6b5fc86bee54bcdf9fb6b47c28977", size = 3502628, upload-time = "2026-04-24T02:02:29.763Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9e/3c679b2ee078425b9e99a91e44f8d132a6830d8ccce5227bc5e9181aeed8/numba-0.65.1-cp312-cp312-win_amd64.whl", hash = "sha256:5971c632be2a2351500431f46213821dba8d02b18a9f7d02fd36bd2743e41a6a", size = 2750611, upload-time = "2026-04-24T02:02:31.477Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/14a4579049c1eb673afd0de0cb4842982acd55b9ce2643e763db858bcea0/numba-0.65.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:1735c15c1134a5108b4d6a5c77fc0947924ea066a738dc09a52008c13df9cad3", size = 2681344, upload-time = "2026-04-24T02:02:33.65Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/22/b8d873f6466b20aa563fc9b33acd48dec89a07803ddaa2f1c8ca1cd33126/numba-0.65.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c09f49117ef255e1f1c6dad0c7a1ed39868243862a73be5706793241a3755f1b", size = 3810619, upload-time = "2026-04-24T02:02:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/62/08/e16a8b5d9a018962ebb5c66be662317cde32b9f5dab08441f90bed5522fb/numba-0.65.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:594a8680b3fadac99e97e489b1fd89007177e5336713745c3b769528c635a464", size = 3509783, upload-time = "2026-04-24T02:02:38.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a5/03c970d57f4c1741354837353ce39fb5206952ae1dba8922d29c86f64805/numba-0.65.1-cp313-cp313-win_amd64.whl", hash = "sha256:85be74c0d036842699a30058f82fb88fc5ffdc59f7615cab5792ea92914c9b62", size = 2750534, upload-time = "2026-04-24T02:02:39.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2e/8aed9b726d9ba5f11ad287645fd479e88278db3060a25cb1225d730eb2b7/numba-0.65.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:33f5eb68eb1c843511615d14663ce60258525d6a4c65ab040e2c2b0c4cf17450", size = 2681554, upload-time = "2026-04-24T02:02:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/87/96/f3eb235fafa82a34e2ab5dd7dc9ffff998ebf5f0bbc23fa56a96aeb44da6/numba-0.65.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71e73029bf53a62cc6afcf96be4bd942290d8b4c55f0a454fb536158115790f7", size = 3779602, upload-time = "2026-04-24T02:02:43.726Z" },
+    { url = "https://files.pythonhosted.org/packages/09/90/b0f09b48752d23640b8284f22aa597737e8adaddc7fbfacc4708b7f73a4c/numba-0.65.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a07635e0be926b9bdbffb09137c230fb13f6ec0e564914ba937cee12ce3eb35", size = 3479532, upload-time = "2026-04-24T02:02:45.427Z" },
+    { url = "https://files.pythonhosted.org/packages/56/46/3f7fc04fb853559e74b210e0b62c19974ec844cefec611f9e535f4da3761/numba-0.65.1-cp314-cp314-win_amd64.whl", hash = "sha256:2a20fcdabdefbdacf88d85caf70c3b18c4bcb7ebb8f82e6a19486383dd26ab63", size = 2752637, upload-time = "2026-04-24T02:02:47.664Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7b/c1a341a9067367778f4152a5f01061cf281fb09582c92c510ec4918cabf6/numba-0.65.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:548dd4b3a4508d5062768d1514b2cd7b015f9a25ec7af651c50dee243965e652", size = 2684600, upload-time = "2026-04-24T02:02:49.653Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/98ddbcf3e4f04a6dd07e1c67249955920579ba4af6bb6868e3088f4ed282/numba-0.65.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:78abc28feff2c2ff8307fff3975b6438352759c9acb797ecd6b1fb6e7e39e31d", size = 3817198, upload-time = "2026-04-24T02:02:51.266Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/83/0dad21057ece5a835599f5d24099b091703995e23dbbf894f259e91c010b/numba-0.65.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee7676cb389555805f9b9a1840cbcd1ea6c8bd5376ab6918e3a29c5ea1dbda20", size = 3533862, upload-time = "2026-04-24T02:02:52.987Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/8be7118ffd4c8440881046eac3d0982cc5ab42909508cf5d67024d62a2e4/numba-0.65.1-cp314-cp314t-win_amd64.whl", hash = "sha256:20609346e3bd75204950dcbbfe383a8d7dbf4902f442aedbf00f97fef4aa8f38", size = 2758237, upload-time = "2026-04-24T02:02:54.612Z" },
 ]
 
 [[package]]
@@ -2052,6 +2140,7 @@ dependencies = [
     { name = "mcp" },
     { name = "mlx-lm" },
     { name = "mlx-vlm" },
+    { name = "mlx-whisper" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "rich" },
@@ -2088,6 +2177,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.0" },
     { name = "mlx-lm", specifier = ">=0.31.1" },
     { name = "mlx-vlm", specifier = ">=0.4.3" },
+    { name = "mlx-whisper", specifier = ">=0.4.3" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "rich", specifier = ">=13.0" },
@@ -3125,6 +3215,77 @@ wheels = [
 ]
 
 [[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675, upload-time = "2026-02-23T00:16:00.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533, upload-time = "2026-02-23T00:16:25.791Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/60/8804678875fc59362b0fb759ab3ecce1f09c10a735680318ac30da8cd76b/scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c", size = 33062057, upload-time = "2026-02-23T00:16:36.931Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300, upload-time = "2026-02-23T00:16:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/7ccbbdcbb54c8fdc20d3b6930137c782a163fa626f0aef920349873421ba/scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444", size = 35127333, upload-time = "2026-02-23T00:17:01.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314, upload-time = "2026-02-23T00:17:12.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/da/0d1df507cf574b3f224ccc3d45244c9a1d732c81dcb26b1e8a766ae271a8/scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff", size = 36607512, upload-time = "2026-02-23T00:17:23.424Z" },
+    { url = "https://files.pythonhosted.org/packages/68/7f/bdd79ceaad24b671543ffe0ef61ed8e659440eb683b66f033454dcee90eb/scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d", size = 24599248, upload-time = "2026-02-23T00:17:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
 name = "sentencepiece"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3243,6 +3404,60 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/4c/1bc81f4cd53e827c4ee67ca951b5935724716049452d8dfa09b8b82372bb/tiktoken-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7bfe1849caa65d1e1d9871817170ec497bbb7984e182012e1bdce72f66608cdb", size = 1036353, upload-time = "2026-05-15T04:50:21.757Z" },
+    { url = "https://files.pythonhosted.org/packages/75/91/10b9c7076bc02c246c853201fdbbe300a4b8c5ed7b84c25f7403f4e32655/tiktoken-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:91c180fe255bd5a86d8316210d2833a1d4d33d026cd86a67812f4773743c8d26", size = 984644, upload-time = "2026-05-15T04:50:23.256Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e4/fceae98015fab47fcd49b8bd7f46145bcd187a47e0add1e5378ed67ef980/tiktoken-0.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:059c8ecf554eb5b41e6e054ba467b871b03277d267dee7244380aca4359747d4", size = 1119261, upload-time = "2026-05-15T04:50:24.348Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/fe42ad00de01a8c4a49ad8649a2c8a316835a9cad5961b11d21eac0020a5/tiktoken-0.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:36217497eaffc158607a3b26f065300db2aefd43b115263f3b9688ce38146173", size = 1138253, upload-time = "2026-05-15T04:50:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/ccee1ecccca107e9a16efcecdeeb964c325305038554d466ece65b42338f/tiktoken-0.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:303f7d91b4fce3baddbcde05c139091d4caa5026ac7214c1dc7ff7a71ee429ff", size = 1185747, upload-time = "2026-05-15T04:50:27.02Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/03/cd0cba295522b91eb55c6b2704f1df895f8226cfe60ab10d4d51d0cc9e69/tiktoken-0.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5d48843bee149630eb735a99e1f4a85b47308d21868ea63163f6e87768d3cfed", size = 1241265, upload-time = "2026-05-15T04:50:28.815Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/25/a10efd564402d82c2ff50d12057353ace447aa8007deceaa48641f63d35c/tiktoken-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:fc1c44cd37b43fc46bae593129164f4f281e82ea116b57a85aa81bda57eafc94", size = 876509, upload-time = "2026-05-15T04:50:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/85/8e/144bde4e01df66b34bb865557c7cd754ed08b036217ebd79c9db5e9048a9/tiktoken-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:32ac870a806cfb260a02d0cb70426aef02e038297f8ad50df5040bb5af360791", size = 1034888, upload-time = "2026-05-15T04:50:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/36/18/d4ac9d20956cdebca04841316660ed584c2fecdc2b81722a28bc7ad3b1e4/tiktoken-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d9980f11429ed2d737c463bb1fb78cf330caa026adf002f714aced7849a687b", size = 982970, upload-time = "2026-05-15T04:50:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ed/6bb8d05b9f731f749fee5c6f5ca63e981143c826a5985877330507bd13b7/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3f277ebea5edd7b8bf03c6f9431e1d67d517530115572b2dc1d465326e8f88c7", size = 1115741, upload-time = "2026-05-15T04:50:34.475Z" },
+    { url = "https://files.pythonhosted.org/packages/34/de/2ca96b07a82d972b74fe4b46de055b79c904e45c7eab699354a0bfa697dc/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a116178fa7e1b4065bff05214360373a65cac22f965be7b3f73d00a0dbfe7649", size = 1136523, upload-time = "2026-05-15T04:50:35.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/dc/9dafec002c2d4424378563cf4cf5c7fb93631d2a55013c8b87554ee4012c/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c397ddda233208345b01bd30f2fca79ff730e55731d0108a603f9bc57f6af3b", size = 1181954, upload-time = "2026-05-15T04:50:36.99Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d0/1f8578c45b2f24759b46f0b50d31878c63c73e6bf0f2227e10ec5c5408dc/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:95097e4f89b06403976e498abf61a0ee73a7497e73fb599cb211d8197a054d91", size = 1240069, upload-time = "2026-05-15T04:50:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/90/28d7f154888610aa9237e541986beb62b479df29d193a5a0617dbb1514d0/tiktoken-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:8f2d16e7a7c783ad81f36e457d046d1f1c8af70b22aec8a13238efe531977c41", size = 874748, upload-time = "2026-05-15T04:50:39.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/83/b096c859c2a47c11731bf2f5885f4028b809dfe2396582883eed9cae372f/tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154", size = 1034228, upload-time = "2026-05-15T04:50:40.988Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/8b/96cc178cc584e65d363134500f297790b06cd48cdeb1e8fcf7bbe60f4715/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2", size = 1116355, upload-time = "2026-05-15T04:50:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b9/6de04ebdf904edfaad87788011b3735087a0c9ea671b9027e1e4e965e8c8/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486", size = 1182415, upload-time = "2026-05-15T04:50:46.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/42/a6/c1936d16055436cb32e6c6128d68629622e00f4768562f55653752d34768/tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7", size = 874829, upload-time = "2026-05-15T04:50:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/acb5992c3772b5a36284f742cfb7a5895aa4471d1848ac31464ad50d7fdf/tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67", size = 1033600, upload-time = "2026-05-15T04:50:50.4Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/ca1541b053e7648254d2e4b42a253e1bb4359f2c91a0a8d49228c794e1a0/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d", size = 1115518, upload-time = "2026-05-15T04:50:53.543Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/002b68de6827091d5ae90b048f326e8aad8d953520950e5ce1508879414f/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2", size = 1181826, upload-time = "2026-05-15T04:50:56.296Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4d/bc07d1f1635d4897a202acc0ae11c2886eaa7325c359ba4741b47bf8e225/tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec", size = 873820, upload-time = "2026-05-15T04:50:59.528Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/93/0dd6adca026a616c3a92974566b43381eea4b475ce1f36c062b8271a9ac5/tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471", size = 1034977, upload-time = "2026-05-15T04:51:00.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/c8ae9aff00d625c50659b4513e707a0462c4bf5d4d6cc1b802103225c02e/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881", size = 1116036, upload-time = "2026-05-15T04:51:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/6a5dddd1d0a6018ecb389bd0353e6b4a515eb4d2286611bd0ace1937b9e1/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24", size = 1135544, upload-time = "2026-05-15T04:51:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/585032b4384b2f7dcdaddcb52865c83a701a420d09e3c2b4a2be1c450c57/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273", size = 1182217, upload-time = "2026-05-15T04:51:06.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/993ff1ded3958215fd341a847b8e5ffeb5de473f435296870d314fc91ac4/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51", size = 1239404, upload-time = "2026-05-15T04:51:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3d/fef7e06e3b33e7538db0ced734cf9fe23b6832d2ac4990c119c377aec55e/tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58", size = 918686, upload-time = "2026-05-15T04:51:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/82/a7fc44582bc32ab00de988a2299bf77c077f59068b233109e34b7d6ca7e6/tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b", size = 1034454, upload-time = "2026-05-15T04:51:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/2ab43f62788a9266187a9bfc1d3af99ad83e5eaa25fbef168a69cd5ad14f/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a", size = 1115526, upload-time = "2026-05-15T04:51:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/64/39/1494321ed323ce7a14d88e3cd6cb9058625977df1c6961ddc492bd10a9f3/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad", size = 1136466, upload-time = "2026-05-15T04:51:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds an OpenAI-compatible speech-to-text route backed by `mlx-whisper`, with whisper models managed as a first-class kind through the existing `ModelManager`. Closes #366.

- **Route** `POST /v1/audio/transcriptions` (`routers/audio.py`): multipart upload (`file` + `model`, optional `language`/`prompt`/`response_format`/`temperature`/`timestamp_granularities[]`), streamed to a temp file under `OLMLX_AUDIO_MAX_BYTES` (default 100 MB; 413 on overflow, temp cleaned up in `finally`).
- **Response formats**: `json`, `verbose_json` (`{task, language, duration, text, segments[]}`), `text`, `srt`, `vtt`.
- **Engine**: `_detect_model_kind` returns `"whisper"` (via `model_type == "whisper"` or mlx whisper dims `n_mels`/`n_audio_state`); `_load_model` loads via `mlx_whisper.load_models.load_model`; `LoadedModel.is_whisper` guards the LLM-only prompt-cache probe and KV-quant/spectral paths. `generate_transcription` acquires the inference lock + active-ref, injects the managed model into `mlx_whisper.transcribe.ModelHolder` (race-free under the serialized lock), and runs the synchronous transcribe in a worker thread.
- **Lifecycle fix**: `_close_loaded_model` releases the `ModelHolder` reference on eviction/expiry (identity-guarded) so whisper GPU weights are actually freed.
- **Middleware**: `ForceJSONMiddleware` now skips `multipart/form-data` so the upload's content-type/boundary survives.
- **Config/CLI/deps**: `OLMLX_AUDIO_MAX_BYTES` setting; `whisper-turbo`/`whisper-large` seeded into `DEFAULT_MODELS`; `mlx-whisper` dependency added; CLAUDE.md updated.

**Requires ffmpeg on PATH** (mlx-whisper decodes via ffmpeg); a missing/failed decode surfaces as HTTP 400. Streaming transcription and diarization are out of scope.

Design + plan: `docs/superpowers/specs/2026-05-28-whisper-transcription-endpoint-design.md`, `docs/superpowers/plans/2026-05-28-whisper-transcription-endpoint.md`.

## Test Plan

- [x] Full suite: `uv run pytest` — 2986 passed, 3 skipped
- [x] `uv run ruff check` / `ruff format` — clean
- [x] App builds and route registers (`create_app()` smoke import)
- [ ] Manual: `client.audio.transcriptions.create(file=..., model="whisper-turbo")` against a running server (requires ffmpeg + a whisper model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)