### PR TITLE
fix(speculative): sub-chunk prefill to bound activation memory

### DIFF
--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -30,6 +30,16 @@ from olmlx.engine.gdn_rollback import (
 
 logger = logging.getLogger(__name__)
 
+# Sub-chunk size for prefill forward passes. Matches mlx-lm's
+# ``generate_step`` ``prefill_step_size`` default so the speculative decoder
+# bounds activation memory the same way mlx-lm's native prefill does. A single
+# forward over a long prompt OOMs Metal — the attention-score intermediate for
+# a ~38k-token prefill exceeds the ~41 GB single-buffer limit (observed on
+# Qwen3.6-35B-A3B-6bit). Speculative decoders own their own prefill (prompt
+# caching is gated off for them), so they don't inherit the prompt-cache path's
+# segmented-prefill chunking — this is the equivalent bound for that path.
+_PREFILL_CHUNK = 2048
+
 
 def _logits(out: Any) -> mx.array:
     # mlx-vlm's language_model returns LanguageModelOutput(logits=...);
@@ -92,6 +102,28 @@ def _eval_cache(cache: list) -> None:
         )
 
 
+def _chunked_prefill(model: Any, tokens: mx.array, cache: list) -> None:
+    """Run ``model`` over ``tokens`` (shape (1, T)) to populate ``cache``,
+    in sub-chunks of at most ``_PREFILL_CHUNK`` tokens.
+
+    Logits are discarded; cache state is materialised (and the Metal buffer
+    cache cleared) after every sub-chunk so peak activation memory stays at
+    roughly one sub-chunk's worth instead of the whole prompt's. Mirrors
+    mlx-lm's prefill loop — without this, a single forward over a long prompt
+    OOMs Metal (the attention-score intermediate exceeds the ~41 GB
+    single-buffer limit). Standard KV-cached attention is chunking-invariant,
+    so the resulting cache state is identical to a single forward.
+    """
+    n = tokens.shape[1]
+    pos = 0
+    while pos < n:
+        stop = min(pos + _PREFILL_CHUNK, n)
+        model(tokens[:, pos:stop], cache=cache)
+        _eval_cache(cache)
+        mx.clear_cache()
+        pos = stop
+
+
 def _prefill_last_logit(model: Any, prompt: mx.array, cache: list) -> mx.array:
     """Return the logit for the last prompt position without materialising
     the full [batch, seq_len, vocab] tensor.
@@ -111,8 +143,10 @@ def _prefill_last_logit(model: Any, prompt: mx.array, cache: list) -> mx.array:
     if prompt.shape[1] <= 1:
         return _logits(model(prompt, cache=cache))[0, -1, :]
     prefix, last = prompt[:, :-1], prompt[:, -1:]
-    model(prefix, cache=cache)  # output discarded; lm_head never materialised
-    _eval_cache(cache)  # materialise KV state before the single-token pass
+    # Pass 1: fill the KV cache from the prefix in bounded sub-chunks. Output
+    # is discarded (lm_head never materialised over seq_len-1 positions) and
+    # cache state is materialised between passes for OOM avoidance.
+    _chunked_prefill(model, prefix, cache)
     return _logits(model(last, cache=cache))[0, 0, :]
 
 
@@ -372,9 +406,9 @@ class SpeculativeDecoder:
         )
         mx.eval(self._last_target_logit)
 
-        # Populate draft cache; logits not needed.
-        self._draft(prompt, cache=self._draft_cache)
-        _eval_cache(self._draft_cache)
+        # Populate draft cache; logits not needed. Sub-chunked like the target
+        # prefill above so a long prompt doesn't OOM Metal in one forward.
+        _chunked_prefill(self._draft, prompt, self._draft_cache)
 
         self._cache_seq_len = prompt.shape[1]
 

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -262,6 +262,94 @@ class TestPrefillLastLogit:
         assert cache[0].offset == prompt.shape[1]
 
 
+class _RecordingModel:
+    """Wraps a model and records the seq_len of every ``__call__``.
+
+    Used to assert that prefill bounds each forward pass to at most
+    ``_PREFILL_CHUNK`` tokens, the way mlx-lm's native prefill loop does —
+    a single forward over a very long prompt OOMs Metal (the
+    attention-score intermediate for a ~38k-token prefill exceeds the
+    ~41 GB single-buffer limit).
+    """
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.layers = inner.layers
+        self.calls: list[int] = []
+
+    def __call__(self, input_ids, cache=None):
+        self.calls.append(int(input_ids.shape[1]))
+        return self._inner(input_ids, cache=cache)
+
+    def __getattr__(self, name):
+        # Delegate anything not set on the wrapper (e.g. named_modules, used
+        # by find_gdn_class during SpeculativeDecoder construction) to inner.
+        if name == "_inner":
+            raise AttributeError(name)
+        return getattr(self._inner, name)
+
+
+class TestChunkedPrefill:
+    """Prefill must sub-chunk long prompts so no single ``model()`` forward
+    materialises an activation graph large enough to OOM Metal."""
+
+    def test_prefix_forward_bounded_to_chunk_size(self):
+        from mlx_lm.models.cache import make_prompt_cache
+
+        from olmlx.engine.speculative import _PREFILL_CHUNK, _prefill_last_logit
+
+        inner = MockModel(32, 16)
+        model = _RecordingModel(inner)
+        cache = make_prompt_cache(inner)
+        n = _PREFILL_CHUNK * 2 + 10
+        prompt = mx.zeros((1, n), dtype=mx.int32)
+
+        result = _prefill_last_logit(model, prompt, cache)
+        mx.eval(result)
+
+        # No single forward may exceed the chunk size (pass 2 is 1 token).
+        assert max(model.calls) <= _PREFILL_CHUNK
+        # Cache must still be fully populated to the prompt length.
+        assert cache[0].offset == n
+
+    def test_chunked_prefill_matches_naive_causal(self, monkeypatch):
+        """Sub-chunking must not change the last-position logit: standard
+        KV-cached attention is mathematically chunking-invariant."""
+        from mlx_lm.models.cache import KVCache
+
+        from olmlx.engine import speculative
+        from olmlx.engine.speculative import _prefill_last_logit
+
+        # Force several sub-chunks over a short prompt.
+        monkeypatch.setattr(speculative, "_PREFILL_CHUNK", 2)
+
+        model = _CausalMockModel(vocab_size=32, hidden_size=16)
+        prompt = mx.array([[1, 2, 3, 4, 5, 6, 7]])
+
+        naive = model(prompt, cache=[KVCache()])[0, -1, :]
+        mx.eval(naive)
+
+        result = _prefill_last_logit(model, prompt, [KVCache()])
+        mx.eval(result)
+
+        assert mx.allclose(result, naive, atol=1e-4)
+
+    def test_draft_prefill_chunks_long_prompt(self):
+        """SpeculativeDecoder.prefill must also chunk the draft forward."""
+        from olmlx.engine.speculative import _PREFILL_CHUNK, SpeculativeDecoder
+
+        draft = _RecordingModel(MockModel(32, 16))
+        target = _RecordingModel(MockModel(32, 16))
+        decoder = SpeculativeDecoder(
+            draft_model=draft, target_model=target, num_speculative_tokens=2
+        )
+        n = _PREFILL_CHUNK * 2 + 5
+        decoder.prefill(mx.zeros((1, n), dtype=mx.int32))
+
+        assert max(draft.calls) <= _PREFILL_CHUNK
+        assert max(target.calls) <= _PREFILL_CHUNK
+
+
 class _CausalAttention:
     """Minimal scaled-dot-product attention over a real KV cache.
 


