### PR TITLE
fix(registry): refuse to clobber unreadable models.json

### DIFF
--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -930,6 +930,14 @@ def _load_registry_for_audit() -> "Any":
     (asymmetric output → multiple restart cycles to surface every
     problem). Standalone callers of the audit helpers (e.g. tests)
     still get the helper's own retry-and-skip fallback.
+
+    Note: ``ModelsConfigError`` (raised by ``ModelRegistry.load`` when
+    ``models.json`` is corrupt/unreadable) is intentionally NOT caught
+    here. Returning ``None`` for that case would silently skip startup
+    and let a later save clobber the file — exactly the behaviour the
+    strict load was added to prevent. The exception propagates to
+    ``cli_main``, which prints it and exits cleanly. Do not add a
+    ``ModelsConfigError`` branch here.
     """
     from olmlx.engine.registry import ModelRegistry
 
@@ -3597,7 +3605,17 @@ def cli_main():
 
     handler = _resolve_handler(cmd, sub_name)
     if handler:
-        return handler(args)
+        # ``ModelsConfigError`` surfaces from ``registry.load()`` /
+        # ``_save_mappings_locked()`` when ``models.json`` is unreadable
+        # or corrupt — refusing to clobber the file. Convert to a clean
+        # exit with the error text instead of dumping a traceback.
+        from olmlx.engine.registry import ModelsConfigError
+
+        try:
+            return handler(args)
+        except ModelsConfigError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
 
     # Unknown subcommand — print help for the parent command
     parser.parse_args([cmd, "--help"])

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -21,6 +21,17 @@ _VALID_SPECULATIVE_STRATEGIES: frozenset[str] = frozenset(
 
 logger = logging.getLogger(__name__)
 
+
+class ModelsConfigError(Exception):
+    """Raised when ``models.json`` exists but cannot be read as a JSON object.
+
+    We refuse to silently substitute an empty registry and continue, because
+    a subsequent save would overwrite the on-disk file and lose the user's
+    config. Callers (CLI entry points, app lifespan) surface this as a
+    startup failure so the operator can repair or remove the file.
+    """
+
+
 # Experimental keys that can be overridden per-model.
 # Distributed settings are excluded — they affect process startup, not per-model behavior.
 PER_MODEL_EXPERIMENTAL_KEYS: frozenset[str] = frozenset(
@@ -1091,18 +1102,33 @@ class ModelRegistry:
         self._aliases_path = settings.models_config.parent / "aliases.json"
 
     def load(self):
-        """Load model mappings from config file and aliases."""
+        """Load model mappings from config file and aliases.
+
+        Raises ``ModelsConfigError`` when ``models.json`` exists but cannot
+        be parsed as a JSON object — refusing to load prevents a later save
+        from clobbering an unreadable file with empty in-memory state.
+        """
         if settings.models_config.exists():
             try:
                 with open(settings.models_config) as f:
                     raw = json.load(f)
             except json.JSONDecodeError as exc:
-                logger.warning(
-                    "Corrupted %s, starting with empty config: %s",
-                    settings.models_config,
-                    exc,
+                raise ModelsConfigError(
+                    f"Could not parse {settings.models_config}: {exc}. "
+                    f"Refusing to start so the file is not overwritten — "
+                    f"fix the JSON or remove the file and retry."
+                ) from exc
+            except OSError as exc:
+                raise ModelsConfigError(
+                    f"Could not read {settings.models_config}: {exc}. "
+                    f"Refusing to start — check file permissions and retry."
+                ) from exc
+            if not isinstance(raw, dict):
+                raise ModelsConfigError(
+                    f"{settings.models_config} must contain a JSON object, "
+                    f"got {type(raw).__name__}. Refusing to start so the "
+                    f"file is not overwritten."
                 )
-                raw = {}
             self._mappings = {}
             self._raw_unrecognized = {}
             self._dirty_keys = set()
@@ -1281,20 +1307,30 @@ class ModelRegistry:
             try:
                 with open(settings.models_config) as f:
                     loaded = json.load(f)
-                if not isinstance(loaded, dict):
-                    raise ValueError(f"Expected dict, got {type(loaded).__name__}")
-                disk_data = loaded
-                disk_read_ok = True
-            except (json.JSONDecodeError, ValueError, OSError):
-                pass  # corrupt, wrong type, or unreadable
+            except (json.JSONDecodeError, OSError) as exc:
+                # Refuse to overwrite an unreadable on-disk file — silently
+                # rewriting it from in-memory state would clobber the
+                # user's config. Surface the error to the caller (a model
+                # load, pull, or auto-register).
+                raise ModelsConfigError(
+                    f"Refusing to overwrite {settings.models_config}: "
+                    f"existing file is unreadable ({exc}). Fix or remove "
+                    f"the file and retry."
+                ) from exc
+            if not isinstance(loaded, dict):
+                raise ModelsConfigError(
+                    f"Refusing to overwrite {settings.models_config}: "
+                    f"existing file is not a JSON object (got "
+                    f"{type(loaded).__name__})."
+                )
+            disk_data = loaded
+            disk_read_ok = True
 
         if not disk_read_ok and self._mappings:
-            # File was missing or corrupt — write full in-memory state to
-            # avoid silently dropping live entries. Removed keys are already
+            # File was missing — write full in-memory state to avoid
+            # silently dropping live entries. Removed keys are already
             # absent from _mappings (remove() pops them), so they won't
             # reappear. dirty/removed snapshots are not needed here.
-            if file_exists:
-                logger.warning("models.json corrupt; writing full in-memory state")
             disk_data = {k: v.to_entry() for k, v in self._mappings.items()}
         else:
             # Remove explicitly deleted keys

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2046,17 +2046,19 @@ class TestCreateStore:
         data = json.loads(config_path.read_text())
         assert data == DEFAULT_MODELS
 
-    def test_malformed_config_logs_warning(self, tmp_path, monkeypatch, caplog):
-        """Malformed models.json should log a warning and start with empty config."""
-        config_path = tmp_path / "models.json"
-        config_path.write_text("{bad json")
-        monkeypatch.setattr("olmlx.cli.settings.models_config", config_path)
-        import logging
+    def test_malformed_config_raises_without_clobbering(self, tmp_path, monkeypatch):
+        """Malformed models.json must raise rather than silently clearing the file."""
+        from olmlx.engine.registry import ModelsConfigError
 
-        with caplog.at_level(logging.WARNING):
-            store = _create_store()
-        assert store is not None
-        assert "Corrupted" in caplog.text
+        config_path = tmp_path / "models.json"
+        original = "{bad json"
+        config_path.write_text(original)
+        monkeypatch.setattr("olmlx.cli.settings.models_config", config_path)
+        with pytest.raises(ModelsConfigError):
+            _create_store()
+        # File contents must be untouched — losing the user's config to a
+        # parse error is exactly what we're guarding against.
+        assert config_path.read_text() == original
 
     def test_ensure_config_permission_error_raises(self, tmp_path, monkeypatch):
         """Permission error in ensure_config should propagate."""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -7,7 +7,12 @@ from unittest.mock import patch
 
 import pytest
 
-from olmlx.engine.registry import ModelConfig, ModelRegistry, _atomic_write_json
+from olmlx.engine.registry import (
+    ModelConfig,
+    ModelRegistry,
+    ModelsConfigError,
+    _atomic_write_json,
+)
 
 
 class TestModelRegistry:
@@ -1173,17 +1178,33 @@ class TestRegistryModelConfig:
 
 
 class TestCorruptedJsonFiles:
-    """Regression tests for #180: corrupted JSON config files should not crash."""
+    """Regression tests for corrupted JSON config files.
 
-    def test_load_corrupted_models_json(self, tmp_path, monkeypatch):
-        """Corrupted models.json should log a warning, not crash."""
+    ``models.json`` is treated as authoritative user state: a corrupt file
+    is a startup-blocking error (refusing to silently clobber it later),
+    while ``aliases.json`` is rebuildable and tolerates a warn-and-skip.
+    """
+
+    def test_load_corrupted_models_json_raises(self, tmp_path, monkeypatch):
+        """Corrupted models.json must raise — never silently clear the file."""
         config_path = tmp_path / "models.json"
         config_path.write_text("{invalid json content!!!")
         monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
         reg = ModelRegistry()
