### PR TITLE
fix(prompt_cache): support gpt-oss / Harmony chat templates

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1690,13 +1690,31 @@ def apply_chat_template_text(
     )
 
 
+_KNOWN_EOM_TOKEN_STRINGS: tuple[str, ...] = (
+    # Harmony format (gpt-oss): ``eos_token_id`` is ``<|return|>``
+    # (end-of-generation, never appears in input), but the actual
+    # end-of-message marker is ``<|end|>``.
+    "<|end|>",
+    # Gemma chat template: ``eos_token_id`` is the base ``<eos>``;
+    # the per-message terminator is ``<end_of_turn>``.
+    "<end_of_turn>",
+)
+
+
 def _message_boundary_token_ids(tokenizer: Any) -> set[int]:
     """Return the set of token IDs that mark end-of-message in chat templates.
 
-    Primary signal: ``tokenizer.eos_token_id``.  For Qwen3 this is
-    ``<|im_end|>``, for Llama 3 ``<|eot_id|>``, for Gemma ``<end_of_turn>``.
-    All three are reliably the end-of-message marker in their respective
-    chat templates.
+    Combines two signals:
+
+    1. ``tokenizer.eos_token_id`` — works for templates where the EOS IS
+       the message-end marker: Qwen3 ``<|im_end|>``, Llama 3 ``<|eot_id|>``,
+       Nemotron-style ``<|im_end|>``.
+
+    2. Known per-template message-end strings looked up via
+       ``convert_tokens_to_ids`` — for templates where the EOS is *not* the
+       message-end marker (gpt-oss Harmony format, where eos is
+       ``<|return|>`` but messages end with ``<|end|>``; Gemma chat where
+       the per-turn marker is ``<end_of_turn>`` not the base ``<eos>``).
 
     For tokenizers like Llama 2's where ``eos_token_id`` (``</s>``) can in
     principle appear inside content, ``tokenize_segmented_chat`` falls back
@@ -1704,13 +1722,25 @@ def _message_boundary_token_ids(tokenizer: Any) -> set[int]:
     guard; ``_setup_via_checkpoint_path`` then skips the checkpoint path
     for the request.
     """
+    out: set[int] = set()
     eos = getattr(tokenizer, "eos_token_id", None)
