### PR TITLE
fix(prompt_cache): correct decode tok/s on cache-hit timing

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -602,6 +602,7 @@ def _derive_timing_stats(
     prompt_tps: float,
     gen_tps: float,
     eval_timer_ns: int,
+    prefilled_count: int | None = None,
 ) -> tuple[float, float]:
     """Populate ``stats.prompt_eval_duration`` and ``stats.eval_duration`` from
     mlx-lm's measured prefill/decode rates, with conservative fallbacks for
@@ -622,7 +623,22 @@ def _derive_timing_stats(
     tok/s). The sum invariant still holds; the split is just heuristic.
     mlx-lm reports both rates in practice, so this path is essentially
     unreached.
+
+    ``prefilled_count`` is the number of tokens mlx-lm actually prefilled —
+    which differs from ``stats.prompt_eval_count`` on a prompt-cache hit, where
+    the caller reports the *full* prompt size but mlx-lm only re-prefilled the
+    uncached suffix (and measured ``prompt_tps`` over that suffix). The prefill
+    *duration* must be derived from the count the rate was measured over, else
+    ``full_count / suffix_rate`` inflates ``raw_prompt_ns`` enough to crowd
+    decode down to a sliver in the proportional clamp — producing an impossible
+    decode tok/s. Defaults to ``stats.prompt_eval_count`` (no cache hit, or the
+    non-streaming path where the reported count already matches the rate).
     """
+    prefill_count = (
+        prefilled_count
+        if prefilled_count is not None and prefilled_count > 0
+        else stats.prompt_eval_count
+    )
     # Explicit zero of the fields this helper owns — several branches below
     # write only one of the two, so initialize both up front to make the
     # mutation contract independent of the caller's TimingStats state.