-        reg.load()
-        # Should fall back to empty mappings
-        assert reg._mappings == {}
+        with pytest.raises(ModelsConfigError, match="Could not parse"):
+            reg.load()
+        # On-disk contents must be untouched.
+        assert config_path.read_text() == "{invalid json content!!!"
+
+    def test_load_non_object_models_json_raises(self, tmp_path, monkeypatch):
+        """models.json that isn't a JSON object must raise without clobbering."""
+        config_path = tmp_path / "models.json"
+        config_path.write_text("[1, 2, 3]")
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        with pytest.raises(ModelsConfigError, match="JSON object"):
+            reg.load()
+        assert config_path.read_text() == "[1, 2, 3]"
 
     def test_load_corrupted_aliases_json(self, tmp_path, monkeypatch):
         """Corrupted aliases.json should log a warning, not crash."""
@@ -1444,8 +1465,8 @@ class TestDiskMergeOnSave:
         # prevent silent data loss.
         assert saved["modelA:latest"] == "org/model-a"
 
-    def test_save_with_corrupt_file(self, tmp_path, monkeypatch):
-        """If models.json is corrupted while running, full in-memory state is restored."""
+    def test_save_with_corrupt_file_refuses_to_clobber(self, tmp_path, monkeypatch):
+        """If models.json is corrupted mid-run, the save must refuse to clobber."""
         config = {"modelA:latest": "org/model-a"}
         config_path = tmp_path / "models.json"
         config_path.write_text(json.dumps(config))