-    if eos is None:
-        return set()
-    # Some tokenizers wrap the EOS in a list of valid stops.
-    if isinstance(eos, (list, tuple, set)):
-        return {int(x) for x in eos if x is not None}
-    return {int(eos)}
+    if eos is not None:
+        if isinstance(eos, (list, tuple, set)):
+            out.update(int(x) for x in eos if x is not None)
+        else:
+            out.add(int(eos))
+    convert = getattr(tokenizer, "convert_tokens_to_ids", None)
+    unk = getattr(tokenizer, "unk_token_id", None)
+    if callable(convert):
+        for tok_str in _KNOWN_EOM_TOKEN_STRINGS:
+            try:
+                tok_id = convert(tok_str)
+            except Exception:
+                continue
+            if tok_id is None or tok_id == unk:
+                continue
+            out.add(int(tok_id))
+    return out
 
 
 def tokenize_segmented_chat(
@@ -1804,11 +1834,14 @@ def tokenize_segmented_chat(
         if tok in eom_ids:
             boundaries.append(i + 1)
 
-    # Most chat templates emit exactly one EOM per message.  When the
-    # count doesn't match, the template either doesn't follow the EOM
-    # convention or emits multiple markers per message (rare).  Fall
-    # back to single segment rather than guess.
-    if len(boundaries) != len(messages):
+    # Most chat templates emit exactly one EOM per message. Some
+    # (Harmony / gpt-oss) emit extras because the template injects a
+    # baseline preamble (system message about output channels) that the
+    # caller didn't supply. Accept extras by treating them as preamble
+    # segments at the start with the first caller-supplied role; reject
+    # only when boundaries < messages (the template emitted FEWER EOMs
+    # than expected, which means we can't safely align roles).
+    if len(boundaries) < len(messages):
         return SegmentedPrompt(
             segments=[Segment(tokens=full, role=messages[-1]["role"])]
         )
@@ -1818,10 +1851,16 @@ def tokenize_segmented_chat(
     if boundaries[-1] < len(full):
         boundaries[-1] = len(full)
 
+    # Build the role list, padding the front with extras using
+    # ``messages[0]["role"]`` so the LRU eviction tier still picks a
+    # sensible (typically "system") priority for the injected preamble.
+    extras = len(boundaries) - len(messages)
+    roles: list[Any] = [messages[0]["role"]] * extras + [m["role"] for m in messages]
+
     segments: list[Segment] = []
     start = 0
     for k, end in enumerate(boundaries):
-        segments.append(Segment(tokens=full[start:end], role=messages[k]["role"]))
+        segments.append(Segment(tokens=full[start:end], role=roles[k]))
         start = end
     return SegmentedPrompt(segments=segments)
 

--- a/tests/test_inference_checkpoint_drive.py
+++ b/tests/test_inference_checkpoint_drive.py
@@ -109,6 +109,50 @@ def test_drive_skips_segments_below_already_covered():
     assert suffix == [5]
 
 
+def test_tokenize_segmented_chat_accepts_extra_eom_boundaries():
+    """For templates like gpt-oss Harmony that inject a baseline
+    system/developer message, the EOM-boundary count exceeds the input
+    message count by 1+. The function must accept extras and treat them
+    as preamble segments rather than falling back to a single segment."""
+
+    class _HarmonyLikeTokenizer:
+        eos_token_id = 9
+        unk_token_id = None
+
+        def convert_tokens_to_ids(self, tok_str):
+            return None
+
+        def apply_chat_template(self, messages, **kwargs):
+            # Template emits: <PREAMBLE_ROLE 7> ... <EOM 9>, then the
+            # caller's messages each as <ROLE_TAG> ... <EOM 9>.
+            ROLE = {"system": 1, "user": 2, "assistant": 3}
+            out = [7, 100, 101, 9]  # preamble emitted by the template
+            for m in messages:
+                out.append(ROLE[m["role"]])
+                out.extend(ord(c) for c in m["content"])
+                out.append(9)
+            return out
+
+    tok = _HarmonyLikeTokenizer()
+    messages = [
+        {"role": "system", "content": "AB"},
+        {"role": "user", "content": "CD"},
+    ]
+    full = tok.apply_chat_template(messages)
+    sp = tokenize_segmented_chat(tok, messages, full_tokens=list(full))
+    # 3 EOMs in `full`: one for the template-injected preamble plus one
+    # per caller message. Result: 3 segments.
+    assert len(sp.segments) == 3, (
+        f"expected 3 segments (1 preamble + 2 caller), got {len(sp.segments)}"
+    )
+    # The flatten() must still equal the input.
+    assert sp.flatten() == list(full)
+    # Preamble role takes the first caller-supplied role.
+    assert sp.segments[0].role == "system"
+    assert sp.segments[1].role == "system"  # caller's first message
+    assert sp.segments[2].role == "user"  # caller's second message
+
+
 def test_tokenize_segmented_chat_returns_one_segment_per_message():
     tok = _FakeTokenizer()
     messages = [
@@ -261,6 +305,45 @@ def test_message_boundary_token_ids_returns_empty_when_none():
         eos_token_id = None
 
     assert _message_boundary_token_ids(_NoEos()) == set()
+
+
+def test_message_boundary_token_ids_picks_up_harmony_end_token():
+    """For gpt-oss / Harmony format, eos_token_id is <|return|> (end of
+    generation, never in input prompts). The actual per-message marker
+    is <|end|>. The helper must include any known per-template marker
+    that the tokenizer can resolve to a real (non-UNK) token id."""
+
+    class _HarmonyTokenizer:
+        eos_token_id = 200002  # <|return|>
+        unk_token_id = None
+
+        def convert_tokens_to_ids(self, tok_str):
+            mapping = {
+                "<|end|>": 200007,
+                "<end_of_turn>": None,  # not present in this template
+            }
+            return mapping.get(tok_str)
+
+    ids = _message_boundary_token_ids(_HarmonyTokenizer())
+    assert ids == {200002, 200007}, (
+        f"expected eos + <|end|>, got {ids} — Harmony-format models won't "
+        f"see message boundaries without the extra lookup"
+    )
+
+
+def test_message_boundary_token_ids_skips_unk_lookups():
+    """Tokenizers return unk_token_id for unknown strings — these must
+    NOT pollute the boundary set."""
+
+    class _UnkReturningTokenizer:
+        eos_token_id = 9
+        unk_token_id = 0
+
+        def convert_tokens_to_ids(self, _):
+            return self.unk_token_id
+
+    ids = _message_boundary_token_ids(_UnkReturningTokenizer())
+    assert ids == {9}, f"unk leaked into boundary set: {ids}"
 
 
 def test_tokenize_segmented_chat_falls_back_when_no_eos():


### PR DESCRIPTION
## Summary

Two gaps in the checkpoint mechanism (#397) prevented gpt-oss models from engaging it. Surfaced by a multi-model verification pass on locally-cached models.

### Gap 1: `_message_boundary_token_ids` only knew about `eos_token_id`

For Harmony format (gpt-oss): `eos_token_id` is `<|return|>` (end-of-generation, never appears in input prompts). The actual per-message terminator is `<|end|>`. The single-token lookup found 0 EOMs, the function returned a single-segment fallback, and the checkpoint path stored nothing.

**Fix:** added `_KNOWN_EOM_TOKEN_STRINGS = ("<|end|>", "<end_of_turn>")`, resolved via `tokenizer.convert_tokens_to_ids`, filtering None/UNK. The helper now returns both the EOS and any known per-template marker.

### Gap 2: strict `boundaries == messages` count check

gpt-oss's Harmony template injects a baseline preamble (a system message describing output channels) before caller-supplied messages, producing N+1 EOMs for N messages. The strict `!=` guard then rejected and fell back to single segment.

**Fix:** loosened to `boundaries < messages` (reject only when EOMs are missing). Extras at the front are treated as preamble segments and labeled with the first caller-supplied role for the LRU eviction tier.

## End-to-end verification

`mlx-community/gpt-oss-20b-MXFP4-Q8`, 3-request shared-system-prompt scenario:

|                | Before (post-#397) | After |
|----------------|--------------------|-------|
| Wall (warm)    | 449 ms             | 283 ms (**1.6x**) |
| `radix_hits`   | 0                  | 2 |
| `bytes_in_ram` | 0                  | 17 MB |

Before: silent fallback to flat path which is also blocked for non-trimmable `RotatingKVCache`/`ChunkedKVCache` layouts — zero cross-request reuse.
After: checkpoint path engaged via Harmony EOM, real KV reuse, real speedup.

## Tests

- `test_message_boundary_token_ids_picks_up_harmony_end_token`
- `test_message_boundary_token_ids_skips_unk_lookups`
- `test_tokenize_segmented_chat_accepts_extra_eom_boundaries`

All passing locally (246 in `test_inference_checkpoint_drive.py` + `test_inference.py`).

## Multi-model verification (full set)

|                                         | Cache layout                        | Result |
|-----------------------------------------|--------------------------------------|--------|
| `Qwen3-0.6B-4bit`                       | Pure KVCache                         | Flat path: `cache_id_hits=2`, 29 MB |
| `Qwen3.5-0.8B-MLX-4bit`                 | ArraysCache hybrid SSM               | Checkpoint: `radix_hits=2`, 22 MB |
| `Nemotron-Cascade-2-30B-A3B-4bit`       | ArraysCache Mamba hybrid             | Checkpoint: `radix_hits=2`, 51 MB |
| `gemma-4-e2b-it-OptiQ-4bit`             | VLM (Gemma 4)                        | Correctly excluded (VLM gate from `aabc3aa`) |
| `gpt-oss-20b-MXFP4-Q8`                  | RotatingKVCache + ChunkedKVCache     | **This PR**: checkpoint engaged, `radix_hits=2`, 17 MB |
| `Qwen3-Next-80B-A3B-Instruct-4bit`      | Mixed RotatingKVCache + ArraysCache  | Correctly excluded (#396) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)