### PR TITLE
fix(model_manager): pin-on-load to close the model handoff race (#393)

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1284,18 +1284,16 @@ def _inference_ref(
 
     When *adopt* is True the caller obtained ``lm`` via
     ``ensure_loaded(..., pin=True)``, which already incremented ``active_refs``
-    under the lock — so this context manager does NOT increment again; it
-    merely *adopts* that existing pin and releases it on exit. This closes the
-    handoff window: the model is pinned continuously from inside
-    ``ensure_loaded`` (under the lock) through the awaits that precede this
-    block (inference-lock acquisition, async prompt-cache setup) until exit.
-    The caller is responsible for releasing the pin (via ``lm.release_ref()``)
-    on any error path that bypasses this context manager.
+    under the lock. This context manager does NOT increment on entry and does
+    NOT release on exit; the caller's outer try/finally owns the single pin
+    release. This avoids races where an exception path here and the caller's
+    cleanup could double-release. Expiry refresh still runs on exit so the
+    model's deadline reflects the inference that just happened.
 
-    With *adopt* False (the legacy path) this increments on entry as before;
-    a small unprotected window then exists between ``ensure_loaded`` and here,
-    but that path is only used where the caller does not hold the model across
-    awaits.
+    With *adopt* False (the legacy path) this increments on entry and releases
+    on exit as before; a small unprotected window then exists between
+    ``ensure_loaded`` and here, but that path is only used where the caller
+    does not hold the model across awaits.
 
     Bug #118: Python ``+=`` on int is not atomic. Concurrent async tasks can
     race on ``active_refs``. Use the model's ``_active_refs_lock`` to protect
@@ -1310,7 +1308,8 @@ def _inference_ref(
     try:
         yield
     finally:
-        lm.release_ref()
+        if not adopt:
+            lm.release_ref()
         # Refresh expiry so the model doesn't expire immediately after inference.
         # Honour per-request keep_alive when available (fix #338).
         # Falls back to settings.default_keep_alive when no per-request value
@@ -1326,6 +1325,31 @@ def _inference_ref(
             lm.expires_at = time.time() + ka
         else:
             lm.expires_at = None
+
+
+async def _release_pin_after_gen(
+    gen: AsyncGenerator[dict, None], lm: LoadedModel
+) -> AsyncGenerator[dict, None]:
+    """Forward ``gen`` and release ``lm``'s pin on any generator exit.
+
+    Used by the streaming entry points to release the pin acquired by
+    ``ensure_loaded(pin=True)`` once the underlying generator finishes
+    (normally, via exception, or via aclose on client disconnect). The
+    inner generator's ``_inference_ref(adopt=True)`` does NOT release —
+    only this wrapper does — so the pin is released exactly once.
+
+    The finally explicitly closes ``gen`` so the wrapped generator's own
+    finally blocks (e.g. the inference-lock release in
+    ``_stream_completion``) fire when the client disconnects mid-stream.
+    """
+    try:
+        async for chunk in gen:
+            yield chunk
+    finally:
+        try:
+            await gen.aclose()
+        finally:
+            lm.release_ref()
 
 
 def _build_generate_kwargs(options: dict | None, is_vlm: bool = False) -> dict:
@@ -1976,7 +2000,7 @@ async def generate_completion(
     stats = TimingStats()
 
     with Timer() as load_timer:
-        lm = await manager.ensure_loaded(model_name, keep_alive)
+        lm = await manager.ensure_loaded(model_name, keep_alive, pin=True)
     stats.load_duration = load_timer.duration_ns
 
     # /api/generate defaults thinking OFF when unspecified (None), unlike the
@@ -2073,9 +2097,14 @@ async def generate_completion(
         else False
     )
 
-    if stream:
-        return _prepend_meta(
-            _stream_completion(
+    # The pin acquired by ``ensure_loaded(pin=True)`` is released exactly
+    # once: by the stream wrapper after the generator exits, by the
+    # non-stream finally below, or by the except below if anything raises
+    # before delegation.
+    delegated = False
+    try:
+        if stream:
+            gen = _stream_completion(
                 lm,
                 prompt,
                 mt,
@@ -2084,22 +2113,39 @@ async def generate_completion(
                 images,
                 keep_alive=keep_alive,
                 grammar_active=grammar_active,
-            ),
-            {"thinking_expected": thinking_expected},
-        )
-    else:
-        result = await _full_completion(
-            lm,
-            prompt,
-            mt,
-            gen_kwargs,
-            stats,
-            images,
-            keep_alive=keep_alive,
-            grammar_active=grammar_active,
-        )
-        result["thinking_expected"] = thinking_expected
-        return result
+                adopt_pin=True,
+            )
+            delegated = True
+            return _prepend_meta(
+                _release_pin_after_gen(gen, lm),
+                {"thinking_expected": thinking_expected},
+            )
+        else:
+            try:
+                result = await _full_completion(
+                    lm,
+                    prompt,
+                    mt,
+                    gen_kwargs,
+                    stats,
+                    images,
+                    keep_alive=keep_alive,
+                    grammar_active=grammar_active,
+                    adopt_pin=True,
+                )
+                result["thinking_expected"] = thinking_expected
+                return result
+            finally:
+                # Release exactly once on every exit path — success or
+                # exception. Set ``delegated`` so the outer except doesn't
+                # try to release again.
+                if not delegated:
+                    lm.release_ref()
+                    delegated = True
+    except BaseException:
+        if not delegated:
+            lm.release_ref()
+        raise
 
 
 @dataclasses.dataclass
@@ -2660,6 +2706,7 @@ async def _stream_completion(
     cache_id: str = "",
     keep_alive: str | None = None,
     grammar_active: bool = False,
+    adopt_pin: bool = False,
 ) -> AsyncGenerator[dict, None]:
     # Use explicit acquire/release instead of `async with` to prevent
     # CancelledError from releasing the lock before cleanup completes.
@@ -3043,6 +3090,7 @@ async def _full_completion(
     cache_id: str = "",
     keep_alive: str | None = None,
     grammar_active: bool = False,
+    adopt_pin: bool = False,
 ) -> dict:
     # inference_timeout is not enforced for non-streaming: the GPU thread
     # cannot be safely cancelled (releasing the lock while Metal is still
@@ -3050,8 +3098,13 @@ async def _full_completion(
     # this via CancellableStream.cancel() + drain_and_join().
     # Pop stop sequences before passing gen_kwargs to mlx-lm (unsupported).
     stop_sequences: list[str] | None = gen_kwargs.pop("stop", None)
+    # When adopt_pin is True the caller passed an ``lm`` already pinned via
+    # ``ensure_loaded(pin=True)``. ``_inference_ref(adopt=True)`` does NOT
+    # release the pin — the caller's outer finally is responsible for the
+    # single release. This avoids races between an early exception path
+    # here and the caller's cleanup.
     async with _inference_locked(lm.inference_queue_timeout, sync_mode=lm.sync_mode):
-        with _inference_ref(lm, keep_alive=keep_alive):
+        with _inference_ref(lm, keep_alive=keep_alive, adopt=adopt_pin):
             # Cache setup must happen under the inference lock so two
             # concurrent requests can't race to read/mutate the same store
             # entry.  The gate at the call site has already excluded VLM
@@ -3424,7 +3477,7 @@ async def generate_chat(
     stats = TimingStats()
 
     with Timer() as load_timer:
-        lm = await manager.ensure_loaded(model_name, keep_alive)
+        lm = await manager.ensure_loaded(model_name, keep_alive, pin=True)
     stats.load_duration = load_timer.duration_ns
 
     images = _extract_images(messages)
@@ -3566,9 +3619,14 @@ async def generate_chat(
     # #307) `</think>` token — shares the rules with `_apply_chat_template`.
     thinking_expected = _resolve_thinking_active(caps, tools, enable_thinking)
 
-    if stream:
-        return _prepend_meta(
-            _stream_completion(
+    # The pin acquired by ``ensure_loaded(pin=True)`` is released exactly
+    # once: by the stream wrapper after the generator exits, by the
+    # non-stream finally below, or by the except below if anything raises
+    # before delegation.
+    delegated = False
+    try:
+        if stream:
+            gen = _stream_completion(
                 lm,
                 prompt,
                 mt,
@@ -3580,28 +3638,43 @@ async def generate_chat(
                 cache_id=cache_id,
                 keep_alive=keep_alive,
                 grammar_active=grammar_active,
-            ),
-            {"thinking_expected": thinking_expected},
-        )
-    else:
-        result = await _full_completion(
-            lm,
-            prompt,
-            mt,
-            gen_kwargs,
-            stats,
-            images,
-            has_tools=bool(tools),
-            use_prompt_cache=use_prompt_cache,
-            prompt_tokens=prompt_tokens,
-            cache_id=cache_id,
-            keep_alive=keep_alive,
-            grammar_active=grammar_active,
-        )
-        # Mirror the streaming meta chunk so non-streaming routers can gate
-        # orphan `</think>` handling on the same signal (issue #307).
-        result["thinking_expected"] = thinking_expected
-        return result
+                adopt_pin=True,
+            )
+            delegated = True
+            return _prepend_meta(
+                _release_pin_after_gen(gen, lm),
+                {"thinking_expected": thinking_expected},
+            )
+        else:
+            try:
+                result = await _full_completion(
+                    lm,
+                    prompt,
+                    mt,
+                    gen_kwargs,
+                    stats,
+                    images,
+                    has_tools=bool(tools),
+                    use_prompt_cache=use_prompt_cache,
+                    prompt_tokens=prompt_tokens,
+                    cache_id=cache_id,
+                    keep_alive=keep_alive,
+                    grammar_active=grammar_active,
+                    adopt_pin=True,
+                )
+                # Mirror the streaming meta chunk so non-streaming routers
+                # can gate orphan `</think>` handling on the same signal
+                # (issue #307).
+                result["thinking_expected"] = thinking_expected
+                return result
+            finally:
+                if not delegated:
+                    lm.release_ref()
+                    delegated = True
+    except BaseException:
+        if not delegated:
+            lm.release_ref()
+        raise
 
 
 # Streaming routers consult this when the engine signals
@@ -3661,72 +3734,77 @@ async def generate_embeddings(
     keep_alive: int | str | None = None,
 ) -> list[list[float]]:
     """Generate embeddings using the model's hidden states or embed_tokens layer."""
-    lm = await manager.ensure_loaded(model_name, keep_alive)
+    lm = await manager.ensure_loaded(model_name, keep_alive, pin=True)
 
-    async with _inference_locked(lm.inference_queue_timeout, sync_mode=lm.sync_mode):
-        with _inference_ref(lm, keep_alive=keep_alive):
-            embeddings = []
+    try:
+        async with _inference_locked(
+            lm.inference_queue_timeout, sync_mode=lm.sync_mode
+        ):
+            with _inference_ref(lm, keep_alive=keep_alive, adopt=True):
+                embeddings = []
 
-            tokenizer = lm.text_tokenizer
+                tokenizer = lm.text_tokenizer
 
-            # Check if model has a static embedding layer we can use directly
-            embed_layer = None
-            model_inner = getattr(lm.model, "model", lm.model)
-            if hasattr(model_inner, "embed_tokens"):
-                embed_layer = model_inner.embed_tokens
+                # Check if model has a static embedding layer we can use directly
+                embed_layer = None
+                model_inner = getattr(lm.model, "model", lm.model)
+                if hasattr(model_inner, "embed_tokens"):
+                    embed_layer = model_inner.embed_tokens
 
-            for text in texts:
-                tokens = tokenizer.encode(text)
-                input_ids = mx.array([tokens])
+                for text in texts:
+                    tokens = tokenizer.encode(text)
+                    input_ids = mx.array([tokens])
 
-                if embed_layer is not None:
-                    # Use static token embeddings — no forward pass needed
-                    hidden = embed_layer(input_ids)
-                else:
-                    outputs = lm.model(input_ids)
-                    if hasattr(outputs, "hidden_states") and outputs.hidden_states:
-                        hidden = outputs.hidden_states[-1]
-                    elif hasattr(outputs, "last_hidden_state"):
-                        hidden = outputs.last_hidden_state
+                    if embed_layer is not None:
+                        # Use static token embeddings — no forward pass needed
+                        hidden = embed_layer(input_ids)
                     else:
-                        hidden = outputs
+                        outputs = lm.model(input_ids)
+                        if hasattr(outputs, "hidden_states") and outputs.hidden_states:
+                            hidden = outputs.hidden_states[-1]
+                        elif hasattr(outputs, "last_hidden_state"):
+                            hidden = outputs.last_hidden_state
+                        else:
+                            hidden = outputs
 
-                # Robust shape handling
-                if hidden.ndim == 3:
-                    # (batch, seq, dim) — mean-pool over sequence
-                    embedding = mx.mean(hidden[0], axis=0)
-                elif hidden.ndim == 2:
-                    # (seq, dim) — mean-pool over sequence
-                    embedding = mx.mean(hidden, axis=0)
-                elif hidden.ndim == 1:
-                    embedding = hidden
-                else:
-                    raise ValueError(
-                        f"Unexpected embedding tensor shape: {hidden.shape}"
+                    # Robust shape handling
+                    if hidden.ndim == 3:
+                        # (batch, seq, dim) — mean-pool over sequence
+                        embedding = mx.mean(hidden[0], axis=0)
+                    elif hidden.ndim == 2:
+                        # (seq, dim) — mean-pool over sequence
+                        embedding = mx.mean(hidden, axis=0)
+                    elif hidden.ndim == 1:
+                        embedding = hidden
+                    else:
+                        raise ValueError(
+                            f"Unexpected embedding tensor shape: {hidden.shape}"
+                        )
+
+                    embeddings.append(embedding.tolist())
+
+                # Load-bearing when sync_mode="none": this function runs
+                # synchronously under _inference_locked with no worker thread,
+                # so the lock-boundary exit sync may be skipped. This sync is
+                # then the only Metal barrier before the lock is released —
+                # do not remove without providing an equivalent barrier.
+                # Suppress+log rather than raise: the embeddings have already
+                # been .tolist()'d so the caller should still get the result;
+                # a Metal error here will surface on the next request.
+                try:
+                    mx.synchronize()
+                except Exception:
+                    # WARNING, not DEBUG: under sync_mode="none" this is the
+                    # only Metal barrier in the path; a silent failure here
+                    # typically surfaces as an uncatchable Metal crash on the
+                    # next inference. Operators need to see it now, not after.
+                    logger.warning(
+                        "embeddings post-compute sync failed — next inference will crash",
+                        exc_info=True,
                     )
-
-                embeddings.append(embedding.tolist())
-
-            # Load-bearing when sync_mode="none": this function runs
-            # synchronously under _inference_locked with no worker thread,
-            # so the lock-boundary exit sync may be skipped. This sync is
-            # then the only Metal barrier before the lock is released —
-            # do not remove without providing an equivalent barrier.
-            # Suppress+log rather than raise: the embeddings have already
-            # been .tolist()'d so the caller should still get the result;
-            # a Metal error here will surface on the next request.
-            try:
-                mx.synchronize()
-            except Exception:
-                # WARNING, not DEBUG: under sync_mode="none" this is the
-                # only Metal barrier in the path; a silent failure here
-                # typically surfaces as an uncatchable Metal crash on the
-                # next inference. Operators need to see it now, not after.
-                logger.warning(
-                    "embeddings post-compute sync failed — next inference will crash",
-                    exc_info=True,
-                )
-            return embeddings
+                return embeddings
+    finally:
+        lm.release_ref()
 
 
 async def generate_transcription(
@@ -3757,52 +3835,57 @@ async def generate_transcription(
     # patch() targets) via importlib so ModelHolder injection lands correctly.
     whisper_transcribe = importlib.import_module("mlx_whisper.transcribe")
 
-    lm = await manager.ensure_loaded(model_name, keep_alive)
+    lm = await manager.ensure_loaded(model_name, keep_alive, pin=True)
 
-    # Reject non-whisper models with a clear error (issue #366). Without this,
-    # a text/VLM model name would load fine, get injected into mlx_whisper's
-    # ModelHolder, and produce a cryptic failure inside transcribe(). Raising
-    # ValueError surfaces as HTTP 400 via the app-level handler.
-    if not lm.is_whisper:
-        raise ValueError(
-            f"Model '{model_name}' is not a Whisper model. "
-            "/v1/audio/transcriptions requires a whisper-class model "
-            "(e.g. whisper-turbo or an mlx-community/whisper-* repo)."
-        )
+    try:
+        # Reject non-whisper models with a clear error (issue #366). Without this,
+        # a text/VLM model name would load fine, get injected into mlx_whisper's
+        # ModelHolder, and produce a cryptic failure inside transcribe(). Raising
+        # ValueError surfaces as HTTP 400 via the app-level handler.
+        if not lm.is_whisper:
+            raise ValueError(
+                f"Model '{model_name}' is not a Whisper model. "
+                "/v1/audio/transcriptions requires a whisper-class model "
+                "(e.g. whisper-turbo or an mlx-community/whisper-* repo)."
+            )
 
-    # Resolve the on-disk path used as path_or_hf_repo so the ModelHolder
-    # cache key matches what we inject.
-    if manager.store is not None:
-        load_path = str(manager.store.local_path(lm.hf_path))
-    else:
-        load_path = lm.hf_path
+        # Resolve the on-disk path used as path_or_hf_repo so the ModelHolder
+        # cache key matches what we inject.
+        if manager.store is not None:
+            load_path = str(manager.store.local_path(lm.hf_path))
+        else:
+            load_path = lm.hf_path
 
-    async with _inference_locked(lm.inference_queue_timeout, sync_mode=lm.sync_mode):
-        with _inference_ref(lm):
-            # Inject the managed model so transcribe() reuses it. Safe because
-            # _inference_locked serializes inference (no ModelHolder race).
-            whisper_transcribe.ModelHolder.model = lm.model
-            whisper_transcribe.ModelHolder.model_path = load_path
+        async with _inference_locked(
+            lm.inference_queue_timeout, sync_mode=lm.sync_mode
+        ):
+            with _inference_ref(lm, adopt=True):
+                # Inject the managed model so transcribe() reuses it. Safe because
+                # _inference_locked serializes inference (no ModelHolder race).
+                whisper_transcribe.ModelHolder.model = lm.model
+                whisper_transcribe.ModelHolder.model_path = load_path
 
-            def _run() -> dict:
-                try:
-                    return whisper_transcribe.transcribe(
-                        audio_path,
-                        path_or_hf_repo=load_path,
-                        language=language,
-                        initial_prompt=prompt,
-                        temperature=temperature,
-                        word_timestamps=word_timestamps,
-                    )
-                except FileNotFoundError as exc:
-                    raise ValueError(
-                        "Audio decoding failed: ffmpeg was not found on PATH. "
-                        "Install ffmpeg (e.g. `brew install ffmpeg`) to use "
-                        "/v1/audio/transcriptions."
-                    ) from exc
-                except RuntimeError as exc:
-                    # mlx_whisper.audio.load_audio raises RuntimeError on a
-                    # failed ffmpeg decode (bad/corrupt/unsupported file).
-                    raise ValueError(f"Audio decoding failed: {exc}") from exc
+                def _run() -> dict:
+                    try:
+                        return whisper_transcribe.transcribe(
+                            audio_path,
+                            path_or_hf_repo=load_path,
+                            language=language,
+                            initial_prompt=prompt,
+                            temperature=temperature,
+                            word_timestamps=word_timestamps,
+                        )
+                    except FileNotFoundError as exc:
+                        raise ValueError(
+                            "Audio decoding failed: ffmpeg was not found on PATH. "
+                            "Install ffmpeg (e.g. `brew install ffmpeg`) to use "
+                            "/v1/audio/transcriptions."
+                        ) from exc
+                    except RuntimeError as exc:
+                        # mlx_whisper.audio.load_audio raises RuntimeError on a
+                        # failed ffmpeg decode (bad/corrupt/unsupported file).
+                        raise ValueError(f"Audio decoding failed: {exc}") from exc
 
-            return await asyncio.to_thread(_run)
+                return await asyncio.to_thread(_run)
+    finally:
+        lm.release_ref()

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -2003,106 +2003,108 @@ async def generate_completion(
         lm = await manager.ensure_loaded(model_name, keep_alive, pin=True)
     stats.load_duration = load_timer.duration_ns
 
-    # /api/generate defaults thinking OFF when unspecified (None), unlike the
-    # chat route's "think unless tools".  Coerce once so the template
-    # instruction and the downstream thinking_expected signal stay consistent
-    # (otherwise the splitter would arm the orphan-</think> buffer for thinking
-    # the model was told not to produce).
-    effective_thinking = enable_thinking if enable_thinking is not None else False
-
-    if apply_chat_template and not lm.is_vlm:
-        messages: list[dict] = []
-        if system:
-            messages.append({"role": "system", "content": system})
-        messages.append({"role": "user", "content": prompt})
-        try:
-            prompt = apply_chat_template_text(
-                lm.text_tokenizer,
-                messages,
-                caps=lm.template_caps,
-                enable_thinking=effective_thinking,
-            )
-            logger.info(
-                "Applied chat template for /api/generate (prompt length: %d chars)",
-                len(prompt),
-            )
-            logger.debug("Templated prompt: %s", prompt[:500])
-        except RuntimeError as exc:
-            logger.warning(
-                "Chat template failed for %s, falling back to raw prompt: %s",
-                model_name,
-                exc,
-                exc_info=True,
-            )
-            if system:
-                prompt = f"{system}\n\n{prompt}"
-    elif apply_chat_template and lm.is_vlm:
-        messages: list[dict] = []
-        if system:
-            messages.append({"role": "system", "content": system})
-        messages.append({"role": "user", "content": prompt})
-        try:
-            # Forward the *coerced* effective_thinking (not raw enable_thinking)
-            # so VLM /api/generate is off-by-default like the text path, and so
-            # the explicit instruction matches the thinking_expected signal
-            # computed below.  We deliberately don't defer to the VLM template's
-            # own default: we can't introspect it, so passing an explicit bool
-            # is the only way to keep the thinking-splitter consistent.  This
-            # differs intentionally from generate_chat's no-tools VLM path,
-            # which passes None and lets _apply_chat_template_vlm's guard skip
-            # the kwarg (preserving the template default).  Consequence: every
-            # /api/generate VLM request passes enable_thinking (incl. False) to
-            # the template even for non-thinking VLMs — harmless because HF
-            # templates ignore unknown kwargs.
-            prompt = _apply_chat_template_vlm(
-                lm.tokenizer, lm.model, messages, enable_thinking=effective_thinking
-            )
-            logger.info(
-                "Applied VLM chat template for /api/generate (prompt length: %d chars)",
-                len(prompt),
-            )
-            logger.debug("VLM templated prompt: %s", prompt[:500])
-        except Exception as exc:
-            logger.warning(
-                "VLM chat template failed for %s, falling back to raw prompt: %s",
-                model_name,
-                exc,
-                exc_info=True,
-            )
-            if system:
-                prompt = f"{system}\n\n{prompt}"
-
-    # Merge per-model defaults with request options.  options=None means
-    # "use defaults"; options={} means "override all defaults" (empty).
-    merged_options = (
-        {**lm.default_options, **(options or {})}
-        if lm.default_options and options is None
-        else options
-    )
-    gen_kwargs = _build_generate_kwargs(merged_options, is_vlm=lm.is_vlm)
-    mt = gen_kwargs.pop("max_tokens", max_tokens)
-
-    grammar_active = _install_grammar_processor(lm, gen_kwargs, grammar_spec)
-
-    # Tell routers whether to wait for a (possibly orphaned) `</think>` when
-    # splitting thinking from the response (issue #307) — shares the rules
-    # with `generate_chat`.  Completions never carry tools.  In raw mode no
-    # chat template is applied, so no thinking instruction reached the model:
-    # leave thinking_expected False so the router doesn't arm the orphan-close
-    # heuristic on un-templated output (a literal `</think>` in code/prose).
-    caps = lm.template_caps or TemplateCaps()
-    thinking_expected = (
-        _resolve_thinking_active(caps, None, effective_thinking)
-        if apply_chat_template
-        else False
-    )
-
     # The pin acquired by ``ensure_loaded(pin=True)`` is released exactly
     # once: by the stream wrapper after the generator exits, by the
-    # non-stream finally below, or by the except below if anything raises
-    # before delegation.
-    delegated = False
+    # non-stream finally below, or by the outer except below if anything
+    # raises before delegation. The outer try must scope from RIGHT AFTER
+    # ensure_loaded (PR #394 aider review) so an exception in the chat
+    # template / kwargs setup doesn't leak the pin.
+    pin_released_or_transferred = False
     try:
+        # /api/generate defaults thinking OFF when unspecified (None), unlike the
+        # chat route's "think unless tools".  Coerce once so the template
+        # instruction and the downstream thinking_expected signal stay consistent
+        # (otherwise the splitter would arm the orphan-</think> buffer for thinking
+        # the model was told not to produce).
+        effective_thinking = enable_thinking if enable_thinking is not None else False
+
+        if apply_chat_template and not lm.is_vlm:
+            messages: list[dict] = []
+            if system:
+                messages.append({"role": "system", "content": system})
+            messages.append({"role": "user", "content": prompt})
+            try:
+                prompt = apply_chat_template_text(
+                    lm.text_tokenizer,
+                    messages,
+                    caps=lm.template_caps,
+                    enable_thinking=effective_thinking,
+                )
+                logger.info(
+                    "Applied chat template for /api/generate (prompt length: %d chars)",
+                    len(prompt),
+                )
+                logger.debug("Templated prompt: %s", prompt[:500])
+            except RuntimeError as exc:
+                logger.warning(
+                    "Chat template failed for %s, falling back to raw prompt: %s",
+                    model_name,
+                    exc,
+                    exc_info=True,
+                )
+                if system:
+                    prompt = f"{system}\n\n{prompt}"
+        elif apply_chat_template and lm.is_vlm:
+            messages: list[dict] = []
+            if system:
+                messages.append({"role": "system", "content": system})
+            messages.append({"role": "user", "content": prompt})
+            try:
+                # Forward the *coerced* effective_thinking (not raw enable_thinking)
+                # so VLM /api/generate is off-by-default like the text path, and so
+                # the explicit instruction matches the thinking_expected signal
+                # computed below.  We deliberately don't defer to the VLM template's
+                # own default: we can't introspect it, so passing an explicit bool
+                # is the only way to keep the thinking-splitter consistent.  This
+                # differs intentionally from generate_chat's no-tools VLM path,
+                # which passes None and lets _apply_chat_template_vlm's guard skip
+                # the kwarg (preserving the template default).  Consequence: every
+                # /api/generate VLM request passes enable_thinking (incl. False) to
+                # the template even for non-thinking VLMs — harmless because HF
+                # templates ignore unknown kwargs.
+                prompt = _apply_chat_template_vlm(
+                    lm.tokenizer, lm.model, messages, enable_thinking=effective_thinking
+                )
+                logger.info(
+                    "Applied VLM chat template for /api/generate (prompt length: %d chars)",
+                    len(prompt),
+                )
+                logger.debug("VLM templated prompt: %s", prompt[:500])
+            except Exception as exc:
+                logger.warning(
+                    "VLM chat template failed for %s, falling back to raw prompt: %s",
+                    model_name,
+                    exc,
+                    exc_info=True,
+                )
+                if system:
+                    prompt = f"{system}\n\n{prompt}"
+
+        # Merge per-model defaults with request options.  options=None means
+        # "use defaults"; options={} means "override all defaults" (empty).
+        merged_options = (
+            {**lm.default_options, **(options or {})}
+            if lm.default_options and options is None
+            else options
+        )
+        gen_kwargs = _build_generate_kwargs(merged_options, is_vlm=lm.is_vlm)
+        mt = gen_kwargs.pop("max_tokens", max_tokens)
+
+        grammar_active = _install_grammar_processor(lm, gen_kwargs, grammar_spec)
+
+        # Tell routers whether to wait for a (possibly orphaned) `</think>` when
+        # splitting thinking from the response (issue #307) — shares the rules
+        # with `generate_chat`.  Completions never carry tools.  In raw mode no
+        # chat template is applied, so no thinking instruction reached the model:
+        # leave thinking_expected False so the router doesn't arm the orphan-close
+        # heuristic on un-templated output (a literal `</think>` in code/prose).
+        caps = lm.template_caps or TemplateCaps()
+        thinking_expected = (
+            _resolve_thinking_active(caps, None, effective_thinking)
+            if apply_chat_template
+            else False
+        )
+
         if stream:
             gen = _stream_completion(
                 lm,
@@ -2115,7 +2117,10 @@ async def generate_completion(
                 grammar_active=grammar_active,
                 adopt_pin=True,
             )
-            delegated = True
+            # Ownership of the pin transfers to the wrapper; its finally
+            # releases on any generator exit. Mark the flag for the outer
+            # except so it doesn't double-release.
+            pin_released_or_transferred = True
             return _prepend_meta(
                 _release_pin_after_gen(gen, lm),
                 {"thinking_expected": thinking_expected},
@@ -2137,13 +2142,13 @@ async def generate_completion(
                 return result
             finally:
                 # Release exactly once on every exit path — success or
-                # exception. Set ``delegated`` so the outer except doesn't
-                # try to release again.
-                if not delegated:
+                # exception. Set the flag so the outer except doesn't try
+                # to release again.
+                if not pin_released_or_transferred:
                     lm.release_ref()
-                    delegated = True
+                    pin_released_or_transferred = True
     except BaseException:
-        if not delegated:
+        if not pin_released_or_transferred:
             lm.release_ref()
         raise
 
@@ -3480,151 +3485,155 @@ async def generate_chat(
         lm = await manager.ensure_loaded(model_name, keep_alive, pin=True)
     stats.load_duration = load_timer.duration_ns
 
-    images = _extract_images(messages)
-
-    # Normalise OpenAI-format tool_calls ({function: {name, arguments: "json"}})
-    # to the flat format chat templates expect ({name, arguments: {...}}).
-    messages = _normalize_tool_calls_in_messages(messages)
-
-    # When native tools are used, clients (e.g. opencode, Claude Code) may
-    # include their own tool-format instructions in the system message that
-    # conflict with the model's native tool call format.  With long prompts,
-    # models like Gemma 4 follow the client's text instructions instead of
-    # generating native tool call tokens.  Appending a short override to the
-    # system message steers the model back to the native format.  We pass
-    # the model's own chat template so the helper can suppress patterns the
-    # template uses natively (e.g. Mistral's `[TOOL_CALLS]`).
-    caps = lm.template_caps or TemplateCaps()
-    if tools and caps.supports_tools:
-        template_text = _get_chat_template_text(lm.tokenizer)
-        messages = _add_native_tool_hint(messages, template_text)
-
-    if lm.is_vlm:
-        # VLM models must use the VLM generation path for tokenization.
-        # Pass tools natively through the template when supported — this
-        # produces model-native formatting (e.g. <|tool> tags for Gemma 4)
-        # which is far more effective than injecting JSON into the system
-        # message.  Fall back to system-message injection for models whose
-        # template lacks tool support.
-        # Resolve enable_thinking for templates that support it.
-        vlm_thinking = enable_thinking if caps.supports_enable_thinking else None
-        # Convert role="tool" messages to tool_responses format for models
-        # that don't support OpenAI-style tool messages (e.g. Gemma 4).
-        if caps.uses_tool_responses:
-            messages = _convert_tool_messages_to_responses(messages)
-        if tools and caps.supports_tools:
-            prompt = _apply_chat_template_vlm(
-                lm.tokenizer,
-                lm.model,
-                messages,
-                images,
-                tools=tools,
-                enable_thinking=vlm_thinking,
-            )
-            logger.info("VLM chat prompt with %d tools (native template)", len(tools))
-        elif tools:
-            vlm_messages = _inject_tools_into_system(list(messages), tools)
-            prompt = _apply_chat_template_vlm(
-                lm.tokenizer,
-                lm.model,
-                vlm_messages,
-                images,
-                enable_thinking=vlm_thinking,
-            )
-            logger.info(
-                "VLM chat prompt with %d tools (injected into system)", len(tools)
-            )
-        else:
-            prompt = _apply_chat_template_vlm(
-                lm.tokenizer,
-                lm.model,
-                messages,
-                images,
-                enable_thinking=vlm_thinking,
-            )
-        logger.debug("Prompt (first 2000 chars): %s", prompt[:2000])
-        logger.debug("Prompt (last 2000 chars): %s", prompt[-2000:])
-        if enable_thinking is not None and vlm_thinking is None:
-            logger.debug(
-                "enable_thinking=%s ignored for VLM model (template does not support it)",
-                enable_thinking,
-            )
-    else:
-        prompt = apply_chat_template_text(
-            lm.text_tokenizer,
-            messages,
-            tools,
-            caps=lm.template_caps,
-            enable_thinking=enable_thinking,
-        )
-        if tools:
-            logger.info("Chat prompt with %d tools", len(tools))
-        logger.debug("Prompt (first 2000 chars): %s", prompt[:2000])
-        logger.debug("Prompt (last 2000 chars): %s", prompt[-2000:])
-
-    # Merge per-model defaults with request options.  options=None means
-    # "use defaults"; options={} means "override all defaults" (empty).
-    merged_options = (
-        {**lm.default_options, **(options or {})}
-        if lm.default_options and options is None
-        else options
-    )
-    gen_kwargs = _build_generate_kwargs(merged_options, is_vlm=lm.is_vlm)
-    mt = gen_kwargs.pop("max_tokens", max_tokens)
-
-    grammar_active = _install_grammar_processor(
-        lm, gen_kwargs, grammar_spec, has_tools=bool(tools)
-    )
-
-    # Prompt caching applies to both streaming and non-streaming requests
-    # (issue #342).  Disabled in distributed mode because rank 0 processes
-    # only suffix tokens on cache hits while workers process the full
-    # prompt, causing all_sum call count mismatch and deadlock.  Disabled
-    # for speculative regardless of stream mode (issue #346): the
-    # speculative decoder owns its own internal target/draft caches and
-    # would receive a misaligned suffix-only prompt on a cache hit —
-    # ``async_speculative_stream`` does not consume ``gen_kwargs['prompt_cache']``.
-    # Also disabled for VLMs on the non-streaming path because
-    # ``mlx_vlm.generate`` accepts neither ``prompt_cache`` nor ``input_ids``.
-    use_prompt_cache = (
-        settings.prompt_cache
-        and make_prompt_cache is not None
-        and not lm.is_distributed
-        and not lm.is_speculative
-        and (stream or not lm.is_vlm)
-    )
-    prompt_tokens = None
-    if use_prompt_cache:
-        prompt_tokens = tokenize_for_cache(lm.text_tokenizer, prompt)
-        # Memory-only peek for debug logging; the authoritative lookup happens
-        # inside _stream_completion/_full_completion under the inference lock.
-        cached_state = lm.prompt_cache_store.peek(cache_id)
-        logger.debug(
-            "Prompt cache enabled: %d prompt tokens, existing cache=%s",
-            len(prompt_tokens),
-            f"{len(cached_state.tokens)} tokens" if cached_state else "none",
-        )
-    else:
-        logger.debug(
-            "Prompt cache disabled: setting=%s stream=%s vlm=%s speculative=%s "
-            "make_prompt_cache=%s",
-            settings.prompt_cache,
-            stream,
-            lm.is_vlm,
-            lm.is_speculative,
-            make_prompt_cache is not None,
-        )
-
-    # Tell streaming routers whether to wait for a (possibly orphaned, see
-    # #307) `</think>` token — shares the rules with `_apply_chat_template`.
-    thinking_expected = _resolve_thinking_active(caps, tools, enable_thinking)
-
     # The pin acquired by ``ensure_loaded(pin=True)`` is released exactly
     # once: by the stream wrapper after the generator exits, by the
-    # non-stream finally below, or by the except below if anything raises
-    # before delegation.
-    delegated = False
+    # non-stream finally below, or by the outer except below if anything
+    # raises before delegation. The outer try must scope from RIGHT AFTER
+    # ensure_loaded (PR #394 aider review) so an exception in the chat
+    # template / kwargs setup doesn't leak the pin.
+    pin_released_or_transferred = False
     try:
+        images = _extract_images(messages)
+
+        # Normalise OpenAI-format tool_calls ({function: {name, arguments: "json"}})
+        # to the flat format chat templates expect ({name, arguments: {...}}).
+        messages = _normalize_tool_calls_in_messages(messages)
+
+        # When native tools are used, clients (e.g. opencode, Claude Code) may
+        # include their own tool-format instructions in the system message that
+        # conflict with the model's native tool call format.  With long prompts,
+        # models like Gemma 4 follow the client's text instructions instead of
+        # generating native tool call tokens.  Appending a short override to the
+        # system message steers the model back to the native format.  We pass
+        # the model's own chat template so the helper can suppress patterns the
+        # template uses natively (e.g. Mistral's `[TOOL_CALLS]`).
+        caps = lm.template_caps or TemplateCaps()
+        if tools and caps.supports_tools:
+            template_text = _get_chat_template_text(lm.tokenizer)
+            messages = _add_native_tool_hint(messages, template_text)
+
+        if lm.is_vlm:
+            # VLM models must use the VLM generation path for tokenization.
+            # Pass tools natively through the template when supported — this
+            # produces model-native formatting (e.g. <|tool> tags for Gemma 4)
+            # which is far more effective than injecting JSON into the system
+            # message.  Fall back to system-message injection for models whose
+            # template lacks tool support.
+            # Resolve enable_thinking for templates that support it.
+            vlm_thinking = enable_thinking if caps.supports_enable_thinking else None
+            # Convert role="tool" messages to tool_responses format for models
+            # that don't support OpenAI-style tool messages (e.g. Gemma 4).
+            if caps.uses_tool_responses:
+                messages = _convert_tool_messages_to_responses(messages)
+            if tools and caps.supports_tools:
+                prompt = _apply_chat_template_vlm(
+                    lm.tokenizer,
+                    lm.model,
+                    messages,
+                    images,
+                    tools=tools,
+                    enable_thinking=vlm_thinking,
+                )
+                logger.info(
+                    "VLM chat prompt with %d tools (native template)", len(tools)
+                )
+            elif tools:
+                vlm_messages = _inject_tools_into_system(list(messages), tools)
+                prompt = _apply_chat_template_vlm(
+                    lm.tokenizer,
+                    lm.model,
+                    vlm_messages,
+                    images,
+                    enable_thinking=vlm_thinking,
+                )
+                logger.info(
+                    "VLM chat prompt with %d tools (injected into system)", len(tools)
+                )
+            else:
+                prompt = _apply_chat_template_vlm(
+                    lm.tokenizer,
+                    lm.model,
+                    messages,
+                    images,
+                    enable_thinking=vlm_thinking,
+                )
+            logger.debug("Prompt (first 2000 chars): %s", prompt[:2000])
+            logger.debug("Prompt (last 2000 chars): %s", prompt[-2000:])
+            if enable_thinking is not None and vlm_thinking is None:
+                logger.debug(
+                    "enable_thinking=%s ignored for VLM model (template does not support it)",
+                    enable_thinking,
+                )
+        else:
+            prompt = apply_chat_template_text(
+                lm.text_tokenizer,
+                messages,
+                tools,
+                caps=lm.template_caps,
+                enable_thinking=enable_thinking,
+            )
+            if tools:
+                logger.info("Chat prompt with %d tools", len(tools))
+            logger.debug("Prompt (first 2000 chars): %s", prompt[:2000])
+            logger.debug("Prompt (last 2000 chars): %s", prompt[-2000:])
+
+        # Merge per-model defaults with request options.  options=None means
+        # "use defaults"; options={} means "override all defaults" (empty).
+        merged_options = (
+            {**lm.default_options, **(options or {})}
+            if lm.default_options and options is None
+            else options
+        )
+        gen_kwargs = _build_generate_kwargs(merged_options, is_vlm=lm.is_vlm)
+        mt = gen_kwargs.pop("max_tokens", max_tokens)
+
+        grammar_active = _install_grammar_processor(
+            lm, gen_kwargs, grammar_spec, has_tools=bool(tools)
+        )
+
+        # Prompt caching applies to both streaming and non-streaming requests
+        # (issue #342).  Disabled in distributed mode because rank 0 processes
+        # only suffix tokens on cache hits while workers process the full
+        # prompt, causing all_sum call count mismatch and deadlock.  Disabled
+        # for speculative regardless of stream mode (issue #346): the
+        # speculative decoder owns its own internal target/draft caches and
+        # would receive a misaligned suffix-only prompt on a cache hit —
+        # ``async_speculative_stream`` does not consume ``gen_kwargs['prompt_cache']``.
+        # Also disabled for VLMs on the non-streaming path because
+        # ``mlx_vlm.generate`` accepts neither ``prompt_cache`` nor ``input_ids``.
+        use_prompt_cache = (
+            settings.prompt_cache
+            and make_prompt_cache is not None
+            and not lm.is_distributed
+            and not lm.is_speculative
+            and (stream or not lm.is_vlm)
+        )
+        prompt_tokens = None
+        if use_prompt_cache:
+            prompt_tokens = tokenize_for_cache(lm.text_tokenizer, prompt)
+            # Memory-only peek for debug logging; the authoritative lookup happens
+            # inside _stream_completion/_full_completion under the inference lock.
+            cached_state = lm.prompt_cache_store.peek(cache_id)
+            logger.debug(
+                "Prompt cache enabled: %d prompt tokens, existing cache=%s",
+                len(prompt_tokens),
+                f"{len(cached_state.tokens)} tokens" if cached_state else "none",
+            )
+        else:
+            logger.debug(
+                "Prompt cache disabled: setting=%s stream=%s vlm=%s speculative=%s "
+                "make_prompt_cache=%s",
+                settings.prompt_cache,
+                stream,
+                lm.is_vlm,
+                lm.is_speculative,
+                make_prompt_cache is not None,
+            )
+
+        # Tell streaming routers whether to wait for a (possibly orphaned, see
+        # #307) `</think>` token — shares the rules with `_apply_chat_template`.
+        thinking_expected = _resolve_thinking_active(caps, tools, enable_thinking)
+
         if stream:
             gen = _stream_completion(
                 lm,
@@ -3640,7 +3649,10 @@ async def generate_chat(
                 grammar_active=grammar_active,
                 adopt_pin=True,
             )
-            delegated = True
+            # Ownership of the pin transfers to the wrapper; its finally
+            # releases on any generator exit. Mark the flag for the outer
+            # except so it doesn't double-release.
+            pin_released_or_transferred = True
             return _prepend_meta(
                 _release_pin_after_gen(gen, lm),
                 {"thinking_expected": thinking_expected},
@@ -3668,11 +3680,11 @@ async def generate_chat(
                 result["thinking_expected"] = thinking_expected
                 return result
             finally:
-                if not delegated:
+                if not pin_released_or_transferred:
                     lm.release_ref()
-                    delegated = True
+                    pin_released_or_transferred = True
     except BaseException:
-        if not delegated:
+        if not pin_released_or_transferred:
             lm.release_ref()
         raise
 

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1277,16 +1277,25 @@ async def _inference_locked(
 
 
 @contextlib.contextmanager
-def _inference_ref(lm: LoadedModel, keep_alive: int | str | None = None):
+def _inference_ref(
+    lm: LoadedModel, keep_alive: int | str | None = None, *, adopt: bool = False
+):
     """Track active inference on a model to prevent expiry during use.
 
-    Note: there is a small window between ``ensure_loaded()`` (which returns
-    the LoadedModel) and the point where ``_inference_ref`` increments
-    ``active_refs``.  During that window the expiry checker could remove the
-    model from ``_loaded``.  This is **safe**: the caller already holds a
-    Python reference to the LoadedModel object, so the model and tokenizer
-    remain alive in memory.  The only side-effect is that the next request
-    would re-load the model into ``_loaded``.
+    When *adopt* is True the caller obtained ``lm`` via
+    ``ensure_loaded(..., pin=True)``, which already incremented ``active_refs``
+    under the lock — so this context manager does NOT increment again; it
+    merely *adopts* that existing pin and releases it on exit. This closes the
+    handoff window: the model is pinned continuously from inside
+    ``ensure_loaded`` (under the lock) through the awaits that precede this
+    block (inference-lock acquisition, async prompt-cache setup) until exit.
+    The caller is responsible for releasing the pin (via ``lm.release_ref()``)
+    on any error path that bypasses this context manager.
+
+    With *adopt* False (the legacy path) this increments on entry as before;
+    a small unprotected window then exists between ``ensure_loaded`` and here,
+    but that path is only used where the caller does not hold the model across
+    awaits.
 
     Bug #118: Python ``+=`` on int is not atomic. Concurrent async tasks can
     race on ``active_refs``. Use the model's ``_active_refs_lock`` to protect
@@ -1296,13 +1305,12 @@ def _inference_ref(lm: LoadedModel, keep_alive: int | str | None = None):
     When a request passes a specific keep_alive, that value is honoured after
     inference instead of being silently replaced with the global default.
     """
-    with lm._active_refs_lock:
-        lm.active_refs += 1
+    if not adopt:
+        lm.acquire_ref()
     try:
         yield
     finally:
-        with lm._active_refs_lock:
-            lm.active_refs -= 1
+        lm.release_ref()
         # Refresh expiry so the model doesn't expire immediately after inference.
         # Honour per-request keep_alive when available (fix #338).
         # Falls back to settings.default_keep_alive when no per-request value

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -443,6 +443,16 @@ class LoadedModel:
                 ram_budget_bytes=ram_budget_bytes,
             )
 
+    def acquire_ref(self) -> None:
+        """Pin the model so eviction/expiry skip it (active_refs += 1)."""
+        with self._active_refs_lock:
+            self.active_refs += 1
+
+    def release_ref(self) -> None:
+        """Release a pin taken by :meth:`acquire_ref` (active_refs -= 1)."""
+        with self._active_refs_lock:
+            self.active_refs -= 1
+
     @property
     def is_speculative(self) -> bool:
         return self.speculative_decoder is not None
@@ -869,9 +879,19 @@ class ModelManager:
                 del lm
 
     async def ensure_loaded(
-        self, name: str, keep_alive: int | str | None = None
+        self, name: str, keep_alive: int | str | None = None, *, pin: bool = False
     ) -> LoadedModel:
-        """Ensure a model is loaded and return it."""
+        """Ensure a model is loaded and return it.
+
+        When *pin* is True the returned model has ``active_refs`` incremented
+        by one **under the lock**, before it is handed back. This closes the
+        handoff window between ``ensure_loaded`` returning and the caller's
+        ``_inference_ref`` taking its reference: during that window (which spans
+        awaits — inference-lock acquisition, async prompt-cache setup) a
+        concurrent load's eviction could otherwise close a model this caller is
+        about to use. The caller MUST release the pin exactly once (the
+        inference paths adopt it via ``_inference_ref(..., adopt=True)``).
+        """
         normalized = self.registry.normalize_name(name)
         if normalized != name:
             logger.info("Normalized model name '%s' -> '%s'", name, normalized)
@@ -912,6 +932,8 @@ class ModelManager:
                         lm.expires_at = time.time() + ka
                     else:
                         lm.expires_at = None
+                    if pin:
+                        lm.acquire_ref()
                     return lm
 
                 # Resolve before eviction — reject unknown models without
@@ -1105,6 +1127,8 @@ class ModelManager:
                     lm = self._loaded[normalized]
                     ka = self._resolve_keep_alive(keep_alive)
                     lm.expires_at = (time.time() + ka) if ka is not None else None
+                    if pin:
+                        lm.acquire_ref()
                     return lm
 
                 if len(self._loaded) >= settings.max_loaded_models:
@@ -1323,6 +1347,8 @@ class ModelManager:
                     # probe state between registration and the yield point.
                     self._loaded[normalized] = lm
                     await self._probe_cache_capabilities(lm)
+                    if pin:
+                        lm.acquire_ref()
                     return lm
                 except BaseException:
                     # Drop references and flush Metal allocator so the memory

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -1346,9 +1346,21 @@ class ModelManager:
                     # Metal flush), so no coroutine can observe an incomplete
                     # probe state between registration and the yield point.
                     self._loaded[normalized] = lm
-                    await self._probe_cache_capabilities(lm)
+                    # Acquire the pin BEFORE the probe's await. unload() does
+                    # not take self._lock; it only checks active_refs > 0.
+                    # If we left active_refs at 0 across the probe's Metal
+                    # flush yield, a concurrent unload could pop and close
+                    # the model before this call returns. Release the pin
+                    # if the probe fails so the outer except's cleanup can
+                    # pop the model normally.
                     if pin:
                         lm.acquire_ref()
+                    try:
+                        await self._probe_cache_capabilities(lm)
+                    except BaseException:
+                        if pin:
+                            lm.release_ref()
+                        raise
                     return lm
                 except BaseException:
                     # Drop references and flush Metal allocator so the memory

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -813,29 +813,32 @@ async def anthropic_count_tokens(req: AnthropicMessagesRequest, request: Request
     )
     resolved_model = _resolve_anthropic_model(req.model)
     manager = request.app.state.model_manager
-    lm = await manager.ensure_loaded(resolved_model)
+    lm = await manager.ensure_loaded(resolved_model, pin=True)
 
-    messages = _convert_messages(req)
-    tools = _convert_tools(req)
+    try:
+        messages = _convert_messages(req)
+        tools = _convert_tools(req)
 
-    enable_thinking: bool | None = None
-    if req.thinking is not None:
-        enable_thinking = _THINKING_TYPE_MAP.get(req.thinking.type)
+        enable_thinking: bool | None = None
+        if req.thinking is not None:
+            enable_thinking = _THINKING_TYPE_MAP.get(req.thinking.type)
 
-    with _inference_ref(lm):
-        loop = asyncio.get_running_loop()
-        token_count = await loop.run_in_executor(
-            None,
-            partial(
-                count_chat_tokens,
-                lm.text_tokenizer,
-                messages,
-                tools,
-                lm.template_caps,
-                enable_thinking=enable_thinking,
-            ),
-        )
-    return AnthropicTokenCountResponse(input_tokens=token_count)
+        with _inference_ref(lm, adopt=True):
+            loop = asyncio.get_running_loop()
+            token_count = await loop.run_in_executor(
+                None,
+                partial(
+                    count_chat_tokens,
+                    lm.text_tokenizer,
+                    messages,
+                    tools,
+                    lm.template_caps,
+                    enable_thinking=enable_thinking,
+                ),
+            )
+        return AnthropicTokenCountResponse(input_tokens=token_count)
+    finally:
+        lm.release_ref()
 
 
 @router.post(

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -13,6 +13,7 @@ from olmlx.engine.inference import (
     _apply_seed,
     _build_generate_kwargs,
     _full_completion,
+    _inference_ref,
     _make_frequency_penalty_processor,
     _make_presence_penalty_processor,
     estimate_kv_cache_bytes,
@@ -31,6 +32,7 @@ from olmlx.engine.inference import (
     ServerBusyError,
 )
 from olmlx.engine.template_caps import TemplateCaps
+from olmlx.engine.model_manager import LoadedModel
 from olmlx.engine.inference import _derive_timing_stats
 from olmlx.utils.streaming import CancellableStream, StreamToken
 from olmlx.utils.timing import TimingStats
@@ -55,6 +57,29 @@ class TestDeriveTimingStats:
         _derive_timing_stats(stats, 0.0, 0.0, eval_timer_ns=1_000_000_000)
         assert stats.prompt_eval_duration == 1_000_000_000
         assert stats.eval_duration == 0
+
+    def test_inference_ref_adopt_does_not_double_count(self):
+        """adopt=True must NOT increment on entry (the pin already did), and
+        must release exactly once on exit — net 0 change while a pre-pinned
+        model stays pinned (refs==1) for the duration."""
+        lm = LoadedModel(
+            name="a", hf_path="a/a", model=MagicMock(), tokenizer=MagicMock()
+        )
+        lm.acquire_ref()  # simulate ensure_loaded(pin=True)
+        assert lm.active_refs == 1
+        with _inference_ref(lm, adopt=True):
+            assert lm.active_refs == 1  # adopted, not double-counted
+        assert lm.active_refs == 0  # released exactly once on exit
+
+    def test_inference_ref_legacy_increments(self):
+        """adopt=False (legacy) increments on entry, releases on exit."""
+        lm = LoadedModel(
+            name="a", hf_path="a/a", model=MagicMock(), tokenizer=MagicMock()
+        )
+        assert lm.active_refs == 0
+        with _inference_ref(lm):
+            assert lm.active_refs == 1
+        assert lm.active_refs == 0
 
     def test_decode_subtracts_prefill_from_wall_clock(self):
         """When gen_tps is missing but prompt_tps is known, decode-only time

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -58,10 +58,12 @@ class TestDeriveTimingStats:
         assert stats.prompt_eval_duration == 1_000_000_000
         assert stats.eval_duration == 0
 
-    def test_inference_ref_adopt_does_not_double_count(self):
-        """adopt=True must NOT increment on entry (the pin already did), and
-        must release exactly once on exit — net 0 change while a pre-pinned
-        model stays pinned (refs==1) for the duration."""
+    def test_inference_ref_adopt_does_not_touch_ref_count(self):
+        """adopt=True must NOT increment on entry (the pin already did) and
+        must NOT release on exit — the caller's outer try/finally owns the
+        single pin release. Splitting acquire/release like this avoids
+        races where _inference_ref's finally and the caller's cleanup
+        could both try to release. Net 0 change across the with block."""
         lm = LoadedModel(
             name="a", hf_path="a/a", model=MagicMock(), tokenizer=MagicMock()
         )
@@ -69,7 +71,9 @@ class TestDeriveTimingStats:
         assert lm.active_refs == 1
         with _inference_ref(lm, adopt=True):
             assert lm.active_refs == 1  # adopted, not double-counted
-        assert lm.active_refs == 0  # released exactly once on exit
+        assert lm.active_refs == 1  # still pinned; caller releases
+        lm.release_ref()
+        assert lm.active_refs == 0
 
     def test_inference_ref_legacy_increments(self):
         """adopt=False (legacy) increments on entry, releases on exit."""

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -3164,6 +3164,59 @@ class TestMemoryCheck:
         assert "qwen3:latest" not in manager._loaded
 
     @pytest.mark.asyncio
+    async def test_ensure_loaded_pin_increments_active_refs(self, registry, mock_store):
+        """ensure_loaded(pin=True) returns the model already pinned (refs==1)."""
+        manager = ModelManager(registry, mock_store)
+        total_ram = 64 * self.GB
+        with (
+            patch.object(
+                manager,
+                "_load_model",
+                return_value=(MagicMock(), MagicMock(), False, TemplateCaps(), None),
+            ),
+            patch(
+                "olmlx.utils.memory.get_metal_memory",
+                side_effect=[1 * self.GB, int(total_ram * 0.40)],
+            ),
+            patch("olmlx.utils.memory.get_system_memory_bytes", return_value=total_ram),
+            patch("olmlx.utils.memory.is_memory_pressure_high", return_value=False),
+            patch("olmlx.engine.model_manager.gc.collect"),
+            patch("olmlx.engine.model_manager.mx.clear_cache"),
+            patch("olmlx.engine.model_manager.mx.synchronize"),
+        ):
+            lm = await manager.ensure_loaded("qwen3", pin=True)
+        assert lm.active_refs == 1
+        # Re-ensuring the already-loaded model with pin=True pins again.
+        with patch("olmlx.utils.memory.is_memory_pressure_high", return_value=False):
+            lm2 = await manager.ensure_loaded("qwen3", pin=True)
+        assert lm2 is lm
+        assert lm.active_refs == 2
+
+    @pytest.mark.asyncio
+    async def test_ensure_loaded_default_does_not_pin(self, registry, mock_store):
+        """Default ensure_loaded (pin=False) leaves active_refs at 0."""
+        manager = ModelManager(registry, mock_store)
+        total_ram = 64 * self.GB
+        with (
+            patch.object(
+                manager,
+                "_load_model",
+                return_value=(MagicMock(), MagicMock(), False, TemplateCaps(), None),
+            ),
+            patch(
+                "olmlx.utils.memory.get_metal_memory",
+                side_effect=[1 * self.GB, int(total_ram * 0.40)],
+            ),
+            patch("olmlx.utils.memory.get_system_memory_bytes", return_value=total_ram),
+            patch("olmlx.utils.memory.is_memory_pressure_high", return_value=False),
+            patch("olmlx.engine.model_manager.gc.collect"),
+            patch("olmlx.engine.model_manager.mx.clear_cache"),
+            patch("olmlx.engine.model_manager.mx.synchronize"),
+        ):
+            lm = await manager.ensure_loaded("qwen3")
+        assert lm.active_refs == 0
+
+    @pytest.mark.asyncio
     async def test_inference_headroom_default_does_not_reject(
         self, registry, mock_store, monkeypatch
     ):
@@ -4130,6 +4183,25 @@ class TestEvictLruIfNeeded:
         manager._loaded["only"] = only
         assert manager._pop_one_idle_lru(exclude="only") is None
         assert "only" in manager._loaded
+
+    def test_pinned_model_not_evicted(self, registry, mock_store):
+        """A pinned model (acquire_ref) is not idle, so eviction skips it.
+
+        This is the protection ensure_loaded(pin=True) buys: a model pinned
+        under the lock cannot be popped by the pressure-eviction loop in the
+        handoff window before the caller's _inference_ref adopts the pin.
+        """
+        manager = ModelManager(registry, mock_store)
+        lm = LoadedModel(
+            name="a", hf_path="a/a", model=MagicMock(), tokenizer=MagicMock()
+        )
+        manager._loaded["a"] = lm
+        lm.acquire_ref()
+        assert lm.active_refs == 1
+        assert manager._pop_one_idle_lru() is None  # pinned → protected
+        lm.release_ref()
+        assert lm.active_refs == 0
+        assert manager._pop_one_idle_lru() is lm  # released → evictable
 
     @pytest.mark.asyncio
     async def test_close_evictees_does_not_touch_gc_or_metal(

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -304,6 +304,91 @@ class TestModelManager:
         assert "qwen3:latest" in manager._loaded
 
     @pytest.mark.asyncio
+    async def test_ensure_loaded_pin_survives_unload_during_probe(
+        self, registry, mock_store, monkeypatch
+    ):
+        """Regression for PR #394 review: unload() runs without the manager
+        lock, so during a freshly-loaded model's _probe_cache_capabilities
+        await it can pop the model out from under a caller that asked for
+        a pin. The pin must be acquired BEFORE the probe await so the
+        active_refs == 0 check in unload() rejects the close."""
+        import asyncio
+
+        from olmlx.engine.model_manager import ActiveRequestsError
+
+        monkeypatch.setattr("olmlx.engine.model_manager.settings.max_loaded_models", 10)
+        monkeypatch.setattr(
+            "olmlx.engine.model_manager.mx.metal.is_available", lambda: True
+        )
+        manager = ModelManager(registry, mock_store)
+
+        probe_in_flight = asyncio.Event()
+        probe_done = asyncio.Event()
+
+        model = MagicMock()
+        tokenizer = MagicMock()
+        tokenizer.chat_template = None
+
+        async def _stalling_probe(lm):
+            lm.supports_cache_trim = True
+            lm.supports_cache_persistence = True
+            probe_in_flight.set()
+            await probe_done.wait()
+
+        manager._probe_cache_capabilities = _stalling_probe  # type: ignore[method-assign]
+
+        total_ram = 64 * 1024**3
+
+        with (
+            patch.object(
+                manager,
+                "_load_model",
+                return_value=(model, tokenizer, False, TemplateCaps(), None),
+            ),
+            patch.object(manager, "_flush_metal", new_callable=AsyncMock),
+            patch.object(manager, "_close_loaded_model"),
+            patch(
+                "olmlx.utils.memory.get_metal_memory",
+                return_value=1 * 1024**3,
+            ),
+            patch(
+                "olmlx.utils.memory.get_system_memory_bytes",
+                return_value=total_ram,
+            ),
+            patch(
+                "olmlx.utils.memory.is_memory_pressure_high",
+                return_value=False,
+            ),
+            patch("olmlx.engine.model_manager.gc.collect"),
+        ):
+            # Caller asks for a pin.
+            load_task = asyncio.ensure_future(manager.ensure_loaded("qwen3", pin=True))
+
+            # Wait until the probe has started (model is registered in _loaded).
+            await asyncio.wait_for(probe_in_flight.wait(), timeout=5.0)
+
+            # Concurrent unload while the probe is still awaiting. With the
+            # bug, active_refs is still 0 here and unload pops the model.
+            # With the fix, the pin was already acquired and unload raises.
+            unload_raised = False
+            try:
+                await manager.unload("qwen3")
+            except ActiveRequestsError:
+                unload_raised = True
+
+            # Let the probe finish.
+            probe_done.set()
+            lm = await asyncio.wait_for(load_task, timeout=5.0)
+
+        assert unload_raised, (
+            "unload() should have raised ActiveRequestsError; the pin was "
+            "not acquired before the probe await."
+        )
+        assert "qwen3:latest" in manager._loaded
+        assert manager._loaded["qwen3:latest"] is lm
+        assert lm.active_refs == 1  # caller still holds the pin
+
+    @pytest.mark.asyncio
     async def test_ensure_loaded_refreshes_expiry(self, mock_manager):
         lm = await mock_manager.ensure_loaded("qwen3", keep_alive="10m")
         assert lm.expires_at is not None

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -1692,6 +1692,33 @@ class TestPinReleasedAcrossStreamingHandoff:
     case where the wrapper's aclose propagates to the inner generator."""
 
     @pytest.mark.asyncio
+    async def test_pin_released_when_setup_raises_before_dispatch(self, mock_manager):
+        """Regression for PR #394 aider review: an exception in the
+        chat-template / kwargs setup code (between ensure_loaded(pin=True)
+        and the dispatch try block) must release the pin so the model
+        doesn't stay permanently pinned."""
+        from olmlx.engine.inference import generate_chat
+
+        lm = mock_manager._loaded["qwen3:latest"]
+        # Apply chat template blows up before dispatch.
+        lm.tokenizer.apply_chat_template = MagicMock(
+            side_effect=RuntimeError("synthetic template failure")
+        )
+        assert lm.active_refs == 0
+
+        with pytest.raises(RuntimeError, match="synthetic template failure"):
+            await generate_chat(
+                mock_manager,
+                "qwen3",
+                [{"role": "user", "content": "hi"}],
+                stream=False,
+            )
+
+        # The pin must be released — not stuck at 1 — even though the
+        # exception fired before the dispatch try block.
+        assert lm.active_refs == 0
+
+    @pytest.mark.asyncio
     async def test_pin_released_on_aclose_mid_stream(self, mock_manager):
         from olmlx.engine.inference import generate_chat
 

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -1686,6 +1686,61 @@ class TestCacheExactMatchTrimAlignment:
         assert cache_info["cache_creation_tokens"] == 1
 
 
+class TestPinReleasedAcrossStreamingHandoff:
+    """The pin acquired by ensure_loaded(pin=True) must be released when the
+    streaming generator exits, including the mid-stream client-disconnect
+    case where the wrapper's aclose propagates to the inner generator."""
+
+    @pytest.mark.asyncio
+    async def test_pin_released_on_aclose_mid_stream(self, mock_manager):
+        from olmlx.engine.inference import generate_chat
+
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.tokenizer.apply_chat_template = MagicMock(return_value="prompt")
+        lm.tokenizer.bos_token = None
+        lm.tokenizer.encode = MagicMock(return_value=[10, 20, 30])
+        assert lm.active_refs == 0
+
+        mock_make_cache = MagicMock(return_value=[MagicMock()])
+        mock_mx = MagicMock()
+        with (
+            patch("olmlx.engine.inference.mx", mock_mx),
+            patch(
+                "olmlx.engine.inference.async_mlx_stream",
+                return_value=_make_mock_stream(
+                    _make_stream_tokens("hi", prompt_tokens=3)
+                ),
+            ),
+            patch("olmlx.engine.inference.make_prompt_cache", mock_make_cache),
+            patch("olmlx.engine.inference.settings") as mock_settings,
+        ):
+            mock_settings.prompt_cache = True
+            mock_settings.prompt_cache_max_tokens = 32768
+            mock_settings.default_keep_alive = "5m"
+            mock_settings.inference_timeout = None
+            mock_settings.sync_mode = "full"
+            gen = await generate_chat(
+                mock_manager,
+                "qwen3",
+                [{"role": "user", "content": "hi"}],
+                stream=True,
+            )
+            # Iterate to first cache_info, then close (mid-stream disconnect).
+            while True:
+                chunk = await gen.__anext__()
+                if chunk.get("cache_info") is True:
+                    break
+            # The pin is held during streaming.
+            assert lm.active_refs == 1, "pin must be held while the stream is in flight"
+            await gen.aclose()
+
+        # After aclose, the pin is released — even though _inference_ref's
+        # finally and the lock/cache cleanup ran via GeneratorExit, the
+        # _release_pin_after_gen wrapper's aclose-in-finally propagated and
+        # its finally released exactly once.
+        assert lm.active_refs == 0
+
+
 class TestLockReleasedOnCacheInfoDisconnect:
     @pytest.mark.asyncio
     async def test_lock_released_when_generator_closed_at_cache_info(

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -1999,7 +1999,7 @@ class TestAnthropicModelResolution:
             )
 
         assert resp.status_code == 200
-        mock_ensure.assert_called_with("qwen3-8b:latest")
+        mock_ensure.assert_called_with("qwen3-8b:latest", pin=True)
 
 
 class TestXCacheIDHeader:


### PR DESCRIPTION
Closes #393. Split out of #392 (memory-pressure eviction, #223) — see #393 for the full background and the aider review thread that surfaced this.

## The race

`ensure_loaded()` returns a `LoadedModel` to a caller, but the caller doesn't increment `active_refs` until later (inside `_inference_ref`). The inference paths `await` **before** that point (`_acquire_inference_lock`, `await _setup_prompt_cache`, `_kv_cache_preflight_check`), so during those awaits a concurrent `ensure_loaded` can run its eviction, classify this model as idle (`active_refs == 0`), pop it and close its resources — breaking the first caller (notably Flash/Flash-MoE, whose weight-store FDs get closed mid-stream). Pre-existing and shared by `_pop_lru_evictees` and `_expire_stale`.

## This PR — core mechanism (backward-compatible)

- `LoadedModel.acquire_ref()` / `release_ref()`
- `ensure_loaded(..., pin=False)` — `pin=True` increments `active_refs` **under the lock** at all 3 return points → the returned model is pinned atomically, no window
- `_inference_ref(..., adopt=False)` — `adopt=True` adopts the existing pin (no re-increment), releases on exit

Both params default off, so every existing call site is unchanged. 5 new tests; full suite green (510 passed).

## Remaining (draft → ready): integrate the 7 consumers

Each inference consumer must switch to `ensure_loaded(pin=True)` + `_inference_ref(adopt=True)` with a try/finally that releases the adopted pin on **every** error path that bypasses the `with`:

- [ ] `generate_completion` (stream + full delegation)
- [ ] `generate_chat`
- [ ] `_stream_completion` (pre-`with` raises: lock-acquire timeout, deferred-cleanup, sync)
- [ ] `_full_completion`
- [ ] `generate_embeddings`
- [ ] `generate_transcription`
- [ ] anthropic `/v1/messages`
- [ ] **never-started streaming generator** handling (its `finally` can't run) — wrap or accept reliance on the asyncio async-gen finalizer; decide explicitly
- [ ] stress test: load/evict loop asserts no `active_refs` leak

**Failure mode to guard against:** a missed release leaks a pin → that model becomes permanently un-evictable (`"All loaded models are in use"`). Every release path gets a test first.

Draft until the integration + leak-stress tests land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)