### PR TITLE
feat(registry): per-model prompt_cache override in models.json

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -4077,8 +4077,16 @@ async def generate_chat(
         # ``async_speculative_stream`` does not consume ``gen_kwargs['prompt_cache']``.
         # Also disabled for VLMs on the non-streaming path because
         # ``mlx_vlm.generate`` accepts neither ``prompt_cache`` nor ``input_ids``.
+        # Per-model ``prompt_cache`` (set in models.json) overrides the global
+        # ``OLMLX_PROMPT_CACHE`` toggle. Surfaced for architectures that hit
+        # checkpoint-path bugs (e.g. Qwen3-Coder-Next MoE-quantized GatedDeltaNet
+        # targets where chunked prefill crosses expert-routing thresholds) while
+        # other models on the same server keep caching enabled.
+        effective_prompt_cache = (
+            lm.prompt_cache if lm.prompt_cache is not None else settings.prompt_cache
+        )
         use_prompt_cache = (
-            settings.prompt_cache
+            effective_prompt_cache
             and make_prompt_cache is not None
             and not lm.is_distributed
             and not lm.is_speculative
@@ -4097,9 +4105,10 @@ async def generate_chat(
             )
         else:
             logger.debug(
-                "Prompt cache disabled: setting=%s stream=%s vlm=%s speculative=%s "
-                "make_prompt_cache=%s",
+                "Prompt cache disabled: setting=%s per_model=%s stream=%s vlm=%s "
+                "speculative=%s make_prompt_cache=%s",
                 settings.prompt_cache,
+                lm.prompt_cache,
                 stream,
                 lm.is_vlm,
                 lm.is_speculative,

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -516,6 +516,14 @@ class LoadedModel:
     # ``generate_chat`` consults this when the request didn't set the
     # flag.  None means defer to the engine default.
     enable_thinking: bool | None = None
+    # Per-model override for the cross-request prompt cache toggle.
+    # ``generate_chat`` honours this in place of ``settings.prompt_cache``
+    # when set. None means defer to the global setting. Surfaced for
+    # architectures that crash or degrade on the checkpoint path while
+    # other models continue to benefit from caching (e.g. Qwen3-Coder-Next
+    # MoE-quantized targets where chunked prefill triggers GatedDeltaNet
+    # numerical drift across expert-routing thresholds).
+    prompt_cache: bool | None = None
 
     def __post_init__(self):
         if self.prompt_cache_store is None:
@@ -1434,6 +1442,7 @@ class ModelManager:
                         inference_timeout=model_config.inference_timeout,
                         sync_mode=model_config.sync_mode,
                         enable_thinking=model_config.enable_thinking,
+                        prompt_cache=model_config.prompt_cache,
                     )
                     # Register before probe so concurrent callers see the
                     # model while the probe's async Metal flush releases the

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -349,6 +349,12 @@ class ModelConfig:
     #: Applied by ``generate_chat`` when the request didn't set the flag.
     #: ``None`` means fall back to the engine default (think unless tools).
     enable_thinking: bool | None = None
+    #: Per-model override for the cross-request prompt cache toggle. When set,
+    #: fully overrides ``OLMLX_PROMPT_CACHE`` for this model — useful when a
+    #: specific architecture surfaces a checkpoint-path bug while the rest of
+    #: the registry continues to benefit from caching. ``None`` means defer to
+    #: the global ``settings.prompt_cache`` (default behaviour).
+    prompt_cache: bool | None = None
     #: Unrecognized keys from the JSON entry, preserved for round-trip fidelity.
     _extra: dict[str, Any] = field(default_factory=dict, repr=False)
 
@@ -526,6 +532,10 @@ class ModelConfig:
         ):
             raise ValueError(
                 f"'enable_thinking' must be a bool or None, got {self.enable_thinking!r}"
+            )
+        if self.prompt_cache is not None and not isinstance(self.prompt_cache, bool):
+            raise ValueError(
+                f"'prompt_cache' must be a bool or None, got {self.prompt_cache!r}"
             )
 
     def resolved_speculative(self) -> SpeculativeConfig:
@@ -859,6 +869,7 @@ class ModelConfig:
             flash_speculative_draft_model = entry.get("flash_speculative_draft_model")
             flash_speculative_tokens = entry.get("flash_speculative_tokens")
             enable_thinking_raw = entry.get("enable_thinking")
+            prompt_cache_raw = entry.get("prompt_cache")
 
             kv_cache_quant_raw = entry.get("kv_cache_quant")
             if kv_cache_quant_raw is not None:
@@ -924,6 +935,7 @@ class ModelConfig:
                 flash_speculative_draft_model=flash_speculative_draft_model,
                 flash_speculative_tokens=flash_speculative_tokens,
                 enable_thinking=enable_thinking_raw,
+                prompt_cache=prompt_cache_raw,
                 _extra=extra,
             )
         raise TypeError(
@@ -962,6 +974,7 @@ class ModelConfig:
             and self.flash_speculative_draft_model is None
             and self.flash_speculative_tokens is None
             and self.enable_thinking is None
+            and self.prompt_cache is None
             and not self._extra
         ):
             return self.hf_path