@@ -1453,15 +1474,15 @@ class TestDiskMergeOnSave:
         reg = ModelRegistry()
         reg.load()
 
-        # Corrupt the file
-        config_path.write_text("{broken json!!!")
+        # External corruption after load — e.g. user editing the file.
+        corrupt = "{broken json!!!"
+        config_path.write_text(corrupt)
 
-        # Add a new mapping — should restore all entries
-        reg.add_mapping("modelB", "org/model-b")
+        with pytest.raises(ModelsConfigError, match="unreadable"):
+            reg.add_mapping("modelB", "org/model-b")
 
-        saved = json.loads(config_path.read_text())
-        assert saved["modelB:latest"] == "org/model-b"
-        assert saved["modelA:latest"] == "org/model-a"
+        # File contents must be untouched.
+        assert config_path.read_text() == corrupt
 
     def test_save_with_externally_emptied_file(self, tmp_path, monkeypatch):
         """An intentionally emptied {} file should not restore in-memory entries."""


### PR DESCRIPTION
## Summary

- A corrupt or unreadable `~/.olmlx/models.json` was silently treated as empty in `ModelRegistry.load()`; the next save (e.g. auto-registering an HF path on first model load) then overwrote the file from in-memory state, destroying the user's config.
- `ModelRegistry.load()` and `_save_mappings_locked()` now raise a new `ModelsConfigError` on `JSONDecodeError` / `OSError` / non-object JSON instead of swallowing it.
- `cli_main()` catches it and exits with `Error: <message>` and code 1, so the operator sees the problem clearly and the file is left untouched. `aliases.json` (rebuildable) keeps its warn-and-skip behavior.

## Test plan

- [x] `tests/test_registry.py::TestCorruptedJsonFiles` — corrupt and non-object `models.json` raise `ModelsConfigError`; file contents unchanged.
- [x] `tests/test_registry.py::test_save_with_corrupt_file_refuses_to_clobber` — mid-run corruption causes `add_mapping` to raise; file contents unchanged.
- [x] `tests/test_cli.py::test_malformed_config_raises_without_clobbering` — `_create_store()` surfaces the error; on-disk file untouched.
- [x] `uv run pytest tests/test_registry.py tests/test_cli.py` — 322 passed (3 unrelated pre-existing failures in `TestServeFlash*` deselected; they reproduce on `main` and trip on the local `~/.olmlx/models.json` migration check, not this change).
- [x] `uv run ruff check` + `uv run ruff format --check` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)