### PR DESCRIPTION
## Problem

Running a longer job in OpenCode against a speculative-decoding target OOMs during prefill:

```
[ERROR] olmlx.utils.streaming: Inference error (RuntimeError):
[metal::malloc] Attempting to allocate 94852772352 bytes which is greater
than the maximum allowed buffer size of 41747087360 bytes.
  ...
  File ".../engine/speculative.py", line 370, in prefill
  File ".../engine/speculative.py", line 115, in _prefill_last_logit
  File ".../engine/speculative.py", line 75, in _eval_cache
    mx.eval(*arrs)
```

(Observed on `Qwen3.6-35B-A3B-6bit`.)

## Root cause

`_prefill_last_logit` ran `model(prefix, cache=cache)` as **one forward pass over the entire prefix**, with no activation-memory bound. For a long prompt (~38k+ tokens), a full-attention layer's QK score intermediate exceeds Metal's ~41 GB single-buffer limit — the 94.8 GB allocation is exactly the shape of an unchunked attention-score graph (≈ heads × N² × 2 bytes). The draft prefill had the same unchunked forward.

The prompt-cache path already solved this identical OOM by sub-chunking at `_PREFILL_CHUNK=2048` (`_drive_segmented_prefill._run`), but **speculative decoders own their own prefill** (prompt caching is gated off for them), so they never inherited the bound.

## Fix

- Add `_PREFILL_CHUNK = 2048` and a `_chunked_prefill(model, tokens, cache)` helper that runs the forward in ≤2048-token sub-chunks, materialising cache state and clearing the Metal buffer cache per chunk.
- `_prefill_last_logit` pass 1 now uses it (pass 2's single-token lm_head step — which avoids the `[seq, vocab]` OOM — is unchanged).
- The main decoder's draft prefill uses it too. PLD and dual decoders already route through `_prefill_last_logit`, so they're covered automatically.

Mirrors mlx-lm's own `prefill_step_size` loop and is mathematically identical for KV-cached attention. The speculative path uses no `mx.stream`, so prefill and decode share the default stream — **no cross-stream hazard** (unlike the prompt-cache path).

## Tests

New `TestChunkedPrefill` (written failing first, TDD):
- no single forward exceeds `_PREFILL_CHUNK`
- chunked prefill == naive single-pass logit on a real causal-attention mock
- decoder-level test covering both draft and target prefill

Full speculative / eagle / pld / flash / hybrid / tree suites pass (114 tests). Ruff clean.

## Note

This bounds **prefill** memory — the OOM is gone — but a 38k-token prompt with a draft model is still a heavy speculative workload. For throughput on very long contexts the non-speculative path may serve better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)