### PR TITLE
fix(anthropic): fold stray system-role turn into leading system

### DIFF
--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -153,16 +153,36 @@ def _convert_messages(req: AnthropicMessagesRequest) -> list[dict]:
     """
     messages = []
 
-    # System message (strip billing headers to preserve KV cache)
+    # System content is collected into a single leading message. The Anthropic
+    # API carries it in a dedicated top-level field, but some clients (e.g.
+    # Claude Code) also place a ``system`` turn inside ``messages``. Appending
+    # such a turn verbatim leaves a second system message at a non-zero index,
+    # which strict chat templates (Qwen3.6) reject with "System message must be
+    # at the beginning." — a 500 on every request. Fold all system content to
+    # the front instead.
+    system_parts: list[str] = []
+
+    # Top-level system (strip billing headers to preserve KV cache)
     system = _strip_billing_headers(req.system)
     if system:
         if isinstance(system, str):
-            messages.append({"role": "system", "content": system})
+            system_parts.append(system)
         else:
             text = " ".join(b.text for b in system if b.text)
-            messages.append({"role": "system", "content": text})
+            if text:
+                system_parts.append(text)
 
     for msg in req.messages:
+        if msg.role == "system":
+            if isinstance(msg.content, str):
+                if msg.content:
+                    system_parts.append(msg.content)
+            else:
+                text = " ".join(b.text for b in msg.content if b.text)
+                if text:
+                    system_parts.append(text)
+            continue
+
         if isinstance(msg.content, str):
             messages.append({"role": msg.role, "content": msg.content})
             continue
@@ -219,6 +239,9 @@ def _convert_messages(req: AnthropicMessagesRequest) -> list[dict]:
                     )
             if text_parts:
                 messages.append({"role": "user", "content": " ".join(text_parts)})
+
+    if system_parts:
+        messages.insert(0, {"role": "system", "content": "\n\n".join(system_parts)})
 
     return messages
 

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -172,6 +172,48 @@ class TestConvertMessages:
         assert "Part 1" in messages[0]["content"]
         assert "Part 2" in messages[0]["content"]
 
+    def test_system_role_message_folded_into_leading_system(self):
+        """A ``system``-role message inside ``messages`` is folded into the
+        leading system block instead of appended at a non-zero index.
+
+        The Anthropic API carries system content in a dedicated top-level
+        field, but some clients (e.g. Claude Code) also place a ``system``
+        turn inside ``messages``.  Appending it verbatim produced a second
+        system message at index >= 1, which strict chat templates (Qwen3.6)
+        reject with "System message must be at the beginning." — a 500 on
+        every ``/v1/messages`` request.  Regression for that failure.
+        """
+        req = AnthropicMessagesRequest(
+            model="test",
+            system=[AnthropicContentBlock(type="text", text="Top-level system.")],
+            messages=[
+                AnthropicMessage(role="system", content="Inline system."),
+                AnthropicMessage(role="user", content="hello"),
+            ],
+        )
+        messages = _convert_messages(req)
+        # Exactly one system message, and it is first.
+        system_indices = [i for i, m in enumerate(messages) if m["role"] == "system"]
+        assert system_indices == [0]
+        assert "Top-level system." in messages[0]["content"]
+        assert "Inline system." in messages[0]["content"]
+        assert [m["role"] for m in messages] == ["system", "user"]
+
+    def test_system_role_message_without_top_level_system(self):
+        """A ``system``-role message in ``messages`` with no top-level system
+        still becomes the single leading system message."""
+        req = AnthropicMessagesRequest(
+            model="test",
+            messages=[
+                AnthropicMessage(role="system", content="Inline only."),
+                AnthropicMessage(role="user", content="hi"),
+            ],
+        )
+        messages = _convert_messages(req)
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == "Inline only."
+        assert [m["role"] for m in messages] == ["system", "user"]
+
     def test_assistant_with_tool_use(self):
         req = AnthropicMessagesRequest(
             model="test",


### PR DESCRIPTION
## Problem

Every Claude Code request to `/v1/messages` 500'd with:

```
Chat template failed even without tools: System message must be at the beginning.
```

## Root cause

Claude Code sends its system prompt in the top-level `system` field **and** a `system`-role turn inside the `messages` array. `_convert_messages` placed the top-level system at index 0, then appended the in-array `system` turn verbatim at a non-zero index — producing `['system', 'system', 'user']` (matching the log's `messages=2 → Converted 3 messages`).

The strict Qwen3.6 chat template raises `System message must be at the beginning.` for any `system` message that isn't first. Reproduced against the real `unsloth/Qwen3.6-27B-MLX-8bit` template: simple `[system, user, …]` renders fine; the raise only fires with a displaced/duplicate system. Not a regression — triggered by this request shape against a strict template.

## Fix

`_convert_messages` now collects all system content into a single leading block. A `system`-role turn found inside `messages` (string or block content) is folded into that block, guaranteeing exactly one `system` message at index 0. The Anthropic API carries system content in its own top-level field, so folding a stray in-array system turn to the front is the correct normalization.

## Verification

- Two regression tests added to `TestConvertMessages`; the displaced-system case failed before the fix (`[0, 1] == [0]`) and passes after.
- `tests/test_routers_anthropic.py`: **126 passed**.
- End-to-end against the real tokenizer: `['system','system','user']` (RAISE) → `['system','user']` (renders cleanly).
- `ruff check` + `format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)