@@ -1027,6 +1040,8 @@ class ModelConfig:
             result["flash_speculative_tokens"] = self.flash_speculative_tokens
         if self.enable_thinking is not None:
             result["enable_thinking"] = self.enable_thinking
+        if self.prompt_cache is not None:
+            result["prompt_cache"] = self.prompt_cache
         # Filter known keys defensively — from_entry() already excludes them,
         # but _extra can be set directly via ModelConfig construction.
         result.update(

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2216,6 +2216,121 @@ class TestGenerateChatEnableThinking:
         assert call_kwargs["enable_thinking"] is True
 
 
+class TestGenerateChatPerModelPromptCache:
+    """Per-model ``prompt_cache`` override (set in models.json) takes
+    precedence over the global ``OLMLX_PROMPT_CACHE`` setting.
+
+    Surfaced for architectures where the checkpoint cache path mis-prefills
+    (e.g. Qwen3-Coder-Next-4bit, where chunked prefill drifts the
+    GatedDeltaNet recurrent state across MoE expert-routing thresholds).
+    Per-model opt-out keeps caching enabled for healthy models on the same
+    server while disabling it for the broken ones.
+
+    The resolution is asserted via ``lm.prompt_cache_store.peek``: it is
+    called only when ``use_prompt_cache`` resolves true. This keeps the
+    test surface narrow and avoids depending on log message formatting.
+    """
+
+    @pytest.mark.asyncio
+    async def test_per_model_false_overrides_global_true(self, mock_manager):
+        """lm.prompt_cache=False suppresses caching even when settings.prompt_cache=True."""
+        mock_mx = MagicMock()
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.prompt_cache = False  # per-model opt-out
+        lm.prompt_cache_store.peek = MagicMock(return_value=None)
+        lm.tokenizer.apply_chat_template = MagicMock(return_value="formatted prompt")
+
+        with (
+            patch("olmlx.engine.inference.mx", mock_mx),
+            patch("olmlx.engine.inference.settings.prompt_cache", True),
+        ):
+            with patch(
+                "olmlx.engine.inference.asyncio.to_thread", new_callable=AsyncMock
+            ) as mock_thread:
+                mock_thread.return_value = "response"
+                await generate_chat(
+                    mock_manager,
+                    "qwen3",
+                    [{"role": "user", "content": "hi"}],
+                    stream=False,
+                )
+
+        lm.prompt_cache_store.peek.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_per_model_true_overrides_global_false(self, mock_manager):
+        """lm.prompt_cache=True engages caching even when settings.prompt_cache=False."""
+        mock_mx = MagicMock()
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.prompt_cache = True  # per-model opt-in
+        # Replace the store wholesale so downstream cache machinery is inert.
+        peek_mock = MagicMock(return_value=None)
+        lm.prompt_cache_store = MagicMock()
+        lm.prompt_cache_store.peek = peek_mock
+        lm.prompt_cache_store.async_get = AsyncMock(return_value=None)
+        lm.prompt_cache_store.async_set = AsyncMock(return_value=None)
+        lm.prompt_cache_store.async_evict_all_to_disk = AsyncMock(return_value=None)
+        lm.prompt_cache_store.find_by_prefix = MagicMock(return_value=None)
+        lm.prompt_cache_store.fetch_nearest = MagicMock(return_value=None)
+        lm.prompt_cache_store.remove = MagicMock(return_value=None)
+        lm.tokenizer.apply_chat_template = MagicMock(return_value="formatted prompt")
+
+        with (
+            patch("olmlx.engine.inference.mx", mock_mx),
+            patch("olmlx.engine.inference.settings.prompt_cache", False),
+        ):
+            with patch(
+                "olmlx.engine.inference.asyncio.to_thread", new_callable=AsyncMock
+            ) as mock_thread:
+                mock_thread.return_value = "response"
+                await generate_chat(
+                    mock_manager,
+                    "qwen3",
+                    [{"role": "user", "content": "hi"}],
+                    stream=False,
+                )
+
+        peek_mock.assert_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("global_value", [True, False])
+    async def test_per_model_none_defers_to_global(self, mock_manager, global_value):
+        """lm.prompt_cache=None (default) honours settings.prompt_cache."""
+        mock_mx = MagicMock()
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.prompt_cache = None  # explicit default
+        peek_mock = MagicMock(return_value=None)
+        lm.prompt_cache_store = MagicMock()
+        lm.prompt_cache_store.peek = peek_mock
+        lm.prompt_cache_store.async_get = AsyncMock(return_value=None)
+        lm.prompt_cache_store.async_set = AsyncMock(return_value=None)
+        lm.prompt_cache_store.async_evict_all_to_disk = AsyncMock(return_value=None)
+        lm.prompt_cache_store.find_by_prefix = MagicMock(return_value=None)
+        lm.prompt_cache_store.fetch_nearest = MagicMock(return_value=None)
+        lm.prompt_cache_store.remove = MagicMock(return_value=None)
+        lm.tokenizer.apply_chat_template = MagicMock(return_value="formatted prompt")
+
+        with (
+            patch("olmlx.engine.inference.mx", mock_mx),
+            patch("olmlx.engine.inference.settings.prompt_cache", global_value),
+        ):
+            with patch(
+                "olmlx.engine.inference.asyncio.to_thread", new_callable=AsyncMock
+            ) as mock_thread:
+                mock_thread.return_value = "response"
+                await generate_chat(
+                    mock_manager,
+                    "qwen3",
+                    [{"role": "user", "content": "hi"}],
+                    stream=False,
+                )
+
+        if global_value:
+            peek_mock.assert_called()
+        else:
+            peek_mock.assert_not_called()
+
+
 class TestFullCompletionInner:
     @pytest.mark.asyncio
     async def test_result_with_text_attr(self, mock_manager):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -711,6 +711,31 @@ class TestModelConfig:
         mc = ModelConfig(hf_path="org/model")
         assert mc.to_entry() == "org/model"
 
+    def test_prompt_cache_default_none(self):
+        """``prompt_cache`` defaults to None (global setting applies)."""
+        mc = ModelConfig.from_entry({"hf_path": "org/model"})
+        assert mc.prompt_cache is None
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_prompt_cache_parsed(self, value):
+        """``prompt_cache`` parses bool from a dict entry."""
+        mc = ModelConfig.from_entry({"hf_path": "org/model", "prompt_cache": value})
+        assert mc.prompt_cache is value
+
+    def test_prompt_cache_non_bool_rejected(self):
+        """Non-bool prompt_cache raises ValueError."""
+        with pytest.raises(ValueError, match="prompt_cache"):
+            ModelConfig.from_entry({"hf_path": "org/model", "prompt_cache": "no"})
+
+    def test_prompt_cache_round_trip(self):
+        """``prompt_cache`` survives to_entry → from_entry."""
+        mc = ModelConfig(hf_path="org/model", prompt_cache=False)
+        entry = mc.to_entry()
+        assert isinstance(entry, dict)
+        assert entry["prompt_cache"] is False
+        round_trip = ModelConfig.from_entry(entry)
+        assert round_trip.prompt_cache is False
+
 
 class TestRegistryModelConfig:
     def test_load_mixed_format(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Add an optional \`prompt_cache: bool\` field to \`ModelConfig\` so the operator can disable cross-request prompt caching for a specific model while keeping it enabled globally for the rest of the registry. \`None\` (default) means defer to \`OLMLX_PROMPT_CACHE\`.

## Motivation

\`mlx-community/Qwen3-Coder-Next-4bit\` reliably produces off-topic content — raw pretraining-data dumps (BibTeX entries, math problems, 2004-era PGP-signed emails) — on any multi-message prompt above ~500 tokens. Bisected:

| Setting | 30 tok | 379 tok | 532 tok | 651 tok | 5000 tok |
|---------|--------|---------|---------|---------|----------|
| Cache ON | ✓ | ✓ | ✗ garbage | ✗ garbage | ✗ garbage |
| Cache OFF | ✓ | ✓ | ✓ | ✓ | ✓ |
| Direct mlx-lm (bypass olmlx) | ✓ | ✓ | ✓ | ✓ | ✓ |

The discriminator is *multi-message prompt that crosses an interior message boundary*, which triggers the 2-chunk prefill in \`_drive_segmented_prefill\` (chunk 1: \`0..deepest_interior_boundary\`, snapshot, chunk 2: \`boundary..tail\`). On Qwen3-Coder-Next-4bit the per-chunk \`gated_delta_kernel\` recurrent state drifts enough from a single-pass forward to cross MoE expert-routing thresholds. The model effectively loses the prompt and generates from its pretraining prior.

Same failure family as #404 (which bounded chunks to two), but on this checkpoint *even two is too many*. A proper fix needs a snapshot strategy that doesn't split the forward pass on chunking-noisy architectures — out of scope for this PR. This per-model opt-out unblocks affected deployments now.

## Change

Mirrors the per-model \`enable_thinking\` pattern from #400/#402:

- \`ModelConfig.prompt_cache: bool | None = None\` in \`engine/registry.py\` with isinstance validation, \`from_entry\` parse, \`to_entry\` round-trip, and the compaction check that lets bare-string entries stay bare.
- \`LoadedModel.prompt_cache: bool | None = None\` in \`engine/model_manager.py\`, populated from \`ModelConfig\` at load time.
- Single consultation site in \`generate_chat\` (\`engine/inference.py\`): \`effective_prompt_cache = lm.prompt_cache if lm.prompt_cache is not None else settings.prompt_cache\`. The downstream cache machinery is unchanged.

User-side after merge:

\`\`\`json
\"mlx-community/Qwen3-Coder-Next-4bit:latest\": {
  \"hf_path\": \"mlx-community/Qwen3-Coder-Next-4bit\",
  \"flash_moe\": true,
  \"prompt_cache\": false,
  ...
}
\`\`\`

## Test plan

- [x] \`TestModelConfig\` — 4 new tests in \`tests/test_registry.py\` covering default, parse (parametrized True/False), non-bool validation rejection, and \`to_entry\`/\`from_entry\` round-trip.
- [x] \`TestGenerateChatPerModelPromptCache\` — 4 new tests in \`tests/test_inference.py\` covering all combinations of \`{lm.prompt_cache, settings.prompt_cache}\` precedence: per-model False suppresses global True; per-model True engages despite global False; per-model None (parametrized) defers to global.
- [x] \`uv run pytest tests/test_inference.py tests/test_registry.py tests/test_model_manager.py\` — 630 passed, 3 skipped, no regressions.
- [x] \`ruff check\` + \`ruff format --check\` clean on all five touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)