### PR TITLE
fix(prompt_cache): exact-match suffix, KV-quant bytes, stale terminal

### DIFF
--- a/olmlx/engine/prompt_cache/radix.py
+++ b/olmlx/engine/prompt_cache/radix.py
@@ -96,15 +96,21 @@ class PrefixCacheIndex:
     def find_strict_prefix(
         self, tokens: list[int], min_depth: int = 0
     ) -> tuple[str | None, int]:
-        """Return the deepest terminal whose stored token sequence is a strict
-        prefix of ``tokens`` (terminal depth <= len(tokens) and every token
-        along the path matches).
+        """Return the deepest terminal whose stored token sequence is a
+        *proper* prefix of ``tokens`` (terminal depth < len(tokens) and
+        every token along the path matches).
 
         Distinct from ``find_longest_prefix`` which also surfaces siblings
         that diverge past the shared prefix. Strict-prefix is the lookup
         the non-trimmable checkpoint path needs: only safe to reuse a stored
-        cache when its tokens fully match a prefix of the new request — no
-        trim required, no divergence to discard.
+        cache when its tokens are a proper prefix of the new request — no
+        trim required, no divergence to discard, and *no exact-length
+        match* either. An exact-length match would leave the checkpoint
+        driver with no prefill work to do (``already_covered == len(flat)``)
+        while still handing the last prompt token back to stream_generate as
+        the decode seed — re-feeding that token at an extra position
+        relative to the cache yields wrong output (the model sees the
+        prompt's last token twice).
 
         ``min_depth`` short-circuits below-threshold matches with
         ``(None, 0)`` (consistent with ``find_longest_prefix``).
@@ -112,7 +118,12 @@ class PrefixCacheIndex:
         node = self._root
         best_cid: str | None = None
         best_depth = 0
+        # Walk at most len(tokens) - 1 tokens: a proper prefix of ``tokens``
+        # has length strictly less than len(tokens).
+        max_depth = len(tokens) - 1
         for depth, tok in enumerate(tokens, start=1):
+            if depth > max_depth:
+                break
             child = node.children.get(tok)
             if child is None:
                 break

--- a/olmlx/engine/prompt_cache/store.py
+++ b/olmlx/engine/prompt_cache/store.py
@@ -35,12 +35,19 @@ def _estimate_state_bytes(state: CachedPromptState) -> int:
     """Best-effort byte estimate of a cached state.
 
     Walks the per-layer cache list and sums ``nbytes`` of any mlx array
-    encountered. Falls back to ``layer.state`` for layer types that don't
-    expose ``.keys`` / ``.values`` directly — most importantly
-    ``ArraysCache`` (used by Qwen3.5 / Nemotron-H / Jamba hybrid layers),
-    which would otherwise report 0 bytes and let the RAM budget overrun
-    silently for the model families the checkpoint path primarily targets.
-    Unknown layer types still contribute 0.
+    encountered. Falls back to ``layer.__dict__`` plus ``layer.state`` for
+    layer types that don't expose ``.keys`` / ``.values`` directly — most
+    importantly ``ArraysCache`` (used by Qwen3.5 / Nemotron-H / Jamba
+    hybrid layers), which would otherwise report 0 bytes and let the RAM
+    budget overrun silently for the model families the checkpoint path
+    primarily targets, and ``TurboQuantKVCache`` / ``SpectralQuantKVCache``,
+    which hold full-precision dequantisation side buffers
+    (``_key_dequant`` / ``_value_dequant``) that ``.state`` deliberately
+    excludes (they are recoverable from the packed indices + norms) — a
+    state-only walk would undercount their snapshot RAM by ~8x at 4-bit
+    and ~16x at 2-bit, defeating the ``ram_budget_bytes`` soft-eviction
+    guard. Walking ``__dict__`` plus the ``.state`` view (deduped by
+    ``id``) covers both surfaces. Unknown layer types still contribute 0.
     """
     total = 0
     for layer in state.cache or ():
@@ -54,11 +61,19 @@ def _estimate_state_bytes(state: CachedPromptState) -> int:
                 seen_attr = True
         if seen_attr:
             continue
-        # Fallback path: layers (e.g. ArraysCache) that expose state via
-        # ``.state``, a tuple or list of arrays. Walk arbitrarily nested
-        # tuples/lists so future cache layouts that group arrays in
-        # sub-containers still get counted.
-        stack: list[Any] = [getattr(layer, "state", None)]
+        # Fallback path: walk every mlx array owned by the layer. Walking
+        # ``__dict__`` catches side buffers (e.g. TurboQuant's
+        # ``_key_dequant``) that aren't surfaced through ``.state``;
+        # walking ``.state`` covers layer types whose backing storage
+        # lives in a sub-container exposed only via the property
+        # (``ArraysCache``). Container types (tuple / list / dict) are
+        # traversed; ``id()`` dedup prevents double-counting the same
+        # underlying array when it appears in both views.
+        seen_ids: set[int] = set()
+        stack: list[Any] = []
+        if hasattr(layer, "__dict__"):
+            stack.extend(vars(layer).values())
+        stack.append(getattr(layer, "state", None))
         while stack:
             item = stack.pop()
             if item is None:
@@ -66,8 +81,20 @@ def _estimate_state_bytes(state: CachedPromptState) -> int:
             if isinstance(item, (tuple, list)):
                 stack.extend(item)
                 continue
+            if isinstance(item, dict):
+                stack.extend(item.values())
+                continue
             nbytes = getattr(item, "nbytes", None)
-            if isinstance(nbytes, int):
+            # Guard against non-array objects that happen to have an
+            # ``nbytes`` attribute by additionally requiring ``ndim``
+            # (which mx.array has, but ints / Dtype singletons / etc. do
+            # not).
+            ndim = getattr(item, "ndim", None)
+            if isinstance(nbytes, int) and ndim is not None:
+                key = id(item)
+                if key in seen_ids:
+                    continue
+                seen_ids.add(key)
                 total += nbytes
     return total
 
@@ -628,10 +655,14 @@ class PromptCacheStore:
             return None
         state = self._entries.get(cid)
         if state is None:
-            # Trie out of sync — defensive (matches find_by_prefix).
-            # The stale terminal stays in the trie because we don't carry
-            # the token path; a full re-build on the next
-            # ``async_evict_all_to_disk`` clears it.
+            # Trie out of sync — defensive. Strict-prefix's descent path
+            # is exactly ``tokens[:depth]`` (the stored entry's tokens are
+            # a proper prefix of the query), so we can drop the stale
+            # terminal here. Otherwise every future query that hits the
+            # same subtree would short-circuit on the same stale cid and
+            # produce indefinite radix misses for an otherwise-recoverable
+            # prefix.
+            self._radix.remove(tokens[:depth], cid)
             self.metrics.radix_misses += 1
             return None
         self._entries.move_to_end(cid)

--- a/tests/test_prompt_cache_radix.py
+++ b/tests/test_prompt_cache_radix.py
@@ -435,3 +435,24 @@ class TestStrictPrefix:
         idx.insert([1], "tiny")
         assert idx.find_strict_prefix([1, 2, 3], min_depth=2) == (None, 0)
         assert idx.find_strict_prefix([1, 2, 3], min_depth=1) == ("tiny", 1)
+
+    def test_find_strict_prefix_excludes_exact_length_match(self):
+        """A stored entry whose tokens equal the query is NOT a proper
+        prefix. Returning it would cause the checkpoint-path driver to
+        no-op while still seeding stream_generate with the prompt's last
+        token — re-feeding that token at an extra position past the cache
+        depth produces wrong output (the model sees the last token twice).
+        """
+        idx = PrefixCacheIndex()
+        idx.insert([1, 2, 3], "exact")
+        assert idx.find_strict_prefix([1, 2, 3], min_depth=1) == (None, 0)
+
+    def test_find_strict_prefix_falls_back_to_proper_prefix_when_exact_excluded(
+        self,
+    ):
+        """When a stored entry exactly matches the query, the lookup
+        must fall back to a strictly-shorter terminal."""
+        idx = PrefixCacheIndex()
+        idx.insert([1, 2], "shorter")
+        idx.insert([1, 2, 3], "exact-match")
+        assert idx.find_strict_prefix([1, 2, 3], min_depth=1) == ("shorter", 2)

--- a/tests/test_prompt_cache_store_multi.py
+++ b/tests/test_prompt_cache_store_multi.py
@@ -43,14 +43,31 @@ def test_fetch_nearest_returns_none_when_no_strict_prefix():
     assert store.fetch_nearest([1, 2, 3, 4]) is None
 
 
-def test_fetch_nearest_exact_match_returns_empty_suffix():
+def test_fetch_nearest_exact_match_returns_none():
+    """An exact-length match is NOT a proper prefix and must not be
+    returned. Returning it would leave the checkpoint driver with no
+    prefill work while still seeding stream_generate with the prompt's
+    last token — re-feeding that token at an extra position past the
+    cache depth produces wrong output (the model sees the last token
+    twice). The lookup must miss so the caller falls back to a fresh
+    cache; a shorter strict prefix (if present) still wins.
+    """
     store = PromptCacheStore(max_slots=8)
+    store.insert_checkpoint(_state([1, 2, 3]))
+    assert store.fetch_nearest([1, 2, 3]) is None
+
+
+def test_fetch_nearest_exact_match_falls_back_to_shorter_prefix():
+    """When the deepest stored entry exactly matches the query, the
+    lookup must fall back to a strictly-shorter proper-prefix entry."""
+    store = PromptCacheStore(max_slots=8)
+    store.insert_checkpoint(_state([1, 2]))
     store.insert_checkpoint(_state([1, 2, 3]))
     hit = store.fetch_nearest([1, 2, 3])
     assert hit is not None
     state, suffix = hit
-    assert state.tokens == [1, 2, 3]
-    assert suffix == []
+    assert state.tokens == [1, 2]
+    assert suffix == [3]
 
 
 def test_insert_checkpoint_dedupes_on_identical_tokens():
@@ -105,3 +122,43 @@ def test_estimate_state_bytes_still_counts_kvcache_keys_values():
     nbytes = _estimate_state_bytes(state)
     expected = _KvCacheLike.keys.nbytes + _KvCacheLike.values.nbytes
     assert nbytes == expected
+
+
+def test_estimate_state_bytes_counts_owned_arrays_outside_state():
+    """Regression for the TurboQuant/SpectralQuant snapshot RAM undercount:
+    KV-quant caches hold full-precision dequantisation side buffers
+    (e.g. ``_key_dequant`` / ``_value_dequant``) that ``.state``
+    deliberately excludes (they are recoverable from packed indices +
+    norms). A state-only walk would undercount the snapshot RAM by ~8x
+    at 4-bit and ~16x at 2-bit, defeating ``ram_budget_bytes``
+    soft-eviction.
+    """
+    import mlx.core as mx
+    from olmlx.engine.prompt_cache.state import CachedPromptState
+    from olmlx.engine.prompt_cache.store import _estimate_state_bytes
+
+    class _TurboLike:
+        def __init__(self):
+            # Small "packed" state (what .state returns).
+            self._key_indices = mx.zeros((1, 4, 16, 4), dtype=mx.uint8)
+            self._value_indices = mx.zeros((1, 4, 16, 4), dtype=mx.uint8)
+            # Large full-precision dequant side buffers (NOT in .state).
+            self._key_dequant = mx.zeros((1, 4, 16, 64), dtype=mx.float16)
+            self._value_dequant = mx.zeros((1, 4, 16, 64), dtype=mx.float16)
+
+        @property
+        def state(self):
+            return [self._key_indices, self._value_indices]
+
+    layer = _TurboLike()
+    state = CachedPromptState(tokens=[1], cache=[layer])
+    nbytes = _estimate_state_bytes(state)
+    expected = (
+        layer._key_indices.nbytes
+        + layer._value_indices.nbytes
+        + layer._key_dequant.nbytes
+        + layer._value_dequant.nbytes
+    )
+    assert nbytes == expected, (
+        f"expected {expected} bytes (including dequant side buffers), got {nbytes}"
+    )


### PR DESCRIPTION
## Summary

Three independently-rooted correctness fixes in the message-boundary checkpoint subsystem, surfaced by a review pass over the 7-day diff.

- **Wrong-output bug in `find_strict_prefix`** — accepted terminals at depth `== len(tokens)`, so a checkpoint exactly matching a later request's prompt returned `suffix=[]`. The drive then no-op'd but still seeded `stream_generate` with `[flat[-1]]`, making the model see the last prompt token twice. Reachable on multi-turn chats where a new request matches a prior request's deepest interior boundary exactly. Loop now stops at `len(tokens) - 1`.
- **TurboQuant/SpectralQuant RAM accounting undercount** — `_estimate_state_bytes` fell back to `layer.state`, which deliberately excludes the full-precision `_key_dequant`/`_value_dequant` side buffers. Undercount was ~8x at 4-bit and ~16x at 2-bit, defeating the `OLMLX_PROMPT_CACHE_RAM_BUDGET_GB` soft-eviction guard. Now walks `__dict__` plus `.state` with `id()` dedup.
- **Stale radix terminal lingering after `_entries` desync** — `fetch_nearest`'s defensive `cid not in _entries` branch now drops the stale trie terminal at `tokens[:depth]` (safe because strict-prefix's descent path is exactly the stored entry's tokens). Previously, the same stale cid would be returned on every future query into that subtree.

## Test plan

- [x] `tests/test_prompt_cache_radix.py` — two new tests pin the corrected `find_strict_prefix` semantics
- [x] `tests/test_prompt_cache_store_multi.py` — replaces the test that pinned the buggy `fetch_nearest` exact-match return; adds TurboQuant-shaped layer regression test for `_estimate_state_bytes`
- [x] Full prompt cache + inference + model_manager + registry suite: 667 passed, 4 skipped (no regressions)
- [x] `uv run ruff check` and `ruff format --check` clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)