### PR TITLE
ci: add aider-code-review workflow with gpt-5.5

### DIFF
--- a/.github/workflows/aider-code-review.yml
+++ b/.github/workflows/aider-code-review.yml
@@ -1,0 +1,25 @@
+name: Aider Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  aider-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Aider Code Review
+        uses: motsognirr/aider-code-review@v1
+        with:
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          model: gpt-5.5


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs [`motsognirr/aider-code-review`](https://github.com/motsognirr/aider-code-review) on pull requests, configured to use the `gpt-5.5` model.

- Triggers on `pull_request` (`opened`, `synchronize`)
- `model: gpt-5.5` — a `gpt-*` model, so it routes to the `openai_api_key` secret per the action's docs
- Permissions: `contents: read`, `pull-requests: write`

## Setup required

Add an **`OPENAI_API_KEY`** repository secret (Settings → Secrets and variables → Actions) for the action to authenticate. `GITHUB_TOKEN` is provided automatically.

## Test Plan

- [x] Workflow YAML parses
- [ ] Action runs and posts review comments on a PR (requires `OPENAI_API_KEY` secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)