### PR TITLE
fix(prompt_cache): exclude TurboQuant/SpectralQuant from checkpoint path

### DIFF
--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2098,8 +2098,22 @@ class ModelManager:
             # path's _drive_segmented_prefill calls ``model(arr, cache=cache)``
             # text-only, which crashes (mlx-vlm models require image inputs)
             # or silently produces wrong cache state.  mlx-vlm also doesn't
-            # forward ``prompt_cache`` from gen_kwargs.
-            lm.uses_checkpoint_persistence = ckpt_ok and not trim_ok and not lm.is_vlm
+            # forward ``prompt_cache`` from gen_kwargs.  TurboQuant /
+            # SpectralQuant caches are excluded because their layer state
+            # holds an ``mx.Dtype`` reference that ``copy.deepcopy`` (used
+            # by ``snapshot_cache_for_persistence``) can't pickle —
+            # mirrors the existing disk-save exclusion in
+            # ``_is_serializable_cache``.
+            kv_quant_blocks_snapshot = lm.kv_cache_quant is not None and (
+                lm.kv_cache_quant.startswith("turboquant:")
+                or lm.kv_cache_quant.startswith("spectral:")
+            )
+            lm.uses_checkpoint_persistence = (
+                ckpt_ok
+                and not trim_ok
+                and not lm.is_vlm
+                and not kv_quant_blocks_snapshot
+            )
             lm.supports_cache_trim = trim_ok
             lm.supports_cache_persistence = persist_ok or lm.uses_checkpoint_persistence
             probe_succeeded = True

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -234,6 +234,34 @@ def _is_serializable_cache(cache: list) -> bool:
     )
 
 
+# KV-quant config string prefixes whose backing cache class stores an
+# ``mx.Dtype`` reference that ``copy.deepcopy`` (used by
+# ``snapshot_cache_for_persistence``) can't pickle.  See
+# ``_is_serializable_cache`` for the parallel class-level allowlist used
+# at the disk-save layer.  Centralised so a rename of either prefix is a
+# one-line update.
+_KV_QUANT_PREFIXES_BLOCKING_SNAPSHOT: tuple[str, ...] = (
+    "turboquant:",
+    "spectral:",
+)
+
+
+def _kv_quant_blocks_snapshot(kv_cache_quant: str | None) -> bool:
+    """True iff ``kv_cache_quant`` selects a quantization wrapper whose
+    layer state can't be deep-copied (the checkpoint path requirement).
+
+    Prefix-based because the probe constructs the bare (unquantized) cache
+    by design — see the comment on ``_probe_cache_capabilities`` — so we
+    can't check via ``isinstance`` like ``_is_serializable_cache`` does.
+    """
+    if kv_cache_quant is None:
+        return False
+    return any(
+        kv_cache_quant.startswith(prefix)
+        for prefix in _KV_QUANT_PREFIXES_BLOCKING_SNAPSHOT
+    )
+
+
 # mlx-lm cache classes whose `trim(n)` reliably removes exactly n tokens from
 # any offset (no silent under-delivery).  Class-name allowlist is authoritative
 # because `is_trimmable()` on a fresh (offset==0) cache cannot detect rotate
@@ -2104,15 +2132,11 @@ class ModelManager:
             # by ``snapshot_cache_for_persistence``) can't pickle —
             # mirrors the existing disk-save exclusion in
             # ``_is_serializable_cache``.
-            kv_quant_blocks_snapshot = lm.kv_cache_quant is not None and (
-                lm.kv_cache_quant.startswith("turboquant:")
-                or lm.kv_cache_quant.startswith("spectral:")
-            )
             lm.uses_checkpoint_persistence = (
                 ckpt_ok
                 and not trim_ok
                 and not lm.is_vlm
-                and not kv_quant_blocks_snapshot
+                and not _kv_quant_blocks_snapshot(lm.kv_cache_quant)
             )
             lm.supports_cache_trim = trim_ok
             lm.supports_cache_persistence = persist_ok or lm.uses_checkpoint_persistence

