### PR TITLE
fix(inference): always merge per-model default options under request options

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1356,12 +1356,15 @@ async def _release_pin_after_gen(
             lm.release_ref()
 
 
-def _merge_default_options(defaults: dict, request: dict | None) -> dict:
+def _merge_default_options(defaults: dict | None, request: dict | None) -> dict:
     """Merge per-model default options with per-request options.
 
     Request values win per-key; keys absent from the request fall back to
     model defaults.  ``request=None`` and ``request={}`` both mean "use
     defaults"; any non-None ``request`` is layered on top of ``defaults``.
+    ``defaults=None`` is accepted symmetrically with ``request`` and treated
+    as an empty dict so callers that haven't normalised the field can still
+    use this helper without a guard.
 
     History: prior versions dropped *all* defaults whenever the request
     supplied *any* options — so a request that sent ``top_k`` without
@@ -1371,7 +1374,7 @@ def _merge_default_options(defaults: dict, request: dict | None) -> dict:
     ``"temperature": 0.7`` was discarded.  The current always-merge form
     matches Ollama's per-model options semantics.
     """
-    return {**defaults, **(request or {})}
+    return {**(defaults or {}), **(request or {})}
 
 
 def _build_generate_kwargs(options: dict | None, is_vlm: bool = False) -> dict:

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1356,6 +1356,24 @@ async def _release_pin_after_gen(
             lm.release_ref()
 
 
+def _merge_default_options(defaults: dict, request: dict | None) -> dict:
+    """Merge per-model default options with per-request options.
+
+    Request values win per-key; keys absent from the request fall back to
+    model defaults.  ``request=None`` and ``request={}`` both mean "use
+    defaults"; any non-None ``request`` is layered on top of ``defaults``.
+
+    History: prior versions dropped *all* defaults whenever the request
+    supplied *any* options — so a request that sent ``top_k`` without
+    ``temperature`` silently lost the model's default temperature and ran
+    greedy (no sampler built).  Surfaced via opencode + Qwen3-Coder-Next-4bit
+    where opencode sent ``{top_k, top_p, min_p}`` and ``models.json``'s
+    ``"temperature": 0.7`` was discarded.  The current always-merge form
+    matches Ollama's per-model options semantics.
+    """
+    return {**defaults, **(request or {})}
+
+
 def _build_generate_kwargs(options: dict | None, is_vlm: bool = False) -> dict:
     """Convert Ollama options dict to mlx_lm/mlx_vlm generate kwargs.
 
@@ -2259,13 +2277,7 @@ async def generate_completion(
                 if system:
                     prompt = f"{system}\n\n{prompt}"
 
-        # Merge per-model defaults with request options.  options=None means
-        # "use defaults"; options={} means "override all defaults" (empty).
-        merged_options = (
-            {**lm.default_options, **(options or {})}
-            if lm.default_options and options is None
-            else options
-        )
+        merged_options = _merge_default_options(lm.default_options, options)
         gen_kwargs = _build_generate_kwargs(merged_options, is_vlm=lm.is_vlm)
         mt = gen_kwargs.pop("max_tokens", max_tokens)
 
@@ -4044,13 +4056,7 @@ async def generate_chat(
             logger.debug("Prompt (first 2000 chars): %s", prompt[:2000])
             logger.debug("Prompt (last 2000 chars): %s", prompt[-2000:])
 
-        # Merge per-model defaults with request options.  options=None means
-        # "use defaults"; options={} means "override all defaults" (empty).
-        merged_options = (
-            {**lm.default_options, **(options or {})}
-            if lm.default_options and options is None
-            else options
-        )
+        merged_options = _merge_default_options(lm.default_options, options)
         gen_kwargs = _build_generate_kwargs(merged_options, is_vlm=lm.is_vlm)
         mt = gen_kwargs.pop("max_tokens", max_tokens)
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -12,6 +12,7 @@ from olmlx.engine.inference import (
     _acquire_inference_lock,
     _apply_seed,
     _build_generate_kwargs,
+    _merge_default_options,
     _full_completion,
     _inference_ref,
     _make_frequency_penalty_processor,
@@ -182,6 +183,64 @@ class TestDeriveTimingStats:
         _derive_timing_stats(stats, 0.0, 0.0, eval_timer_ns=200_000_000)
         assert stats.prompt_eval_duration == 0
         assert stats.eval_duration == 0
+
+
+class TestMergeDefaultOptions:
+    """Per-model defaults from ``models.json`` must layer under request options.
+
+    Request-key wins per-key; keys absent from the request fall back to the
+    model default.  Pre-fix, supplying *any* key in the request dropped *all*
+    defaults — so a request that sent ``top_k`` without ``temperature``
+    silently lost the model's default temperature and ran greedy (no sampler
+    built).  Surfaced via opencode + ``mlx-community/Qwen3-Coder-Next-4bit``
+    where opencode sent ``{top_k, top_p, min_p}`` and ``models.json``'s
+    ``"temperature": 0.7`` vanished from the merge.
+    """
+
+    def test_none_request_yields_defaults(self):
+        assert _merge_default_options({"temperature": 0.7}, None) == {
+            "temperature": 0.7
+        }
+
+    def test_empty_request_yields_defaults(self):
+        """``{}`` from ``build_inference_options`` (request supplied no params)
+        must still apply model defaults."""
+        assert _merge_default_options({"temperature": 0.7}, {}) == {"temperature": 0.7}
+
+    def test_partial_request_layers_under_defaults(self):
+        """Regression for the opencode case: top_k in request, temperature in
+        defaults — both must end up in the merged dict."""
+        merged = _merge_default_options(
+            {"temperature": 0.7, "top_p": 0.8},
+            {"top_k": 20, "min_p": 0.0},
+        )
+        assert merged == {
+            "temperature": 0.7,
+            "top_p": 0.8,
+            "top_k": 20,
+            "min_p": 0.0,
+        }
+
+    def test_request_overrides_default_per_key(self):
+        merged = _merge_default_options(
+            {"temperature": 0.7, "top_p": 0.8},
+            {"temperature": 0.2},
+        )
+        assert merged == {"temperature": 0.2, "top_p": 0.8}
+
+    def test_empty_defaults_passes_request_through(self):
+        assert _merge_default_options({}, {"temperature": 0.5}) == {"temperature": 0.5}
+
+    def test_both_empty_yields_empty(self):
+        assert _merge_default_options({}, None) == {}
+        assert _merge_default_options({}, {}) == {}
+
+    def test_does_not_mutate_inputs(self):
+        defaults = {"temperature": 0.7}
+        request = {"top_k": 20}
+        _merge_default_options(defaults, request)
+        assert defaults == {"temperature": 0.7}
+        assert request == {"top_k": 20}
 
 
 class TestBuildGenerateKwargs:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -235,6 +235,14 @@ class TestMergeDefaultOptions:
         assert _merge_default_options({}, None) == {}
         assert _merge_default_options({}, {}) == {}
 
+    def test_none_defaults_accepted_symmetrically(self):
+        """Defensive: helper accepts ``None`` for defaults the same way it does
+        for request, so callers that haven't normalised the field don't crash."""
+        assert _merge_default_options(None, {"temperature": 0.5}) == {
+            "temperature": 0.5
+        }
+        assert _merge_default_options(None, None) == {}
+
     def test_does_not_mutate_inputs(self):
         defaults = {"temperature": 0.7}
         request = {"top_k": 20}


### PR DESCRIPTION
## Summary

\`generate_chat\` and \`generate_completion\` both used the same merge pattern that **dropped all per-model defaults whenever the request supplied any options**:

\`\`\`python
merged = (
    {**lm.default_options, **(options or {})}
    if lm.default_options and options is None
    else options
)
\`\`\`

A request that sent \`top_k\` without \`temperature\` therefore lost the model's default temperature. \`_build_generate_kwargs\` then warned \`top_k/top_p/min_p provided without temperature; no sampler will be built\` and ran greedy decoding.

## Repro

opencode + \`mlx-community/Qwen3-Coder-Next-4bit:latest\`:

- \`models.json\` entry sets \`"options": { "temperature": 0.7, "top_p": 0.8, "top_k": 20, "repeat_penalty": 1.05 }\`
- opencode sends \`{top_k, top_p, min_p}\` (no temperature)
- Merge result with old code: \`{top_k, top_p, min_p}\` — temperature gone
- Sampler skipped → greedy decoding → on a 17k-token tool-heavy prompt the hybrid linear-attn + MoE target loops hard

Server log shows the warning right before the request:

\`\`\`
[WARNING] olmlx.engine.inference: [1ffa837a] top_k/top_p/min_p provided without temperature; no sampler will be built and these params will have no effect
[DEBUG] olmlx.engine.inference: [1ffa837a] Prompt cache enabled: 17680 prompt tokens, existing cache=none
\`\`\`

## Change

- Extracted the merge into \`_merge_default_options(defaults, request)\` next to \`_build_generate_kwargs\`. Always merges; request wins per-key. Matches Ollama's per-model options semantics and what a user reading \`options\` in \`models.json\` would expect.
- Replaced both inline merges in \`generate_chat\` and \`generate_completion\` with the helper.

Behaviour matrix:

| \`request\` | Old merged | New merged |
|---|---|---|
| \`None\` | defaults | defaults |
| \`{}\` | \`{}\` (defaults dropped) | defaults |
| \`{\"top_k\": 20}\` | \`{\"top_k\": 20}\` (defaults dropped) | \`{\"temperature\": 0.7, \"top_k\": 20}\` (merged) |
| \`{\"temperature\": 0.2}\` | \`{\"temperature\": 0.2}\` (defaults dropped) | \`{\"temperature\": 0.2, \"top_p\": 0.8, \"top_k\": 20}\` (request wins per-key) |

The middle two rows are the behavior change. Both correct under the documented semantics; only the third row reflects a real prior bug.

## Test plan

- [x] New \`TestMergeDefaultOptions\` class in \`tests/test_inference.py\` with 7 cases covering \`None\` / \`{}\` request, partial request layering under defaults, per-key override precedence, empty defaults, both empty, and no input mutation.
- [x] No existing tests pinned the buggy merge — confirmed via grep for \`default_options\` and \`merged_options\` across \`tests/\`. Only two pre-existing tests reference \`default_options\` and they just check the field is populated on \`LoadedModel\`.
- [x] \`uv run pytest tests/test_inference.py\` — 236 passed, 3 skipped.
- [x] \`uv run ruff check\` + \`uv run ruff format --check\` clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)