### PR TITLE
fix(speculative_stream): strip special tokens from streamed text

### DIFF
--- a/olmlx/engine/speculative_stream.py
+++ b/olmlx/engine/speculative_stream.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 class TokenizerProtocol(Protocol):
     """Protocol for tokenizer with decode method."""
 
-    def decode(self, token_ids: list[int]) -> str: ...
+    def decode(self, token_ids: list[int], skip_special_tokens: bool = ...) -> str: ...
 
 
 class SpeculativeDecoderProtocol(Protocol):
@@ -63,9 +63,14 @@ def speculative_stream_generate(
     gen_count = 1
 
     # Incremental text decoding: decode full sequence and diff against previous length.
+    # ``skip_special_tokens=True`` matches mlx-lm's ``stream_generate`` default and
+    # prevents EOS / chat-template markers (e.g. Qwen ``<|im_end|>``) from leaking
+    # into the streamed text — without it the final chunk that carries the EOS
+    # token contains the literal string for that token, which clients render as
+    # plain text (issue surfaced via opencode + speculative-enabled Qwen3.5-27B).
     prev_text_len = 0
     if tokenizer is not None:
-        full_text = tokenizer.decode(generated)
+        full_text = tokenizer.decode(generated, skip_special_tokens=True)
         new_text = full_text
         prev_text_len = len(full_text)
     else:
@@ -117,7 +122,7 @@ def speculative_stream_generate(
             gen_elapsed = time.perf_counter() - t0
 
             if tokenizer is not None:
-                full_text = tokenizer.decode(generated)
+                full_text = tokenizer.decode(generated, skip_special_tokens=True)
                 new_text = full_text[prev_text_len:]
                 prev_text_len = len(full_text)
             else:

--- a/tests/test_speculative_stream_base.py
+++ b/tests/test_speculative_stream_base.py
@@ -67,3 +67,115 @@ class TestSpeculativeStreamBase:
         )
 
         assert base is flash
+
+
+class TestSpecialTokenTextStripping:
+    """Stop tokens (e.g. Qwen ``<|im_end|>``) must not leak into streamed text.
+
+    Pre-fix, ``tokenizer.decode(generated)`` was called without
+    ``skip_special_tokens=True``, so the chunk that carried the EOS token also
+    carried its literal string form. Clients (opencode, anthropic SDK, raw
+    SSE consumers) then rendered ``<|im_end|>`` as plain text right before the
+    ``finish_reason=stop`` signal.
+
+    The non-speculative path used by every other model went through mlx-lm's
+    ``stream_generate`` which sets ``skip_special_tokens=True`` by default,
+    hiding the bug to non-speculative configurations.
+    """
+
+    class _StubDecoder:
+        """Emits a fixed token sequence including a final EOS-special token."""
+
+        def __init__(self, tokens: list[int]) -> None:
+            self._tokens = tokens
+            self._idx = 0
+
+        def prefill(self, prompt):  # noqa: ARG002 - protocol compliance
+            self._idx = 1
+            return self._tokens[0]
+
+        def step(self) -> tuple[list[int], int]:
+            if self._idx >= len(self._tokens):
+                # Decoder exhausted — caller should have stopped on EOS earlier.
+                return ([], 0)
+            tok = self._tokens[self._idx]
+            self._idx += 1
+            return ([tok], 1)
+
+        def reset(self) -> None:
+            self._idx = 0
+
+    class _MockTokenizer:
+        """Models a Qwen-style tokenizer where token 99 is a special EOS marker.
+
+        Honours ``skip_special_tokens`` like real HuggingFace tokenizers do —
+        without it, token 99 renders as the literal string ``<|im_end|>``.
+        """
+
+        eos_token_id = 99
+
+        def decode(self, tokens: list[int], skip_special_tokens: bool = False) -> str:
+            parts: list[str] = []
+            for t in tokens:
+                if t == 99:
+                    if not skip_special_tokens:
+                        parts.append("<|im_end|>")
+                else:
+                    parts.append(f"w{t}")
+            return "".join(parts)
+
+    def test_streamed_text_omits_eos_special_token(self):
+        from olmlx.engine.speculative_stream import speculative_stream_generate
+
+        decoder = self._StubDecoder([1, 2, 3, 99])
+        tok = self._MockTokenizer()
+        cancel = threading.Event()
+
+        responses = list(
+            speculative_stream_generate(
+                decoder,
+                [10, 11],
+                max_tokens=8,
+                cancel_event=cancel,
+                eos_token_id=tok.eos_token_id,
+                tokenizer=tok,
+            )
+        )
+
+        full_streamed = "".join(r.text for r in responses)
+        assert "<|im_end|>" not in full_streamed, (
+            f"special token leaked into streamed text: {full_streamed!r}"
+        )
+        # And the substantive content tokens did make it through.
+        for marker in ("w1", "w2", "w3"):
+            assert marker in full_streamed, (
+                f"expected content token {marker!r} missing from {full_streamed!r}"
+            )
+        # The final chunk should carry finish_reason=stop on the EOS token.
+        assert responses[-1].token == 99
+        assert responses[-1].finish_reason == "stop"
+
+    def test_streamed_text_omits_eos_when_first_token_is_eos(self):
+        """Edge case: prefill returns EOS as the very first token."""
+        from olmlx.engine.speculative_stream import speculative_stream_generate
+
+        decoder = self._StubDecoder([99])
+        tok = self._MockTokenizer()
+        cancel = threading.Event()
+
+        responses = list(
+            speculative_stream_generate(
+                decoder,
+                [10, 11],
+                max_tokens=8,
+                cancel_event=cancel,
+                eos_token_id=tok.eos_token_id,
+                tokenizer=tok,
+            )
+        )
+
+        assert len(responses) == 1
+        assert responses[0].token == 99
+        assert "<|im_end|>" not in responses[0].text, (
+            f"prefill EOS leaked: {responses[0].text!r}"
+        )


### PR DESCRIPTION
## Summary

The speculative streaming path called `tokenizer.decode(generated)` without `skip_special_tokens=True`, so the chunk that carried an EOS token (Qwen `<|im_end|>`, Llama `<|eot_id|>`, etc.) emitted the token's literal string in `text` right before the `finish_reason=stop` signal. Clients (opencode, Anthropic SDK, raw SSE consumers) then rendered the special token as plain text in the assistant response.

The non-speculative path goes through mlx-lm's `stream_generate` which defaults to `skip_special_tokens=True` — that's why only speculative-enabled entries surface the leak.

## Reproduction

Reported via opencode driving `mlx-community/Qwen3.5-27B-4bit:latest`. Confirmed by a multi-turn `/api/chat` audit across 14 models: every speculative-enabled Qwen3 entry leaks `<|im_end|>` on every turn; every non-speculative entry is clean. The current registry entries affected:

- `mlx-community/Qwen3.5-27B-4bit`
- `mlx-community/Qwen3.5-35B-A3B-4bit`
- `unsloth/Qwen3.6-27B-MLX-8bit`

## Change

Two-line production change in `olmlx/engine/speculative_stream.py`: pass `skip_special_tokens=True` to both `tokenizer.decode()` call sites (prefill's first-token decode + per-step incremental decode). Protocol signature updated accordingly so the kwarg is part of the structural contract. Comment added at the prefill site explaining the gotcha.

## Test plan

- [x] New `TestSpecialTokenTextStripping` class in `tests/test_speculative_stream_base.py` with a stub decoder + mock tokenizer that exercises the bug: a token marked as the EOS-special must not appear as its literal string in any yielded `StreamToken.text`.
- [x] Covers two cases: (a) EOS at end of a normal sequence, (b) EOS as the very first token from `prefill()`.
- [x] `uv run pytest tests/ -k "speculative or stream"` — 373 passed, 1 skipped, no regressions.
- [x] `uv run ruff check` + `uv run ruff format --check` on the touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)