--- a/tests/test_probe_cache_capabilities_v2.py
+++ b/tests/test_probe_cache_capabilities_v2.py
@@ -87,3 +87,51 @@ def test_probe_excludes_vlm_from_checkpoint_path_regardless_of_layer_layout(
     # rules — ArraysCache is non-trimmable so the existing #284 fold
     # keeps it non-persistable too.
     assert lm.supports_cache_persistence is False
+
+
+def test_probe_excludes_turboquant_from_checkpoint_path(monkeypatch):
+    """Regression: TurboQuantKVCache holds an mx.Dtype object that
+    copy.deepcopy can't pickle. Without this gate the checkpoint path
+    would crash with TypeError: cannot pickle 'Dtype' object on every
+    request for a TurboQuant-quantized model whose underlying layout
+    would otherwise qualify (e.g. Qwen3-Coder-Next, Qwen3-Next mixed
+    isn't affected because it's already excluded by #396)."""
+    lm = LoadedModel(
+        name="x",
+        hf_path="y",
+        model=None,
+        tokenizer=None,
+        kv_cache_quant="turboquant:4",
+    )
+    cache = _fake_cache_with(ArraysCache)
+    monkeypatch.setattr(
+        "mlx_lm.models.cache.make_prompt_cache",
+        lambda model: cache,
+    )
+    mgr = ModelManager.__new__(ModelManager)
+    mgr._pending_cleanups = {"skip_metal_flush": True}
+    asyncio.run(mgr._probe_cache_capabilities(lm))
+    assert lm.uses_checkpoint_persistence is False, (
+        "TurboQuant must be excluded from the checkpoint path"
+    )
+
+
+def test_probe_excludes_spectralquant_from_checkpoint_path(monkeypatch):
+    """Same as TurboQuant — SpectralQuant exposes the same Dtype-bearing
+    state that breaks deepcopy."""
+    lm = LoadedModel(
+        name="x",
+        hf_path="y",
+        model=None,
+        tokenizer=None,
+        kv_cache_quant="spectral:4",
+    )
+    cache = _fake_cache_with(ArraysCache)
+    monkeypatch.setattr(
+        "mlx_lm.models.cache.make_prompt_cache",
+        lambda model: cache,
+    )
+    mgr = ModelManager.__new__(ModelManager)
+    mgr._pending_cleanups = {"skip_metal_flush": True}
+    asyncio.run(mgr._probe_cache_capabilities(lm))
+    assert lm.uses_checkpoint_persistence is False


### PR DESCRIPTION
## Bug

Reported in production:

```
[ERROR] olmlx.routers.openai: Error during OpenAI streaming: cannot pickle 'Dtype' object
[...]
File "olmlx/engine/prompt_cache/checkpoint.py", line 101, in snapshot_cache_for_persistence
    return copy.deepcopy(cache)
TypeError: cannot pickle 'Dtype' object
```

Hit on a model configured with `kv_cache_quant: turboquant:4` whose underlying layer composition (10/40 ArraysCache layers) would otherwise qualify for the checkpoint path.

## Root cause

`TurboQuantKVCache` and `SpectralQuantKVCache` hold an `mx.Dtype` object in their layer state. `copy.deepcopy` (used by `snapshot_cache_for_persistence` for each per-boundary snapshot) can't pickle `mx.Dtype`. Every checkpoint-eligible request on a TurboQuant/Spectral-quantized model crashes mid-stream.

## Fix

Gate `lm.uses_checkpoint_persistence = False` at probe time when `lm.kv_cache_quant` indicates TurboQuant or SpectralQuant. Mirrors the existing `_is_serializable_cache` exclusion already in place for the disk-save path.

These models keep their **within-request** cache reuse (which is what TurboQuant/Spectral exist for — compressing the cache during generation). They just don't get **cross-request** reuse via the new checkpoint mechanism.

## Affected models in typical setups

Any model with both `kv_cache_quant: turboquant:*` (or `spectral:*`) AND a layout that engages the checkpoint path:
- `mlx-community/Qwen3-Coder-Next-4bit` (ArraysCache hybrid + `turboquant:4`)
- Any other ArraysCache/Mamba model with TurboQuant configured

Mixed Qwen3-Next layouts were already excluded by #396, so the bug only surfaced for the above.

## Tests

- `test_probe_excludes_turboquant_from_checkpoint_path`
- `test_probe_excludes_spectralquant_from_checkpoint_path`

Both pin the per-quant exclusion against the same `[ArraysCache]` layout that previously triggered the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)