@@ -645,8 +661,8 @@ def _derive_timing_stats(
         gen_tps = float(gen_tps)
 
     raw_prompt_ns = (
-        int(stats.prompt_eval_count / prompt_tps * 1e9)
-        if prompt_tps > 0 and stats.prompt_eval_count > 0
+        int(prefill_count / prompt_tps * 1e9)
+        if prompt_tps > 0 and prefill_count > 0
         else 0
     )
     raw_decode_ns = (
@@ -715,8 +731,12 @@ def _derive_timing_stats(
     # duration than the one we actually report.
     if stats.eval_duration > 0 and stats.eval_count > 0:
         gen_tps = stats.eval_count / (stats.eval_duration / 1e9)
-    if stats.prompt_eval_duration > 0 and stats.prompt_eval_count > 0:
-        prompt_tps = stats.prompt_eval_count / (stats.prompt_eval_duration / 1e9)
+    if stats.prompt_eval_duration > 0 and prefill_count > 0:
+        # Use prefill_count (what was actually prefilled), not the reported
+        # prompt_eval_count, so the logged rate matches the work the duration
+        # measures — otherwise a cache hit shows full_count / suffix_time, a
+        # fictitious "rate" far above the hardware's real prefill throughput.
+        prompt_tps = prefill_count / (stats.prompt_eval_duration / 1e9)
 
     return prompt_tps, gen_tps
 
@@ -3599,6 +3619,12 @@ async def _stream_completion(
                 getattr(token, "prompt_tps", 0) or 0,
                 getattr(token, "generation_tps", 0) or 0,
                 eval_timer.duration_ns,
+                # On a cache hit stats.prompt_eval_count is the full prompt but
+                # token.prompt_tokens (and prompt_tps) cover only the re-prefilled
+                # suffix — apportion the prefill duration against the suffix.
+                prefilled_count=(
+                    getattr(token, "prompt_tokens", None) if token is not None else None
+                ),
             )
 
         stats.total_duration = total_timer.duration_ns
@@ -4002,6 +4028,10 @@ async def _full_completion_inner(
         getattr(result, "prompt_tps", 0) or 0,
         getattr(result, "generation_tps", 0) or 0,
         eval_timer.duration_ns,
+        # Non-streaming reports the mlx-lm-prefilled count as prompt_eval_count
+        # already, so this matches — passed explicitly for parity with the
+        # streaming path's cache-hit handling.
+        prefilled_count=getattr(result, "prompt_tokens", None),
     )
     total_secs = stats.total_duration / 1e9 if stats.total_duration else 0
     logger.info(

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -154,6 +154,33 @@ class TestDeriveTimingStats:
         # prompt_eval_duration is 100 ms, prompt_eval_count is 5 → 50 tok/s.
         assert p == pytest.approx(50.0)
 
+    def test_cache_hit_uses_prefilled_count_not_full_prompt(self):
+        """Streaming cache-hit regression: stats.prompt_eval_count is the FULL
+        prompt (reported to the caller), but mlx-lm's prompt_tps was measured
+        over only the re-prefilled suffix. Dividing the full count by the
+        suffix rate inflates raw prefill duration, which the proportional
+        clamp then lets crowd decode down to a ~1ms sliver — producing an
+        impossible decode tok/s. Passing the actually-prefilled count keeps
+        the prefill duration honest so decode keeps mlx-lm's measured rate."""
+        stats = TimingStats(prompt_eval_count=40_000, eval_count=100)
+        # mlx-lm prefilled a 50-token suffix at 5000 tok/s (10ms) and decoded
+        # 100 tokens at 50 tok/s (2.0s). Wall-clock ~2.01s.
+        p, g = _derive_timing_stats(
+            stats,
+            5000.0,
+            50.0,
+            eval_timer_ns=2_010_000_000,
+            prefilled_count=50,
+        )
+        # Prefill duration reflects the suffix (10ms), not the full prompt.
+        assert stats.prompt_eval_duration == 10_000_000
+        # Decode keeps essentially all of wall-clock → mlx-lm's real 50 tok/s,
+        # NOT the bogus ~250 tok/s the inflated-prefill clamp would produce.
+        assert stats.eval_duration == 2_000_000_000
+        assert g == pytest.approx(50.0)
+        # Prompt rate is the genuine suffix prefill rate (count matches rate).
+        assert p == pytest.approx(5000.0)
+
     def test_non_numeric_rate_treated_as_missing(self):
         """Defensive boundary: a non-Python-numeric scalar (e.g. MagicMock
         from a sloppy test, numpy/mlx scalar from mlx-lm) must not be trusted


### PR DESCRIPTION
## Problem

Generation throughput logged on a prompt-cache hit was physically impossible:

```
Generation complete: 40491 prompt tokens (24095.8 tok/s), 69 tokens generated (49275.2 tok/s), 1.68s total
```

No LLM decodes 69 tokens in ~1.4 ms. The prefill rate was also overstated.

## Root cause

On a cache hit the streaming path hands mlx-lm only the **uncached suffix**, so `token.prompt_tps` is measured over that suffix. But the streaming loop deliberately overrides `stats.prompt_eval_count` to the **full** prompt size (for transparency to the caller). `_derive_timing_stats` then computed `raw_prompt_ns = full_count / suffix_rate`, pretending the entire prompt was prefilled at the suffix's rate. That inflated the prefill duration far past wall-clock, so the proportional clamp handed ~all of `eval_timer` to prefill and left decode a ~1 ms sliver — producing the bogus 49,275 tok/s, with the prefill rate degenerating into `full_count / eval_timer` (24,095).

The non-streaming path never hit this: it sets `prompt_eval_count = result.prompt_tokens` (the actually-prefilled count, consistent with the rate).

## Fix

Add a `prefilled_count` argument to `_derive_timing_stats` so the prefill **duration** is apportioned against the count the rate was measured over (the suffix), while the API still reports the full prompt size. Decode keeps mlx-lm's real measured rate; the logged prompt rate becomes the genuine prefill throughput. The non-streaming caller passes the same value explicitly for parity.

## Testing

- Added `test_cache_hit_uses_prefilled_count_not_full_prompt` reproducing the inflated-prefill → bogus-decode-rate path (fails before, passes after).
- 14/14 timing tests, 325/325 inference + prompt-cache tests pass.
- ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)