### PR TITLE
fix(tests): real_model tests must bypass the autouse MLX mock

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -149,8 +149,19 @@ def _fake_generate(model, tokenizer, *, prompt, max_tokens=512, **kwargs):
 
 
 @pytest.fixture(autouse=True)
-def mock_mlx_primitives(monkeypatch):
-    """Patch all MLX primitives so tests don't need a GPU."""
+def mock_mlx_primitives(request, monkeypatch):
+    """Patch all MLX primitives so tests don't need a GPU.
+
+    No-op for tests marked ``real_model``: those load an actual MLX model and
+    must hit the real ``mlx_lm`` / ``mlx_vlm`` load + generate path.  Without
+    this guard the autouse patches would silently mock ``mlx_lm.generate``
+    (returning a canned "Hello world"), so a ``real_model`` test would pass
+    against the mock instead of the model it claims to exercise.
+    """
+    if request.node.get_closest_marker("real_model"):
+        yield {}
+        return
+
     patches = []
 
     def _start(target, replacement=None):


### PR DESCRIPTION
## Summary

The `mock_mlx_primitives` **autouse** fixture in `tests/integration/conftest.py` patches `mlx_lm.load` / `mlx_lm.generate` (plus `snapshot_download` and memory probes) for *every* test in the package — including the ones marked `real_model`. As a result the `test_real_model.py` smoke tests passed against the canned `"Hello world"` mock instead of loading an actual model: false coverage.

This makes the fixture a **no-op when the test carries the `real_model` marker**, so those tests hit the real `mlx_lm` / `mlx_vlm` load + generate path. The marker now genuinely means "no mocks." (Discovered while adding the live VLM tools+images test in #433.)

## Test Plan

- [x] `uv run pytest tests/integration/test_real_model.py -m real_model` → **6 passed in 7.46s**, genuinely loading Qwen2.5-0.5B (the mock returned instantly with "Hello world").
- [x] `uv run pytest tests/integration -m "not real_model"` → 40 passed, 1 skipped — the mock still applies to normal integration tests.
- [x] `ruff check` + `ruff format --check` clean.

Note: `test_real_model.py`'s assertions remain intentionally loose (`len(text) > 0`); now that the mock is bypassed they exercise the real model, but tightening them is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)