### PR TITLE
test: add regression coverage across 17 modules; fix question-tool event bug

### DIFF
--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -861,7 +861,7 @@ class ChatSession:
                     ):
                         continue
                     try:
-                        payload = json.loads(content[len("__question__") :])
+                        payload = json.loads(content[len("__question__:") :])
                         yield {
                             "type": "question",
                             "header": payload.get("header", ""),

--- a/tests/test_api_bench_coverage.py
+++ b/tests/test_api_bench_coverage.py
@@ -1,0 +1,577 @@
+"""Regression coverage for olmlx.bench.api_bench run/orchestration paths.
+
+Focuses on the previously-uncovered logic: run_single (streaming + non-stream
+timing, tps source selection, error handling, token estimation fallback),
+_warmup / _unload best-effort wrappers, _print_table fallback rendering,
+build_arg_parser defaults, _get_olmlx_version, and the main() sweep loop.
+
+All HTTP is faked — no network, no real server. httpx is only used to build
+Response objects and to be the type the code calls; a FakeClient stands in for
+httpx.Client everywhere a request would go out.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+
+import httpx
+import pytest
+
+from olmlx.bench import api_bench
+from olmlx.bench.api_bench import (
+    OllamaChatAdapter,
+    OpenAIChatAdapter,
+    RunRecord,
+    _get_olmlx_version,
+    _print_table,
+    _unload,
+    _warmup,
+    build_arg_parser,
+    run_single,
+)
+from olmlx.bench.prompts import BenchPrompt
+
+
+_DUMMY_REQ = httpx.Request("POST", "http://x/api/chat")
+
+
+def make_response(status=200, *, json=None, text=None):
+    """Build an httpx.Response with a request attached so raise_for_status works."""
+    if json is not None:
+        return httpx.Response(status, json=json, request=_DUMMY_REQ)
+    if text is not None:
+        return httpx.Response(status, text=text, request=_DUMMY_REQ)
+    return httpx.Response(status, request=_DUMMY_REQ)
+
+
+@pytest.fixture
+def prompt() -> BenchPrompt:
+    return BenchPrompt(
+        name="t",
+        category="test",
+        messages=[{"role": "user", "content": "hello"}],
+        max_tokens=32,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Fake httpx client                                                           #
+# --------------------------------------------------------------------------- #
+
+
+class _FakeStreamResponse:
+    def __init__(self, lines, status=200):
+        self._lines = lines
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "boom",
+                request=_DUMMY_REQ,
+                response=httpx.Response(self.status_code, request=_DUMMY_REQ),
+            )
+
+    def iter_lines(self):
+        yield from self._lines
+
+
+class FakeClient:
+    """Stands in for httpx.Client. Records calls; replays scripted responses."""
+
+    def __init__(self, *, post_responses=None, stream_lines=None, stream_status=200):
+        # post_responses: list of httpx.Response OR Exception to raise, popped FIFO.
+        self._post_responses = list(post_responses or [])
+        self._stream_lines = stream_lines or []
+        self._stream_status = stream_status
+        self.post_calls: list[dict] = []
+        self.stream_calls: list[dict] = []
+
+    def post(self, url, *, json=None, headers=None, timeout=None):
+        self.post_calls.append(
+            {"url": url, "json": json, "headers": headers, "timeout": timeout}
+        )
+        if not self._post_responses:
+            return make_response(200, json={})
+        nxt = self._post_responses.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return nxt
+
+    @contextlib.contextmanager
+    def stream(self, method, url, *, json=None, headers=None, timeout=None):
+        self.stream_calls.append(
+            {"method": method, "url": url, "json": json, "timeout": timeout}
+        )
+        yield _FakeStreamResponse(self._stream_lines, status=self._stream_status)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+# --------------------------------------------------------------------------- #
+# run_single — non-streaming                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_run_single_nonstream_uses_eval_duration_for_tps(prompt):
+    resp = make_response(
+        200,
+        json={
+            "message": {"content": "hi there friend"},
+            "prompt_eval_count": 5,
+            "eval_count": 10,
+            "eval_duration": 2_000_000_000,  # 2s for 10 tokens -> 5 tok/s
+            "prompt_eval_duration": 1_000_000,
+        },
+    )
+    client = FakeClient(post_responses=[resp])
+    rec = run_single(
+        client, "http://x", OllamaChatAdapter(), prompt, "m", 32, False, 1.0, 0
+    )
+    assert rec.error is None
+    assert rec.output_tokens == 10
+    assert rec.prompt_tokens == 5
+    assert rec.tps_source == "eval_duration"
+    assert rec.tokens_per_sec == pytest.approx(5.0)
+    assert rec.tokens_estimated is False
+    assert rec.ttft_ms is None  # non-stream never records ttft
+    assert rec.mode == "nostream"
+    assert rec.api == "ollama-chat"
+    # URL joined without double slash.
+    assert client.post_calls[0]["url"] == "http://x/api/chat"
+
+
+def test_run_single_nonstream_estimates_tokens_when_usage_missing(prompt):
+    # OpenAI adapter with no usage -> output_tokens estimated from text.
+    resp = make_response(
+        200,
+        json={"choices": [{"message": {"content": "one two three four five"}}]},
+    )
+    client = FakeClient(post_responses=[resp])
+    rec = run_single(
+        client, "http://x", OpenAIChatAdapter(), prompt, "m", 32, False, 1.0, 0
+    )
+    assert rec.tokens_estimated is True
+    assert rec.output_tokens is not None and rec.output_tokens > 0
+    # No eval_duration and no prompt_eval_duration on this path -> rtt_fallback.
+    assert rec.tps_source == "rtt_fallback"
+    assert rec.tokens_per_sec is not None
+
+
+def test_run_single_nonstream_decode_estimate_via_prompt_eval(prompt, monkeypatch):
+    # Force total_ms large and prompt_eval_duration present so the
+    # decode_estimate (non-stream) branch is taken instead of eval_duration.
+    resp = make_response(
+        200,
+        json={
+            "message": {"content": "abc"},
+            "eval_count": 8,
+            # Small prompt_eval_duration (ns) so total_ms - prompt_eval stays
+            # positive even though the faked round-trip is near-instant. With no
+            # eval_duration the tps falls through to the non-stream decode
+            # estimate branch.
+            "prompt_eval_duration": 100,
+        },
+    )
+    client = FakeClient(post_responses=[resp])
+    rec = run_single(
+        client, "http://x", OllamaChatAdapter(), prompt, "m", 32, False, 1.0, 0
+    )
+    assert rec.tps_source == "decode_estimate"
+    assert rec.tokens_per_sec is not None
+
+
+def test_run_single_nonstream_http_error_recorded(prompt):
+    err_resp = make_response(500, json={"error": "kaboom"})
+    client = FakeClient(post_responses=[err_resp])
+    rec = run_single(
+        client, "http://x", OllamaChatAdapter(), prompt, "m", 32, False, 1.0, 0
+    )
+    assert rec.error is not None
+    assert "HTTPStatusError" in rec.error or "Error" in rec.error
+    assert rec.tokens_per_sec is None
+    assert rec.total_ms >= 0
+
+
+def test_run_single_nonstream_exception_before_response(prompt):
+    boom = httpx.ConnectError("refused")
+    client = FakeClient(post_responses=[boom])
+    rec = run_single(
+        client, "http://x", OllamaChatAdapter(), prompt, "m", 32, False, 1.0, 0
+    )
+    assert rec.error is not None
+    assert "ConnectError" in rec.error
+    assert rec.total_ms >= 0
+
+
+def test_run_single_zero_output_tokens_no_tps(prompt):
+    # Empty text, no usage -> output_tokens stays None, no tps computed.
+    resp = make_response(200, json={"message": {"content": ""}})
+    client = FakeClient(post_responses=[resp])
+    rec = run_single(
+        client, "http://x", OllamaChatAdapter(), prompt, "m", 32, False, 1.0, 0
+    )
+    assert rec.error is None
+    assert rec.output_tokens is None
+    assert rec.tokens_per_sec is None
+    assert rec.tps_source is None
+
+
+# --------------------------------------------------------------------------- #
+# run_single — streaming                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_run_single_stream_aggregates_text_and_ttft(prompt):
+    lines = [
+        json.dumps({"message": {"content": "he"}, "done": False}),
+        json.dumps({"message": {"content": "llo"}, "done": False}),
+        json.dumps(
+            {
+                "message": {"content": ""},
+                "done": True,
+                "eval_count": 4,
+                "prompt_eval_count": 9,
+                "eval_duration": 1_000_000_000,
+            }
+        ),
+    ]
+    client = FakeClient(stream_lines=lines)
+    rec = run_single(
+        client, "http://x/", OllamaChatAdapter(), prompt, "m", 32, True, 1.0, 0
+    )
+    assert rec.error is None
+    assert rec.mode == "stream"
+    assert rec.ttft_ms is not None and rec.ttft_ms >= 0
+    assert rec.output_tokens == 4
+    assert rec.prompt_tokens == 9
+    assert rec.tps_source == "eval_duration"
+    # stream call carries the POST body and joined url.
+    assert client.stream_calls[0]["url"] == "http://x/api/chat"
+    assert client.stream_calls[0]["method"] == "POST"
+
+
+def test_run_single_stream_decode_estimate_when_no_eval_duration(prompt):
+    lines = [
+        json.dumps({"message": {"content": "x"}, "done": False}),
+        json.dumps(
+            {"message": {"content": ""}, "done": True, "eval_count": 3}
+        ),  # no eval_duration
+    ]
+    client = FakeClient(stream_lines=lines)
+    rec = run_single(
+        client, "http://x", OllamaChatAdapter(), prompt, "m", 32, True, 1.0, 0
+    )
+    assert rec.output_tokens == 3
+    assert rec.tps_source == "decode_estimate"
+
+
+def test_run_single_stream_missing_done_sets_error(prompt):
+    # No done event -> "stream ended without done event" error.
+    lines = [json.dumps({"message": {"content": "partial"}, "done": False})]
+    client = FakeClient(stream_lines=lines)
+    rec = run_single(
+        client, "http://x", OllamaChatAdapter(), prompt, "m", 32, True, 1.0, 0
+    )
+    assert rec.error is not None
+    assert "done" in rec.error
+    # Text still aggregated; tokens estimated since no usage seen.
+    assert rec.tokens_estimated is True
+
+
+def test_run_single_stream_http_error(prompt):
+    client = FakeClient(stream_lines=[], stream_status=503)
+    rec = run_single(
+        client, "http://x", OllamaChatAdapter(), prompt, "m", 32, True, 1.0, 0
+    )
+    assert rec.error is not None
+    assert "HTTPStatusError" in rec.error
+
+
+# --------------------------------------------------------------------------- #
+# _warmup / _unload                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_warmup_posts_nonstream_request():
+    client = FakeClient(post_responses=[make_response(200, json={})])
+    _warmup(client, "http://x/", "m", 1.0, OllamaChatAdapter())
+    assert len(client.post_calls) == 1
+    call = client.post_calls[0]
+    assert call["url"] == "http://x/api/chat"
+    assert call["json"]["stream"] is False
+    assert call["json"]["model"] == "m"
+
+
+def test_warmup_swallows_errors(capsys):
+    client = FakeClient(post_responses=[httpx.ConnectError("down")])
+    # Must not raise.
+    _warmup(client, "http://x", "m", 1.0, OllamaChatAdapter())
+    err = capsys.readouterr().err
+    assert "warmup" in err
+
+
+def test_unload_posts_to_api_unload():
+    client = FakeClient(post_responses=[make_response(200, json={})])
+    _unload(client, "http://x/", "mymodel", 1.0)
+    call = client.post_calls[0]
+    assert call["url"] == "http://x/api/unload"
+    assert call["json"] == {"model": "mymodel"}
+
+
+def test_unload_logs_http_error_status(capsys):
+    client = FakeClient(post_responses=[make_response(404, text="nope")])
+    _unload(client, "http://x", "mymodel", 1.0)
+    err = capsys.readouterr().err
+    assert "unload" in err
+    assert "404" in err
+
+
+def test_unload_swallows_exceptions(capsys):
+    client = FakeClient(post_responses=[httpx.ConnectError("x")])
+    _unload(client, "http://x", "m", 1.0)
+    err = capsys.readouterr().err
+    assert "unload" in err
+
+
+# --------------------------------------------------------------------------- #
+# _print_table (fallback path), version, arg parser                           #
+# --------------------------------------------------------------------------- #
+
+
+def _summary_row():
+    return {
+        "api": "openai-chat",
+        "mode": "stream",
+        "model": "m",
+        "prompt": "p",
+        "runs": 2,
+        "ttft_p50_ms": 12.5,
+        "tps_p50": 50.0,
+        "total_p50_ms": 200.0,
+    }
+
+
+def test_print_table_fallback_tabs(monkeypatch, capsys):
+    # Force the ImportError fallback by making rich import fail.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name.startswith("rich"):
+            raise ImportError("no rich")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    errors = [
+        RunRecord(
+            api="x",
+            mode="stream",
+            model="m",
+            prompt="p",
+            run_index=0,
+            ttft_ms=None,
+            total_ms=1.0,
+            prompt_tokens=None,
+            output_tokens=None,
+            tokens_per_sec=None,
+            tokens_estimated=False,
+            tps_source=None,
+            error="boom",
+        )
+    ]
+    _print_table([_summary_row()], errors)
+    out = capsys.readouterr()
+    assert "openai-chat" in out.out
+    assert "12.50" in out.out  # _fmt float formatting
+    assert "1 errored runs" in out.err
+
+
+def test_print_table_fallback_handles_none_float(monkeypatch, capsys):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name.startswith("rich"):
+            raise ImportError("no rich")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    row = _summary_row()
+    row["ttft_p50_ms"] = None
+    row["tps_p50"] = None
+    _print_table([row], [])
+    out = capsys.readouterr().out
+    # None floats render as "-" and there are no error lines.
+    assert "-" in out
+
+
+def test_get_olmlx_version_returns_string():
+    v = _get_olmlx_version()
+    assert isinstance(v, str)
+    assert v != ""
+
+
+def test_get_olmlx_version_unknown_on_lookup_failure(monkeypatch):
+    import importlib.metadata as md
+
+    def boom(_name):
+        raise md.PackageNotFoundError("x")
+
+    monkeypatch.setattr(md, "version", boom)
+    assert _get_olmlx_version() == "unknown"
+
+
+def test_arg_parser_defaults():
+    parser = build_arg_parser()
+    args = parser.parse_args(["--models", "qwen3:8b"])
+    assert args.models == "qwen3:8b"
+    assert args.url == "http://localhost:11434"
+    assert args.modes == "stream,nostream"
+    assert args.runs == 1
+    assert args.warmup == 1
+    assert args.timeout == pytest.approx(300.0)
+    assert args.no_json is False
+
+
+def test_arg_parser_requires_models():
+    parser = build_arg_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+
+
+# --------------------------------------------------------------------------- #
+# main() — full sweep with fully faked client                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_main_runs_sweep_and_writes_json(tmp_path, monkeypatch):
+    """Drive main() end-to-end: warmup + one nostream run + unload, write JSON."""
+    out_file = tmp_path / "bench.json"
+
+    nostream_resp = make_response(
+        200,
+        json={
+            "message": {"content": "hello world"},
+            "prompt_eval_count": 3,
+            "eval_count": 5,
+            "eval_duration": 1_000_000_000,
+            "prompt_eval_duration": 1_000_000,
+        },
+    )
+    # Calls in order: warmup POST, run_single POST (nostream), unload POST.
+    client = FakeClient(
+        post_responses=[
+            make_response(200, json={}),  # warmup
+            nostream_resp,  # the single run
+            make_response(200, json={}),  # unload
+        ]
+    )
+    monkeypatch.setattr(api_bench.httpx, "Client", lambda *a, **k: client)
+
+    main_argv = [
+        "--models",
+        "m",
+        "--apis",
+        "ollama-chat",
+        "--modes",
+        "nostream",
+        "--prompts",
+        "factual",
+        "--runs",
+        "1",
+        "--warmup",
+        "1",
+        "--output",
+        str(out_file),
+    ]
+    rc = api_bench.main(main_argv)
+    assert rc == 0  # no errored runs
+    assert out_file.exists()
+    payload = json.loads(out_file.read_text())
+    assert payload["server_url"] == "http://localhost:11434"
+    assert payload["records"]
+    rec = payload["records"][0]
+    assert rec["api"] == "ollama-chat"
+    assert rec["output_tokens"] == 5
+    assert payload["summary"]
+    # Three POSTs total: warmup, run, unload.
+    assert len(client.post_calls) == 3
+
+
+def test_main_returns_1_on_errored_run(tmp_path, monkeypatch):
+    # warmup=0 -> first POST is the run itself, second is the unload.
+    client = FakeClient(
+        post_responses=[
+            make_response(500, json={"error": "boom"}),  # run -> error
+            make_response(200, json={}),  # unload
+        ]
+    )
+    monkeypatch.setattr(api_bench.httpx, "Client", lambda *a, **k: client)
+    rc = api_bench.main(
+        [
+            "--models",
+            "m",
+            "--apis",
+            "ollama-chat",
+            "--modes",
+            "nostream",
+            "--prompts",
+            "factual",
+            "--runs",
+            "1",
+            "--warmup",
+            "0",
+            "--no-json",
+        ]
+    )
+    assert rc == 1
+
+
+def test_main_empty_models_raises(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(api_bench.httpx, "Client", lambda *a, **k: client)
+    with pytest.raises(SystemExit):
+        api_bench.main(["--models", " , ", "--no-json"])
+
+
+def test_main_default_output_path_under_home(tmp_path, monkeypatch):
+    # Redirect Path.home() so the default ~/.olmlx/bench path lands in tmp_path.
+    monkeypatch.setattr(api_bench.Path, "home", staticmethod(lambda: tmp_path))
+    client = FakeClient(
+        post_responses=[
+            make_response(
+                200,
+                json={"message": {"content": "hi"}, "eval_count": 1},
+            ),
+            make_response(200, json={}),  # unload
+        ]
+    )
+    monkeypatch.setattr(api_bench.httpx, "Client", lambda *a, **k: client)
+    rc = api_bench.main(
+        [
+            "--models",
+            "m",
+            "--apis",
+            "ollama-chat",
+            "--modes",
+            "nostream",
+            "--prompts",
+            "factual",
+            "--runs",
+            "1",
+            "--warmup",
+            "0",
+        ]
+    )
+    assert rc == 0
+    bench_dir = tmp_path / ".olmlx" / "bench"
+    written = list(bench_dir.glob("api_bench_*.json"))
+    assert len(written) == 1

--- a/tests/test_bench_worker_coverage.py
+++ b/tests/test_bench_worker_coverage.py
@@ -1,0 +1,469 @@
+"""Regression coverage for olmlx.bench.worker.
+
+Exercises the subprocess worker's server-wait poll loop, prompt dispatch over
+HTTP (success / HTTPError / generic exception), the think-value recognizer, and
+the ``main`` entry point — all with urllib and subprocess fully mocked. No
+network, no real server, no real model.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from olmlx.bench import worker
+from olmlx.bench.worker import (
+    _run_prompts,
+    _wait_for_server,
+    is_recognized_think_value,
+)
+
+
+# --------------------------------------------------------------------------
+# is_recognized_think_value
+# --------------------------------------------------------------------------
+class TestIsRecognizedThinkValue:
+    @pytest.mark.parametrize(
+        "value", ["true", "True", " 1 ", "ON", "yes", "false", "0", "off", "no"]
+    )
+    def test_recognized(self, value):
+        assert is_recognized_think_value(value) is True
+
+    @pytest.mark.parametrize("value", ["tru", "enabled", "", "maybe", "2"])
+    def test_unrecognized(self, value):
+        assert is_recognized_think_value(value) is False
+
+
+# --------------------------------------------------------------------------
+# _wait_for_server
+# --------------------------------------------------------------------------
+class TestWaitForServer:
+    def _proc(self, poll_return=None):
+        proc = MagicMock()
+        proc.poll.return_value = poll_return
+        return proc
+
+    def test_returns_true_on_http_200(self):
+        proc = self._proc(poll_return=None)
+        resp = MagicMock()
+        resp.status = 200
+        cm = MagicMock()
+        cm.__enter__.return_value = resp
+        cm.__exit__.return_value = False
+        with patch.object(worker.urllib.request, "urlopen", return_value=cm):
+            assert _wait_for_server(11435, proc, timeout=5) is True
+
+    def test_returns_false_when_process_dead(self):
+        # Process already exited -> no HTTP attempt, immediate False.
+        proc = self._proc(poll_return=1)
+        with patch.object(worker.urllib.request, "urlopen") as uo:
+            assert _wait_for_server(11435, proc, timeout=5) is False
+            uo.assert_not_called()
+
+    def test_retries_then_succeeds(self):
+        proc = self._proc(poll_return=None)
+        resp = MagicMock()
+        resp.status = 200
+        cm = MagicMock()
+        cm.__enter__.return_value = resp
+        cm.__exit__.return_value = False
+        calls = {"n": 0}
+
+        def fake_urlopen(req, timeout=5):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise urllib.error.URLError("conn refused")
+            return cm
+
+        with (
+            patch.object(worker.urllib.request, "urlopen", side_effect=fake_urlopen),
+            patch.object(worker.time, "sleep") as sleep,
+        ):
+            assert _wait_for_server(11435, proc, timeout=5) is True
+        assert calls["n"] == 2
+        # The connection error path must sleep before retrying.
+        sleep.assert_called()
+
+    def test_returns_false_on_timeout(self):
+        proc = self._proc(poll_return=None)
+        # monotonic: first call sets deadline (=100+5), while-check is past it.
+        times = iter([100.0, 200.0, 300.0])
+        with (
+            patch.object(worker.time, "monotonic", side_effect=lambda: next(times)),
+            patch.object(worker.urllib.request, "urlopen") as uo,
+        ):
+            assert _wait_for_server(11435, proc, timeout=5) is False
+            uo.assert_not_called()
+
+    def test_non_200_status_keeps_polling_until_timeout(self):
+        proc = self._proc(poll_return=None)
+        resp = MagicMock()
+        resp.status = 503
+        cm = MagicMock()
+        cm.__enter__.return_value = resp
+        cm.__exit__.return_value = False
+        # deadline: enter loop once, then expire.
+        times = iter([0.0, 1.0, 1000.0])
+        with (
+            patch.object(worker.time, "monotonic", side_effect=lambda: next(times)),
+            patch.object(worker.urllib.request, "urlopen", return_value=cm),
+            patch.object(worker.time, "sleep"),
+        ):
+            assert _wait_for_server(11435, proc, timeout=5) is False
+
+
+# --------------------------------------------------------------------------
+# _run_prompts
+# --------------------------------------------------------------------------
+def _prompt(name="p1", category="general", max_tokens=None):
+    p = {
+        "name": name,
+        "category": category,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    if max_tokens is not None:
+        p["max_tokens"] = max_tokens
+    return p
+
+
+def _ok_response(payload, status=200):
+    resp = MagicMock()
+    resp.status = status
+    resp.read.return_value = json.dumps(payload).encode()
+    cm = MagicMock()
+    cm.__enter__.return_value = resp
+    cm.__exit__.return_value = False
+    return cm
+
+
+class TestRunPrompts:
+    def test_success_maps_ollama_fields(self, monkeypatch):
+        monkeypatch.delenv("OLMLX_BENCH_THINK", raising=False)
+        payload = {
+            "message": {"content": "hello world"},
+            "eval_count": 12,
+            "eval_duration": 999,
+            "prompt_eval_count": 3,
+            "prompt_eval_duration": 7,
+            "total_duration": 1234,
+        }
+        captured = {}
+
+        def fake_urlopen(req, timeout=300):
+            captured["req"] = req
+            return _ok_response(payload)
+
+        with patch.object(worker.urllib.request, "urlopen", side_effect=fake_urlopen):
+            results = _run_prompts(11435, "qwen3", [_prompt()], None)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r["output_text"] == "hello world"
+        assert r["status_code"] == 200
+        assert r["error"] is None
+        assert r["eval_count"] == 12
+        assert r["eval_duration_ns"] == 999
+        assert r["prompt_eval_count"] == 3
+        assert r["prompt_eval_duration_ns"] == 7
+        assert r["total_duration_ns"] == 1234
+        # Request body sanity: model, deterministic options, no think field.
+        body = json.loads(captured["req"].data.decode())
+        assert body["model"] == "qwen3"
+        assert body["stream"] is False
+        assert body["options"]["seed"] == 42
+        assert body["options"]["temperature"] == 0.0
+        assert body["options"]["num_predict"] == 256  # default fallback
+        assert "think" not in body
+
+    def test_max_tokens_override_beats_prompt(self, monkeypatch):
+        monkeypatch.delenv("OLMLX_BENCH_THINK", raising=False)
+        captured = {}
+
+        def fake_urlopen(req, timeout=300):
+            captured["body"] = json.loads(req.data.decode())
+            return _ok_response({"message": {"content": "x"}})
+
+        with patch.object(worker.urllib.request, "urlopen", side_effect=fake_urlopen):
+            _run_prompts(11435, "m", [_prompt(max_tokens=99)], max_tokens_override=512)
+        assert captured["body"]["options"]["num_predict"] == 512
+
+    def test_prompt_max_tokens_used_when_no_override(self, monkeypatch):
+        monkeypatch.delenv("OLMLX_BENCH_THINK", raising=False)
+        captured = {}
+
+        def fake_urlopen(req, timeout=300):
+            captured["body"] = json.loads(req.data.decode())
+            return _ok_response({"message": {"content": "x"}})
+
+        with patch.object(worker.urllib.request, "urlopen", side_effect=fake_urlopen):
+            _run_prompts(11435, "m", [_prompt(max_tokens=77)], None)
+        assert captured["body"]["options"]["num_predict"] == 77
+
+    def test_think_true_adds_think_field(self, monkeypatch):
+        monkeypatch.setenv("OLMLX_BENCH_THINK", "true")
+        captured = {}
+
+        def fake_urlopen(req, timeout=300):
+            captured["body"] = json.loads(req.data.decode())
+            return _ok_response({"message": {"content": "x"}})
+
+        with patch.object(worker.urllib.request, "urlopen", side_effect=fake_urlopen):
+            _run_prompts(11435, "m", [_prompt()], None)
+        assert captured["body"]["think"] is True
+
+    def test_think_false_adds_think_field(self, monkeypatch):
+        monkeypatch.setenv("OLMLX_BENCH_THINK", "off")
+        captured = {}
+
+        def fake_urlopen(req, timeout=300):
+            captured["body"] = json.loads(req.data.decode())
+            return _ok_response({"message": {"content": "x"}})
+
+        with patch.object(worker.urllib.request, "urlopen", side_effect=fake_urlopen):
+            _run_prompts(11435, "m", [_prompt()], None)
+        assert captured["body"]["think"] is False
+
+    def test_missing_message_content_defaults_empty(self, monkeypatch):
+        monkeypatch.delenv("OLMLX_BENCH_THINK", raising=False)
+        with patch.object(
+            worker.urllib.request, "urlopen", return_value=_ok_response({})
+        ):
+            results = _run_prompts(11435, "m", [_prompt()], None)
+        r = results[0]
+        assert r["output_text"] == ""
+        assert r["eval_count"] == 0
+        assert r["total_duration_ns"] == 0
+
+    def test_http_error_captures_error_body(self, monkeypatch):
+        monkeypatch.delenv("OLMLX_BENCH_THINK", raising=False)
+        err = urllib.error.HTTPError(
+            url="http://x",
+            code=500,
+            msg="boom",
+            hdrs=None,
+            fp=io.BytesIO(b"internal explosion detail"),
+        )
+        with patch.object(worker.urllib.request, "urlopen", side_effect=err):
+            results = _run_prompts(11435, "m", [_prompt(name="bad")], None)
+        r = results[0]
+        assert r["prompt_name"] == "bad"
+        assert r["status_code"] == 500
+        assert r["error"] == "internal explosion detail"
+        assert r["output_text"] == ""
+
+    def test_http_error_body_truncated_to_500_chars(self, monkeypatch):
+        monkeypatch.delenv("OLMLX_BENCH_THINK", raising=False)
+        big = b"E" * 2000
+        err = urllib.error.HTTPError(
+            url="http://x", code=502, msg="bad", hdrs=None, fp=io.BytesIO(big)
+        )
+        with patch.object(worker.urllib.request, "urlopen", side_effect=err):
+            results = _run_prompts(11435, "m", [_prompt()], None)
+        assert len(results[0]["error"]) == 500
+
+    def test_http_error_read_failure_falls_back(self, monkeypatch):
+        monkeypatch.delenv("OLMLX_BENCH_THINK", raising=False)
+        err = urllib.error.HTTPError(
+            url="http://x", code=503, msg="bad", hdrs=None, fp=None
+        )
+        # .read() on an HTTPError with fp=None raises; the except must catch it.
+        with patch.object(err, "read", side_effect=ValueError("no fp")):
+            with patch.object(worker.urllib.request, "urlopen", side_effect=err):
+                results = _run_prompts(11435, "m", [_prompt()], None)
+        assert results[0]["error"] == "HTTP 503"
+        assert results[0]["status_code"] == 503
+
+    def test_generic_exception_captured(self, monkeypatch):
+        monkeypatch.delenv("OLMLX_BENCH_THINK", raising=False)
+        with patch.object(
+            worker.urllib.request,
+            "urlopen",
+            side_effect=urllib.error.URLError("conn refused"),
+        ):
+            results = _run_prompts(11435, "m", [_prompt(name="z")], None)
+        r = results[0]
+        assert r["status_code"] == 0
+        assert "conn refused" in r["error"]
+        assert r["prompt_name"] == "z"
+
+    def test_multiple_prompts_preserve_order(self, monkeypatch):
+        monkeypatch.delenv("OLMLX_BENCH_THINK", raising=False)
+        responses = [
+            _ok_response({"message": {"content": "a"}}),
+            _ok_response({"message": {"content": "b"}}),
+        ]
+        with patch.object(worker.urllib.request, "urlopen", side_effect=responses):
+            results = _run_prompts(
+                11435, "m", [_prompt(name="p1"), _prompt(name="p2")], None
+            )
+        assert [r["prompt_name"] for r in results] == ["p1", "p2"]
+        assert [r["output_text"] for r in results] == ["a", "b"]
+
+
+# --------------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------------
+class TestMain:
+    def _args(self, tmp_path, prompts):
+        prompts_json = tmp_path / "prompts.json"
+        results_json = tmp_path / "results.json"
+        prompts_json.write_text(json.dumps(prompts))
+        return prompts_json, results_json
+
+    def test_happy_path_writes_results(self, tmp_path, monkeypatch):
+        prompts = [_prompt(name="p1")]
+        prompts_json, results_json = self._args(tmp_path, prompts)
+        argv = [
+            "worker",
+            "--model",
+            "qwen3",
+            "--prompts-json",
+            str(prompts_json),
+            "--results-json",
+            str(results_json),
+        ]
+        proc = MagicMock()
+        proc.poll.return_value = None  # still running during finally
+        fake_results = [{"prompt_name": "p1", "output_text": "done"}]
+
+        with (
+            patch.object(worker.sys, "argv", argv),
+            patch.object(worker.subprocess, "Popen", return_value=proc),
+            patch.object(worker, "_wait_for_server", return_value=True),
+            patch.object(worker, "_run_prompts", return_value=fake_results) as run_mock,
+        ):
+            worker.main()
+
+        written = json.loads(results_json.read_text())
+        assert written == fake_results
+        run_mock.assert_called_once()
+        # finally block terminates a still-running server.
+        proc.terminate.assert_called_once()
+        proc.wait.assert_called()
+
+    def test_server_failed_to_start_writes_error_record(self, tmp_path):
+        prompts_json, results_json = self._args(tmp_path, [_prompt()])
+        argv = [
+            "worker",
+            "--model",
+            "m",
+            "--prompts-json",
+            str(prompts_json),
+            "--results-json",
+            str(results_json),
+        ]
+        proc = MagicMock()
+        # poll() returns 7 (dead) so main records exit code, and finally skips term.
+        proc.poll.return_value = 7
+        proc.returncode = 7
+
+        with (
+            patch.object(worker.sys, "argv", argv),
+            patch.object(worker.subprocess, "Popen", return_value=proc),
+            patch.object(worker, "_wait_for_server", return_value=False),
+            patch.object(worker, "_run_prompts") as run_mock,
+        ):
+            worker.main()
+
+        written = json.loads(results_json.read_text())
+        assert len(written) == 1
+        rec = written[0]
+        assert rec["prompt_name"] == "__server_error__"
+        assert rec["category"] == "error"
+        assert "exit=7" in rec["error"]
+        # No prompts run when the server never came up.
+        run_mock.assert_not_called()
+        # Server already dead -> no terminate.
+        proc.terminate.assert_not_called()
+
+    def test_server_timeout_records_timeout_marker(self, tmp_path):
+        prompts_json, results_json = self._args(tmp_path, [_prompt()])
+        argv = [
+            "worker",
+            "--model",
+            "m",
+            "--prompts-json",
+            str(prompts_json),
+            "--results-json",
+            str(results_json),
+        ]
+        proc = MagicMock()
+        proc.poll.return_value = None  # never exited -> "timeout" string
+
+        with (
+            patch.object(worker.sys, "argv", argv),
+            patch.object(worker.subprocess, "Popen", return_value=proc),
+            patch.object(worker, "_wait_for_server", return_value=False),
+        ):
+            worker.main()
+
+        rec = json.loads(results_json.read_text())[0]
+        assert "exit=timeout" in rec["error"]
+        # Process still alive at the failure branch -> finally terminates it.
+        proc.terminate.assert_called_once()
+
+    def test_kill_on_terminate_timeout(self, tmp_path):
+        prompts_json, results_json = self._args(tmp_path, [_prompt()])
+        argv = [
+            "worker",
+            "--model",
+            "m",
+            "--prompts-json",
+            str(prompts_json),
+            "--results-json",
+            str(results_json),
+        ]
+        proc = MagicMock()
+        proc.poll.return_value = None
+        # First wait (after terminate) times out -> kill, second wait returns.
+        proc.wait.side_effect = [
+            worker.subprocess.TimeoutExpired(cmd="x", timeout=15),
+            None,
+        ]
+
+        with (
+            patch.object(worker.sys, "argv", argv),
+            patch.object(worker.subprocess, "Popen", return_value=proc),
+            patch.object(worker, "_wait_for_server", return_value=True),
+            patch.object(worker, "_run_prompts", return_value=[]),
+        ):
+            worker.main()
+
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
+        assert proc.wait.call_count == 2
+
+    def test_kill_wait_also_times_out_is_swallowed(self, tmp_path):
+        prompts_json, results_json = self._args(tmp_path, [_prompt()])
+        argv = [
+            "worker",
+            "--model",
+            "m",
+            "--prompts-json",
+            str(prompts_json),
+            "--results-json",
+            str(results_json),
+        ]
+        proc = MagicMock()
+        proc.poll.return_value = None
+        # Both the terminate-wait and the post-kill wait time out; main must
+        # not propagate the second TimeoutExpired.
+        proc.wait.side_effect = [
+            worker.subprocess.TimeoutExpired(cmd="x", timeout=15),
+            worker.subprocess.TimeoutExpired(cmd="x", timeout=5),
+        ]
+
+        with (
+            patch.object(worker.sys, "argv", argv),
+            patch.object(worker.subprocess, "Popen", return_value=proc),
+            patch.object(worker, "_wait_for_server", return_value=True),
+            patch.object(worker, "_run_prompts", return_value=[]),
+        ):
+            worker.main()  # should return cleanly
+
+        proc.kill.assert_called_once()
+        assert proc.wait.call_count == 2

--- a/tests/test_builtin_tools_coverage.py
+++ b/tests/test_builtin_tools_coverage.py
@@ -1,0 +1,449 @@
+"""Regression coverage for olmlx.chat.builtin_tools.
+
+Targets currently-uncovered branches: path-traversal guards, file-size limit,
+read_directory, question/TodoWrite handlers, glob truncation, grep error/
+fallback paths, web_fetch SSRF guards (private-IP / missing host / redirect),
+and the _is_private_ip / _resolve_path helpers. All tests are hermetic: only
+tmp_path, in-process subprocesses (echo/sleep), and mocked network openers.
+"""
+
+import ipaddress
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from olmlx.chat.builtin_tools import (
+    BuiltinToolManager,
+    _GLOB_MAX_RESULTS,
+    _is_private_ip,
+    _resolve_path,
+)
+from olmlx.chat.config import ChatConfig
+from olmlx.chat.errors import ToolError
+
+
+@pytest.fixture
+def config(tmp_path):
+    return ChatConfig(model_name="test:latest", plans_dir=tmp_path / "plans")
+
+
+@pytest.fixture
+def manager(config):
+    return BuiltinToolManager(config)
+
+
+# -- _resolve_path / traversal guards --
+
+
+class TestResolvePath:
+    def test_relative_traversal_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="outside allowed directory"):
+            _resolve_path("../escape.txt", base_dir=tmp_path)
+
+    def test_relative_resolves_under_base(self, tmp_path):
+        resolved = _resolve_path("sub/file.txt", base_dir=tmp_path)
+        assert resolved == (tmp_path / "sub" / "file.txt").resolve()
+
+    def test_absolute_path_passthrough(self, tmp_path):
+        target = tmp_path / "abs.txt"
+        assert _resolve_path(str(target)) == target.resolve()
+
+    def test_relative_default_base_is_cwd(self, tmp_path, monkeypatch):
+        # base_dir=None branch resolves against cwd.
+        monkeypatch.chdir(tmp_path)
+        resolved = _resolve_path("inside.txt")
+        assert resolved == (tmp_path / "inside.txt").resolve()
+
+    @pytest.mark.asyncio
+    async def test_read_file_traversal_returns_user_error(
+        self, manager, monkeypatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+        result = await manager.call_tool("read_file", {"path": "../../../etc/passwd"})
+        assert isinstance(result, ToolError)
+        assert result.tool_name == "read_file"
+        assert result.is_user_error is True
+        assert "outside allowed directory" in result.message
+
+
+# -- read_file edge cases --
+
+
+class TestReadFileEdges:
+    @pytest.mark.asyncio
+    async def test_offset_beyond_eof_returns_empty(self, manager, tmp_path):
+        f = tmp_path / "short.txt"
+        f.write_text("only one line\n")
+        result = await manager.call_tool("read_file", {"path": str(f), "offset": 50})
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_limit_stops_at_eof(self, manager, tmp_path):
+        f = tmp_path / "two.txt"
+        f.write_text("a\nb\n")
+        # limit exceeds available lines -> readline returns "" -> break path.
+        result = await manager.call_tool("read_file", {"path": str(f), "limit": 10})
+        assert "1\ta" in result
+        assert "2\tb" in result
+        # Only two numbered lines emitted.
+        assert result.count("\t") == 2
+
+    @pytest.mark.asyncio
+    async def test_file_too_large_is_user_error(self, manager, tmp_path):
+        from olmlx.chat import builtin_tools
+
+        f = tmp_path / "big.txt"
+        f.write_text("x\n")
+        # Shrink the limit instead of writing 10 MB to keep the test fast/hermetic.
+        with patch.object(builtin_tools, "_READ_FILE_MAX_BYTES", 1):
+            result = await manager.call_tool("read_file", {"path": str(f)})
+        assert isinstance(result, ToolError)
+        assert result.is_user_error is True
+        assert "limit is" in result.message
+
+
+# -- write_file error path --
+
+
+class TestWriteFileErrors:
+    @pytest.mark.asyncio
+    async def test_write_oserror_is_system_error(self, manager, tmp_path):
+        # Make the parent a file so mkdir/write raises OSError.
+        clash = tmp_path / "clash"
+        clash.write_text("i am a file")
+        target = clash / "child.txt"
+        result = await manager.call_tool(
+            "write_file", {"path": str(target), "content": "data"}
+        )
+        assert isinstance(result, ToolError)
+        assert result.tool_name == "write_file"
+        assert result.is_user_error is False
+        assert "Error writing file" in result.message
+
+    @pytest.mark.asyncio
+    async def test_write_byte_count_uses_utf8_encoding(self, manager, tmp_path):
+        f = tmp_path / "u.txt"
+        # "é" is 2 bytes in UTF-8 -> reported byte count must be 2, not 1 char.
+        result = await manager.call_tool("write_file", {"path": str(f), "content": "é"})
+        assert "Wrote 2 bytes" in result
+
+
+# -- edit_file system-error path --
+
+
+class TestEditFileErrors:
+    @pytest.mark.asyncio
+    async def test_edit_read_oserror_is_system_error(self, manager, tmp_path):
+        # Path points at a directory -> read_text raises OSError (IsADirectoryError).
+        d = tmp_path / "adir"
+        d.mkdir()
+        result = await manager.call_tool(
+            "edit_file", {"path": str(d), "old_text": "x", "new_text": "y"}
+        )
+        assert isinstance(result, ToolError)
+        assert result.tool_name == "edit_file"
+        assert result.is_user_error is False
+
+
+# -- glob truncation --
+
+
+class TestGlobTruncation:
+    @pytest.mark.asyncio
+    async def test_glob_truncates_at_max(self, manager, tmp_path):
+        for i in range(_GLOB_MAX_RESULTS + 5):
+            (tmp_path / f"f{i:04d}.txt").write_text("")
+        result = await manager.call_tool(
+            "glob", {"pattern": "*.txt", "path": str(tmp_path)}
+        )
+        lines = result.splitlines()
+        assert lines[-1] == f"... truncated at {_GLOB_MAX_RESULTS} results"
+        # _GLOB_MAX_RESULTS match lines + 1 truncation notice.
+        assert len(lines) == _GLOB_MAX_RESULTS + 1
+
+    @pytest.mark.asyncio
+    async def test_glob_default_path_dot(self, manager, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "only.md").write_text("")
+        # No "path" arg -> default "." branch.
+        result = await manager.call_tool("glob", {"pattern": "*.md"})
+        assert "only.md" in result
+
+
+# -- grep error / fallback paths (mock the subprocess search) --
+
+
+class TestGrepBranches:
+    @pytest.mark.asyncio
+    async def test_grep_rg_error_returns_system_error(self, manager):
+        async def fake_create(*cmd, **kwargs):
+            proc = MagicMock()
+
+            async def communicate():
+                return (b"", b"rg: bad regex")
+
+            proc.communicate = communicate
+            proc.returncode = 2
+            return proc
+
+        with patch(
+            "olmlx.chat.builtin_tools.asyncio.create_subprocess_exec",
+            side_effect=fake_create,
+        ):
+            result = await manager.call_tool("grep", {"pattern": "(", "path": "."})
+        assert isinstance(result, ToolError)
+        assert result.tool_name == "grep"
+        assert result.is_user_error is False
+        assert "bad regex" in result.message
+
+    @pytest.mark.asyncio
+    async def test_grep_falls_back_to_grep_when_rg_missing(self, manager):
+        calls = []
+
+        async def fake_create(*cmd, **kwargs):
+            calls.append(cmd[0])
+            if cmd[0] == "rg":
+                raise FileNotFoundError("rg")
+            proc = MagicMock()
+
+            async def communicate():
+                return (b"path:1:hit\n", b"")
+
+            proc.communicate = communicate
+            proc.returncode = 0
+            return proc
+
+        with patch(
+            "olmlx.chat.builtin_tools.asyncio.create_subprocess_exec",
+            side_effect=fake_create,
+        ):
+            result = await manager.call_tool("grep", {"pattern": "hit", "path": "."})
+        assert "hit" in result
+        assert "rg" in calls and "grep" in calls
+
+    @pytest.mark.asyncio
+    async def test_grep_no_tools_available(self, manager):
+        async def fake_create(*cmd, **kwargs):
+            raise FileNotFoundError(cmd[0])
+
+        with patch(
+            "olmlx.chat.builtin_tools.asyncio.create_subprocess_exec",
+            side_effect=fake_create,
+        ):
+            result = await manager.call_tool("grep", {"pattern": "x", "path": "."})
+        assert isinstance(result, ToolError)
+        assert "not available" in result.message
+
+    @pytest.mark.asyncio
+    async def test_grep_output_truncated(self, manager):
+        from olmlx.chat import builtin_tools
+
+        async def fake_create(*cmd, **kwargs):
+            proc = MagicMock()
+
+            async def communicate():
+                return (b"y" * 5000, b"")
+
+            proc.communicate = communicate
+            proc.returncode = 0
+            return proc
+
+        with patch.object(builtin_tools, "_GREP_MAX_BYTES", 100):
+            with patch(
+                "olmlx.chat.builtin_tools.asyncio.create_subprocess_exec",
+                side_effect=fake_create,
+            ):
+                result = await manager.call_tool("grep", {"pattern": "y", "path": "."})
+        assert result.endswith("... truncated")
+        assert len(result) <= 100 + len("\n... truncated")
+
+
+# -- read_directory --
+
+
+class TestReadDirectory:
+    @pytest.mark.asyncio
+    async def test_lists_files_and_dirs(self, manager, tmp_path):
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "a.txt").write_text("hello")  # 5 bytes
+        result = await manager.call_tool("read_directory", {"path": str(tmp_path)})
+        assert "sub/" in result
+        assert "a.txt (5 bytes)" in result
+
+    @pytest.mark.asyncio
+    async def test_not_a_directory_is_user_error(self, manager, tmp_path):
+        f = tmp_path / "file.txt"
+        f.write_text("x")
+        result = await manager.call_tool("read_directory", {"path": str(f)})
+        assert isinstance(result, ToolError)
+        assert result.tool_name == "read_directory"
+        assert result.is_user_error is True
+        assert "not a directory" in result.message
+
+    @pytest.mark.asyncio
+    async def test_traversal_rejected(self, manager, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        result = await manager.call_tool("read_directory", {"path": "../../.."})
+        assert isinstance(result, ToolError)
+        assert result.is_user_error is True
+        assert "outside allowed directory" in result.message
+
+
+# -- question + TodoWrite handlers --
+
+
+class TestQuestionHandler:
+    @pytest.mark.asyncio
+    async def test_question_serializes_payload(self, manager):
+        import json
+
+        result = await manager.call_tool(
+            "question",
+            {
+                "header": "Pick",
+                "question": "Which one?",
+                "multiple": True,
+                "options": ["a", "b"],
+            },
+        )
+        assert result.startswith("__question__:")
+        payload = json.loads(result[len("__question__:") :])
+        assert payload == {
+            "header": "Pick",
+            "question": "Which one?",
+            "multiple": True,
+            "options": ["a", "b"],
+        }
+
+    @pytest.mark.asyncio
+    async def test_question_defaults(self, manager):
+        import json
+
+        result = await manager.call_tool("question", {})
+        payload = json.loads(result[len("__question__:") :])
+        assert payload["multiple"] is False
+        assert payload["options"] is None
+
+
+class TestTodoWrite:
+    @pytest.mark.asyncio
+    async def test_empty_clears_list(self, manager):
+        result = await manager.call_tool("TodoWrite", {"todos": []})
+        assert result == "Todo list cleared."
+
+    @pytest.mark.asyncio
+    async def test_formats_items_with_defaults(self, manager):
+        result = await manager.call_tool(
+            "TodoWrite",
+            {
+                "todos": [
+                    {"content": "first", "priority": "high", "status": "completed"},
+                    {"content": "second"},  # defaults: medium / pending
+                ]
+            },
+        )
+        lines = result.splitlines()
+        assert lines[0] == "[completed] [high] 1. first"
+        assert lines[1] == "[pending] [medium] 2. second"
+
+
+# -- create_plan / update_plan / read_plan error paths --
+
+
+class TestPlanErrors:
+    @pytest.mark.asyncio
+    async def test_create_plan_oserror(self, manager, config, tmp_path):
+        # Make plans_dir collide with an existing file so mkdir raises.
+        config.plans_dir.parent.mkdir(parents=True, exist_ok=True)
+        blocker = config.plans_dir
+        blocker.write_text("not a dir")
+        result = await manager.call_tool("create_plan", {"content": "# Plan"})
+        assert isinstance(result, ToolError)
+        assert result.tool_name == "create_plan"
+        assert result.is_user_error is False
+
+
+# -- web_fetch SSRF guards --
+
+
+class TestWebFetchGuards:
+    @pytest.mark.asyncio
+    async def test_missing_hostname_user_error(self, manager):
+        result = await manager.call_tool("web_fetch", {"url": "http:///nohost"})
+        assert isinstance(result, ToolError)
+        assert "missing hostname" in result.message
+        assert result.is_user_error is True
+
+    @pytest.mark.asyncio
+    async def test_fetch_failure_wrapped_as_tool_error(self, manager):
+        # build_opener returns an opener whose open() raises -> generic except path.
+        opener = MagicMock()
+        opener.open.side_effect = OSError("connection refused")
+        with patch("urllib.request.build_opener", return_value=opener):
+            result = await manager.call_tool(
+                "web_fetch", {"url": "https://example.com"}
+            )
+        assert isinstance(result, ToolError)
+        assert result.tool_name == "web_fetch"
+        assert "connection refused" in result.message
+        # OSError is not ValueError -> system error.
+        assert result.is_user_error is False
+
+
+# -- _is_private_ip helper (the SSRF allowlist core) --
+
+
+class TestIsPrivateIP:
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "127.0.0.1",  # loopback
+            "10.0.0.1",  # private
+            "192.168.1.1",  # private
+            "169.254.0.1",  # link-local
+            "224.0.0.1",  # multicast
+        ],
+    )
+    def test_private_ipv4_blocked(self, ip):
+        assert _is_private_ip(ipaddress.ip_address(ip)) is True
+
+    def test_public_ipv4_allowed(self):
+        assert _is_private_ip(ipaddress.ip_address("8.8.8.8")) is False
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "::1",  # loopback
+            "fc00::1",  # unique-local (private)
+            "fe80::1",  # link-local
+            "ff02::1",  # multicast
+            "fec0::1",  # site-local
+        ],
+    )
+    def test_private_ipv6_blocked(self, ip):
+        assert _is_private_ip(ipaddress.ip_address(ip)) is True
+
+    def test_public_ipv6_allowed(self):
+        assert _is_private_ip(ipaddress.ip_address("2001:4860:4860::8888")) is False
+
+
+# -- bash error/empty-output branches (no real model, just /bin/sh) --
+
+
+class TestBashBranches:
+    @pytest.mark.asyncio
+    async def test_bash_no_output(self, manager):
+        result = await manager.call_tool("bash", {"command": "true"})
+        assert result == "(no output)"
+
+    @pytest.mark.asyncio
+    async def test_bash_spawn_oserror(self, manager):
+        with patch(
+            "olmlx.chat.builtin_tools.asyncio.create_subprocess_shell",
+            side_effect=OSError("no shell"),
+        ):
+            result = await manager.call_tool("bash", {"command": "echo hi"})
+        assert isinstance(result, ToolError)
+        assert result.tool_name == "bash"
+        assert "Error running command" in result.message
+        assert result.is_user_error is False

--- a/tests/test_chat_session_coverage.py
+++ b/tests/test_chat_session_coverage.py
@@ -1,0 +1,712 @@
+"""Regression coverage for olmlx.chat.session agent-loop branches.
+
+Focuses on currently-uncovered paths with generate_chat mocked:
+- model load failure rollback
+- generation option passthrough (temperature/top_p/top_k)
+- thinking_expected meta-chunk capture
+- parse_model_output failure handling
+- memory check + history truncation
+- sequential tool execution
+- the question builtin-tool feedback path
+- deferred non-Exception BaseException re-raise from parallel gather
+
+All tests are hermetic: no network, no real model, no GPU, no real FS.
+asyncio_mode=auto so async tests need no decorator.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from olmlx.chat.config import ChatConfig
+from olmlx.chat.session import ChatSession
+from olmlx.engine.template_caps import TemplateCaps
+
+
+def _make_session(
+    *,
+    mcp=None,
+    skills=None,
+    builtin=None,
+    tool_safety=None,
+    model_name="test:latest",
+    thinking=True,
+    max_turns=25,
+    max_tokens=4096,
+    system_prompt=None,
+    template_has_thinking=False,
+    sequential=False,
+    temperature=None,
+    top_p=None,
+    top_k=None,
+):
+    config = ChatConfig(
+        model_name=model_name,
+        thinking=thinking,
+        max_turns=max_turns,
+        max_tokens=max_tokens,
+        system_prompt=system_prompt,
+        sequential_tool_execution=sequential,
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+    )
+    manager = MagicMock()
+    loaded_model = MagicMock()
+    loaded_model.template_caps = TemplateCaps(
+        supports_enable_thinking=template_has_thinking,
+        has_thinking_tags=template_has_thinking,
+    )
+    loaded_model.kv_cache_quant = None
+    manager.ensure_loaded = AsyncMock(return_value=loaded_model)
+    session = ChatSession(
+        config=config,
+        manager=manager,
+        mcp=mcp,
+        skills=skills,
+        builtin=builtin,
+        tool_safety=tool_safety,
+    )
+    return session, manager, loaded_model
+
+
+def _stream(*chunks):
+    """Build a zero-arg async generator factory yielding the given chunks."""
+
+    async def gen(*args, **kwargs):
+        for c in chunks:
+            yield c
+
+    return gen
+
+
+def _patch_no_memory_check():
+    """Disable the memory check so it never truncates (returns 0 system bytes)."""
+    return patch(
+        "olmlx.chat.session.memory_utils.get_system_memory_bytes", return_value=0
+    )
+
+
+# --------------------------------------------------------------------------
+# Model-load failure path (lines 950-957)
+# --------------------------------------------------------------------------
+
+
+async def test_model_load_failure_rolls_back_user_message():
+    session, manager, _ = _make_session()
+    manager.ensure_loaded = AsyncMock(side_effect=RuntimeError("disk full"))
+
+    events = []
+    async for ev in session.send_message("Hello"):
+        events.append(ev)
+
+    types = [e["type"] for e in events]
+    assert "model_load_error" in types
+    assert types[-1] == "done"
+    err = next(e for e in events if e["type"] == "model_load_error")
+    assert "disk full" in err["error"]
+    # The user message appended at the top must have been popped on failure.
+    assert session.messages == []
+
+
+# --------------------------------------------------------------------------
+# Generation option passthrough (lines 940-944)
+# --------------------------------------------------------------------------
+
+
+async def test_sampling_options_passed_through():
+    session, _, _ = _make_session(temperature=0.7, top_p=0.9, top_k=40)
+    captured = {}
+
+    async def gen(*args, **kwargs):
+        captured.update(kwargs)
+        yield {"text": "hi", "done": False}
+        yield {"text": "", "done": True}
+
+    with (
+        _patch_no_memory_check(),
+        patch(
+            "olmlx.chat.session.generate_chat",
+            side_effect=lambda *a, **kw: gen(*a, **kw),
+        ),
+    ):
+        async for _ in session.send_message("Q"):
+            pass
+
+    opts = captured["options"]
+    assert opts["temperature"] == 0.7
+    assert opts["top_p"] == 0.9
+    assert opts["top_k"] == 40
+
+
+async def test_sampling_options_omitted_when_none():
+    session, _, _ = _make_session()
+    captured = {}
+
+    async def gen(*args, **kwargs):
+        captured.update(kwargs)
+        yield {"text": "hi", "done": False}
+        yield {"text": "", "done": True}
+
+    with (
+        _patch_no_memory_check(),
+        patch(
+            "olmlx.chat.session.generate_chat",
+            side_effect=lambda *a, **kw: gen(*a, **kw),
+        ),
+    ):
+        async for _ in session.send_message("Q"):
+            pass
+
+    opts = captured["options"]
+    assert "temperature" not in opts
+    assert "top_p" not in opts
+    assert "top_k" not in opts
+
+
+# --------------------------------------------------------------------------
+# thinking_expected meta chunk (lines 1007-1009)
+# --------------------------------------------------------------------------
+
+
+async def test_thinking_expected_meta_chunk_consumed_not_emitted():
+    """A {'thinking_expected': ...} chunk is consumed and not surfaced as text."""
+    session, _, _ = _make_session()
+
+    stream = _stream(
+        {"thinking_expected": True},
+        {"text": "Answer", "done": False},
+        {"text": "", "done": True},
+    )
+
+    with (
+        _patch_no_memory_check(),
+        patch("olmlx.chat.session.generate_chat", return_value=stream()),
+    ):
+        events = []
+        async for ev in session.send_message("Q"):
+            events.append(ev)
+
+    # The meta chunk must not have produced a token; only "Answer" is visible.
+    token_text = "".join(e["text"] for e in events if e["type"] == "token")
+    assert token_text == "Answer"
+    assert all("thinking_expected" not in e for e in events)
+
+
+# --------------------------------------------------------------------------
+# parse_model_output failure (lines 1061-1075)
+# --------------------------------------------------------------------------
+
+
+async def test_parse_error_drops_tools_and_emits_tool_error():
+    mcp = MagicMock()
+    mcp.get_tools_for_chat.return_value = [
+        {"function": {"name": "x"}, "type": "function"}
+    ]
+    session, _, _ = _make_session(mcp=mcp)
+
+    stream = _stream(
+        {"text": "<think>t</think>visible body", "done": False},
+        {"text": "", "done": True},
+    )
+
+    with (
+        _patch_no_memory_check(),
+        patch("olmlx.chat.session.generate_chat", return_value=stream()),
+        patch(
+            "olmlx.chat.session.parse_model_output",
+            side_effect=ValueError("bad tokens"),
+        ),
+    ):
+        events = []
+        async for ev in session.send_message("Q"):
+            events.append(ev)
+
+    parse_errs = [
+        e for e in events if e["type"] == "tool_error" and e["name"] == "(parse error)"
+    ]
+    assert len(parse_errs) == 1
+    assert "bad tokens" in parse_errs[0]["error"]
+    # Fallback visible text strips thinking and becomes the assistant message.
+    assert session.messages[-1]["role"] == "assistant"
+    assert session.messages[-1]["content"] == "visible body"
+    # No tool calls remained after the parse failure -> loop ends, done emitted.
+    assert events[-1]["type"] == "done"
+
+
+# --------------------------------------------------------------------------
+# Memory check + truncation (lines 388-496, 967-976)
+# --------------------------------------------------------------------------
+
+
+async def test_memory_truncation_emits_event_and_drops_messages():
+    """When KV estimate exceeds the limit, history is truncated and reported."""
+    session, manager, lm = _make_session(model_name="m:1")
+
+    # Seed a long history: system + many user/assistant pairs.
+    session.messages.append({"role": "system", "content": "sys"})
+    for i in range(12):
+        session.messages.append({"role": "user", "content": f"u{i}"})
+        session.messages.append({"role": "assistant", "content": f"a{i}"})
+    before = len(session.messages)
+
+    stream = _stream(
+        {"text": "ok", "done": False},
+        {"text": "", "done": True},
+    )
+
+    with (
+        patch(
+            "olmlx.chat.session.memory_utils.get_system_memory_bytes",
+            return_value=100,
+        ),
+        patch(
+            "olmlx.chat.session.memory_utils.get_metal_memory",
+            return_value=0,
+        ),
+        # settings.memory_limit_fraction * 100 -> some positive limit.
+        patch(
+            "olmlx.chat.session.apply_chat_template_text",
+            return_value="prompt",
+        ),
+        patch(
+            "olmlx.chat.session.tokenize_for_cache",
+            return_value=list(range(50)),
+        ),
+        # First (pre-truncate) estimate huge, post-truncate small enough.
+        patch(
+            "olmlx.chat.session.estimate_kv_cache_bytes",
+            side_effect=[10**12, 1, 1],
+        ),
+        patch("olmlx.chat.session.generate_chat", return_value=stream()),
+    ):
+        events = []
+        async for ev in session.send_message("new question"):
+            events.append(ev)
+
+    trunc = [e for e in events if e["type"] == "memory_truncated"]
+    assert len(trunc) == 1
+    # The new user message + assistant reply were appended during the turn,
+    # but the conversation must be shorter than before + 2 (history removed).
+    assert len(session.messages) < before + 2
+    manager.invalidate_prompt_cache.assert_called_with("m:1", "chat")
+
+
+async def test_memory_check_noop_when_system_memory_unknown():
+    """get_system_memory_bytes()<=0 short-circuits; no truncation, no estimate."""
+    session, _, lm = _make_session()
+    session.messages.append({"role": "user", "content": "old"})
+
+    estimate = MagicMock()
+    stream = _stream({"text": "hi", "done": False}, {"text": "", "done": True})
+
+    with (
+        patch(
+            "olmlx.chat.session.memory_utils.get_system_memory_bytes",
+            return_value=0,
+        ),
+        patch("olmlx.chat.session.estimate_kv_cache_bytes", estimate),
+        patch("olmlx.chat.session.generate_chat", return_value=stream()),
+    ):
+        events = []
+        async for ev in session.send_message("Q"):
+            events.append(ev)
+
+    assert not any(e["type"] == "memory_truncated" for e in events)
+    estimate.assert_not_called()
+
+
+async def test_memory_check_under_limit_does_not_truncate():
+    session, _, lm = _make_session()
+    session.messages.append({"role": "user", "content": "old"})
+    stream = _stream({"text": "hi", "done": False}, {"text": "", "done": True})
+
+    with (
+        patch(
+            "olmlx.chat.session.memory_utils.get_system_memory_bytes",
+            return_value=10**9,
+        ),
+        patch(
+            "olmlx.chat.session.memory_utils.get_metal_memory",
+            return_value=0,
+        ),
+        patch(
+            "olmlx.chat.session.apply_chat_template_text",
+            return_value="prompt",
+        ),
+        patch(
+            "olmlx.chat.session.tokenize_for_cache",
+            return_value=[1, 2, 3],
+        ),
+        patch(
+            "olmlx.chat.session.estimate_kv_cache_bytes",
+            return_value=1,
+        ),
+        patch("olmlx.chat.session.generate_chat", return_value=stream()),
+    ):
+        events = []
+        async for ev in session.send_message("Q"):
+            events.append(ev)
+
+    assert not any(e["type"] == "memory_truncated" for e in events)
+
+
+async def test_memory_check_exception_is_swallowed():
+    """If the memory check raises, send_message proceeds anyway."""
+    session, _, _ = _make_session()
+    stream = _stream({"text": "hi", "done": False}, {"text": "", "done": True})
+
+    with (
+        patch.object(
+            ChatSession,
+            "_check_memory_and_truncate",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch("olmlx.chat.session.generate_chat", return_value=stream()),
+    ):
+        events = []
+        async for ev in session.send_message("Q"):
+            events.append(ev)
+
+    # Generation still happened despite the failed memory check.
+    assert "".join(e["text"] for e in events if e["type"] == "token") == "hi"
+    assert events[-1]["type"] == "done"
+
+
+async def test_emergency_second_pass_truncation():
+    """First-pass truncation still over limit -> emergency 2-message keep."""
+    session, manager, lm = _make_session(model_name="m:2", max_tokens=10)
+    session.messages.append({"role": "system", "content": "sys"})
+    for i in range(10):
+        session.messages.append({"role": "user", "content": f"u{i}"})
+        session.messages.append({"role": "assistant", "content": f"a{i}"})
+    original_len = len(session.messages)
+
+    with (
+        patch(
+            "olmlx.chat.session.memory_utils.get_system_memory_bytes",
+            return_value=100,
+        ),
+        patch(
+            "olmlx.chat.session.memory_utils.get_metal_memory",
+            return_value=0,
+        ),
+        patch(
+            "olmlx.chat.session.apply_chat_template_text",
+            return_value="prompt",
+        ),
+        patch(
+            "olmlx.chat.session.tokenize_for_cache",
+            return_value=list(range(50)),
+        ),
+        # initial, after-first-pass, after-emergency-pass — all over limit.
+        patch(
+            "olmlx.chat.session.estimate_kv_cache_bytes",
+            return_value=10**12,
+        ),
+    ):
+        truncated = await session._check_memory_and_truncate(lm, 10)
+
+    assert truncated is True
+    assert len(session.messages) < original_len
+    # Emergency pass keeps only a small tail (system + ~last turn), well below
+    # the first-pass target of _MIN_MESSAGES_AFTER_TRUNCATE (6) + system.
+    assert len(session.messages) <= 6
+    # System message preserved at the front.
+    assert session.messages[0]["role"] == "system"
+    manager.invalidate_prompt_cache.assert_called_with("m:2", "chat")
+
+
+async def test_sequential_execution_generic_exception_yields_error():
+    """A regular Exception in the sequential path is captured per-tool."""
+    mcp = MagicMock()
+    mcp.get_tools_for_chat.return_value = [
+        {"function": {"name": "t1"}, "type": "function"}
+    ]
+    session, _, _ = _make_session(mcp=mcp, sequential=True)
+
+    async def fake_exec(tu):
+        raise RuntimeError("kaboom")
+
+    tus = [{"name": "t1", "input": {}, "id": "1"}]
+    with patch.object(session, "_exec_tool", side_effect=fake_exec):
+        events = []
+        async for ev in session._execute_tool_calls(tus):
+            events.append(ev)
+
+    err = [e for e in events if e["type"] == "tool_error"]
+    assert len(err) == 1
+    assert "kaboom" in err[0]["error"]
+    assert "Error calling t1" in session.messages[-1]["content"]
+
+
+async def test_estimate_conversation_tokens_returns_zero_on_error():
+    """_estimate_conversation_tokens swallows tokenizer errors and returns 0."""
+    session, _, lm = _make_session()
+    session.messages.append({"role": "user", "content": "hi"})
+
+    with patch(
+        "olmlx.chat.session.apply_chat_template_text",
+        side_effect=RuntimeError("tokenizer exploded"),
+    ):
+        result = await session._estimate_conversation_tokens(lm)
+
+    assert result == 0
+
+
+# --------------------------------------------------------------------------
+# Sequential tool execution (lines 750-773)
+# --------------------------------------------------------------------------
+
+
+async def test_sequential_tool_execution_runs_in_order():
+    mcp = MagicMock()
+    mcp.get_tools_for_chat.return_value = [
+        {"function": {"name": "tool_a"}, "type": "function"},
+        {"function": {"name": "tool_b"}, "type": "function"},
+    ]
+    order = []
+
+    async def call_tool(name, args, timeout=30.0):
+        order.append(name)
+        return f"result-{name}"
+
+    mcp.call_tool = AsyncMock(side_effect=call_tool)
+    session, _, _ = _make_session(mcp=mcp, sequential=True)
+
+    tus = [
+        {"name": "tool_a", "input": {}, "id": "a"},
+        {"name": "tool_b", "input": {}, "id": "b"},
+    ]
+    events = []
+    async for ev in session._execute_tool_calls(tus):
+        events.append(ev)
+
+    assert order == ["tool_a", "tool_b"]
+    results = [e for e in events if e["type"] == "tool_result"]
+    assert {r["name"] for r in results} == {"tool_a", "tool_b"}
+    # Messages appended in original call order.
+    assert [m["tool_call_id"] for m in session.messages] == ["a", "b"]
+
+
+async def test_sequential_execution_cancelled_pads_and_raises():
+    """CancelledError mid-sequence pads remaining slots and re-raises."""
+    mcp = MagicMock()
+    mcp.get_tools_for_chat.return_value = [
+        {"function": {"name": "t1"}, "type": "function"},
+        {"function": {"name": "t2"}, "type": "function"},
+    ]
+
+    async def call_tool(name, args, timeout=30.0):
+        if name == "t1":
+            raise asyncio.CancelledError("stop")
+        return "ok"
+
+    mcp.call_tool = AsyncMock(side_effect=call_tool)
+    session, _, _ = _make_session(mcp=mcp, sequential=True)
+
+    tus = [
+        {"name": "t1", "input": {}, "id": "1"},
+        {"name": "t2", "input": {}, "id": "2"},
+    ]
+
+    events = []
+    with pytest.raises(asyncio.CancelledError):
+        async for ev in session._execute_tool_calls(tus):
+            events.append(ev)
+
+    # t1 yields a tool_error (task cancelled); history records it.
+    err = [e for e in events if e["type"] == "tool_error"]
+    assert any(e["name"] == "t1" for e in err)
+    tool_msgs = [m for m in session.messages if m["role"] == "tool"]
+    assert any("cancelled" in m["content"] for m in tool_msgs)
+
+
+# --------------------------------------------------------------------------
+# Deferred non-Exception BaseException in parallel gather (lines 895-906)
+# --------------------------------------------------------------------------
+
+
+async def test_parallel_base_exception_reraised():
+    """A non-Exception BaseException from _exec_tool is re-raised after events."""
+    mcp = MagicMock()
+    mcp.get_tools_for_chat.return_value = [
+        {"function": {"name": "boom"}, "type": "function"}
+    ]
+    session, _, _ = _make_session(mcp=mcp, sequential=False)
+
+    class Boom(BaseException):
+        pass
+
+    async def fake_exec(tu):
+        raise Boom("fatal")
+
+    tus = [{"name": "boom", "input": {}, "id": "z"}]
+    with patch.object(session, "_exec_tool", side_effect=fake_exec):
+        events = []
+        with pytest.raises(Boom):
+            async for ev in session._execute_tool_calls(tus):
+                events.append(ev)
+
+    # The tool_error event was still surfaced before the re-raise.
+    assert any(e["type"] == "tool_error" and e["name"] == "boom" for e in events)
+
+
+# --------------------------------------------------------------------------
+# question builtin-tool feedback path (lines 855-874)
+# --------------------------------------------------------------------------
+
+
+async def test_question_tool_payload_yields_question_event():
+    """The 'question' builtin's __question__: payload surfaces a question event.
+
+    Regression test: the source must slice content[len("__question__:"):] so
+    the leading ':' is stripped before json.loads. An off-by-one slice that
+    kept the ':' silently swallowed the event (json.loads raised), so the
+    question never reached the UI.
+    """
+    import json as _json
+
+    builtin = MagicMock()
+    builtin.tool_names = {"question"}
+    builtin.get_tool_definitions.return_value = [
+        {"function": {"name": "question"}, "type": "function"}
+    ]
+    payload = {
+        "header": "Pick one",
+        "question": "Which?",
+        "options": ["a", "b"],
+        "multiple": False,
+    }
+    builtin.call_tool = AsyncMock(return_value="__question__:" + _json.dumps(payload))
+
+    session, _, _ = _make_session(builtin=builtin)
+    tus = [{"name": "question", "input": {}, "id": "q1"}]
+
+    events = []
+    async for ev in session._execute_tool_calls(tus):
+        events.append(ev)
+
+    q_events = [e for e in events if e["type"] == "question"]
+    assert len(q_events) == 1
+    assert q_events[0]["header"] == "Pick one"
+    assert q_events[0]["question"] == "Which?"
+    assert q_events[0]["options"] == ["a", "b"]
+    assert q_events[0]["multiple"] is False
+    assert q_events[0]["id"] == "q1"
+
+
+async def test_question_tool_message_also_appended_to_history():
+    """The raw tool-result message is recorded in history alongside the event.
+
+    Emitting the question event does not consume the result: after the
+    try/except the original __question__: message is still appended so the
+    conversation transcript stays complete.
+    """
+    import json as _json
+
+    builtin = MagicMock()
+    builtin.tool_names = {"question"}
+    builtin.get_tool_definitions.return_value = [
+        {"function": {"name": "question"}, "type": "function"}
+    ]
+    content = "__question__:" + _json.dumps({"header": "h", "question": "q"})
+    builtin.call_tool = AsyncMock(return_value=content)
+
+    session, _, _ = _make_session(builtin=builtin)
+    tus = [{"name": "question", "input": {}, "id": "q1"}]
+
+    async for _ in session._execute_tool_calls(tus):
+        pass
+
+    tool_msgs = [m for m in session.messages if m["role"] == "tool"]
+    assert len(tool_msgs) == 1
+    assert tool_msgs[0]["content"] == content
+
+
+# --------------------------------------------------------------------------
+# _exec_tool no-handler branch (lines 518-523)
+# --------------------------------------------------------------------------
+
+
+async def test_exec_tool_no_handler_returns_user_error():
+    """No MCP/builtin/skill handler -> ToolError(is_user_error=True) event."""
+    session, _, _ = _make_session()  # no mcp, no builtin, no skills
+    tus = [{"name": "ghost_tool", "input": {}, "id": "g"}]
+
+    events = []
+    async for ev in session._execute_tool_calls(tus):
+        events.append(ev)
+
+    err = [e for e in events if e["type"] == "tool_error"]
+    assert len(err) == 1
+    assert err[0]["name"] == "ghost_tool"
+    assert err[0]["is_user_error"] is True
+    assert "No handler" in session.messages[-1]["content"]
+
+
+# --------------------------------------------------------------------------
+# ToolError returned (not raised) from a tool (lines 525-546)
+# --------------------------------------------------------------------------
+
+
+async def test_tool_returning_toolerror_becomes_tool_error_event():
+    from olmlx.chat.errors import ToolError
+
+    mcp = MagicMock()
+    mcp.get_tools_for_chat.return_value = [
+        {"function": {"name": "flaky"}, "type": "function"}
+    ]
+    mcp.call_tool = AsyncMock(
+        return_value=ToolError(
+            message="bad path", tool_name="flaky", is_user_error=True
+        )
+    )
+    session, _, _ = _make_session(mcp=mcp)
+    tus = [{"name": "flaky", "input": {"path": "/x"}, "id": "f"}]
+
+    events = []
+    async for ev in session._execute_tool_calls(tus):
+        events.append(ev)
+
+    err = [e for e in events if e["type"] == "tool_error"]
+    assert len(err) == 1
+    assert err[0]["error"] == "bad path"
+    assert err[0]["is_user_error"] is True
+    assert session.messages[-1]["content"] == "bad path"
+
+
+# --------------------------------------------------------------------------
+# Repetition strip in thinking block (lines 263-272, 1044-1051)
+# --------------------------------------------------------------------------
+
+
+async def test_repetition_during_thinking_emits_thinking_end():
+    """Repetition detected mid-<think> strips the block and closes thinking."""
+    session, _, _ = _make_session(thinking=True)
+    phrase = "<think>" + ("loop loop loop loop " * 1)
+
+    async def gen(*args, **kwargs):
+        # Open a think block then repeat a phrase enough to trip detection.
+        yield {"text": "<think>", "done": False}
+        for _ in range(60):
+            yield {"text": "repeat phrase here. ", "done": False}
+        yield {"text": "", "done": True}
+
+    with (
+        _patch_no_memory_check(),
+        patch(
+            "olmlx.chat.session.generate_chat",
+            side_effect=lambda *a, **kw: gen(*a, **kw),
+        ),
+    ):
+        events = []
+        async for ev in session.send_message("Q"):
+            events.append(ev)
+
+    types = [e["type"] for e in events]
+    assert "repetition_detected" in types
+    assert "thinking_end" in types
+    assert types[-1] == "done"
+    _ = phrase  # silence linters; documents intent

--- a/tests/test_chat_tui_coverage.py
+++ b/tests/test_chat_tui_coverage.py
@@ -1,0 +1,397 @@
+"""Regression coverage for olmlx.chat.tui rendering helpers.
+
+These tests exercise the pure formatting/state methods of ChatTUI and the
+StreamContext state machine with a captured StringIO console (no live
+terminal, no model, no network). They assert on real rendered output and
+branch outcomes to catch formatting/state regressions.
+"""
+
+from io import StringIO
+from unittest.mock import MagicMock
+
+from rich.console import Console
+
+from olmlx.chat.tool_safety import (
+    ToolPolicy,
+    ToolSafetyConfig,
+    ToolSafetyPolicy,
+)
+from olmlx.chat.tui import ChatTUI, StreamContext
+
+
+def make_tui(truncation=None):
+    """ChatTUI with a captured console (force_terminal so styles render)."""
+    tui = ChatTUI(tool_result_truncation=truncation)
+    tui.console = Console(file=StringIO(), force_terminal=True, width=200)
+    return tui
+
+
+def out(tui):
+    return tui.console.file.getvalue()
+
+
+class TestWelcomeAndTools:
+    def test_welcome_lists_each_tool_name_and_description(self):
+        tui = make_tui()
+        tools = [
+            {"function": {"name": "read_file", "description": "Read a file"}},
+            {"function": {"name": "search", "description": "Search the web"}},
+        ]
+        tui.display_welcome("qwen3:8b", tools)
+        text = out(tui)
+        assert "Model: qwen3:8b" in text
+        assert "Tools: 2 available" in text
+        assert "read_file" in text and "Read a file" in text
+        assert "search" in text and "Search the web" in text
+        assert "Commands:" in text
+
+    def test_welcome_tool_missing_fields_uses_placeholder(self):
+        tui = make_tui()
+        tui.display_welcome("m", [{"function": {}}])
+        text = out(tui)
+        # name defaults to "?" when absent
+        assert "?" in text
+
+    def test_welcome_no_tools_mentions_mcp_config(self):
+        tui = make_tui()
+        tui.display_welcome("m", [])
+        text = out(tui)
+        assert "Tools: none" in text
+        assert "mcp.json" in text
+
+    def test_display_tools_lists_entries(self):
+        tui = make_tui()
+        tools = [
+            {"function": {"name": "ls", "description": "list dir"}},
+            {"function": {"name": "cat", "description": "print file"}},
+        ]
+        tui.display_tools(tools)
+        text = out(tui)
+        assert "ls" in text and "list dir" in text
+        assert "cat" in text and "print file" in text
+        assert "available tools" in text
+
+    def test_display_tools_empty_short_circuits(self):
+        tui = make_tui()
+        tui.display_tools([])
+        assert "No tools available" in out(tui)
+
+    def test_stream_response_returns_streamcontext(self):
+        tui = make_tui()
+        ctx = tui.stream_response("seed")
+        assert isinstance(ctx, StreamContext)
+        assert ctx.get_text() == "seed"
+
+
+class TestPanelHelpers:
+    def test_display_tool_call_renders_name_and_json_args(self):
+        tui = make_tui()
+        tui.display_tool_call("read_file", {"path": "/tmp/x", "n": 3})
+        text = out(tui)
+        assert "read_file" in text
+        assert "tool call" in text
+        # arguments are JSON-formatted
+        assert '"path"' in text
+        assert '"/tmp/x"' in text
+
+    def test_display_tool_call_empty_args_shows_braces(self):
+        tui = make_tui()
+        tui.display_tool_call("noop", {})
+        text = out(tui)
+        assert "noop" in text
+        assert "{}" in text
+
+    def test_display_tool_result_below_limit_not_truncated(self):
+        tui = make_tui(truncation=50)
+        tui.display_tool_result("grep", "short output")
+        text = out(tui)
+        assert "short output" in text
+        assert "truncated" not in text
+        assert "tool result: grep" in text
+
+    def test_display_tool_result_over_limit_is_truncated(self):
+        tui = make_tui(truncation=10)
+        tui.display_tool_result("grep", "x" * 40)
+        text = out(tui)
+        assert "... (truncated)" in text
+
+    def test_default_truncation_is_2000(self):
+        tui = make_tui()  # no override
+        assert tui._tool_result_truncation == 2000
+        # exactly-at-limit content is not truncated
+        tui.display_tool_result("t", "y" * 2000)
+        assert "truncated" not in out(tui)
+
+    def test_display_tool_error_renders_message(self):
+        tui = make_tui()
+        tui.display_tool_error("write_file", "permission denied")
+        text = out(tui)
+        assert "permission denied" in text
+        assert "tool error: write_file" in text
+
+    def test_display_error_panel(self):
+        tui = make_tui()
+        tui.display_error("boom")
+        assert "boom" in out(tui)
+        assert "error" in out(tui)
+
+    def test_display_memory_truncated(self):
+        tui = make_tui()
+        tui.display_memory_truncated("dropped 3 old messages")
+        text = out(tui)
+        assert "dropped 3 old messages" in text
+        assert "memory" in text
+
+    def test_display_repetition_detected(self):
+        tui = make_tui()
+        tui.display_repetition_detected()
+        assert "Repetitive output detected" in out(tui)
+
+    def test_display_tool_failures_exceeded(self):
+        tui = make_tui()
+        tui.display_tool_failures_exceeded("too many failures")
+        text = out(tui)
+        assert "too many failures" in text
+        assert "tool failures exceeded" in text
+
+    def test_display_model_load_error(self):
+        tui = make_tui()
+        tui.display_model_load_error("could not load weights")
+        assert "could not load weights" in out(tui)
+
+    def test_display_tool_auto_judging(self):
+        tui = make_tui()
+        tui.display_tool_auto_judging("rm")
+        assert "Judging rm" in out(tui)
+
+
+class TestToolDenied:
+    def test_denied_by_user(self):
+        tui = make_tui()
+        tui.display_tool_denied("rm", reason="user")
+        text = out(tui)
+        assert "denied by user" in text
+        assert "tool denied" in text
+
+    def test_denied_by_auto(self):
+        tui = make_tui()
+        tui.display_tool_denied("rm", reason="auto")
+        assert "denied by safety check" in out(tui)
+
+    def test_denied_default_policy(self):
+        tui = make_tui()
+        tui.display_tool_denied("rm")  # default reason -> "policy"
+        assert "blocked by safety policy" in out(tui)
+
+
+class TestConfirmToolCall:
+    def test_always_allow_short_circuits(self):
+        tui = make_tui()
+        tui._always_allow.add("rm")
+        # No console.input call should be needed; result is True.
+        assert tui.confirm_tool_call("rm", {}) is True
+
+    def test_yes_answer_approves(self):
+        tui = make_tui()
+        tui.console.input = MagicMock(return_value="y")
+        assert tui.confirm_tool_call("ls", {}) is True
+
+    def test_no_answer_rejects(self):
+        tui = make_tui()
+        tui.console.input = MagicMock(return_value="n")
+        assert tui.confirm_tool_call("ls", {}) is False
+
+    def test_always_answer_caches_tool(self):
+        tui = make_tui()
+        tui.console.input = MagicMock(return_value="a")
+        assert tui.confirm_tool_call("ls", {}) is True
+        assert "ls" in tui._always_allow
+        # subsequent call returns True without prompting again
+        tui.console.input = MagicMock(side_effect=AssertionError("should not prompt"))
+        assert tui.confirm_tool_call("ls", {}) is True
+
+    def test_eof_during_confirm_rejects(self):
+        tui = make_tui()
+        tui.console.input = MagicMock(side_effect=EOFError)
+        assert tui.confirm_tool_call("ls", {}) is False
+
+    def test_keyboard_interrupt_during_confirm_rejects(self):
+        tui = make_tui()
+        tui.console.input = MagicMock(side_effect=KeyboardInterrupt)
+        assert tui.confirm_tool_call("ls", {}) is False
+
+
+class TestAskQuestion:
+    def test_with_options_returns_stripped_choice(self):
+        tui = make_tui()
+        tui.console.input = MagicMock(return_value="  yes  ")
+        ans = tui.ask_question("Header", "Pick one", options=["yes", "no"])
+        assert ans == "yes"
+        text = out(tui)
+        assert "Header" in text
+        assert "Pick one" in text
+        assert "yes" in text and "no" in text
+
+    def test_without_options_returns_stripped_answer(self):
+        tui = make_tui()
+        tui.console.input = MagicMock(return_value="  hello ")
+        ans = tui.ask_question("Header", "Type something")
+        assert ans == "hello"
+
+    def test_eof_returns_none(self):
+        tui = make_tui()
+        tui.console.input = MagicMock(side_effect=EOFError)
+        assert tui.ask_question("H", "Q", options=["a"]) is None
+
+    def test_keyboard_interrupt_returns_none(self):
+        tui = make_tui()
+        tui.console.input = MagicMock(side_effect=KeyboardInterrupt)
+        assert tui.ask_question("H", "Q") is None
+
+
+class TestGetUserInput:
+    def test_single_line(self):
+        tui = make_tui()
+        tui.console.input = MagicMock(return_value="hello")
+        assert tui.get_user_input() == "hello"
+
+    def test_line_continuation_joins_with_newline(self):
+        tui = make_tui()
+        tui.console.input = MagicMock(side_effect=["first\\", "second"])
+        assert tui.get_user_input() == "first\nsecond"
+
+    def test_eof_returns_none(self):
+        tui = make_tui()
+        tui.console.input = MagicMock(side_effect=EOFError)
+        assert tui.get_user_input() is None
+
+
+class TestSafetyPolicyDisplay:
+    def test_confirm_default_no_overrides(self):
+        policy = ToolSafetyPolicy(ToolSafetyConfig(default_policy=ToolPolicy.CONFIRM))
+        tui = make_tui()
+        tui.display_safety_policy(policy)
+        text = out(tui)
+        assert "Default policy: confirm" in text
+        assert "no per-tool overrides" in text
+        assert "Local tools" in text
+
+    def test_auto_default_without_judge_shows_not_configured(self):
+        policy = ToolSafetyPolicy(ToolSafetyConfig(default_policy=ToolPolicy.AUTO))
+        tui = make_tui()
+        tui.display_safety_policy(policy)
+        text = out(tui)
+        assert "Default policy: auto" in text
+        assert "NOT CONFIGURED" in text
+
+    async def _judge(self, name, args, ctx):  # pragma: no cover - not called
+        return True
+
+    def test_auto_default_with_judge_shows_available(self):
+        policy = ToolSafetyPolicy(
+            ToolSafetyConfig(default_policy=ToolPolicy.AUTO),
+            llm_judge=self._judge,
+        )
+        tui = make_tui()
+        tui.display_safety_policy(policy)
+        text = out(tui)
+        assert "LLM judge: available" in text
+
+    def test_per_tool_overrides_sorted(self):
+        config = ToolSafetyConfig(
+            default_policy=ToolPolicy.CONFIRM,
+            tool_policies={"zsh": ToolPolicy.DENY, "ls": ToolPolicy.ALLOW},
+        )
+        tui = make_tui()
+        tui.display_safety_policy(ToolSafetyPolicy(config))
+        text = out(tui)
+        # both overrides listed; "ls" should appear before "zsh" (sorted)
+        assert "ls" in text and "zsh" in text
+        assert text.index("ls") < text.index("zsh")
+        assert "allow" in text and "deny" in text
+
+
+class TestStreamContextState:
+    def test_initial_text_written_on_enter(self):
+        console = Console(file=StringIO(), force_terminal=True)
+        ctx = StreamContext(console, initial_text="seed ")
+        with ctx:
+            ctx.update("more")
+        assert ctx.get_text() == "seed more"
+
+    def test_is_active_lifecycle(self):
+        console = Console(file=StringIO(), force_terminal=True)
+        ctx = StreamContext(console)
+        assert ctx.is_active is False
+        with ctx:
+            assert ctx.is_active is True
+        assert ctx.is_active is False
+
+    def test_finish_is_idempotent(self):
+        console = Console(file=StringIO(), force_terminal=True)
+        ctx = StreamContext(console)
+        with ctx:
+            ctx.update("x")
+        # already finished by __exit__; calling again must be a no-op
+        ctx.finish()
+        ctx.finish()
+        assert ctx.is_active is False
+
+    def test_thinking_then_response_separated(self):
+        console = Console(file=StringIO(), force_terminal=True)
+        ctx = StreamContext(console)
+        with ctx:
+            ctx.start_thinking()
+            ctx.update("reasoning")
+            ctx.end_thinking()
+            ctx.update("answer")
+        assert ctx.get_text() == "answer"
+        assert ctx.get_thinking_text() == "reasoning"
+
+    def test_start_thinking_idempotent_state(self):
+        console = Console(file=StringIO(), force_terminal=True)
+        ctx = StreamContext(console)
+        with ctx:
+            ctx.start_thinking()
+            assert ctx._in_thinking is True
+            ctx.start_thinking()  # second call should be a no-op
+            assert ctx._in_thinking is True
+            ctx.end_thinking()
+            assert ctx._in_thinking is False
+            ctx.end_thinking()  # no-op when already off
+            assert ctx._in_thinking is False
+
+    def test_write_ansi_emits_codes_when_tty(self, monkeypatch):
+        import olmlx.chat.tui as tui_mod
+
+        writes: list[str] = []
+        monkeypatch.setattr(tui_mod.sys.stdout, "write", writes.append)
+        monkeypatch.setattr(tui_mod.sys.stdout, "flush", lambda: None)
+        console = Console(file=StringIO(), force_terminal=True)
+        ctx = StreamContext(console)
+        ctx._is_tty = True  # force the tty branch in _write_ansi
+        ctx.start_thinking()  # writes _ITALIC_ON via _write_ansi
+        assert StreamContext._ITALIC_ON in writes
+
+    def test_write_ansi_suppressed_when_not_tty(self, monkeypatch):
+        import olmlx.chat.tui as tui_mod
+
+        writes: list[str] = []
+        monkeypatch.setattr(tui_mod.sys.stdout, "write", writes.append)
+        monkeypatch.setattr(tui_mod.sys.stdout, "flush", lambda: None)
+        console = Console(file=StringIO(), force_terminal=True)
+        ctx = StreamContext(console)
+        ctx._is_tty = False  # non-tty: ANSI codes must be suppressed
+        ctx.start_thinking()
+        assert StreamContext._ITALIC_ON not in writes
+
+    def test_finish_while_in_thinking_resets_flag(self):
+        console = Console(file=StringIO(), force_terminal=True)
+        ctx = StreamContext(console)
+        with ctx:
+            ctx.start_thinking()
+            ctx.update("partial")
+            # exit context manager while still in thinking mode
+        assert ctx._in_thinking is False
+        assert ctx.is_active is False
+        assert ctx.get_thinking_text() == "partial"

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -1,0 +1,383 @@
+"""Regression coverage for olmlx.cli pure helpers and validation branches.
+
+Focus: argparse type validators, config/info printers, legacy-env mirroring,
+and the distributed/dflash/eagle validation guards that exit before any model
+load. Everything here is hermetic — no network, no model loads, no server.
+"""
+
+import json
+import logging
+
+import pytest
+
+from olmlx.cli import (
+    _flash_progress,
+    _legacy_kv_cache_quant_in_dotenv,
+    _non_empty_str,
+    _positive_int,
+    _show_flash_dense_info,
+    _show_flash_moe_info,
+    _surface_legacy_dflash_env,
+    _surface_legacy_distributed_env,
+    build_parser,
+    cmd_bench_compare,
+    cmd_bench_list,
+    cmd_config_show,
+    cmd_dflash_prepare,
+    cmd_eagle_prepare,
+    cmd_flash_info,
+    validate_remote_python,
+)
+
+
+class TestPositiveInt:
+    def test_accepts_positive(self):
+        assert _positive_int("5") == 5
+
+    def test_rejects_zero(self):
+        import argparse
+
+        with pytest.raises(argparse.ArgumentTypeError, match="must be >= 1"):
+            _positive_int("0")
+
+    def test_rejects_non_integer(self):
+        import argparse
+
+        with pytest.raises(argparse.ArgumentTypeError, match="invalid integer"):
+            _positive_int("abc")
+
+
+class TestNonEmptyStr:
+    def test_strips_whitespace(self):
+        assert _non_empty_str("  hf/path  ") == "hf/path"
+
+    def test_rejects_empty(self):
+        import argparse
+
+        with pytest.raises(argparse.ArgumentTypeError, match="non-empty"):
+            _non_empty_str("   ")
+
+
+class TestValidateRemotePython:
+    def test_accepts_simple_path(self):
+        # No exception for a plausible interpreter path.
+        validate_remote_python("/usr/bin/python3")
+
+    def test_accepts_multi_word(self):
+        validate_remote_python("uv run python")
+
+    def test_rejects_shell_metacharacters(self):
+        with pytest.raises(ValueError, match="Invalid remote_python"):
+            validate_remote_python("python; rm -rf /")
+
+    def test_rejects_command_substitution(self):
+        with pytest.raises(ValueError):
+            validate_remote_python("python $(whoami)")
+
+
+class TestFlashProgress:
+    def test_renders_bar_and_percentage(self, capsys):
+        _flash_progress("loading", 0.5)
+        out = capsys.readouterr().out
+        assert "loading" in out
+        assert "50.0%" in out
+        # Half-filled bar at 50%.
+        assert "█" in out and "░" in out
+
+    def test_newline_emitted_at_completion(self, capsys):
+        _flash_progress("done", 1.0)
+        out = capsys.readouterr().out
+        assert "100.0%" in out
+        assert out.endswith("\n")
+
+
+class TestConfigShow:
+    def test_shows_kv_and_flash_and_distributed_sections(self, monkeypatch, capsys):
+        from olmlx.config import settings as _settings
+
+        # Drive the conditional branches: KV quant + flash + distributed.
+        monkeypatch.setattr(_settings, "kv_cache_quant", "turboquant:4")
+        monkeypatch.setattr(_settings, "flash", True)
+        monkeypatch.setattr(_settings, "flash_max_active_neurons", 256)
+        monkeypatch.setattr(_settings, "flash_memory_budget_fraction", 0.25)
+        monkeypatch.setattr(_settings, "distributed", True)
+
+        cmd_config_show(None)
+        out = capsys.readouterr().out
+        assert "KV cache quant:" in out
+        assert "turboquant:4" in out
+        assert "Flash inference:        enabled" in out
+        assert "Max active neurons:" in out
+        assert "256" in out
+        assert "Memory budget frac:" in out
+        assert "Distributed inference:" in out
+        assert "Sideband port:" in out
+
+    def test_omits_optional_sections_when_disabled(self, monkeypatch, capsys):
+        from olmlx.config import settings as _settings
+
+        monkeypatch.setattr(_settings, "kv_cache_quant", None)
+        monkeypatch.setattr(_settings, "flash", False)
+        monkeypatch.setattr(_settings, "distributed", False)
+
+        cmd_config_show(None)
+        out = capsys.readouterr().out
+        assert "Host:" in out  # base section always prints
+        assert "KV cache quant:" not in out
+        assert "Flash inference:" not in out
+        assert "Distributed inference:" not in out
+
+
+class TestShowFlashInfo:
+    def test_show_flash_moe_info(self, tmp_path, capsys):
+        moe_dir = tmp_path / "flash_moe"
+        moe_dir.mkdir()
+        (moe_dir / "flash_moe_config.json").write_text(
+            json.dumps(
+                {
+                    "hidden_size": 4096,
+                    "intermediate_size": 11008,
+                    "num_experts": 128,
+                    "num_experts_per_tok": 8,
+                    "num_moe_layers": 60,
+                    "prepared_at": "2026-01-01",
+                }
+            )
+        )
+        (moe_dir / "layer0.flashexperts").write_bytes(b"x" * 16)
+        _show_flash_moe_info("deepseek:latest", moe_dir)
+        out = capsys.readouterr().out
+        assert "Flash-MoE info for 'deepseek:latest'" in out
+        assert "Num experts:        128" in out
+        assert "Expert files:       1" in out
+        # Size is well under 1GB → printed in MB.
+        assert "MB" in out
+
+    def test_show_flash_dense_info(self, tmp_path, capsys):
+        flash_dir = tmp_path / "flash"
+        flash_dir.mkdir()
+        (flash_dir / "flash_config.json").write_text(
+            json.dumps(
+                {
+                    "hidden_size": 2048,
+                    "intermediate_size": 8192,
+                    "num_layers": 28,
+                    "predictor_rank": 64,
+                    "num_calibration_samples": 512,
+                    "prepared_at": "2026-01-01",
+                }
+            )
+        )
+        (flash_dir / "layer0.flashweights").write_bytes(b"x" * 32)
+        pred_dir = flash_dir / "predictors"
+        pred_dir.mkdir()
+        (pred_dir / "layer0.npz").write_bytes(b"y" * 8)
+        _show_flash_dense_info("qwen:latest", flash_dir)
+        out = capsys.readouterr().out
+        assert "Flash info for 'qwen:latest'" in out
+        assert "Predictor rank:     64" in out
+        assert "Weight files:       1" in out
+        assert "Predictor files:    1" in out
+
+    def test_show_flash_dense_info_missing_config(self, tmp_path, capsys):
+        flash_dir = tmp_path / "flash"
+        flash_dir.mkdir()
+        _show_flash_dense_info("qwen:latest", flash_dir)
+        out = capsys.readouterr().out
+        assert "no config found" in out
+
+
+class TestCmdFlashInfo:
+    def test_reports_not_prepared(self, tmp_path, monkeypatch, capsys):
+        """When neither flash nor flash_moe dir exists, prints the prep hint."""
+        from olmlx.cli import _create_store
+
+        store = _create_store()
+        # local_path returns a dir with no flash artifacts.
+        monkeypatch.setattr(store.registry, "resolve", lambda name: None)
+        monkeypatch.setattr(store, "local_path", lambda hf: tmp_path / "model")
+        monkeypatch.setattr("olmlx.cli._create_store", lambda: store)
+
+        ns = type("NS", (), {"model": "missing/model"})()
+        cmd_flash_info(ns)
+        out = capsys.readouterr().out
+        assert "has not been prepared for flash inference" in out
+        assert "olmlx flash prepare missing/model" in out
+
+
+class TestDflashPrepareValidation:
+    def _args(self, **overrides):
+        parser = build_parser()
+        argv = ["dflash", "prepare", "some/model"]
+        for k, v in overrides.items():
+            argv += [f"--{k.replace('_', '-')}", str(v)]
+        return parser.parse_args(argv)
+
+    def test_block_size_must_be_positive(self):
+        args = self._args(block_size=0)
+        with pytest.raises(SystemExit, match="block-size must be >= 1"):
+            cmd_dflash_prepare(args)
+
+    def test_seq_len_too_small_for_block_size(self):
+        # 2*block_size + 1 = 9 > seq_len 4 → reject before any download.
+        args = self._args(block_size=4, seq_len=4)
+        with pytest.raises(SystemExit, match="too small for --block-size"):
+            cmd_dflash_prepare(args)
+
+    def test_train_windows_per_step_must_be_positive(self):
+        # Keep seq_len valid so the windows check is the one that fires.
+        args = self._args(block_size=2, seq_len=64, train_windows_per_step=0)
+        with pytest.raises(SystemExit, match="train-windows-per-step must be >= 1"):
+            cmd_dflash_prepare(args)
+
+
+class TestEaglePrepareValidation:
+    def _args(self, **overrides):
+        parser = build_parser()
+        # --use-precomputed is a required argparse arg; supply it so the
+        # in-function guards (block_size, etc.) are the ones exercised.
+        argv = ["eagle", "prepare", "some/model", "--use-precomputed", "/tmp/shards"]
+        for k, v in overrides.items():
+            argv += [f"--{k.replace('_', '-')}", str(v)]
+        return parser.parse_args(argv)
+
+    def test_block_size_must_be_positive(self):
+        args = self._args(block_size=0)
+        with pytest.raises(SystemExit, match="block-size must be >= 1"):
+            cmd_eagle_prepare(args)
+
+    def test_use_precomputed_required_at_function_level(self):
+        """The function re-checks ``use_precomputed`` even though argparse
+        marks it required — exercise that guard directly so a programmatic
+        caller (or a parser change) can't slip an empty value past it."""
+        import argparse
+
+        ns = argparse.Namespace(model="some/model", use_precomputed="", block_size=4)
+        with pytest.raises(SystemExit, match="use-precomputed is required"):
+            cmd_eagle_prepare(ns)
+
+
+class TestSurfaceLegacyDflashEnv:
+    def test_forwards_enable_and_strategy(self, monkeypatch, caplog):
+        from olmlx.config import settings as _settings
+
+        monkeypatch.setattr(_settings, "speculative", False)
+        monkeypatch.setattr(_settings, "speculative_strategy", "classic")
+        monkeypatch.setattr(_settings, "speculative_draft_model", None)
+        monkeypatch.delenv("OLMLX_SPECULATIVE", raising=False)
+        monkeypatch.delenv("OLMLX_SPECULATIVE_DRAFT_MODEL", raising=False)
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_DFLASH", "true")
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_DFLASH_DRAFT_MODEL", "draft/dflash")
+
+        with caplog.at_level(logging.WARNING, logger="olmlx.cli"):
+            _surface_legacy_dflash_env()
+
+        assert _settings.speculative is True
+        assert _settings.speculative_strategy == "dflash"
+        assert _settings.speculative_draft_model == "draft/dflash"
+        assert "Deprecated env vars detected" in caplog.text
+
+    def test_noop_when_unset(self, monkeypatch, caplog):
+        from olmlx.config import settings as _settings
+
+        monkeypatch.setattr(_settings, "speculative", False)
+        monkeypatch.setattr(_settings, "speculative_strategy", "classic")
+        for v in (
+            "OLMLX_EXPERIMENTAL_DFLASH",
+            "OLMLX_EXPERIMENTAL_DFLASH_DRAFT_MODEL",
+            "OLMLX_EXPERIMENTAL_DFLASH_BLOCK_SIZE",
+        ):
+            monkeypatch.delenv(v, raising=False)
+
+        with caplog.at_level(logging.WARNING, logger="olmlx.cli"):
+            _surface_legacy_dflash_env()
+
+        assert _settings.speculative is False
+        assert _settings.speculative_strategy == "classic"
+        assert "Deprecated env vars detected" not in caplog.text
+
+    def test_block_size_forwarded_as_int(self, monkeypatch):
+        from olmlx.config import settings as _settings
+
+        monkeypatch.setattr(_settings, "speculative", False)
+        monkeypatch.setattr(_settings, "speculative_tokens", None)
+        monkeypatch.delenv("OLMLX_SPECULATIVE_TOKENS", raising=False)
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_DFLASH_BLOCK_SIZE", "7")
+
+        _surface_legacy_dflash_env()
+        assert _settings.speculative_tokens == 7
+
+
+class TestSurfaceLegacyDistributedEnv:
+    def test_forwards_bool_int_and_path(self, monkeypatch, caplog):
+        from olmlx.config import settings as _settings
+
+        monkeypatch.setattr(_settings, "distributed", False)
+        monkeypatch.setattr(_settings, "distributed_port", 5555)
+        # New names absent so legacy wins.
+        monkeypatch.delenv("OLMLX_DISTRIBUTED", raising=False)
+        monkeypatch.delenv("OLMLX_DISTRIBUTED_PORT", raising=False)
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_DISTRIBUTED", "true")
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_DISTRIBUTED_PORT", "9001")
+
+        with caplog.at_level(logging.WARNING, logger="olmlx.cli"):
+            _surface_legacy_distributed_env()
+
+        assert _settings.distributed is True
+        assert _settings.distributed_port == 9001
+        assert "Forwarding legacy" in caplog.text
+
+    def test_new_var_wins_over_legacy(self, monkeypatch):
+        from olmlx.config import settings as _settings
+
+        monkeypatch.setattr(_settings, "distributed", False)
+        monkeypatch.setenv("OLMLX_DISTRIBUTED", "false")
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_DISTRIBUTED", "true")
+
+        _surface_legacy_distributed_env()
+        # New (explicit) var present → legacy must not flip it on.
+        assert _settings.distributed is False
+
+    def test_invalid_int_logged_and_skipped(self, monkeypatch, caplog):
+        from olmlx.config import settings as _settings
+
+        monkeypatch.setattr(_settings, "distributed_port", 5555)
+        monkeypatch.delenv("OLMLX_DISTRIBUTED_PORT", raising=False)
+        monkeypatch.setenv("OLMLX_EXPERIMENTAL_DISTRIBUTED_PORT", "not-a-number")
+
+        with caplog.at_level(logging.WARNING, logger="olmlx.cli"):
+            _surface_legacy_distributed_env()
+
+        assert _settings.distributed_port == 5555
+        assert "not a valid int" in caplog.text
+
+
+class TestLegacyKvCacheQuantDotenvComment:
+    def test_strips_inline_comment_on_unquoted_value(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text(
+            "OLMLX_EXPERIMENTAL_KV_CACHE_QUANT=turboquant:4  # comment\n"
+        )
+        assert _legacy_kv_cache_quant_in_dotenv() == "turboquant:4"
+
+    def test_export_prefix_stripped(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text(
+            'export OLMLX_EXPERIMENTAL_KV_CACHE_QUANT="spectral:2"\n'
+        )
+        assert _legacy_kv_cache_quant_in_dotenv() == "spectral:2"
+
+
+class TestCmdBenchCompare:
+    def test_run_not_found_raises(self, tmp_path):
+        ns = type("NS", (), {"run1": "no-such-run", "run2": "also-missing"})()
+        with pytest.raises(FileNotFoundError, match="Run not found"):
+            cmd_bench_compare(ns)
+
+
+class TestCmdBenchList:
+    def test_no_runs_message(self, tmp_path, capsys):
+        ns = type("NS", (), {"bench_dir": str(tmp_path)})()
+        cmd_bench_list(ns)
+        out = capsys.readouterr().out
+        assert "No benchmark runs found." in out

--- a/tests/test_extended_runner_coverage.py
+++ b/tests/test_extended_runner_coverage.py
@@ -1,0 +1,541 @@
+"""Regression coverage for olmlx.bench.extended_runner orchestration.
+
+Focus: the HTTP driver (`_drive_prompt`, `_warmup`) and the suite
+orchestration in `run_model` — scenario selection (triage), subset filtering,
+result aggregation, per-prompt persistence, and timeout handling. All HTTP and
+grading is mocked; no network, model, or GPU is touched.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+import olmlx.bench.extended_runner as er
+from olmlx.bench.extended_runner import (
+    ModelRunResult,
+    PromptResult,
+    SuiteAssignment,
+    _drive_prompt,
+    _warmup,
+    aggregate_per_suite,
+    composite_score,
+    run_model,
+    run_model_sync,
+    safe_model_name,
+    suite_of,
+    write_result,
+)
+
+
+# ---------------------------------------------------------------------------
+# Lightweight stand-ins so we never depend on real datasets / loaders.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakePrompt:
+    """Mirror of BenchPrompt's fields used by the runner."""
+
+    name: str
+    category: str
+    messages: list[dict[str, str]] = field(default_factory=list)
+    max_tokens: int = 64
+    grader: str | None = "exact_match"
+    expected: dict[str, Any] = field(default_factory=dict)
+
+
+def _fake_grade(passed=True, score=1.0, detail="match"):
+    gr = MagicMock()
+    gr.passed = passed
+    gr.score = score
+    gr.detail = detail
+    return gr
+
+
+class _Resp:
+    """Minimal httpx.Response stand-in."""
+
+    def __init__(self, payload: dict[str, Any], raise_exc: Exception | None = None):
+        self._payload = payload
+        self._raise_exc = raise_exc
+
+    def raise_for_status(self) -> None:
+        if self._raise_exc is not None:
+            raise self._raise_exc
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _client_returning(*responses):
+    """An AsyncClient mock whose .post() yields the given responses in order."""
+    client = MagicMock()
+    client.post = AsyncMock(side_effect=list(responses))
+    return client
+
+
+# ---------------------------------------------------------------------------
+# suite_of / safe_model_name — small mappers feeding aggregation.
+# ---------------------------------------------------------------------------
+
+
+class TestSuiteOf:
+    def test_known_prefixes_collapse_to_headline_suite(self):
+        assert suite_of("gpqa-physics") == "gpqa"
+        assert suite_of("math500-algebra") == "math500"
+        assert suite_of("ruler-niah-4k") == "ruler-niah"
+        assert suite_of("humaneval-plus") == "humaneval-plus"
+
+    def test_unknown_category_passes_through(self):
+        assert suite_of("totally-novel") == "totally-novel"
+
+
+class TestSafeModelName:
+    def test_slashes_and_specials_become_underscores(self):
+        assert safe_model_name("Qwen/Qwen3-8B:latest") == "Qwen_Qwen3-8B_latest"
+
+    def test_safe_chars_preserved(self):
+        assert safe_model_name("model_v1.2-x") == "model_v1.2-x"
+
+
+# ---------------------------------------------------------------------------
+# aggregate_per_suite — ungraded (None) prompts must be skipped, not counted.
+# ---------------------------------------------------------------------------
+
+
+class TestAggregatePerSuite:
+    def _pr(self, suite, passed):
+        return PromptResult(
+            name="n",
+            category=suite,
+            suite=suite,
+            passed=passed,
+            score=None,
+            detail="",
+            output_text_clip="",
+        )
+
+    def test_pass_rate_per_suite(self):
+        results = [
+            self._pr("gsm8k", True),
+            self._pr("gsm8k", False),
+            self._pr("gpqa", True),
+        ]
+        agg = aggregate_per_suite(results)
+        assert agg == {"gsm8k": pytest.approx(0.5), "gpqa": pytest.approx(1.0)}
+
+    def test_ungraded_none_excluded_entirely(self):
+        # A suite with only ungraded results must not appear (no 0-div, no key).
+        results = [
+            self._pr("ifeval", None),
+            self._pr("gsm8k", True),
+            self._pr("gsm8k", None),
+        ]
+        agg = aggregate_per_suite(results)
+        assert "ifeval" not in agg
+        # gsm8k's lone None is dropped → 1/1 graded.
+        assert agg["gsm8k"] == pytest.approx(1.0)
+
+    def test_empty_input(self):
+        assert aggregate_per_suite([]) == {}
+
+
+# ---------------------------------------------------------------------------
+# write_result — JSON persistence with enum serialization.
+# ---------------------------------------------------------------------------
+
+
+class TestWriteResult:
+    def test_writes_under_raw_with_safe_name_and_enum_value(self, tmp_path):
+        result = ModelRunResult(
+            model="Qwen/Qwen3-8B",
+            tier="core",
+            assignment=SuiteAssignment.FULL_CORE,
+            warmup_tok_per_s=42.0,
+            per_suite_pass_rate={"gsm8k": 1.0},
+            composite=1.0,
+        )
+        path = write_result(tmp_path, result)
+        assert path == tmp_path / "raw" / "Qwen_Qwen3-8B.json"
+        data = json.loads(path.read_text())
+        # Enum is serialized as its .value, not the Enum repr.
+        assert data["assignment"] == "full_core"
+        assert data["model"] == "Qwen/Qwen3-8B"
+        assert data["per_suite_pass_rate"] == {"gsm8k": 1.0}
+
+    def test_creates_raw_dir_when_absent(self, tmp_path):
+        out = tmp_path / "nested" / "out"
+        result = ModelRunResult(
+            model="m",
+            tier="core",
+            assignment=SuiteAssignment.HE_PLUS_ONLY,
+            warmup_tok_per_s=1.0,
+        )
+        path = write_result(out, result)
+        assert path.exists()
+        assert (out / "raw").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# _drive_prompt — HTTP request shaping, grading, transport-error handling.
+# ---------------------------------------------------------------------------
+
+
+class TestDrivePrompt:
+    async def test_happy_path_grades_output(self):
+        client = _client_returning(_Resp({"message": {"content": "ANSWER"}}))
+        prompt = FakePrompt(name="p1", category="gsm8k-x", expected={"answer": "y"})
+        with patch.object(er, "grade", return_value=_fake_grade(True, 1.0, "ok")):
+            res = await _drive_prompt(client, "m", prompt, "gsm8k")
+        assert res.passed is True
+        assert res.score == 1.0
+        assert res.detail == "ok"
+        assert res.suite == "gsm8k"
+        assert res.output_text_clip == "ANSWER"
+
+    async def test_request_body_uses_deterministic_options(self):
+        client = _client_returning(_Resp({"message": {"content": "x"}}))
+        prompt = FakePrompt(
+            name="p", category="gsm8k", messages=[{"role": "user", "content": "hi"}]
+        )
+        prompt.max_tokens = 123
+        with patch.object(er, "grade", return_value=_fake_grade()):
+            await _drive_prompt(client, "the-model", prompt, "gsm8k")
+        _, kwargs = client.post.call_args
+        body = kwargs["json"]
+        assert kwargs["timeout"] == 600.0
+        assert body["model"] == "the-model"
+        assert body["stream"] is False
+        assert body["options"]["temperature"] == 0.0
+        assert body["options"]["seed"] == 42
+        assert body["options"]["num_predict"] == 123
+        assert body["messages"] == prompt.messages
+
+    async def test_output_clip_truncated_to_500_chars(self):
+        long = "z" * 1000
+        client = _client_returning(_Resp({"message": {"content": long}}))
+        prompt = FakePrompt(name="p", category="gsm8k")
+        with patch.object(er, "grade", return_value=_fake_grade()):
+            res = await _drive_prompt(client, "m", prompt, "gsm8k")
+        assert len(res.output_text_clip) == 500
+
+    async def test_http_error_recorded_as_ungraded_not_failed(self):
+        err = httpx.ConnectError("boom")
+        client = MagicMock()
+        client.post = AsyncMock(side_effect=err)
+        prompt = FakePrompt(name="p", category="gsm8k")
+        # grade must NOT be called on the transport-error path.
+        with patch.object(er, "grade") as graded:
+            res = await _drive_prompt(client, "m", prompt, "gsm8k")
+        graded.assert_not_called()
+        assert res.passed is None
+        assert res.score is None
+        assert "transport error" in res.detail
+
+    async def test_raise_for_status_5xx_is_ungraded(self):
+        resp = _Resp(
+            {}, raise_exc=httpx.HTTPStatusError("500", request=None, response=None)
+        )
+        client = _client_returning(resp)
+        prompt = FakePrompt(name="p", category="gsm8k")
+        res = await _drive_prompt(client, "m", prompt, "gsm8k")
+        assert res.passed is None
+
+    async def test_code_exec_gate_off_sets_enabled_false(self, monkeypatch):
+        monkeypatch.delenv("OLMLX_BENCH_CODE_EXEC", raising=False)
+        client = _client_returning(_Resp({"message": {"content": "code"}}))
+        prompt = FakePrompt(name="p", category="humaneval-plus", grader="code_exec")
+        captured = {}
+
+        def fake_grade(grader, output, expected):
+            captured["expected"] = expected
+            return _fake_grade(None, None, "ungraded")
+
+        with patch.object(er, "grade", side_effect=fake_grade):
+            await _drive_prompt(client, "m", prompt, "humaneval-plus")
+        assert captured["expected"]["_enabled"] is False
+
+    async def test_code_exec_gate_on_sets_enabled_true(self, monkeypatch):
+        monkeypatch.setenv("OLMLX_BENCH_CODE_EXEC", "1")
+        client = _client_returning(_Resp({"message": {"content": "code"}}))
+        prompt = FakePrompt(name="p", category="humaneval-plus", grader="code_exec")
+        captured = {}
+
+        def fake_grade(grader, output, expected):
+            captured["expected"] = expected
+            return _fake_grade()
+
+        with patch.object(er, "grade", side_effect=fake_grade):
+            await _drive_prompt(client, "m", prompt, "humaneval-plus")
+        assert captured["expected"]["_enabled"] is True
+
+    async def test_grader_none_defaults_to_exact_match(self):
+        client = _client_returning(_Resp({"message": {"content": "x"}}))
+        prompt = FakePrompt(name="p", category="gsm8k", grader=None)
+        with patch.object(er, "grade", return_value=_fake_grade()) as graded:
+            await _drive_prompt(client, "m", prompt, "gsm8k")
+        assert graded.call_args[0][0] == "exact_match"
+
+    async def test_missing_message_content_grades_empty_string(self):
+        client = _client_returning(_Resp({}))  # no "message" key
+        prompt = FakePrompt(name="p", category="gsm8k")
+        with patch.object(er, "grade", return_value=_fake_grade()) as graded:
+            await _drive_prompt(client, "m", prompt, "gsm8k")
+        # output defaults to "" → passed through to grade.
+        assert graded.call_args[0][1] == ""
+
+
+# ---------------------------------------------------------------------------
+# _warmup — tok/s estimation and the missing/zero eval_duration fallback.
+# ---------------------------------------------------------------------------
+
+
+class TestWarmup:
+    async def test_uses_server_decode_time_when_present(self):
+        # 100 tokens / 0.5s decode = 200 tok/s.
+        client = _client_returning(
+            _Resp({"eval_count": 100, "eval_duration": 500_000_000})
+        )
+        tps = await _warmup(client, "m")
+        assert tps == pytest.approx(200.0)
+
+    async def test_zero_eval_duration_falls_back_to_wallclock(self):
+        # eval_duration=0 must NOT yield ~1e9 tok/s (the old `or 1` bug).
+        client = _client_returning(_Resp({"eval_count": 10, "eval_duration": 0}))
+        with patch.object(er.time, "monotonic", side_effect=[0.0, 2.0]):
+            tps = await _warmup(client, "m")
+        # 10 tokens / 2s wall-clock = 5 tok/s — a finite, sane estimate.
+        assert tps == pytest.approx(5.0)
+        assert tps < 1e6
+
+    async def test_missing_counts_fall_back_without_divzero(self):
+        client = _client_returning(_Resp({}))
+        with patch.object(er.time, "monotonic", side_effect=[0.0, 0.0]):
+            tps = await _warmup(client, "m")
+        # max(eval_count,1)/max(elapsed,0.001) = 1/0.001 = 1000.
+        assert tps == pytest.approx(1000.0)
+
+
+# ---------------------------------------------------------------------------
+# run_model — full orchestration: triage selection, subset filtering,
+# extended dedup, per-prompt persistence, aggregation, timeout breakout.
+# ---------------------------------------------------------------------------
+
+
+def _patch_suites(monkeypatch, core, extended=None):
+    monkeypatch.setattr(er, "assemble_core_suite", lambda: list(core))
+    monkeypatch.setattr(er, "assemble_extended_suite", lambda: list(extended or []))
+
+
+def _patch_client(monkeypatch, warmup_tps):
+    """Make httpx.AsyncClient a context manager; stub _warmup return."""
+
+    class _CtxClient:
+        async def __aenter__(self):
+            return MagicMock()
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(er.httpx, "AsyncClient", lambda **kw: _CtxClient())
+    monkeypatch.setattr(er, "_warmup", AsyncMock(return_value=warmup_tps))
+
+
+class TestRunModelOrchestration:
+    async def test_full_core_runs_all_core_prompts(self, tmp_path, monkeypatch):
+        core = [
+            FakePrompt("he1", "humaneval-plus"),
+            FakePrompt("g1", "gsm8k"),
+            FakePrompt("q1", "gpqa-physics"),
+        ]
+        _patch_suites(monkeypatch, core)
+        _patch_client(monkeypatch, warmup_tps=1000.0)  # fast → FULL_CORE
+
+        async def fake_drive(client, model, prompt, suite):
+            return PromptResult(
+                prompt.name, prompt.category, suite, True, 1.0, "ok", "out"
+            )
+
+        monkeypatch.setattr(er, "_drive_prompt", fake_drive)
+
+        res = await run_model("m", "core", "http://x", tmp_path, remaining_seconds=1e9)
+        assert res.assignment == SuiteAssignment.FULL_CORE
+        assert len(res.prompts) == 3
+        assert res.timed_out is False
+        # All graded True → composite is mean of per-suite (all 1.0).
+        assert res.composite == pytest.approx(1.0)
+        assert set(res.per_suite_pass_rate) == {"humaneval-plus", "gsm8k", "gpqa"}
+
+    async def test_he_plus_only_filters_to_humaneval(self, tmp_path, monkeypatch):
+        core = [
+            FakePrompt("he1", "humaneval-plus"),
+            FakePrompt("g1", "gsm8k"),
+            FakePrompt("q1", "gpqa-physics"),
+        ]
+        _patch_suites(monkeypatch, core)
+        # Slow + tiny budget → HE_PLUS_ONLY.
+        _patch_client(monkeypatch, warmup_tps=1.0)
+        seen = []
+
+        async def fake_drive(client, model, prompt, suite):
+            seen.append(prompt.category)
+            return PromptResult(prompt.name, prompt.category, suite, True, 1.0, "", "")
+
+        monkeypatch.setattr(er, "_drive_prompt", fake_drive)
+        res = await run_model("m", "core", "http://x", tmp_path, remaining_seconds=10)
+        assert res.assignment == SuiteAssignment.HE_PLUS_ONLY
+        assert seen == ["humaneval-plus"]
+
+    async def test_core_minus_gpqa_filters_gpqa(self, tmp_path, monkeypatch):
+        core = [
+            FakePrompt("he1", "humaneval-plus"),
+            FakePrompt("g1", "gsm8k"),
+            FakePrompt("q1", "gpqa-physics"),
+        ]
+        _patch_suites(monkeypatch, core)
+        # 50 tok/s × 1500s = 75k tokens → CORE_MINUS_GPQA band.
+        _patch_client(monkeypatch, warmup_tps=50.0)
+        seen = []
+
+        async def fake_drive(client, model, prompt, suite):
+            seen.append(prompt.category)
+            return PromptResult(prompt.name, prompt.category, suite, True, 1.0, "", "")
+
+        monkeypatch.setattr(er, "_drive_prompt", fake_drive)
+        res = await run_model("m", "core", "http://x", tmp_path, remaining_seconds=1500)
+        assert res.assignment == SuiteAssignment.CORE_MINUS_GPQA
+        assert "gpqa-physics" not in seen
+        assert "gsm8k" in seen and "humaneval-plus" in seen
+
+    async def test_extended_tier_appends_and_dedups_by_name(
+        self, tmp_path, monkeypatch
+    ):
+        core = [FakePrompt("he1", "humaneval-plus")]
+        extended = [
+            FakePrompt("he1", "humaneval-plus"),  # dup name → must be skipped
+            FakePrompt("m1", "math500"),
+        ]
+        _patch_suites(monkeypatch, core, extended)
+        _patch_client(monkeypatch, warmup_tps=1e9)
+        seen = []
+
+        async def fake_drive(client, model, prompt, suite):
+            seen.append(prompt.name)
+            return PromptResult(prompt.name, prompt.category, suite, True, 1.0, "", "")
+
+        monkeypatch.setattr(er, "_drive_prompt", fake_drive)
+        res = await run_model(
+            "m", "extended", "http://x", tmp_path, remaining_seconds=1e9
+        )
+        # he1 graded once, m1 added; duplicate extended he1 dropped.
+        assert seen == ["he1", "m1"]
+        assert res.tier == "extended"
+
+    async def test_partial_json_written_after_each_prompt(self, tmp_path, monkeypatch):
+        core = [FakePrompt("a", "gsm8k"), FakePrompt("b", "gsm8k")]
+        _patch_suites(monkeypatch, core)
+        _patch_client(monkeypatch, warmup_tps=1e9)
+        write_calls = []
+        real_write = er.write_result
+
+        def spy_write(output_dir, result):
+            write_calls.append(len(result.prompts))
+            return real_write(output_dir, result)
+
+        monkeypatch.setattr(er, "write_result", spy_write)
+
+        async def fake_drive(client, model, prompt, suite):
+            return PromptResult(prompt.name, prompt.category, suite, True, 1.0, "", "")
+
+        monkeypatch.setattr(er, "_drive_prompt", fake_drive)
+        await run_model("m", "core", "http://x", tmp_path, remaining_seconds=1e9)
+        # Two partial writes (1, 2 prompts) plus a final write.
+        assert write_calls[:2] == [1, 2]
+        # Final file exists on disk.
+        assert (tmp_path / "raw" / "m.json").exists()
+
+    async def test_per_model_timeout_breaks_loop_and_marks_timed_out(
+        self, tmp_path, monkeypatch
+    ):
+        core = [FakePrompt(f"p{i}", "gsm8k") for i in range(5)]
+        _patch_suites(monkeypatch, core)
+        _patch_client(monkeypatch, warmup_tps=1e9)
+
+        # t_start=0, then deadline check returns increasing time. With
+        # per_model_timeout=10 and deadline=10, the 2nd loop check at t=20
+        # has remaining<=0 → breakout after 1 prompt.
+        times = iter([0.0, 1.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0])
+        monkeypatch.setattr(er.time, "monotonic", lambda: next(times))
+
+        async def fake_drive(client, model, prompt, suite):
+            return PromptResult(prompt.name, prompt.category, suite, True, 1.0, "", "")
+
+        monkeypatch.setattr(er, "_drive_prompt", fake_drive)
+        res = await run_model(
+            "m",
+            "core",
+            "http://x",
+            tmp_path,
+            remaining_seconds=1e9,
+            per_model_timeout=10,
+        )
+        assert res.timed_out is True
+        assert len(res.prompts) == 1
+
+    async def test_per_prompt_timeout_records_failed_result(
+        self, tmp_path, monkeypatch
+    ):
+        core = [FakePrompt("slow", "gsm8k")]
+        _patch_suites(monkeypatch, core)
+        _patch_client(monkeypatch, warmup_tps=1e9)
+
+        async def hang(client, model, prompt, suite):
+            raise AssertionError("should be cancelled by wait_for")
+
+        monkeypatch.setattr(er, "_drive_prompt", hang)
+
+        async def fake_wait_for(coro, timeout):
+            coro.close()  # avoid 'never awaited' warning
+            raise er.asyncio.TimeoutError()
+
+        monkeypatch.setattr(er.asyncio, "wait_for", fake_wait_for)
+        res = await run_model("m", "core", "http://x", tmp_path, remaining_seconds=1e9)
+        assert len(res.prompts) == 1
+        pr = res.prompts[0]
+        assert pr.passed is False
+        assert pr.score == 0.0
+        assert "wait_for timeout" in pr.detail
+
+
+# ---------------------------------------------------------------------------
+# run_model_sync — thin asyncio.run wrapper around run_model.
+# ---------------------------------------------------------------------------
+
+
+class TestRunModelSync:
+    def test_delegates_to_run_model(self, monkeypatch):
+        sentinel = object()
+
+        async def fake_run_model(*args, **kwargs):
+            return sentinel
+
+        monkeypatch.setattr(er, "run_model", fake_run_model)
+        out = run_model_sync("m", "core", "http://x", "/out", 100.0)
+        assert out is sentinel
+
+
+# ---------------------------------------------------------------------------
+# composite_score edge — single suite, defensive against empty (already in
+# sibling test, but pin the single-suite branch explicitly here).
+# ---------------------------------------------------------------------------
+
+
+class TestCompositeScoreSingle:
+    def test_single_suite_returns_its_rate(self):
+        assert composite_score({"gsm8k": 0.7}) == pytest.approx(0.7)

--- a/tests/test_gdn_rollback_coverage.py
+++ b/tests/test_gdn_rollback_coverage.py
@@ -1,0 +1,682 @@
+"""Regression coverage for ``olmlx.engine.gdn_rollback``.
+
+The sibling ``test_gdn_rollback.py`` exercises the rollback *math*
+(``rollback_single`` / ``rollback_autoregressive``). This file targets
+the surrounding machinery that was previously uncovered:
+
+- model/module discovery (``get_model_layers``, ``find_gdn_class``,
+  ``collect_gdn_modules``),
+- the mlx-lm signature probe (``validate_gated_delta_update_signature``),
+- the identity-based ordering helper (``_order_matches``),
+- the class-level monkey-patch lifecycle (``__init__`` / ``_patch`` /
+  ``close`` / ``__del__``, ``for_model``, ``create_buffer``,
+  ``use_buffer``, ``get_active_capture``),
+- ``GDNBuffer`` bookkeeping, and a few rollback branch outcomes not
+  reached by the sibling test (mask concat, mixed-mask error,
+  single-step ordering error, per-step ordering error).
+
+Everything uses a hand-built fake ``GatedDeltaNet`` ``nn.Module``
+subclass plus fake cache layers — no real model load, no GPU, no
+network. Each test finishes in well under a second.
+
+Lock hygiene: ``GDNStateCapture`` acquires a *module-level* lock in
+``__init__`` and releases it in ``close()``. A test that constructs a
+capture and forgets to close it (or fails before closing) would leave
+the lock held and deadlock every subsequent capture-constructing test.
+The autouse ``_drain_gdn_lock`` fixture force-releases the lock after
+each test so one failure can never cascade into a hang.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+import olmlx.engine.gdn_rollback as gr
+from olmlx.engine.gdn_rollback import (
+    GDNBuffer,
+    GDNStateCapture,
+    _GDN_REQUIRED_ATTRS,
+    _order_matches,
+    collect_gdn_modules,
+    find_gdn_class,
+    get_active_capture,
+    get_model_layers,
+    validate_gated_delta_update_signature,
+)
+
+
+@pytest.fixture(autouse=True)
+def _drain_gdn_lock():
+    """Guarantee the module patch lock is free after every test.
+
+    If a test leaks a held lock (construct-without-close, or a failure
+    mid-construction), force-release it so the next test that builds a
+    ``GDNStateCapture`` does not block forever. ``Lock.release`` on an
+    unlocked lock raises ``RuntimeError`` — swallow it.
+    """
+    yield
+    gr._active_capture = None
+    try:
+        gr._GDN_PATCH_LOCK.release()
+    except RuntimeError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Fake model building blocks
+# ---------------------------------------------------------------------------
+
+
+class GatedDeltaNet(nn.Module):
+    """Stand-in for mlx-lm's ``GatedDeltaNet``.
+
+    The class *name* is what ``find_gdn_class`` matches on; every
+    attribute in ``_GDN_REQUIRED_ATTRS`` is attached so the structural
+    check passes. ``__call__`` is never invoked here (we never run a
+    forward), so placeholder scalar values are fine.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        for attr in _GDN_REQUIRED_ATTRS:
+            setattr(self, attr, 1)
+
+
+class _ImpostorGDN(nn.Module):
+    """Named ``GatedDeltaNet`` but lacking the required attributes."""
+
+
+_ImpostorGDN.__name__ = "GatedDeltaNet"
+
+
+class _Inner(nn.Module):
+    def __init__(self, layers: list) -> None:
+        super().__init__()
+        self.layers = layers
+
+
+class _ModelDotModel(nn.Module):
+    """Exposes ``.model.layers`` (first lookup path)."""
+
+    def __init__(self, layers: list) -> None:
+        super().__init__()
+        self.model = _Inner(layers)
+
+
+class _ModelLanguageModel(nn.Module):
+    """Exposes ``.language_model.layers`` (second lookup path)."""
+
+    def __init__(self, layers: list) -> None:
+        super().__init__()
+        self.language_model = _Inner(layers)
+
+
+class _ModelFlatLayers(nn.Module):
+    """Exposes ``.layers`` directly (third lookup path)."""
+
+    def __init__(self, layers: list) -> None:
+        super().__init__()
+        self.layers = layers
+
+
+class _ModelNoLayers(nn.Module):
+    """No recognizable layers attribute."""
+
+
+def _gdn_layer() -> nn.Module:
+    """A transformer-style layer wrapping one GDN submodule."""
+
+    class _Layer(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.self_attn = GatedDeltaNet()
+
+    return _Layer()
+
+
+def _plain_layer() -> nn.Module:
+    class _Layer(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.mlp = nn.Linear(2, 2)
+
+    return _Layer()
+
+
+# ---------------------------------------------------------------------------
+# Cache layer stubs (mirror the sibling test's interface)
+# ---------------------------------------------------------------------------
+
+
+class _StubArrays:
+    """Non-trimmable (ArraysCache-like) cache slot pair."""
+
+    def __init__(self) -> None:
+        self._slots: list = [None, None]
+
+    def is_trimmable(self) -> bool:
+        return False
+
+    def __getitem__(self, idx: int):
+        return self._slots[idx]
+
+    def __setitem__(self, idx: int, value) -> None:
+        self._slots[idx] = value
+
+
+class _StubTrimmable:
+    def __init__(self) -> None:
+        self.trim_calls: list[int] = []
+
+    def is_trimmable(self) -> bool:
+        return True
+
+    def trim(self, n: int) -> int:
+        self.trim_calls.append(n)
+        return n
+
+
+def _capture_tuple(q=1.0, k=10.0, v=100.0, state=0.0, mask=None):
+    """One capture matching ``_capturing_gdn_call``'s 10-tuple layout:
+    (q, k, v, a, b, A_log, dt_bias, state, mask, use_kernel)."""
+    return (
+        mx.full((1, 1, 1, 2), q),
+        mx.full((1, 1, 1, 2), k),
+        mx.full((1, 1, 1, 2), v),
+        mx.full((1, 1, 1, 2), q + 0.1),
+        mx.full((1, 1, 1, 2), q + 0.2),
+        mx.array([0.5]),
+        mx.array([0.1]),
+        mx.full((1,), state),
+        mask,
+        True,
+    )
+
+
+def _conv_data(value=1.0, K=3, S_total=1):
+    return (mx.full((1, K - 1 + S_total, 4), value), K)
+
+
+def _detached_capture() -> GDNStateCapture:
+    """A capture whose patch-install path is bypassed (no lock held).
+
+    Mirrors the sibling test's fixture: ``_closed`` starts ``True`` so
+    ``close()`` is a no-op and the module lock is never touched. Use for
+    pure rollback-math tests that never need a live patch.
+    """
+    cap = GDNStateCapture.__new__(GDNStateCapture)
+    cap._gdn_cls = object
+    cap._active_buffer = None
+    cap._orig_call = None
+    cap._patched_call = None
+    cap._closed = True
+    return cap
+
+
+# ---------------------------------------------------------------------------
+# get_model_layers
+# ---------------------------------------------------------------------------
+
+
+class TestGetModelLayers:
+    def test_model_dot_model_layers(self):
+        layers = [_plain_layer()]
+        assert get_model_layers(_ModelDotModel(layers)) is layers
+
+    def test_language_model_layers(self):
+        layers = [_plain_layer()]
+        assert get_model_layers(_ModelLanguageModel(layers)) is layers
+
+    def test_flat_layers(self):
+        layers = [_plain_layer()]
+        assert get_model_layers(_ModelFlatLayers(layers)) is layers
+
+    def test_no_layers_raises(self):
+        with pytest.raises(AttributeError, match="Cannot find layers"):
+            get_model_layers(_ModelNoLayers())
+
+
+# ---------------------------------------------------------------------------
+# find_gdn_class
+# ---------------------------------------------------------------------------
+
+
+class TestFindGDNClass:
+    def test_finds_gdn_class_in_model(self):
+        model = _ModelDotModel([_plain_layer(), _gdn_layer()])
+        assert find_gdn_class(model) is GatedDeltaNet
+
+    def test_returns_none_when_no_gdn(self):
+        assert find_gdn_class(_ModelDotModel([_plain_layer()])) is None
+
+    def test_skips_same_named_class_missing_attrs(self):
+        """A class literally named ``GatedDeltaNet`` but lacking the
+        required attributes must be skipped, not matched."""
+
+        class _Layer(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.attn = _ImpostorGDN()
+
+        assert find_gdn_class(_ModelDotModel([_Layer()])) is None
+
+
+# ---------------------------------------------------------------------------
+# collect_gdn_modules
+# ---------------------------------------------------------------------------
+
+
+class TestCollectGDNModules:
+    def test_collects_in_layer_order(self):
+        l0 = _plain_layer()
+        l1 = _gdn_layer()
+        l2 = _gdn_layer()
+        model = _ModelDotModel([l0, l1, l2])
+        mods = collect_gdn_modules(model, GatedDeltaNet)
+        assert len(mods) == 2
+        assert mods[0] is l1.self_attn
+        assert mods[1] is l2.self_attn
+
+    def test_multiple_gdn_per_layer_raises(self):
+        class _DoubleLayer(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.a = GatedDeltaNet()
+                self.b = GatedDeltaNet()
+
+        model = _ModelDotModel([_DoubleLayer()])
+        with pytest.raises(RuntimeError, match="GatedDeltaNet submodules"):
+            collect_gdn_modules(model, GatedDeltaNet)
+
+    def test_empty_when_no_gdn_and_none_orphaned(self):
+        model = _ModelDotModel([_plain_layer()])
+        assert collect_gdn_modules(model, GatedDeltaNet) == []
+
+    def test_orphaned_gdn_outside_layers_raises(self):
+        """GDN reachable via ``named_modules`` but not via the layers
+        list (attached at top level) must raise — rollback can't
+        address it."""
+
+        class _Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.model = _Inner([_plain_layer()])
+                self.stray = GatedDeltaNet()
+
+        with pytest.raises(RuntimeError, match="none are reachable"):
+            collect_gdn_modules(_Model(), GatedDeltaNet)
+
+
+# ---------------------------------------------------------------------------
+# _order_matches
+# ---------------------------------------------------------------------------
+
+
+class TestOrderMatches:
+    def test_identity_match(self):
+        a, b, c = object(), object(), object()
+        assert _order_matches([a, b, c], [a, b, c]) is True
+
+    def test_length_mismatch(self):
+        a, b = object(), object()
+        assert _order_matches([a, b], [a]) is False
+
+    def test_reordered_is_false(self):
+        a, b = object(), object()
+        assert _order_matches([a, b], [b, a]) is False
+
+    def test_equal_but_distinct_arrays_is_false(self):
+        """Identity, not equality: two arrays that compare equal but are
+        distinct instances are NOT a match — and crucially this does not
+        raise on ``bool()`` of a multi-element array (the bug
+        ``_order_matches`` exists to avoid)."""
+        x = mx.array([1.0, 2.0])
+        y = mx.array([1.0, 2.0])
+        assert _order_matches([x], [y]) is False
+
+
+# ---------------------------------------------------------------------------
+# validate_gated_delta_update_signature
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSignature:
+    def test_passes_with_real_mlx_lm(self):
+        # Real mlx-lm is installed here; the probe must accept it.
+        validate_gated_delta_update_signature()
+
+    def test_raises_when_gd_mod_is_none(self):
+        with patch.object(gr, "_gd_mod", None):
+            with pytest.raises(RuntimeError, match="unavailable"):
+                validate_gated_delta_update_signature()
+
+    def test_raises_on_missing_param(self):
+        fake_mod = MagicMock()
+
+        def _bad_update(q, k, v):  # missing most params
+            return None
+
+        fake_mod.gated_delta_update = _bad_update
+        with patch.object(gr, "_gd_mod", fake_mod):
+            with pytest.raises(RuntimeError, match="missing parameters"):
+                validate_gated_delta_update_signature()
+
+    def test_raises_when_signature_uninspectable(self):
+        fake_mod = MagicMock()
+        fake_mod.gated_delta_update = object()  # any non-callable target
+        # Force ``inspect.signature`` to fail the way an un-introspectable
+        # callable would (some builtins raise ValueError/TypeError).
+        with (
+            patch.object(gr, "_gd_mod", fake_mod),
+            patch("inspect.signature", side_effect=ValueError("boom")),
+        ):
+            with pytest.raises(RuntimeError, match="Cannot introspect"):
+                validate_gated_delta_update_signature()
+
+
+# ---------------------------------------------------------------------------
+# Patch lifecycle: __init__ / _patch / close / __del__ / for_model
+# ---------------------------------------------------------------------------
+
+
+class TestPatchLifecycle:
+    def test_patch_install_swaps_call_and_registers(self):
+        cap = GDNStateCapture(GatedDeltaNet)
+        try:
+            # The patched closure is now the class ``__call__`` and the
+            # active-capture pointer references this instance.
+            assert GatedDeltaNet.__call__ is cap._patched_call
+            assert cap.gdn_cls is GatedDeltaNet
+            assert get_active_capture() is cap
+            assert cap._orig_call is not None
+        finally:
+            cap.close()
+
+    def test_close_restores_original_and_clears_active(self):
+        cap = GDNStateCapture(GatedDeltaNet)
+        patched = cap._patched_call
+        orig = cap._orig_call
+        cap.close()
+        # The patched closure is gone; the stored original is reinstated.
+        assert GatedDeltaNet.__call__ is not patched
+        assert GatedDeltaNet.__call__ is orig
+        assert get_active_capture() is None
+
+    def test_close_is_idempotent(self):
+        cap = GDNStateCapture(GatedDeltaNet)
+        cap.close()
+        # A second close must not raise (else it would release an
+        # already-released lock).
+        cap.close()
+        assert get_active_capture() is None
+
+    def test_lock_freed_after_close_allows_reinstall(self):
+        cap = GDNStateCapture(GatedDeltaNet)
+        cap.close()
+        # If the lock were leaked, this construction would deadlock.
+        cap2 = GDNStateCapture(GatedDeltaNet)
+        cap2.close()
+        assert get_active_capture() is None
+
+    def test_use_buffer_routes_active_buffer(self):
+        cap = GDNStateCapture(GatedDeltaNet)
+        try:
+            buf = GDNBuffer(expected_modules=[])
+            cap.use_buffer(buf)
+            assert cap._active_buffer is buf
+            cap.use_buffer(None)
+            assert cap._active_buffer is None
+        finally:
+            cap.close()
+
+    def test_del_invokes_close_and_frees_lock(self):
+        """``__del__`` is the belt-and-braces finaliser: if the owner is
+        dropped without an explicit close, it must still restore the
+        class ``__call__`` and release the module lock.
+
+        Garbage-collection timing is not deterministic across CPython
+        builds (a traceback frame can pin the object), so invoke the
+        finaliser directly rather than relying on ``gc.collect``.
+        """
+        cap = GDNStateCapture(GatedDeltaNet)
+        patched = cap._patched_call
+        assert get_active_capture() is cap
+        assert GatedDeltaNet.__call__ is patched
+        cap.__del__()  # idempotent close()
+        assert get_active_capture() is None
+        assert GatedDeltaNet.__call__ is not patched
+        # Lock freed → another capture can install.
+        cap2 = GDNStateCapture(GatedDeltaNet)
+        cap2.close()
+
+    def test_init_raises_when_no_gdn_support(self):
+        with patch.object(gr, "_HAS_GDN", False):
+            with pytest.raises(RuntimeError, match="unavailable"):
+                GDNStateCapture(GatedDeltaNet)
+        # The failed construction must not have acquired the lock.
+        cap = GDNStateCapture(GatedDeltaNet)
+        cap.close()
+
+    def test_for_model_builds_capture_and_buffer(self):
+        model = _ModelDotModel([_plain_layer(), _gdn_layer()])
+        cap, buf = GDNStateCapture.for_model(model)
+        try:
+            assert isinstance(buf, GDNBuffer)
+            assert buf.num_gdn_layers == 1
+            assert cap.gdn_cls is GatedDeltaNet
+        finally:
+            cap.close()
+
+    def test_for_model_raises_when_no_gdn(self):
+        model = _ModelDotModel([_plain_layer()])
+        with pytest.raises(RuntimeError, match="no .*GatedDeltaNet.* submodule"):
+            GDNStateCapture.for_model(model)
+        # for_model never installed a patch, so the lock is free.
+        cap = GDNStateCapture(GatedDeltaNet)
+        cap.close()
+
+    def test_for_model_closes_capture_on_buffer_failure(self):
+        """If buffer creation fails (orphaned GDN), ``for_model`` must
+        close the capture so the lock is released."""
+
+        class _Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                # find_gdn_class sees the stray via named_modules, but the
+                # layers list is empty so collect_gdn_modules raises.
+                self.model = _Inner([])
+                self.stray = GatedDeltaNet()
+
+        with pytest.raises(RuntimeError, match="none are reachable"):
+            GDNStateCapture.for_model(_Model())
+        # Lock released → a fresh capture can install.
+        cap = GDNStateCapture(GatedDeltaNet)
+        cap.close()
+
+    def test_create_buffer_independent_per_model(self):
+        cap = GDNStateCapture(GatedDeltaNet)
+        try:
+            b1 = cap.create_buffer(_ModelDotModel([_gdn_layer()]))
+            b2 = cap.create_buffer(_ModelDotModel([_gdn_layer(), _gdn_layer()]))
+            assert b1.num_gdn_layers == 1
+            assert b2.num_gdn_layers == 2
+            assert b1.expected_modules != b2.expected_modules
+        finally:
+            cap.close()
+
+
+# ---------------------------------------------------------------------------
+# GDNBuffer
+# ---------------------------------------------------------------------------
+
+
+class TestGDNBuffer:
+    def test_num_gdn_layers_and_clear(self):
+        mods = [object(), object()]
+        buf = GDNBuffer(expected_modules=mods)
+        assert buf.num_gdn_layers == 2
+        buf.gdn_inputs = [_capture_tuple()]
+        buf.conv_data = [_conv_data()]
+        buf.captured_modules = [object()]
+        buf.clear()
+        assert buf.gdn_inputs == []
+        assert buf.conv_data == []
+        assert buf.captured_modules == []
+        # expected_modules survives clear().
+        assert buf.num_gdn_layers == 2
+
+
+# ---------------------------------------------------------------------------
+# rollback_single branch coverage
+# ---------------------------------------------------------------------------
+
+
+class TestRollbackSingleBranches:
+    def test_replays_accepted_prefix_and_trims(self):
+        layer = MagicMock(name="layer")
+        buf = GDNBuffer(expected_modules=[layer])
+        # One GDN capture with S=5 tokens so a prefix slice is meaningful.
+        q = mx.broadcast_to(mx.arange(5).reshape(1, 5, 1, 1), (1, 5, 1, 2))
+        cap = list(_capture_tuple())
+        cap[0] = q  # distinct per-position values
+        buf.gdn_inputs = [tuple(cap)]
+        buf.conv_data = [_conv_data(value=7.0, K=3, S_total=5)]
+        buf.captured_modules = [layer]
+
+        trimmable = _StubTrimmable()
+        gdn = _StubArrays()
+        cache = [trimmable, gdn]
+
+        replayed = mx.array([55.0])
+        with patch.object(gr, "_gd_mod") as mock_gd:
+            mock_gd.gated_delta_update.return_value = (None, replayed)
+            _detached_capture().rollback_single(buf, cache=cache, accepted=2, trim=3)
+
+        # Trimmable layer trimmed with the provided amount.
+        assert trimmable.trim_calls == [3]
+        # GDN state slot written with replay output.
+        assert gdn._slots[1] is replayed
+        # gated_delta_update received the first accepted+1 = 3 q positions.
+        q_arg = mock_gd.gated_delta_update.call_args.args[0]
+        assert q_arg.shape == (1, 3, 1, 2)
+        # And the conv state slot was written too (index 0).
+        assert gdn._slots[0] is not None
+
+    def test_single_ordering_mismatch_raises(self):
+        """Single-mode alignment check: captured modules in a different
+        order than expected_modules raises before any replay."""
+        a = MagicMock(name="a")
+        b = MagicMock(name="b")
+        buf = GDNBuffer(expected_modules=[a, b])
+        buf.gdn_inputs = [_capture_tuple(), _capture_tuple()]
+        buf.conv_data = [_conv_data(), _conv_data()]
+        buf.captured_modules = [b, a]  # swapped
+
+        with pytest.raises(RuntimeError, match="ordering invariant violated"):
+            _detached_capture().rollback_single(
+                buf, cache=[_StubArrays(), _StubArrays()], accepted=0, trim=0
+            )
+
+
+# ---------------------------------------------------------------------------
+# rollback_autoregressive branch coverage (new vs sibling)
+# ---------------------------------------------------------------------------
+
+
+class TestRollbackAutoregressiveBranches:
+    def test_full_keep_with_nonzero_trim_raises(self):
+        buf = GDNBuffer(expected_modules=[])
+        with pytest.raises(ValueError, match="implies no rollback"):
+            _detached_capture().rollback_autoregressive(
+                buf, cache=[], num_steps=3, num_keep_steps=3, trim=2
+            )
+
+    def test_mask_present_concatenated(self):
+        """When captures carry a mask, the no-mask fast path is skipped
+        and masks are concatenated along the sequence dim."""
+        layer = MagicMock(name="layer")
+        buf = GDNBuffer(expected_modules=[layer])
+        buf.gdn_inputs = [
+            _capture_tuple(q=1.0, mask=mx.array([[True]])),
+            _capture_tuple(q=2.0, mask=mx.array([[False]])),
+            _capture_tuple(q=3.0, mask=mx.array([[True]])),
+        ]
+        buf.conv_data = [_conv_data(1.0), _conv_data(2.0), _conv_data(3.0)]
+        buf.captured_modules = [layer, layer, layer]
+
+        gdn = _StubArrays()
+        with patch.object(gr, "_gd_mod") as mock_gd:
+            mock_gd.gated_delta_update.return_value = (None, mx.array([0.0]))
+            # Keep 2 of 3 steps so the rollback body (not the no-op) runs.
+            _detached_capture().rollback_autoregressive(
+                buf, cache=[gdn], num_steps=3, num_keep_steps=2, trim=0
+            )
+        mask_arg = mock_gd.gated_delta_update.call_args.args[8]
+        assert mask_arg is not None
+        assert mask_arg.shape == (1, 2)
+
+    def test_mixed_mask_raises(self):
+        """Some captures with mask, others None → ambiguous concat → raise."""
+        layer = MagicMock(name="layer")
+        buf = GDNBuffer(expected_modules=[layer])
+        buf.gdn_inputs = [
+            _capture_tuple(q=1.0, mask=mx.array([[True]])),
+            _capture_tuple(q=2.0, mask=None),
+            _capture_tuple(q=3.0, mask=mx.array([[True]])),
+        ]
+        buf.conv_data = [_conv_data(1.0), _conv_data(2.0), _conv_data(3.0)]
+        buf.captured_modules = [layer, layer, layer]
+
+        with patch.object(gr, "_gd_mod") as mock_gd:
+            mock_gd.gated_delta_update.return_value = (None, mx.array([0.0]))
+            with pytest.raises(RuntimeError, match="Mixed-mask"):
+                _detached_capture().rollback_autoregressive(
+                    buf, cache=[_StubArrays()], num_steps=3, num_keep_steps=2, trim=0
+                )
+
+    def test_first_step_ordering_mismatch_raises(self):
+        """Step 0 visiting modules in the wrong order vs expected_modules
+        must raise. ``num_steps`` must exceed ``num_keep_steps`` or the
+        method short-circuits on the no-op branch before the alignment
+        check runs."""
+        a = MagicMock(name="a")
+        b = MagicMock(name="b")
+        buf = GDNBuffer(expected_modules=[a, b])
+        # 2 layers x 2 steps = 4 captures (alignment count must match).
+        buf.gdn_inputs = [_capture_tuple()] * 4
+        buf.conv_data = [_conv_data()] * 4
+        # Step 0 captured (b, a) instead of (a, b); step 1 mirrors it.
+        buf.captured_modules = [b, a, b, a]
+
+        with pytest.raises(RuntimeError, match="ordering invariant violated"):
+            _detached_capture().rollback_autoregressive(
+                buf,
+                cache=[_StubArrays(), _StubArrays()],
+                num_steps=2,
+                num_keep_steps=1,
+                trim=0,
+            )
+
+    def test_per_step_ordering_mismatch_raises(self):
+        """Step 1 visiting GDN layers in a different order than step 0
+        is caught with a per-step diagnostic."""
+        a = MagicMock(name="a")
+        b = MagicMock(name="b")
+        buf = GDNBuffer(expected_modules=[a, b])
+        buf.gdn_inputs = [_capture_tuple()] * 4
+        buf.conv_data = [_conv_data()] * 4
+        # Step 0: (a, b) correct. Step 1: (b, a) swapped.
+        buf.captured_modules = [a, b, b, a]
+
+        with pytest.raises(RuntimeError, match="different order than step 0"):
+            _detached_capture().rollback_autoregressive(
+                buf,
+                cache=[_StubArrays(), _StubArrays()],
+                num_steps=2,
+                num_keep_steps=1,
+                trim=0,
+            )

--- a/tests/test_ifeval_grader_coverage.py
+++ b/tests/test_ifeval_grader_coverage.py
@@ -1,0 +1,355 @@
+"""Regression coverage for the vendored IFEval verifiable-constraint grader.
+
+Each test feeds a crafted string through ``grade("ifeval", ...)`` and asserts
+the pass/fail outcome for one grader branch. The goal is to pin down the exact
+behaviour of every constraint check (and every ``_compare`` relation) so future
+edits to ``olmlx.bench.ifeval_grader`` can't silently change the pass rate.
+"""
+
+from __future__ import annotations
+
+from olmlx.bench.quality import grade
+
+
+def _grade(output: str, iid: str, kw: dict | None = None):
+    return grade(
+        "ifeval",
+        output,
+        {"instruction_id_list": [iid], "kwargs": [kw or {}]},
+    )
+
+
+class TestKeywordsForbidden:
+    def test_pass_when_absent(self):
+        r = _grade(
+            "a clean reply", "keywords:forbidden_words", {"forbidden_words": ["nope"]}
+        )
+        assert r.passed is True
+
+    def test_fail_case_insensitive(self):
+        # "Banana" present though forbidden is lowercase -> casefold match -> fail.
+        r = _grade(
+            "I ate a Banana",
+            "keywords:forbidden_words",
+            {"forbidden_words": ["banana"]},
+        )
+        assert r.passed is False
+
+
+class TestKeywordsFrequency:
+    def test_at_least_pass(self):
+        r = _grade(
+            "go go go",
+            "keywords:frequency",
+            {"keyword": "go", "relation": "at least", "frequency": 3},
+        )
+        assert r.passed is True
+
+    def test_at_least_fail(self):
+        r = _grade(
+            "go go",
+            "keywords:frequency",
+            {"keyword": "go", "relation": "at least", "frequency": 3},
+        )
+        assert r.passed is False
+
+    def test_case_insensitive_count(self):
+        # findall with re.IGNORECASE counts both cases.
+        r = _grade(
+            "Cat cat CAT",
+            "keywords:frequency",
+            {"keyword": "cat", "relation": "equal to", "frequency": 3},
+        )
+        assert r.passed is True
+
+
+class TestNumberSentences:
+    def test_counts_sentence_terminators(self):
+        r = _grade(
+            "One. Two! Three?",
+            "length_constraints:number_sentences",
+            {"num_sentences": 3, "relation": "equal to"},
+        )
+        assert r.passed is True
+
+    def test_more_than_fail(self):
+        r = _grade(
+            "Only one sentence.",
+            "length_constraints:number_sentences",
+            {"num_sentences": 1, "relation": "more than"},
+        )
+        assert r.passed is False
+
+
+class TestNumberParagraphs:
+    def test_double_newline_split(self):
+        r = _grade(
+            "para one\n\npara two\n\npara three",
+            "length_constraints:number_paragraphs",
+            {"num_paragraphs": 3, "relation": "equal to"},
+        )
+        assert r.passed is True
+
+    def test_at_most_fail(self):
+        r = _grade(
+            "a\n\nb\n\nc",
+            "length_constraints:number_paragraphs",
+            {"num_paragraphs": 2, "relation": "at most"},
+        )
+        assert r.passed is False
+
+
+class TestNthParagraphFirstWord:
+    def test_match(self):
+        r = _grade(
+            "First para.\n\nSecond starts here.",
+            "length_constraints:nth_paragraph_first_word",
+            {"nth_paragraph": 2, "first_word": "Second"},
+        )
+        assert r.passed is True
+
+    def test_out_of_range_fails(self):
+        r = _grade(
+            "only one para",
+            "length_constraints:nth_paragraph_first_word",
+            {"nth_paragraph": 5, "first_word": "only"},
+        )
+        assert r.passed is False
+
+    def test_strips_punctuation_and_casefolds(self):
+        r = _grade(
+            '"Hello, there.',
+            "length_constraints:nth_paragraph_first_word",
+            {"nth_paragraph": 1, "first_word": "hello"},
+        )
+        assert r.passed is True
+
+
+class TestPostscript:
+    def test_present(self):
+        r = _grade("Body text\nP.S. extra", "detectable_content:postscript")
+        assert r.passed is True
+
+    def test_custom_marker_absent(self):
+        r = _grade(
+            "no marker", "detectable_content:postscript", {"postscript_marker": "PPS"}
+        )
+        assert r.passed is False
+
+
+class TestNumberPlaceholders:
+    def test_meets_target(self):
+        r = _grade(
+            "Dear [name], your [item] is ready.",
+            "detectable_content:number_placeholders",
+            {"num_placeholders": 2},
+        )
+        assert r.passed is True
+
+    def test_below_target_fails(self):
+        r = _grade(
+            "Dear [name].",
+            "detectable_content:number_placeholders",
+            {"num_placeholders": 2},
+        )
+        assert r.passed is False
+
+
+class TestBulletLists:
+    def test_exact_count(self):
+        r = _grade(
+            "- one\n- two\n* three",
+            "detectable_format:number_bullet_lists",
+            {"num_bullets": 3},
+        )
+        assert r.passed is True
+
+    def test_wrong_count_fails(self):
+        # Requires exact equality, not >=.
+        r = _grade(
+            "- one\n- two",
+            "detectable_format:number_bullet_lists",
+            {"num_bullets": 1},
+        )
+        assert r.passed is False
+
+
+class TestJsonFormat:
+    def test_plain_json(self):
+        r = _grade('{"a": 1}', "detectable_format:json_format")
+        assert r.passed is True
+
+    def test_fenced_json(self):
+        r = _grade('```json\n{"a": 1}\n```', "detectable_format:json_format")
+        assert r.passed is True
+
+    def test_invalid_json_fails(self):
+        r = _grade("not json at all", "detectable_format:json_format")
+        assert r.passed is False
+
+
+class TestTitle:
+    def test_angle_title_present(self):
+        r = _grade("<<My Title>>\nbody", "detectable_format:title")
+        assert r.passed is True
+
+    def test_no_title_fails(self):
+        r = _grade("just text", "detectable_format:title")
+        assert r.passed is False
+
+
+class TestConstrainedResponse:
+    def test_allowed_option(self):
+        r = _grade("My answer is maybe.", "detectable_format:constrained_response")
+        assert r.passed is True
+
+    def test_disallowed_fails(self):
+        r = _grade("Sure thing.", "detectable_format:constrained_response")
+        assert r.passed is False
+
+
+class TestStartEndQuotation:
+    def test_wrapped_in_quotes(self):
+        r = _grade('  "fully quoted"  ', "startend:quotation")
+        assert r.passed is True
+
+    def test_unquoted_fails(self):
+        r = _grade('"only opens', "startend:quotation")
+        assert r.passed is False
+
+
+class TestEndChecker:
+    def test_trailing_whitespace_tolerated(self):
+        r = _grade(
+            "ends with marker END  \n", "startend:end_checker", {"end_phrase": "END"}
+        )
+        assert r.passed is True
+
+    def test_wrong_end_fails(self):
+        r = _grade("ends differently", "startend:end_checker", {"end_phrase": "END"})
+        assert r.passed is False
+
+
+class TestChangeCase:
+    def test_all_caps_pass(self):
+        r = _grade("HELLO WORLD 123!", "change_case:english_capital")
+        assert r.passed is True
+
+    def test_all_caps_fail_on_lower(self):
+        r = _grade("HELLO world", "change_case:english_capital")
+        assert r.passed is False
+
+    def test_no_letters_fails_caps(self):
+        # bool(letters) guard: a string with no letters cannot be "all capital".
+        r = _grade("12345 !!!", "change_case:english_capital")
+        assert r.passed is False
+
+    def test_all_lower_pass(self):
+        r = _grade("hello world 123", "change_case:english_lowercase")
+        assert r.passed is True
+
+    def test_all_lower_fail_on_upper(self):
+        r = _grade("hello World", "change_case:english_lowercase")
+        assert r.passed is False
+
+
+class TestCapitalWordFrequency:
+    def test_counts_all_caps_words(self):
+        r = _grade(
+            "NASA and FBI met",
+            "change_case:capital_word_frequency",
+            {"capital_frequency": 2, "capital_relation": "at least"},
+        )
+        assert r.passed is True
+
+    def test_single_letter_not_counted(self):
+        # Regex requires 2+ uppercase letters, so "A" is not a capital word.
+        r = _grade(
+            "A lone letter",
+            "change_case:capital_word_frequency",
+            {"capital_frequency": 1, "capital_relation": "at least"},
+        )
+        assert r.passed is False
+
+
+class TestCombination:
+    def test_two_responses_separator(self):
+        r = _grade("first\n******\nsecond", "combination:two_responses")
+        assert r.passed is True
+
+    def test_two_responses_missing(self):
+        r = _grade("first\nsecond", "combination:two_responses")
+        assert r.passed is False
+
+    def test_repeat_prompt_present(self):
+        r = _grade(
+            "Write a poem. Then the poem.",
+            "combination:repeat_prompt",
+            {"prompt_to_repeat": "Write a poem."},
+        )
+        assert r.passed is True
+
+    def test_repeat_prompt_empty_kwarg_fails(self):
+        # Empty/missing prompt_to_repeat is treated as malformed -> fail
+        # (not an unconditional pass via "" in str).
+        r = _grade("anything goes", "combination:repeat_prompt", {})
+        assert r.passed is False
+
+
+class TestLanguageAndUnknown:
+    def test_no_instruction_list_ungraded(self):
+        r = grade("ifeval", "text", {"instruction_id_list": [], "kwargs": []})
+        assert r.passed is None
+        assert r.score is None
+        assert r.detail == "no instruction_id_list"
+
+    def test_unknown_constraint_ungraded(self):
+        r = _grade("text", "language:response_language", {"language": "fr"})
+        # language:response_language is not in CONSTRAINT_CHECKS -> ungraded.
+        assert r.passed is None
+        assert r.score is None
+        assert "unknown constraint" in r.detail
+
+
+class TestCompareRelations:
+    def test_less_than(self):
+        r = _grade(
+            "one two three",
+            "length_constraints:number_words",
+            {"num_words": 5, "relation": "less than"},
+        )
+        assert r.passed is True
+
+    def test_at_most_boundary(self):
+        r = _grade(
+            "one two three four five",
+            "length_constraints:number_words",
+            {"num_words": 5, "relation": "at most"},
+        )
+        assert r.passed is True
+
+    def test_unknown_relation_fails(self):
+        # _compare returns False for any relation it doesn't recognise.
+        r = _grade(
+            "one two three",
+            "length_constraints:number_words",
+            {"num_words": 3, "relation": "approximately"},
+        )
+        assert r.passed is False
+
+
+class TestScoringAggregation:
+    def test_partial_score(self):
+        r = grade(
+            "ifeval",
+            "banana, and more",
+            {
+                "instruction_id_list": ["keywords:existence", "punctuation:no_comma"],
+                "kwargs": [{"keywords": ["banana"]}, {}],
+            },
+        )
+        # keyword passes, comma fails -> 1/2.
+        assert r.passed is False
+        assert r.score == 0.5
+        assert "keywords:existence=ok" in r.detail
+        assert "punctuation:no_comma=fail" in r.detail

--- a/tests/test_inference_coverage.py
+++ b/tests/test_inference_coverage.py
@@ -1,0 +1,737 @@
+"""Regression coverage for branch/error/formatting paths in
+``olmlx.engine.inference``.
+
+The module is already high-coverage; these tests target the remaining
+no-GPU-reachable branches: lm_head vocab-size resolution fallbacks, KV-cache
+byte estimation (turboquant/spectral ratios, MLA layout, sliding-window
+introspection, NAS no-op layers, wrapper-arg failure), option/default merging,
+KV-quant spec parsing, BOS-aware cache tokenization, message-boundary token
+detection, segmented-chat splitting, chat-template-text extraction, token
+counting return-shape handling, penalty-processor out-of-range guards,
+native-tool-hint edge cases, tool-message-to-response conversion, the gpt-oss
+channel filter, and the stop-sequence / finish-reason branches in
+``_full_completion``.
+
+Every test is hermetic and deterministic: no network, no real model load, no
+GPU. Fakes are built from ``SimpleNamespace``/``MagicMock`` and tiny ``mx``
+arrays, so each finishes in well under a second.
+"""
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import mlx.core as mx
+import pytest
+
+import olmlx.engine.inference as _inf_mod
+from olmlx.engine.inference import (
+    _add_native_tool_hint,
+    _convert_tool_messages_to_responses,
+    _full_completion,
+    _get_chat_template_text,
+    _GptOssChannelFilter,
+    _make_frequency_penalty_processor,
+    _make_presence_penalty_processor,
+    _merge_default_options,
+    _message_boundary_token_ids,
+    _parse_kv_cache_quant,
+    _resolve_model_vocab_size,
+    count_chat_tokens,
+    estimate_kv_cache_bytes,
+    tokenize_for_cache,
+    tokenize_segmented_chat,
+)
+
+
+# --------------------------------------------------------------------------- #
+# _resolve_model_vocab_size                                                    #
+# --------------------------------------------------------------------------- #
+class TestResolveModelVocabSize:
+    """The lm_head bitmask sizing helper for grammar-constrained decoding."""
+
+    def test_uses_args_vocab_size_when_positive_int(self):
+        model = SimpleNamespace(args=SimpleNamespace(vocab_size=32000))
+        lm = SimpleNamespace(model=model)
+        assert _resolve_model_vocab_size(lm) == 32000
+
+    def test_falls_through_args_when_vocab_size_not_positive(self):
+        # vocab_size present but <= 0 must be ignored and lm_head weight used.
+        lm_head = SimpleNamespace(weight=SimpleNamespace(shape=(40000, 8)))
+        inner = SimpleNamespace(args=SimpleNamespace(vocab_size=0), lm_head=lm_head)
+        lm = SimpleNamespace(model=inner)
+        assert _resolve_model_vocab_size(lm) == 40000
+
+    def test_prefers_lm_head_output_dim_over_embed(self):
+        # top-level embed_tokens (input dim), nested lm_head (larger output dim):
+        # lm_head must win even though embed_tokens is shallower.
+        nested = SimpleNamespace(
+            lm_head=SimpleNamespace(weight=SimpleNamespace(shape=(50000, 4)))
+        )
+        embed = SimpleNamespace(weight=SimpleNamespace(shape=(48000, 4)))
+        model = SimpleNamespace(args=None, embed_tokens=embed, model=nested)
+        lm = SimpleNamespace(model=model)
+        assert _resolve_model_vocab_size(lm) == 50000
+
+    def test_falls_back_to_embed_when_no_lm_head(self):
+        embed = SimpleNamespace(weight=SimpleNamespace(shape=(33000, 4)))
+        model = SimpleNamespace(args=None, embed_tokens=embed, model=None)
+        lm = SimpleNamespace(model=model)
+        assert _resolve_model_vocab_size(lm) == 33000
+
+    def test_weight_shape_exception_swallowed_returns_none(self):
+        class BadWeight:
+            @property
+            def shape(self):
+                raise RuntimeError("boom")
+
+        model = SimpleNamespace(
+            args=None, lm_head=SimpleNamespace(weight=BadWeight()), model=None
+        )
+        lm = SimpleNamespace(model=model)
+        assert _resolve_model_vocab_size(lm) is None
+
+    def test_no_sources_returns_none(self):
+        model = SimpleNamespace(args=None, model=None)
+        lm = SimpleNamespace(model=model)
+        assert _resolve_model_vocab_size(lm) is None
+
+
+# --------------------------------------------------------------------------- #
+# estimate_kv_cache_bytes                                                      #
+# --------------------------------------------------------------------------- #
+def _uniform_args(**over):
+    base = dict(
+        num_attention_heads=8,
+        num_hidden_layers=4,
+        hidden_size=512,
+        num_key_value_heads=2,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+class TestEstimateKvCacheBytes:
+    def test_zero_or_negative_tokens_is_zero(self):
+        model = SimpleNamespace(args=_uniform_args())
+        assert estimate_kv_cache_bytes(model, 0) == 0
+        assert estimate_kv_cache_bytes(model, -5) == 0
+
+    def test_uniform_args_fallback(self):
+        model = SimpleNamespace(args=_uniform_args())
+        # head_dim = 512/8 = 64; raw = layers*2*kv*head_dim*tokens*2
+        # = 4*2*2*64*10*2 = 20480; *1.3.
+        assert estimate_kv_cache_bytes(model, 10) == int(20480 * 1.3)
+
+    def test_explicit_head_dim_attribute_used(self):
+        # head_dim present on args overrides hidden_size//num_heads.
+        model = SimpleNamespace(args=_uniform_args(head_dim=128))
+        assert estimate_kv_cache_bytes(model, 10) == int(4 * 2 * 2 * 128 * 10 * 2 * 1.3)
+
+    def test_turboquant_ratio_reduces_estimate(self):
+        model = SimpleNamespace(args=_uniform_args())
+        plain = estimate_kv_cache_bytes(model, 10)
+        tq = estimate_kv_cache_bytes(model, 10, kv_cache_quant="turboquant:4")
+        assert tq < plain
+
+    def test_spectral_ratio_reduces_estimate(self):
+        model = SimpleNamespace(args=_uniform_args())
+        plain = estimate_kv_cache_bytes(model, 10)
+        sq = estimate_kv_cache_bytes(model, 10, kv_cache_quant="spectral:2")
+        assert sq < plain
+
+    def test_mla_model_uses_lora_layout(self):
+        args = SimpleNamespace(
+            kv_lora_rank=512, qk_rope_head_dim=64, num_hidden_layers=2
+        )
+        model = SimpleNamespace(args=args)
+        # raw = layers*2*(lora+rope)*tokens*2 = 2*2*576*10*2 = 46080; *1.3.
+        assert estimate_kv_cache_bytes(model, 10) == int(46080 * 1.3)
+
+    def test_layer_introspection_skips_noop_attention(self):
+        real_attn = SimpleNamespace(n_kv_heads=2, head_dim=64)
+        layers = [
+            SimpleNamespace(self_attn=None),  # no-op layer — no KV cache
+            SimpleNamespace(self_attn=real_attn),
+        ]
+        model = SimpleNamespace(
+            args=_uniform_args(), model=SimpleNamespace(layers=layers)
+        )
+        # Only one attention layer counted: 2*kv*head_dim*tokens*2 = 5120; *1.3.
+        assert estimate_kv_cache_bytes(model, 10) == int(5120 * 1.3)
+
+    def test_introspection_alt_kv_head_attr_name(self):
+        # Qwen3-Next exposes num_key_value_heads, not n_kv_heads.
+        attn = SimpleNamespace(num_key_value_heads=2, head_dim=64)
+        model = SimpleNamespace(
+            args=_uniform_args(),
+            model=SimpleNamespace(layers=[SimpleNamespace(self_attn=attn)]),
+        )
+        assert estimate_kv_cache_bytes(model, 10) == int(2 * 2 * 64 * 10 * 2 * 1.3)
+
+    def test_sliding_window_caps_effective_tokens(self):
+        win = 4
+        attn = SimpleNamespace(n_kv_heads=2, head_dim=64, is_sliding=True)
+        model = SimpleNamespace(
+            args=_uniform_args(sliding_window=win),
+            model=SimpleNamespace(layers=[SimpleNamespace(self_attn=attn)]),
+        )
+        capped = estimate_kv_cache_bytes(model, 1000)
+        # Past the window more tokens don't grow the estimate.
+        assert estimate_kv_cache_bytes(model, 100) == capped
+        # Below the window the estimate scales with token count.
+        assert estimate_kv_cache_bytes(model, win - 1) < capped
+        # An identical non-sliding layer scales fully with the prompt.
+        attn_full = SimpleNamespace(n_kv_heads=2, head_dim=64)
+        model_full = SimpleNamespace(
+            args=_uniform_args(),
+            model=SimpleNamespace(layers=[SimpleNamespace(self_attn=attn_full)]),
+        )
+        assert estimate_kv_cache_bytes(model_full, 1000) > capped
+
+    def test_introspection_falls_back_when_kv_heads_unknown(self):
+        # self_attn present but no recognised kv-head attribute → args fallback.
+        attn = SimpleNamespace(head_dim=64)
+        model = SimpleNamespace(
+            args=_uniform_args(),
+            model=SimpleNamespace(layers=[SimpleNamespace(self_attn=attn)]),
+        )
+        assert estimate_kv_cache_bytes(model, 10) == int(20480 * 1.3)
+
+    def test_wrapper_args_without_inner_raises(self):
+        # A text_config wrapper whose language_model can't be resolved must
+        # raise loudly rather than crash opaquely later.
+        args = SimpleNamespace(text_config={"foo": 1})
+        model = SimpleNamespace(args=args)  # no language_model
+        with pytest.raises(AttributeError, match="text_config wrapper"):
+            estimate_kv_cache_bytes(model, 10)
+
+    def test_no_args_anywhere_raises(self):
+        model = SimpleNamespace()  # no args, no config, no language_model
+        with pytest.raises(AttributeError, match="no 'args' attribute"):
+            estimate_kv_cache_bytes(model, 10)
+
+
+# --------------------------------------------------------------------------- #
+# _merge_default_options                                                       #
+# --------------------------------------------------------------------------- #
+class TestMergeDefaultOptions:
+    def test_request_value_wins_per_key(self):
+        merged = _merge_default_options({"temperature": 0.7}, {"temperature": 0.2})
+        assert merged == {"temperature": 0.2}
+
+    def test_partial_request_keeps_unspecified_defaults(self):
+        # The opencode/Qwen3-Coder regression: a request with top_k must NOT
+        # discard the model-default temperature.
+        merged = _merge_default_options(
+            {"temperature": 0.7, "top_p": 0.9}, {"top_k": 40}
+        )
+        assert merged == {"temperature": 0.7, "top_p": 0.9, "top_k": 40}
+
+    def test_none_request_uses_defaults(self):
+        assert _merge_default_options({"temperature": 0.7}, None) == {
+            "temperature": 0.7
+        }
+
+    def test_empty_request_uses_defaults(self):
+        assert _merge_default_options({"temperature": 0.7}, {}) == {"temperature": 0.7}
+
+    def test_none_defaults_treated_as_empty(self):
+        assert _merge_default_options(None, {"top_k": 5}) == {"top_k": 5}
+
+    def test_both_none_yields_empty_dict(self):
+        assert _merge_default_options(None, None) == {}
+
+    def test_returns_new_dict_does_not_mutate_inputs(self):
+        defaults = {"temperature": 0.7}
+        request = {"top_k": 5}
+        merged = _merge_default_options(defaults, request)
+        merged["temperature"] = 999
+        assert defaults == {"temperature": 0.7}
+        assert request == {"top_k": 5}
+
+
+# --------------------------------------------------------------------------- #
+# _parse_kv_cache_quant                                                        #
+# --------------------------------------------------------------------------- #
+class TestParseKvCacheQuant:
+    def test_turboquant_spec(self):
+        assert _parse_kv_cache_quant("turboquant:4") == ("turboquant", 4)
+
+    def test_spectral_spec(self):
+        assert _parse_kv_cache_quant("spectral:2") == ("spectral", 2)
+
+
+# --------------------------------------------------------------------------- #
+# tokenize_for_cache (BOS heuristic)                                           #
+# --------------------------------------------------------------------------- #
+class TestTokenizeForCache:
+    def test_no_bos_adds_special(self):
+        captured = {}
+
+        def encode(text, add_special_tokens):
+            captured["add_special_tokens"] = add_special_tokens
+            return [1, 2, 3]
+
+        tok = SimpleNamespace(bos_token=None, encode=encode)
+        assert tokenize_for_cache(tok, "hello") == [1, 2, 3]
+        # bos_token is None → add_special_tokens must be True.
+        assert captured["add_special_tokens"] is True
+
+    def test_prompt_already_starts_with_bos_skips_special(self):
+        captured = {}
+
+        def encode(text, add_special_tokens):
+            captured["add_special_tokens"] = add_special_tokens
+            return [9]
+
+        tok = SimpleNamespace(bos_token="<s>", encode=encode)
+        tokenize_for_cache(tok, "<s>hi")
+        # prompt already starts with bos → do not add special tokens again.
+        assert captured["add_special_tokens"] is False
+
+    def test_bos_present_but_prompt_lacks_it_adds_special(self):
+        captured = {}
+
+        def encode(text, add_special_tokens):
+            captured["add_special_tokens"] = add_special_tokens
+            return [9]
+
+        tok = SimpleNamespace(bos_token="<s>", encode=encode)
+        tokenize_for_cache(tok, "hi")
+        assert captured["add_special_tokens"] is True
+
+
+# --------------------------------------------------------------------------- #
+# _message_boundary_token_ids                                                  #
+# --------------------------------------------------------------------------- #
+class TestMessageBoundaryTokenIds:
+    def test_list_eos_ids_all_added_nones_skipped(self):
+        tok = SimpleNamespace(eos_token_id=[1, 2, None, 3])
+        assert _message_boundary_token_ids(tok) == {1, 2, 3}
+
+    def test_scalar_eos_plus_known_eom_strings(self):
+        def convert(s):
+            return {"<|end|>": 100, "<end_of_turn>": 101}.get(s)
+
+        tok = SimpleNamespace(
+            eos_token_id=7, convert_tokens_to_ids=convert, unk_token_id=0
+        )
+        assert _message_boundary_token_ids(tok) == {7, 100, 101}
+
+    def test_unk_and_none_eom_ids_skipped(self):
+        def convert(s):
+            # one resolves to unk (skip), one resolves to None (skip).
+            return {"<|end|>": 0, "<end_of_turn>": None}.get(s)
+
+        tok = SimpleNamespace(
+            eos_token_id=7, convert_tokens_to_ids=convert, unk_token_id=0
+        )
+        assert _message_boundary_token_ids(tok) == {7}
+
+    def test_convert_exception_skipped(self):
+        def convert(s):
+            raise ValueError("no such token")
+
+        tok = SimpleNamespace(
+            eos_token_id=5, convert_tokens_to_ids=convert, unk_token_id=None
+        )
+        assert _message_boundary_token_ids(tok) == {5}
+
+    def test_no_eos_no_convert_empty(self):
+        tok = SimpleNamespace(eos_token_id=None)
+        assert _message_boundary_token_ids(tok) == set()
+
+
+# --------------------------------------------------------------------------- #
+# tokenize_segmented_chat                                                      #
+# --------------------------------------------------------------------------- #
+class TestTokenizeSegmentedChat:
+    def test_empty_messages_yields_empty_segments(self):
+        tok = SimpleNamespace(eos_token_id=1)
+        seg = tokenize_segmented_chat(tok, [], full_tokens=[1, 2, 3])
+        assert seg.segments == []
+
+    def test_no_eom_token_single_segment(self):
+        tok = SimpleNamespace(eos_token_id=None)
+        messages = [{"role": "user", "content": "hi"}]
+        seg = tokenize_segmented_chat(tok, messages, full_tokens=[10, 11, 12])
+        assert len(seg.segments) == 1
+        assert seg.segments[0].tokens == [10, 11, 12]
+        assert seg.segments[0].role == "user"
+
+    def test_fewer_boundaries_than_messages_single_segment(self):
+        # Template emitted fewer EOMs than messages → can't align → fallback.
+        tok = SimpleNamespace(eos_token_id=99)
+        messages = [
+            {"role": "user", "content": "a"},
+            {"role": "assistant", "content": "b"},
+        ]
+        seg = tokenize_segmented_chat(tok, messages, full_tokens=[1, 99, 2, 3])
+        assert len(seg.segments) == 1
+        assert seg.segments[0].tokens == [1, 99, 2, 3]
+
+    def test_one_eom_per_message_splits_and_flattens(self):
+        tok = SimpleNamespace(eos_token_id=99)
+        messages = [
+            {"role": "user", "content": "a"},
+            {"role": "assistant", "content": "b"},
+        ]
+        full = [1, 99, 2, 99, 3]  # trailing 3 absorbed into last segment
+        seg = tokenize_segmented_chat(tok, messages, full_tokens=full)
+        assert len(seg.segments) == 2
+        # flatten() must reconstruct the full token list exactly.
+        assert seg.flatten() == full
+        assert seg.segments[0].role == "user"
+        assert seg.segments[1].role == "assistant"
+
+    def test_extra_boundaries_padded_with_first_role(self):
+        # More EOMs than messages (Harmony preamble) → leading extra segment
+        # gets messages[0]['role'].
+        tok = SimpleNamespace(eos_token_id=99)
+        messages = [{"role": "user", "content": "a"}]
+        full = [5, 99, 1, 99]
+        seg = tokenize_segmented_chat(tok, messages, full_tokens=full)
+        assert len(seg.segments) == 2
+        assert seg.segments[0].role == "user"
+        assert seg.flatten() == full
+
+    def test_full_tokens_omitted_uses_apply_chat_template(self):
+        # Mode 2: function tokenizes via apply_chat_template itself.
+        tok = MagicMock()
+        tok.apply_chat_template.return_value = [1, 99, 2, 99]
+        tok.eos_token_id = 99
+        tok.convert_tokens_to_ids = lambda s: None
+        tok.unk_token_id = None
+        messages = [
+            {"role": "user", "content": "a"},
+            {"role": "assistant", "content": "b"},
+        ]
+        seg = tokenize_segmented_chat(tok, messages)
+        assert seg.flatten() == [1, 99, 2, 99]
+        assert len(seg.segments) == 2
+
+
+# --------------------------------------------------------------------------- #
+# count_chat_tokens (return-shape handling)                                    #
+# --------------------------------------------------------------------------- #
+class TestCountChatTokens:
+    def test_flat_token_list(self):
+        tok = MagicMock()
+        tok.apply_chat_template.return_value = [1, 2, 3, 4]
+        assert count_chat_tokens(tok, [{"role": "user", "content": "hi"}]) == 4
+
+    def test_batch_of_one_nested_list(self):
+        tok = MagicMock()
+        tok.apply_chat_template.return_value = [[1, 2, 3]]
+        assert count_chat_tokens(tok, [{"role": "user", "content": "hi"}]) == 3
+
+    def test_mapping_with_input_ids(self):
+        tok = MagicMock()
+        tok.apply_chat_template.return_value = {"input_ids": [7, 8]}
+        assert count_chat_tokens(tok, [{"role": "user", "content": "hi"}]) == 2
+
+    def test_mapping_nested_input_ids(self):
+        tok = MagicMock()
+        tok.apply_chat_template.return_value = {"input_ids": [[7, 8, 9]]}
+        assert count_chat_tokens(tok, [{"role": "user", "content": "hi"}]) == 3
+
+    def test_mapping_without_input_ids_raises(self):
+        tok = MagicMock()
+        tok.apply_chat_template.return_value = {"attention_mask": [1, 1]}
+        with pytest.raises(TypeError, match="without 'input_ids'"):
+            count_chat_tokens(tok, [{"role": "user", "content": "hi"}])
+
+    def test_unexpected_return_type_raises(self):
+        tok = MagicMock()
+        tok.apply_chat_template.return_value = "not a token list"
+        with pytest.raises(TypeError, match="Unexpected return type"):
+            count_chat_tokens(tok, [{"role": "user", "content": "hi"}])
+
+
+# --------------------------------------------------------------------------- #
+# penalty processor out-of-range / incremental paths                          #
+# --------------------------------------------------------------------------- #
+class TestPenaltyProcessorEdgeCases:
+    def test_empty_tokens_noop(self):
+        proc = _make_frequency_penalty_processor(1.0)
+        logits = mx.array([5.0, 5.0])
+        out = proc([], logits)
+        assert mx.allclose(out, logits).item()
+
+    def test_zero_penalty_noop(self):
+        proc = _make_frequency_penalty_processor(0.0)
+        logits = mx.array([5.0, 5.0])
+        out = proc([0, 1], logits)
+        assert mx.allclose(out, logits).item()
+
+    def test_frequency_out_of_range_seed_token_ignored(self):
+        proc = _make_frequency_penalty_processor(1.0)
+        # token 9 is out of range (vocab 2); only token 0 penalised.
+        result = proc([0, 9], mx.array([5.0, 5.0]))
+        assert mx.allclose(result, mx.array([4.0, 5.0])).item()
+
+    def test_frequency_incremental_out_of_range_ignored(self):
+        proc = _make_frequency_penalty_processor(1.0)
+        proc([0], mx.array([5.0, 5.0]))  # init seeds freq {0:1}
+        result = proc([0, 9], mx.array([5.0, 5.0]))  # new token 9 out of range
+        assert mx.allclose(result, mx.array([4.0, 5.0])).item()
+
+    def test_frequency_counts_accumulate(self):
+        proc = _make_frequency_penalty_processor(1.0)
+        proc([0, 0], mx.array([5.0, 5.0]))  # init: token 0 seen twice
+        result = proc([0, 0, 0], mx.array([5.0, 5.0]))  # incremental: +1 → 3
+        assert mx.allclose(result, mx.array([2.0, 5.0])).item()
+
+    def test_presence_incremental_new_token(self):
+        proc = _make_presence_penalty_processor(0.5)
+        proc([0], mx.array([10.0, 10.0]))  # init seeds {0}
+        result = proc([0, 1], mx.array([10.0, 10.0]))  # token 1 newly seen
+        assert mx.allclose(result, mx.array([10.0, 9.5])).item()
+
+    def test_presence_incremental_repeat_token_no_double_penalty(self):
+        proc = _make_presence_penalty_processor(0.5)
+        proc([0], mx.array([10.0, 10.0]))  # init seeds {0}
+        result = proc([0, 0], mx.array([10.0, 10.0]))  # 0 already seen
+        assert mx.allclose(result, mx.array([10.0, 10.0])).item()
+
+    def test_presence_incremental_out_of_range_ignored(self):
+        proc = _make_presence_penalty_processor(0.5)
+        proc([0], mx.array([10.0, 10.0]))
+        result = proc([0, 5], mx.array([10.0, 10.0]))  # 5 out of range
+        assert mx.allclose(result, mx.array([10.0, 10.0])).item()
+
+
+# --------------------------------------------------------------------------- #
+# _get_chat_template_text                                                      #
+# --------------------------------------------------------------------------- #
+class TestGetChatTemplateText:
+    def test_direct_string_template(self):
+        tok = SimpleNamespace(chat_template="{{ messages }}")
+        assert _get_chat_template_text(tok) == "{{ messages }}"
+
+    def test_nested_tokenizer_template(self):
+        inner = SimpleNamespace(chat_template="nested-tpl")
+        tok = SimpleNamespace(chat_template=None, tokenizer=inner)
+        assert _get_chat_template_text(tok) == "nested-tpl"
+
+    def test_list_of_named_templates_joined(self):
+        tok = SimpleNamespace(
+            chat_template=[
+                {"name": "default", "template": "AAA"},
+                {"name": "tool_use", "template": "BBB"},
+                "ignored-non-dict",
+            ]
+        )
+        assert _get_chat_template_text(tok) == "AAA BBB"
+
+    def test_none_everywhere_returns_empty(self):
+        tok = SimpleNamespace(chat_template=None, tokenizer=None)
+        assert _get_chat_template_text(tok) == ""
+
+    def test_non_string_non_list_returns_empty(self):
+        tok = SimpleNamespace(chat_template=12345)
+        assert _get_chat_template_text(tok) == ""
+
+
+# --------------------------------------------------------------------------- #
+# _convert_tool_messages_to_responses                                         #
+# --------------------------------------------------------------------------- #
+class TestConvertToolMessages:
+    def test_no_tool_messages_passthrough(self):
+        messages = [{"role": "user", "content": "hi"}]
+        # Returns the same object unchanged when no tool role is present.
+        assert _convert_tool_messages_to_responses(messages) is messages
+
+    def test_tool_response_merged_into_preceding_assistant_with_name(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc1", "function": {"name": "read", "arguments": {}}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc1", "content": "file body"},
+        ]
+        result = _convert_tool_messages_to_responses(messages)
+        assert len(result) == 1
+        assert result[0]["role"] == "assistant"
+        assert result[0]["tool_responses"] == [
+            {"name": "read", "response": "file body"}
+        ]
+
+    def test_orphan_tool_message_creates_assistant_with_unknown_name(self):
+        messages = [
+            {"role": "tool", "tool_call_id": "tc1", "content": "stranded"},
+        ]
+        result = _convert_tool_messages_to_responses(messages)
+        assert len(result) == 1
+        assert result[0]["role"] == "assistant"
+        assert result[0]["tool_responses"] == [
+            {"name": "unknown", "response": "stranded"}
+        ]
+
+
+# --------------------------------------------------------------------------- #
+# _add_native_tool_hint                                                        #
+# --------------------------------------------------------------------------- #
+class TestAddNativeToolHint:
+    def test_no_system_message_passthrough(self):
+        messages = [{"role": "user", "content": "use <function=foo>"}]
+        assert _add_native_tool_hint(messages) is messages
+
+    def test_empty_messages_passthrough(self):
+        assert _add_native_tool_hint([]) == []
+
+    def test_missing_content_key_treated_as_empty(self):
+        messages = [{"role": "system"}]
+        assert _add_native_tool_hint(messages) == messages
+
+    def test_non_string_content_skipped(self):
+        messages = [{"role": "system", "content": [{"type": "text", "text": "x"}]}]
+        assert _add_native_tool_hint(messages) is messages
+
+    def test_conflict_pattern_appends_hint(self):
+        messages = [{"role": "system", "content": "call <function=Foo>{...}"}]
+        result = _add_native_tool_hint(messages)
+        assert "native tool call format" in result[0]["content"]
+        # Original input not mutated (shallow copy).
+        assert messages[0]["content"] == "call <function=Foo>{...}"
+
+    def test_pattern_in_template_suppressed(self):
+        # When a conflict pattern is native to the template, no hint added.
+        messages = [{"role": "system", "content": "use <|python_tag|>{...}"}]
+        result = _add_native_tool_hint(messages, native_template_text="<|python_tag|>")
+        assert "native tool call format" not in result[0]["content"]
+
+    def test_idempotent_when_hint_already_present(self):
+        from olmlx.engine.inference import _NATIVE_TOOL_HINT
+
+        content = "call <function=Foo> " + _NATIVE_TOOL_HINT
+        messages = [{"role": "system", "content": content}]
+        # Hint already present → return unchanged (no double-append).
+        assert _add_native_tool_hint(messages) is messages
+
+
+# --------------------------------------------------------------------------- #
+# _GptOssChannelFilter                                                         #
+# --------------------------------------------------------------------------- #
+class TestGptOssChannelFilter:
+    def test_final_channel_content_yielded(self):
+        filt = _GptOssChannelFilter()
+        seq = ["<|channel|>", "final", "<|message|>", "answer"]
+        yielded = [t for t in seq if filt.should_yield(t)]
+        assert yielded == ["answer"]
+        assert filt.get_fallback_texts() == []
+
+    def test_analysis_buffered_and_used_as_fallback_when_no_final(self):
+        filt = _GptOssChannelFilter()
+        seq = ["<|channel|>", "analysis", "<|message|>", "thinking..."]
+        yielded = [t for t in seq if filt.should_yield(t)]
+        assert yielded == []  # analysis is not yielded inline
+        # No final channel → analysis text is the fallback.
+        assert filt.get_fallback_texts() == ["thinking..."]
+
+    def test_no_channel_plain_text_yielded(self):
+        filt = _GptOssChannelFilter()
+        # Plain non-structural text in init state is passed through.
+        assert filt.should_yield("hello") is True
+
+    def test_structural_tokens_never_yielded(self):
+        filt = _GptOssChannelFilter()
+        assert filt.should_yield("<|start|>") is False
+        assert filt.should_yield("<|end|>") is False
+
+    def test_full_text_accumulates_all_tokens(self):
+        filt = _GptOssChannelFilter()
+        for t in ["<|channel|>", "final", "<|message|>", "hi"]:
+            filt.should_yield(t)
+        assert filt.get_full_text() == "<|channel|>final<|message|>hi"
+
+
+# --------------------------------------------------------------------------- #
+# _full_completion stop-sequence / finish-reason branches                      #
+# --------------------------------------------------------------------------- #
+def _patch_lock_and_ref(monkeypatch):
+    """Replace the GPU lock/ref context managers so _full_completion runs its
+    post-processing branches without touching Metal."""
+
+    @contextlib.asynccontextmanager
+    async def fake_locked(*a, **k):
+        yield None
+
+    @contextlib.contextmanager
+    def fake_ref(*a, **k):
+        yield None
+
+    monkeypatch.setattr(_inf_mod, "_inference_locked", fake_locked)
+    monkeypatch.setattr(_inf_mod, "_inference_ref", fake_ref)
+
+
+def _mock_lm():
+    lm = MagicMock()
+    lm.inference_queue_timeout = 30.0
+    lm.sync_mode = None
+    return lm
+
+
+class TestFullCompletionFinishReason:
+    async def test_timeout_done_reason_passthrough_no_finish_reason(self, monkeypatch):
+        _patch_lock_and_ref(monkeypatch)
+
+        async def fake_inner(*a, **k):
+            return {
+                "text": "partial output",
+                "done": True,
+                "stats": MagicMock(),
+                "done_reason": "timeout",
+            }
+
+        monkeypatch.setattr(_inf_mod, "_full_completion_inner", fake_inner)
+        result = await _full_completion(_mock_lm(), "prompt", 50, {}, MagicMock())
+        # No stop sequences → text unchanged, done_reason preserved, no
+        # finish_reason injected.
+        assert result["text"] == "partial output"
+        assert result["done_reason"] == "timeout"
+        assert "finish_reason" not in result
+
+    async def test_stop_sequence_truncates_and_sets_reason(self, monkeypatch):
+        _patch_lock_and_ref(monkeypatch)
+
+        async def fake_inner(*a, **k):
+            return {"text": "hello STOP world", "done": True, "stats": MagicMock()}
+
+        monkeypatch.setattr(_inf_mod, "_full_completion_inner", fake_inner)
+        result = await _full_completion(
+            _mock_lm(), "prompt", 50, {"stop": ["STOP"]}, MagicMock()
+        )
+        assert result["text"] == "hello "
+        assert result["finish_reason"] == "stop"
+
+    async def test_stop_sequence_not_present_leaves_text_untouched(self, monkeypatch):
+        _patch_lock_and_ref(monkeypatch)
+
+        async def fake_inner(*a, **k):
+            return {"text": "no marker here", "done": True, "stats": MagicMock()}
+
+        monkeypatch.setattr(_inf_mod, "_full_completion_inner", fake_inner)
+        result = await _full_completion(
+            _mock_lm(), "prompt", 50, {"stop": ["ZZZ"]}, MagicMock()
+        )
+        assert result["text"] == "no marker here"
+        assert "finish_reason" not in result
+
+    async def test_earliest_stop_sequence_wins(self, monkeypatch):
+        _patch_lock_and_ref(monkeypatch)
+
+        async def fake_inner(*a, **k):
+            return {"text": "aa END bb HALT cc", "done": True, "stats": MagicMock()}
+
+        monkeypatch.setattr(_inf_mod, "_full_completion_inner", fake_inner)
+        # HALT is later in the text but listed first: earliest position wins.
+        result = await _full_completion(
+            _mock_lm(), "prompt", 50, {"stop": ["HALT", "END"]}, MagicMock()
+        )
+        assert result["text"] == "aa "
+        assert result["finish_reason"] == "stop"

--- a/tests/test_mcp_client_coverage.py
+++ b/tests/test_mcp_client_coverage.py
@@ -1,0 +1,640 @@
+"""Regression coverage for olmlx.chat.mcp_client.
+
+Focuses on the connect/retry/teardown lifecycle, tool discovery,
+tool invocation routing, and uniform error propagation. All MCP
+transports and sessions are mocked; no network, subprocess, or
+filesystem access.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import olmlx.chat.mcp_client as mcp_client_mod
+from olmlx.chat.errors import ToolError
+from olmlx.chat.mcp_client import MCPClientManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fakes
+# ---------------------------------------------------------------------------
+
+
+def _tool(name, description=None, input_schema=None):
+    """Build a fake MCP tool object (attribute access, like the real SDK)."""
+    ns = SimpleNamespace(name=name, description=description)
+    if input_schema is not None:
+        ns.inputSchema = input_schema
+    return ns
+
+
+def _list_tools_result(*tools):
+    return SimpleNamespace(tools=list(tools))
+
+
+def _content_text(text):
+    return SimpleNamespace(text=text)
+
+
+def _content_other(value):
+    """Content block without a .text attribute (exercises str() fallback)."""
+    return value
+
+
+class FakeSessionCM:
+    """Stand-in for ClientSession(...) — an async context manager whose
+    __aenter__ returns a session object."""
+
+    def __init__(self, session):
+        self._session = session
+        self.aexit_calls = []
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.aexit_calls.append((exc_type, exc_val, exc_tb))
+        return None
+
+
+class FakeTransportCM:
+    """Stand-in for stdio_client()/sse_client() transport context manager."""
+
+    def __init__(self, streams=("read", "write"), enter_exc=None):
+        self._streams = streams
+        self._enter_exc = enter_exc
+        self.aexit_calls = []
+        self.aenter_calls = 0
+
+    async def __aenter__(self):
+        self.aenter_calls += 1
+        if self._enter_exc is not None:
+            raise self._enter_exc
+        return self._streams
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.aexit_calls.append((exc_type, exc_val, exc_tb))
+        return None
+
+
+def _make_session(tools=(), call_result=None, *, initialize_exc=None):
+    session = MagicMock(name="MCPSession")
+    session.initialize = AsyncMock(
+        side_effect=initialize_exc if initialize_exc is not None else None
+    )
+    session.list_tools = AsyncMock(return_value=_list_tools_result(*tools))
+    session.call_tool = AsyncMock(return_value=call_result)
+    return session
+
+
+def _patch_clientsession(monkeypatch, session_cm):
+    """Patch `mcp.ClientSession` (imported lazily inside _connect_transport)."""
+    import mcp
+
+    monkeypatch.setattr(
+        mcp, "ClientSession", MagicMock(return_value=session_cm), raising=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# _connect_transport: success path + tool discovery
+# ---------------------------------------------------------------------------
+
+
+async def test_connect_transport_registers_server_and_tools(monkeypatch):
+    session = _make_session(
+        tools=[
+            _tool(
+                "read_file",
+                "Read a file",
+                {"type": "object", "properties": {"path": {"type": "string"}}},
+            ),
+            _tool("ping"),
+        ]
+    )
+    session_cm = FakeSessionCM(session)
+    transport_cm = FakeTransportCM(streams=("r", "w"))
+    _patch_clientsession(monkeypatch, session_cm)
+
+    mgr = MCPClientManager()
+    await mgr._connect_transport("srv", transport_cm)
+
+    # Server recorded with both context managers for teardown.
+    assert "srv" in mgr._servers
+    assert mgr._servers["srv"]["session"] is session
+    assert mgr._servers["srv"]["session_cm"] is session_cm
+    assert mgr._servers["srv"]["transport_cm"] is transport_cm
+
+    # Tools discovered and routed.
+    assert mgr._tool_to_server == {"read_file": "srv", "ping": "srv"}
+    names = {t["function"]["name"] for t in mgr.get_tools_for_chat()}
+    assert names == {"read_file", "ping"}
+
+    # initialize() and list_tools() actually invoked.
+    session.initialize.assert_awaited_once()
+    session.list_tools.assert_awaited_once()
+    # No teardown on success.
+    assert transport_cm.aexit_calls == []
+    assert session_cm.aexit_calls == []
+
+
+async def test_discover_tools_missing_input_schema_uses_default(monkeypatch):
+    # Tool object without an inputSchema attribute -> default empty schema.
+    session = _make_session(tools=[_tool("noschema", "desc")])
+    session_cm = FakeSessionCM(session)
+    _patch_clientsession(monkeypatch, session_cm)
+
+    mgr = MCPClientManager()
+    await mgr._connect_transport("srv", FakeTransportCM())
+
+    tool = mgr.get_tools_for_chat()[0]
+    assert tool["function"]["parameters"] == {"type": "object", "properties": {}}
+    # None description coalesces to "".
+    assert tool["function"]["description"] == "desc"
+
+
+async def test_discover_tools_none_description_coalesces(monkeypatch):
+    session = _make_session(tools=[_tool("t", None, {"type": "object"})])
+    session_cm = FakeSessionCM(session)
+    _patch_clientsession(monkeypatch, session_cm)
+
+    mgr = MCPClientManager()
+    await mgr._connect_transport("srv", FakeTransportCM())
+    assert mgr.get_tools_for_chat()[0]["function"]["description"] == ""
+
+
+async def test_duplicate_tool_name_across_servers_is_skipped(monkeypatch):
+    # First server.
+    s1 = _make_session(tools=[_tool("shared", "first", {"type": "object"})])
+    _patch_clientsession(monkeypatch, FakeSessionCM(s1))
+    mgr = MCPClientManager()
+    await mgr._connect_transport("srvA", FakeTransportCM())
+
+    # Second server exposing the same tool name.
+    s2 = _make_session(
+        tools=[
+            _tool("shared", "second", {"type": "object"}),
+            _tool("unique", "u", {"type": "object"}),
+        ]
+    )
+    _patch_clientsession(monkeypatch, FakeSessionCM(s2))
+    await mgr._connect_transport("srvB", FakeTransportCM())
+
+    # The shared tool stays mapped to the first server; only unique is added.
+    assert mgr._tool_to_server["shared"] == "srvA"
+    assert mgr._tool_to_server["unique"] == "srvB"
+    names = [t["function"]["name"] for t in mgr.get_tools_for_chat()]
+    assert names.count("shared") == 1
+
+
+# ---------------------------------------------------------------------------
+# _connect_transport: teardown on failure
+# ---------------------------------------------------------------------------
+
+
+async def test_initialize_failure_tears_down_session_and_transport(monkeypatch):
+    session = _make_session(initialize_exc=RuntimeError("init boom"))
+    session_cm = FakeSessionCM(session)
+    transport_cm = FakeTransportCM()
+    _patch_clientsession(monkeypatch, session_cm)
+
+    mgr = MCPClientManager()
+    with pytest.raises(RuntimeError, match="init boom"):
+        await mgr._connect_transport("srv", transport_cm)
+
+    # Both context managers closed, server NOT registered.
+    assert "srv" not in mgr._servers
+    assert len(session_cm.aexit_calls) == 1
+    assert len(transport_cm.aexit_calls) == 1
+    # The exc_info propagated into __aexit__ carries the RuntimeError.
+    assert session_cm.aexit_calls[0][0] is RuntimeError
+
+
+async def test_transport_aenter_failure_propagates_without_session(monkeypatch):
+    transport_cm = FakeTransportCM(enter_exc=ConnectionError("refused"))
+    # ClientSession should never be constructed if transport __aenter__ fails.
+    import mcp
+
+    sentinel = MagicMock(side_effect=AssertionError("must not construct session"))
+    monkeypatch.setattr(mcp, "ClientSession", sentinel, raising=True)
+
+    mgr = MCPClientManager()
+    with pytest.raises(ConnectionError, match="refused"):
+        await mgr._connect_transport("srv", transport_cm)
+    assert "srv" not in mgr._servers
+    # Transport __aexit__ is NOT called because __aenter__ itself raised.
+    assert transport_cm.aexit_calls == []
+
+
+async def test_discover_tools_failure_tears_down_everything(monkeypatch):
+    session = _make_session()
+    session.list_tools = AsyncMock(side_effect=ValueError("list failed"))
+    session_cm = FakeSessionCM(session)
+    transport_cm = FakeTransportCM()
+    _patch_clientsession(monkeypatch, session_cm)
+
+    mgr = MCPClientManager()
+    with pytest.raises(ValueError, match="list failed"):
+        await mgr._connect_transport("srv", transport_cm)
+
+    assert "srv" not in mgr._servers
+    assert len(session_cm.aexit_calls) == 1
+    assert len(transport_cm.aexit_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# connect_all: dispatch by transport + retry/backoff
+# ---------------------------------------------------------------------------
+
+
+async def test_connect_all_dispatches_stdio_and_sse(monkeypatch):
+    called = []
+
+    async def fake_stdio(self, name, cfg):
+        called.append(("stdio", name, cfg))
+
+    async def fake_sse(self, name, cfg):
+        called.append(("sse", name, cfg))
+
+    monkeypatch.setattr(MCPClientManager, "_connect_stdio", fake_stdio)
+    monkeypatch.setattr(MCPClientManager, "_connect_sse", fake_sse)
+
+    mgr = MCPClientManager()
+    config = {
+        "fs": {"transport": "stdio", "command": "x"},
+        "web": {"transport": "sse", "url": "http://h"},
+    }
+    await mgr.connect_all(config)
+
+    assert ("stdio", "fs", config["fs"]) in called
+    assert ("sse", "web", config["web"]) in called
+
+
+async def test_connect_all_retries_then_succeeds(monkeypatch):
+    attempts = {"n": 0}
+
+    async def flaky_stdio(self, name, cfg):
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise ConnectionError("not yet")
+
+    sleeps = []
+
+    async def fake_sleep(d):
+        sleeps.append(d)
+
+    monkeypatch.setattr(MCPClientManager, "_connect_stdio", flaky_stdio)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    mgr = MCPClientManager()
+    await mgr.connect_all({"fs": {"transport": "stdio", "command": "x"}})
+
+    # Succeeded on third attempt; two backoff sleeps with exponential delays.
+    assert attempts["n"] == 3
+    assert sleeps == [1, 2]
+
+
+async def test_connect_all_gives_up_after_max_attempts(monkeypatch):
+    attempts = {"n": 0}
+
+    async def always_fail(self, name, cfg):
+        attempts["n"] += 1
+        raise ConnectionError("down")
+
+    async def fake_sleep(d):
+        pass
+
+    monkeypatch.setattr(MCPClientManager, "_connect_stdio", always_fail)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    mgr = MCPClientManager()
+    # Should not raise even when all attempts fail.
+    await mgr.connect_all(
+        {"fs": {"transport": "stdio", "command": "x"}}, max_attempts=2
+    )
+    assert attempts["n"] == 2
+    assert mgr._servers == {}
+
+
+async def test_connect_all_max_attempts_floor_is_one(monkeypatch):
+    attempts = {"n": 0}
+
+    async def always_fail(self, name, cfg):
+        attempts["n"] += 1
+        raise ConnectionError("down")
+
+    monkeypatch.setattr(MCPClientManager, "_connect_stdio", always_fail)
+
+    mgr = MCPClientManager()
+    # 0 (and negatives) clamp to a single attempt; no sleep is reached.
+    await mgr.connect_all(
+        {"fs": {"transport": "stdio", "command": "x"}}, max_attempts=0
+    )
+    assert attempts["n"] == 1
+
+
+async def test_connect_all_backoff_capped_at_ten(monkeypatch):
+    async def always_fail(self, name, cfg):
+        raise ConnectionError("down")
+
+    sleeps = []
+
+    async def fake_sleep(d):
+        sleeps.append(d)
+
+    monkeypatch.setattr(MCPClientManager, "_connect_stdio", always_fail)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    mgr = MCPClientManager()
+    await mgr.connect_all(
+        {"fs": {"transport": "stdio", "command": "x"}}, max_attempts=8
+    )
+    # 2**attempt for attempts 0..6 (the last attempt does not sleep), capped at 10.
+    assert sleeps == [1, 2, 4, 8, 10, 10, 10]
+
+
+# ---------------------------------------------------------------------------
+# _connect_stdio / _connect_sse: wiring to transports
+# ---------------------------------------------------------------------------
+
+
+async def test_connect_stdio_builds_params_and_connects(monkeypatch):
+    import mcp
+    import mcp.client.stdio as stdio_mod
+
+    captured = {}
+
+    def fake_stdio_client(params):
+        captured["params"] = params
+        return FakeTransportCM()
+
+    monkeypatch.setattr(stdio_mod, "stdio_client", fake_stdio_client, raising=True)
+    monkeypatch.setattr(
+        mcp_client_mod, "sanitize_mcp_env", lambda env: {"SAFE": "1"}, raising=True
+    )
+
+    session = _make_session(tools=[_tool("t", "d", {"type": "object"})])
+    _patch_clientsession(monkeypatch, FakeSessionCM(session))
+
+    mgr = MCPClientManager()
+    await mgr._connect_stdio(
+        "fs",
+        {"command": "mytool", "args": ["--flag"], "env": {"USER_VAR": "x"}},
+    )
+
+    params = captured["params"]
+    assert isinstance(params, mcp.StdioServerParameters)
+    assert params.command == "mytool"
+    assert params.args == ["--flag"]
+    assert params.env == {"SAFE": "1"}
+    assert "fs" in mgr._servers
+
+
+async def test_connect_stdio_defaults_args_when_missing(monkeypatch):
+    import mcp.client.stdio as stdio_mod
+
+    captured = {}
+
+    def fake_stdio_client(params):
+        captured["params"] = params
+        return FakeTransportCM()
+
+    monkeypatch.setattr(stdio_mod, "stdio_client", fake_stdio_client, raising=True)
+    session = _make_session()
+    _patch_clientsession(monkeypatch, FakeSessionCM(session))
+
+    mgr = MCPClientManager()
+    await mgr._connect_stdio("fs", {"command": "mytool"})
+    assert captured["params"].args == []
+
+
+async def test_connect_sse_uses_url(monkeypatch):
+    import mcp.client.sse as sse_mod
+
+    captured = {}
+
+    def fake_sse_client(url):
+        captured["url"] = url
+        return FakeTransportCM()
+
+    monkeypatch.setattr(sse_mod, "sse_client", fake_sse_client, raising=True)
+    session = _make_session()
+    _patch_clientsession(monkeypatch, FakeSessionCM(session))
+
+    mgr = MCPClientManager()
+    await mgr._connect_sse("web", {"url": "http://example/mcp"})
+    assert captured["url"] == "http://example/mcp"
+    assert "web" in mgr._servers
+
+
+# ---------------------------------------------------------------------------
+# call_tool: routing + result extraction + error mapping
+# ---------------------------------------------------------------------------
+
+
+async def test_call_tool_success_joins_text_content():
+    mgr = MCPClientManager()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=SimpleNamespace(
+            isError=False,
+            content=[_content_text("line1"), _content_text("line2")],
+        )
+    )
+    mgr._tool_to_server["echo"] = "srv"
+    mgr._servers["srv"] = {"session": session}
+
+    result = await mgr.call_tool("echo", {"a": 1})
+    assert result == "line1\nline2"
+    session.call_tool.assert_awaited_once_with("echo", {"a": 1})
+
+
+async def test_call_tool_non_text_content_str_fallback():
+    mgr = MCPClientManager()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=SimpleNamespace(
+            isError=False, content=[_content_other(123), _content_text("x")]
+        )
+    )
+    mgr._tool_to_server["t"] = "srv"
+    mgr._servers["srv"] = {"session": session}
+
+    result = await mgr.call_tool("t", {})
+    assert result == "123\nx"
+
+
+async def test_call_tool_empty_content_returns_empty_string():
+    mgr = MCPClientManager()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=SimpleNamespace(isError=False, content=[])
+    )
+    mgr._tool_to_server["t"] = "srv"
+    mgr._servers["srv"] = {"session": session}
+
+    assert await mgr.call_tool("t", {}) == ""
+
+
+async def test_call_tool_is_error_returns_tool_error():
+    mgr = MCPClientManager()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=SimpleNamespace(
+            isError=True, content=[_content_text("server says nope")]
+        )
+    )
+    mgr._tool_to_server["t"] = "srv"
+    mgr._servers["srv"] = {"session": session}
+
+    result = await mgr.call_tool("t", {})
+    assert isinstance(result, ToolError)
+    assert result.message == "server says nope"
+    assert result.is_user_error is False
+    assert result.tool_name == "t"
+
+
+async def test_call_tool_is_error_non_text_content_str_fallback():
+    mgr = MCPClientManager()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=SimpleNamespace(
+            isError=True, content=[_content_other(42), _content_text("detail")]
+        )
+    )
+    mgr._tool_to_server["t"] = "srv"
+    mgr._servers["srv"] = {"session": session}
+
+    result = await mgr.call_tool("t", {})
+    assert isinstance(result, ToolError)
+    # Non-text content stringified, joined with the text block.
+    assert result.message == "42\ndetail"
+    assert result.is_user_error is False
+
+
+async def test_call_tool_is_error_with_empty_content_default_message():
+    mgr = MCPClientManager()
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=SimpleNamespace(isError=True, content=[])
+    )
+    mgr._tool_to_server["t"] = "srv"
+    mgr._servers["srv"] = {"session": session}
+
+    result = await mgr.call_tool("t", {})
+    assert isinstance(result, ToolError)
+    assert result.message == "MCP server returned an error"
+
+
+async def test_call_tool_unknown_tool_user_error():
+    mgr = MCPClientManager()
+    result = await mgr.call_tool("ghost", {})
+    assert isinstance(result, ToolError)
+    assert "Unknown tool" in result.message
+    assert result.is_user_error is True
+
+
+async def test_call_tool_server_disconnected_system_error():
+    mgr = MCPClientManager()
+    # Tool mapped, but the server entry is gone.
+    mgr._tool_to_server["t"] = "vanished"
+    result = await mgr.call_tool("t", {})
+    assert isinstance(result, ToolError)
+    assert "not connected" in result.message
+    assert result.is_user_error is False
+
+
+async def test_call_tool_timeout_returns_tool_error():
+    mgr = MCPClientManager()
+    session = MagicMock()
+
+    async def never():
+        await asyncio.Event().wait()
+
+    session.call_tool = MagicMock(return_value=never())
+    mgr._tool_to_server["slow"] = "srv"
+    mgr._servers["srv"] = {"session": session}
+
+    result = await mgr.call_tool("slow", {}, timeout=0.01)
+    assert isinstance(result, ToolError)
+    assert "timed out" in result.message
+    assert result.is_user_error is False
+
+
+async def test_call_tool_exception_returns_tool_error():
+    mgr = MCPClientManager()
+    session = MagicMock()
+    session.call_tool = AsyncMock(side_effect=RuntimeError("kaboom"))
+    mgr._tool_to_server["t"] = "srv"
+    mgr._servers["srv"] = {"session": session}
+
+    result = await mgr.call_tool("t", {})
+    assert isinstance(result, ToolError)
+    assert "Error calling t" in result.message
+    assert "kaboom" in result.message
+    assert result.is_user_error is False
+
+
+# ---------------------------------------------------------------------------
+# disconnect_all: teardown ordering + error resilience
+# ---------------------------------------------------------------------------
+
+
+async def test_disconnect_all_closes_session_then_transport_and_clears():
+    mgr = MCPClientManager()
+    order = []
+
+    session_cm = MagicMock()
+    session_cm.__aexit__ = AsyncMock(side_effect=lambda *a: order.append("session"))
+    transport_cm = MagicMock()
+    transport_cm.__aexit__ = AsyncMock(side_effect=lambda *a: order.append("transport"))
+
+    mgr._servers["srv"] = {
+        "session": MagicMock(),
+        "session_cm": session_cm,
+        "transport_cm": transport_cm,
+    }
+    mgr._tool_to_server["t"] = "srv"
+    mgr._tools = [{"function": {"name": "t"}}]
+
+    await mgr.disconnect_all()
+
+    # Session closed before transport.
+    assert order == ["session", "transport"]
+    session_cm.__aexit__.assert_awaited_once_with(None, None, None)
+    transport_cm.__aexit__.assert_awaited_once_with(None, None, None)
+    # State fully cleared.
+    assert mgr._servers == {}
+    assert mgr._tool_to_server == {}
+    assert mgr._tools == []
+
+
+async def test_disconnect_all_suppresses_close_errors():
+    mgr = MCPClientManager()
+    session_cm = MagicMock()
+    session_cm.__aexit__ = AsyncMock(side_effect=RuntimeError("close fail"))
+    transport_cm = MagicMock()
+    transport_cm.__aexit__ = AsyncMock()
+
+    mgr._servers["srv"] = {
+        "session": MagicMock(),
+        "session_cm": session_cm,
+        "transport_cm": transport_cm,
+    }
+
+    # Must not raise despite session_cm failing; transport still attempted.
+    await mgr.disconnect_all()
+    transport_cm.__aexit__.assert_awaited_once()
+    assert mgr._servers == {}
+
+
+async def test_disconnect_all_handles_missing_cms():
+    mgr = MCPClientManager()
+    # Server dict missing the cm keys (defensive .get(...) path).
+    mgr._servers["srv"] = {"session": MagicMock()}
+    await mgr.disconnect_all()
+    assert mgr._servers == {}

--- a/tests/test_model_manager_coverage.py
+++ b/tests/test_model_manager_coverage.py
@@ -1,0 +1,535 @@
+"""Regression coverage for olmlx.engine.model_manager.
+
+Focuses on pure logic with heavily mocked LoadedModel/mlx objects:
+- cache-classification discriminators (persistence / trim / checkpoint),
+- LoadedModel ref counting + property unwrapping,
+- LRU eviction ordering and active_refs protection,
+- keep-alive / expiry math,
+- error/edge paths in config sanitation, chat-template loading, draft
+  attention version resolution, vocab matching, flash-dir detection,
+  and prompt-cache invalidation.
+
+These complement (not duplicate) tests/test_model_manager.py.
+"""
+
+import json
+import logging
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from olmlx.engine.model_manager import (
+    LoadedModel,
+    ModelManager,
+    _cache_supports_checkpoint_persistence,
+    _cache_supports_persistence,
+    _cache_supports_trim,
+    _ensure_tokenizer_eos_in_stops,
+    _is_serializable_cache,
+    _kv_quant_blocks_snapshot,
+    _layer_layout_is_mixed_excluded,
+    _resolve_attention_causal,
+    _sanitize_model_config_in_place,
+)
+
+
+def _fake_layer(class_name: str):
+    """Return an object whose ``type(obj).__name__`` is ``class_name``."""
+
+    cls = type(class_name, (), {})
+    return cls()
+
+
+# --------------------------------------------------------------------------
+# Cache-classification discriminators (pure, allowlist-based).
+# --------------------------------------------------------------------------
+
+
+class TestCacheClassification:
+    def test_trim_allowlist_accepts_all_known(self):
+        cache = [_fake_layer("KVCache"), _fake_layer("QuantizedKVCache")]
+        assert _cache_supports_trim(cache) is True
+
+    def test_trim_rejects_rotating(self):
+        cache = [_fake_layer("KVCache"), _fake_layer("RotatingKVCache")]
+        assert _cache_supports_trim(cache) is False
+
+    def test_persistence_empty_list_is_false(self):
+        # Empty == no evidence of safety; a false-positive here crashes the
+        # next request, so the helper must refuse to claim safety.
+        assert _cache_supports_persistence([]) is False
+
+    def test_persistence_rejects_arrays_cache(self):
+        # ArraysCache (gated-delta SSM state, issue #284) is the motivating
+        # exclusion from the flat persistence allowlist.
+        cache = [_fake_layer("KVCache"), _fake_layer("ArraysCache")]
+        assert _cache_supports_persistence(cache) is False
+
+    def test_persistence_no_mro_walk_subclass_rejected(self):
+        # Exact class-name match (no MRO walk): a subclass of an allowlisted
+        # class must NOT pass — that is the documented safety guarantee.
+        class KVCache:  # base in allowlist by name
+            pass
+
+        class BadSSMCache(KVCache):
+            pass
+
+        # type(obj).__name__ == "BadSSMCache", not in allowlist.
+        assert _cache_supports_persistence([BadSSMCache()]) is False
+
+    def test_checkpoint_accepts_arrays_cache(self):
+        # ArraysCache IS in the checkpoint allowlist (snapshot helper evals
+        # the lazy graph), unlike the flat path.
+        cache = [_fake_layer("ArraysCache"), _fake_layer("KVCache")]
+        assert _cache_supports_checkpoint_persistence(cache) is True
+
+    def test_checkpoint_empty_is_false(self):
+        assert _cache_supports_checkpoint_persistence([]) is False
+
+    def test_checkpoint_rejects_unknown_layer(self):
+        cache = [_fake_layer("KVCache"), _fake_layer("MysterySSMCache")]
+        assert _cache_supports_checkpoint_persistence(cache) is False
+
+    def test_mixed_excluded_empty_set_never_fires(self):
+        # _EXCLUDED_MIXED_LAYER_PAIRS is currently empty (#396 lifted), so no
+        # layout is mixed-excluded.
+        cache = [_fake_layer("RotatingKVCache"), _fake_layer("ArraysCache")]
+        assert _layer_layout_is_mixed_excluded(cache) is False
+
+    def test_mixed_excluded_empty_cache_false(self):
+        assert _layer_layout_is_mixed_excluded([]) is False
+
+
+class TestKvQuantSnapshotGate:
+    def test_none_does_not_block(self):
+        assert _kv_quant_blocks_snapshot(None) is False
+
+    def test_turboquant_does_not_block(self):
+        # _KV_QUANT_PREFIXES_BLOCKING_SNAPSHOT is empty: turboquant handles
+        # its own deepcopy, so it must not be reported as blocking.
+        assert _kv_quant_blocks_snapshot("turboquant:4") is False
+
+    def test_spectral_does_not_block(self):
+        assert _kv_quant_blocks_snapshot("spectral:2") is False
+
+
+class TestIsSerializableCache:
+    def test_plain_kvcache_is_serializable(self):
+        # No TurboQuant/Spectral wrappers -> safetensors-serializable.
+        assert _is_serializable_cache([_fake_layer("KVCache")]) is True
+
+    def test_turboquant_cache_not_serializable(self):
+        from olmlx.engine.turboquant_cache import TurboQuantKVCache
+
+        tq = TurboQuantKVCache.__new__(TurboQuantKVCache)
+        assert _is_serializable_cache([_fake_layer("KVCache"), tq]) is False
+
+
+# --------------------------------------------------------------------------
+# LoadedModel: ref-counting, properties.
+# --------------------------------------------------------------------------
+
+
+class TestLoadedModelRefs:
+    def _lm(self, **kw):
+        kw.setdefault("model", MagicMock())
+        kw.setdefault("tokenizer", MagicMock())
+        return LoadedModel(
+            name="m:latest",
+            hf_path="org/model",
+            **kw,
+        )
+
+    def test_acquire_release_ref_round_trips(self):
+        lm = self._lm()
+        assert lm.active_refs == 0
+        lm.acquire_ref()
+        lm.acquire_ref()
+        assert lm.active_refs == 2
+        lm.release_ref()
+        assert lm.active_refs == 1
+
+    def test_is_speculative_reflects_decoder(self):
+        lm = self._lm()
+        assert lm.is_speculative is False
+        lm.speculative_decoder = MagicMock()
+        assert lm.is_speculative is True
+
+    def test_text_tokenizer_unwraps_vlm_processor(self):
+        inner = MagicMock(name="inner_tok")
+        processor = MagicMock()
+        processor.tokenizer = inner
+        lm = self._lm(is_vlm=True, tokenizer=processor)
+        assert lm.text_tokenizer is inner
+
+    def test_text_tokenizer_returns_tokenizer_for_text_model(self):
+        tok = MagicMock()
+        # Even if a text tokenizer happens to expose .tokenizer, the
+        # non-VLM path must return the tokenizer itself.
+        tok.tokenizer = MagicMock()
+        lm = self._lm(is_vlm=False, tokenizer=tok)
+        assert lm.text_tokenizer is tok
+
+
+# --------------------------------------------------------------------------
+# _resolve_attention_causal: draft-checkpoint version math.
+# --------------------------------------------------------------------------
+
+
+class TestResolveAttentionCausal:
+    def test_missing_version_defaults_bidirectional(self):
+        # Absent key -> default 2 -> bidirectional (causal=False).
+        assert _resolve_attention_causal({}) is False
+
+    def test_version_2_is_bidirectional(self):
+        assert _resolve_attention_causal({"dflash_attention_version": 2}) is False
+
+    def test_version_1_is_causal_and_warns(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="olmlx.engine.model_manager"):
+            assert _resolve_attention_causal({"dflash_attention_version": 1}) is True
+        assert "causal attention" in caplog.text
+
+    def test_string_version_parsed(self):
+        # Hand-edited config storing "2" must parse as int 2.
+        assert _resolve_attention_causal({"dflash_attention_version": "2"}) is False
+
+    def test_fractional_treated_as_v1(self):
+        # 1.5 -> int(float()) == 1 -> causal (fractional values are misconfigs).
+        assert _resolve_attention_causal({"dflash_attention_version": 1.5}) is True
+
+    def test_unparseable_version_defaults_bidirectional(self):
+        assert (
+            _resolve_attention_causal({"dflash_attention_version": "nonsense"}) is False
+        )
+
+
+# --------------------------------------------------------------------------
+# _sanitize_model_config_in_place: layer_types truncation.
+# --------------------------------------------------------------------------
+
+
+class TestSanitizeModelConfig:
+    def test_truncates_excess_layer_types(self, tmp_path):
+        cfg = {
+            "num_hidden_layers": 2,
+            "layer_types": ["a", "b", "c", "d"],
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        _sanitize_model_config_in_place(tmp_path)
+        out = json.loads((tmp_path / "config.json").read_text())
+        assert out["layer_types"] == ["a", "b"]
+
+    def test_leaves_matching_layer_types_untouched(self, tmp_path):
+        cfg = {"num_hidden_layers": 2, "layer_types": ["a", "b"]}
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        _sanitize_model_config_in_place(tmp_path)
+        out = json.loads((tmp_path / "config.json").read_text())
+        assert out["layer_types"] == ["a", "b"]
+
+    def test_missing_config_is_noop(self, tmp_path):
+        # No config.json -> returns without error.
+        _sanitize_model_config_in_place(tmp_path)
+        assert not (tmp_path / "config.json").exists()
+
+    def test_invalid_json_is_noop(self, tmp_path):
+        (tmp_path / "config.json").write_text("{not valid json")
+        # Must swallow JSONDecodeError and leave the file untouched.
+        _sanitize_model_config_in_place(tmp_path)
+        assert (tmp_path / "config.json").read_text() == "{not valid json"
+
+
+# --------------------------------------------------------------------------
+# _ensure_tokenizer_eos_in_stops: #308 workaround branch coverage.
+# --------------------------------------------------------------------------
+
+
+class TestEnsureEosInStops:
+    def test_adds_inner_eos_to_stop_set(self):
+        tok = MagicMock()
+        tok.add_eos_token = MagicMock()  # callable marker
+        tok.eos_token_ids = {7}
+        tok._tokenizer = MagicMock()
+        tok._tokenizer.eos_token_id = 42
+        _ensure_tokenizer_eos_in_stops(tok)
+        assert 42 in tok.eos_token_ids
+
+    def test_non_set_stops_skips(self):
+        tok = MagicMock()
+        tok.add_eos_token = MagicMock()
+        tok.eos_token_ids = [7]  # not a set -> skip
+        tok._tokenizer = MagicMock()
+        tok._tokenizer.eos_token_id = 42
+        # Must not raise; list left unmodified.
+        _ensure_tokenizer_eos_in_stops(tok)
+        assert tok.eos_token_ids == [7]
+
+    def test_no_add_eos_token_marker_is_noop(self):
+        tok = object()  # no add_eos_token attribute
+        _ensure_tokenizer_eos_in_stops(tok)  # must not raise
+
+    def test_list_inner_eos_filters_ints(self):
+        tok = MagicMock()
+        tok.add_eos_token = MagicMock()
+        tok.eos_token_ids = set()
+        tok._tokenizer = MagicMock()
+        tok._tokenizer.eos_token_id = [1, "x", 2]
+        _ensure_tokenizer_eos_in_stops(tok)
+        assert tok.eos_token_ids == {1, 2}
+
+
+# --------------------------------------------------------------------------
+# Flash-dir detection helpers.
+# --------------------------------------------------------------------------
+
+
+class TestFlashDirDetection:
+    def test_flash_dir_none_when_no_layout(self, registry, mock_store):
+        manager = ModelManager(registry, mock_store)
+        d = mock_store.local_path("org/m")
+        d.joinpath("flash").mkdir(parents=True)
+        # Directory exists but no flash_layout.json -> None.
+        assert manager._flash_dir("org/m") is None
+
+    def test_flash_dir_returns_path_when_layout_present(self, registry, mock_store):
+        manager = ModelManager(registry, mock_store)
+        flash = mock_store.local_path("org/m") / "flash"
+        flash.mkdir(parents=True)
+        (flash / "flash_layout.json").write_text("{}")
+        assert manager._flash_dir("org/m") == flash
+
+    def test_flash_dir_none_without_store(self, registry):
+        manager = ModelManager(registry, store=None)
+        assert manager._flash_dir("org/m") is None
+
+    def test_flash_moe_dir_returns_path_when_layout_present(self, registry, mock_store):
+        manager = ModelManager(registry, mock_store)
+        moe = mock_store.local_path("org/m") / "flash_moe"
+        moe.mkdir(parents=True)
+        (moe / "flash_moe_layout.json").write_text("{}")
+        assert manager._flash_moe_dir("org/m") == moe
+
+    def test_flash_moe_dir_none_without_store(self, registry):
+        manager = ModelManager(registry, store=None)
+        assert manager._flash_moe_dir("org/m") is None
+
+
+# --------------------------------------------------------------------------
+# _check_vocab_match.
+# --------------------------------------------------------------------------
+
+
+class TestCheckVocabMatch:
+    def _model(self, vocab):
+        m = MagicMock()
+        m.args = MagicMock()
+        m.args.vocab_size = vocab
+        return m
+
+    def test_matching_vocab_ok(self):
+        ModelManager._check_vocab_match(self._model(1000), self._model(1000))
+
+    def test_mismatched_vocab_raises(self):
+        with pytest.raises(ValueError, match="vocab_size"):
+            ModelManager._check_vocab_match(self._model(1000), self._model(2000))
+
+    def test_missing_vocab_warns_and_returns(self, caplog):
+        # target.args has no vocab_size attribute path -> None -> warn+return.
+        target = MagicMock()
+        target.args = None
+        draft = self._model(1000)
+        with caplog.at_level(logging.WARNING, logger="olmlx.engine.model_manager"):
+            ModelManager._check_vocab_match(target, draft)
+        assert "Could not verify vocab" in caplog.text
+
+
+# --------------------------------------------------------------------------
+# invalidate_prompt_cache.
+# --------------------------------------------------------------------------
+
+
+class TestInvalidatePromptCache:
+    def test_removes_entry_for_loaded_model(self, mock_manager):
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.prompt_cache_store = MagicMock()
+        mock_manager.invalidate_prompt_cache("qwen3", "cache-123")
+        lm.prompt_cache_store.remove.assert_called_once_with("cache-123")
+
+    def test_noop_for_unloaded_model(self, mock_manager):
+        # Must not raise when the model isn't loaded.
+        mock_manager.invalidate_prompt_cache("not-loaded", "cache-123")
+
+
+# --------------------------------------------------------------------------
+# _load_chat_template: file-based loading branches.
+# --------------------------------------------------------------------------
+
+
+class TestLoadChatTemplate:
+    def test_keeps_existing_template(self, tmp_path):
+        tok = MagicMock()
+        tok.chat_template = "existing"
+        ModelManager._load_chat_template(tok, str(tmp_path))
+        assert tok.chat_template == "existing"
+
+    def test_loads_from_jinja(self, tmp_path):
+        tok = MagicMock()
+        tok.chat_template = None
+        (tmp_path / "chat_template.jinja").write_text("JINJA-TEMPLATE")
+        ModelManager._load_chat_template(tok, str(tmp_path))
+        assert tok.chat_template == "JINJA-TEMPLATE"
+
+    def test_loads_from_json(self, tmp_path):
+        tok = MagicMock()
+        tok.chat_template = None
+        (tmp_path / "chat_template.json").write_text(
+            json.dumps({"chat_template": "JSON-TEMPLATE"})
+        )
+        ModelManager._load_chat_template(tok, str(tmp_path))
+        assert tok.chat_template == "JSON-TEMPLATE"
+
+    def test_malformed_json_leaves_template_none(self, tmp_path):
+        tok = MagicMock()
+        tok.chat_template = None
+        (tmp_path / "chat_template.json").write_text("{not json")
+        # JSONDecodeError is swallowed; no hf_path so no hub fallback.
+        ModelManager._load_chat_template(tok, str(tmp_path))
+        assert tok.chat_template is None
+
+
+# --------------------------------------------------------------------------
+# LRU eviction ordering + active_refs protection.
+# --------------------------------------------------------------------------
+
+
+class TestLruEvictionOrdering:
+    def _add(self, manager, name, loaded_at, active_refs=0):
+        lm = LoadedModel(
+            name=name,
+            hf_path=f"org/{name}",
+            model=MagicMock(),
+            tokenizer=MagicMock(),
+            loaded_at=loaded_at,
+            active_refs=active_refs,
+        )
+        manager._loaded[name] = lm
+        return lm
+
+    def test_pop_lru_evicts_oldest_first(self, registry, mock_store, monkeypatch):
+        # limit==loaded==3: the loop pops while len >= limit, so it removes
+        # exactly one (the LRU/oldest) to drop below the limit.
+        monkeypatch.setattr("olmlx.engine.model_manager.settings.max_loaded_models", 3)
+        manager = ModelManager(registry, mock_store)
+        now = time.time()
+        self._add(manager, "old", now - 100)
+        self._add(manager, "mid", now - 50)
+        self._add(manager, "new", now - 1)
+        evictees = manager._pop_lru_evictees()
+        assert [e.name for e in evictees] == ["old"]
+        assert "old" not in manager._loaded
+        assert set(manager._loaded) == {"mid", "new"}
+
+    def test_pop_lru_skips_active_and_evicts_oldest_idle(
+        self, registry, mock_store, monkeypatch
+    ):
+        monkeypatch.setattr("olmlx.engine.model_manager.settings.max_loaded_models", 3)
+        manager = ModelManager(registry, mock_store)
+        now = time.time()
+        # Oldest model is pinned (active) -> must be protected; the next
+        # oldest idle model is evicted instead.
+        self._add(manager, "old_active", now - 100, active_refs=1)
+        self._add(manager, "mid_idle", now - 50)
+        self._add(manager, "new_idle", now - 1)
+        evictees = manager._pop_lru_evictees()
+        assert [e.name for e in evictees] == ["mid_idle"]
+        assert "old_active" in manager._loaded
+
+    def test_pop_lru_raises_when_all_active(self, registry, mock_store, monkeypatch):
+        monkeypatch.setattr("olmlx.engine.model_manager.settings.max_loaded_models", 1)
+        manager = ModelManager(registry, mock_store)
+        self._add(manager, "a", time.time(), active_refs=1)
+        self._add(manager, "b", time.time(), active_refs=1)
+        with pytest.raises(RuntimeError, match="in use"):
+            manager._pop_lru_evictees()
+
+    def test_pop_one_idle_lru_picks_oldest(self, registry, mock_store):
+        manager = ModelManager(registry, mock_store)
+        now = time.time()
+        self._add(manager, "old", now - 100)
+        self._add(manager, "new", now - 1)
+        popped = manager._pop_one_idle_lru()
+        assert popped.name == "old"
+        assert "old" not in manager._loaded
+
+    def test_pop_one_idle_lru_none_when_all_active(self, registry, mock_store):
+        manager = ModelManager(registry, mock_store)
+        self._add(manager, "a", time.time(), active_refs=2)
+        assert manager._pop_one_idle_lru() is None
+        assert "a" in manager._loaded
+
+
+# --------------------------------------------------------------------------
+# keep-alive / expiry math.
+# --------------------------------------------------------------------------
+
+
+class TestExpiryMath:
+    def _add(self, manager, name, expires_at, active_refs=0):
+        lm = LoadedModel(
+            name=name,
+            hf_path=f"org/{name}",
+            model=MagicMock(),
+            tokenizer=MagicMock(),
+            expires_at=expires_at,
+            active_refs=active_refs,
+        )
+        manager._loaded[name] = lm
+        return lm
+
+    def test_resolve_keep_alive_uses_default_when_none(self, registry, mock_store):
+        manager = ModelManager(registry, mock_store)
+        with patch("olmlx.engine.model_manager.settings.default_keep_alive", "5m"):
+            assert manager._resolve_keep_alive(None) == 300.0
+
+    def test_resolve_keep_alive_explicit_overrides_default(self, registry, mock_store):
+        manager = ModelManager(registry, mock_store)
+        assert manager._resolve_keep_alive("30s") == 30.0
+
+    async def test_expire_stale_removes_only_expired_idle(self, registry, mock_store):
+        manager = ModelManager(registry, mock_store)
+        manager._close_loaded_model = MagicMock()
+        now = time.time()
+        self._add(manager, "expired", now - 10)  # past -> expire
+        self._add(manager, "fresh", now + 1000)  # future -> keep
+        self._add(manager, "never", None)  # never-expire -> keep
+        with patch.object(manager, "_flush_metal", new_callable=AsyncMock):
+            await manager._expire_stale()
+        assert "expired" not in manager._loaded
+        assert "fresh" in manager._loaded
+        assert "never" in manager._loaded
+
+    async def test_expire_stale_skips_active_even_if_expired(
+        self, registry, mock_store
+    ):
+        manager = ModelManager(registry, mock_store)
+        manager._close_loaded_model = MagicMock()
+        now = time.time()
+        # Expired in the keep-alive sense but serving a request -> protected.
+        self._add(manager, "busy", now - 10, active_refs=1)
+        with patch.object(manager, "_flush_metal", new_callable=AsyncMock):
+            await manager._expire_stale()
+        assert "busy" in manager._loaded
+        manager._close_loaded_model.assert_not_called()
+
+    async def test_expire_stale_no_flush_when_nothing_expired(
+        self, registry, mock_store
+    ):
+        manager = ModelManager(registry, mock_store)
+        manager._close_loaded_model = MagicMock()
+        self._add(manager, "fresh", time.time() + 1000)
+        with patch.object(
+            manager, "_flush_metal", new_callable=AsyncMock
+        ) as mock_flush:
+            await manager._expire_stale()
+        # Nothing popped -> flush must be skipped.
+        mock_flush.assert_not_awaited()

--- a/tests/test_moe_weight_store_coverage.py
+++ b/tests/test_moe_weight_store_coverage.py
@@ -1,0 +1,486 @@
+"""Regression coverage for olmlx.engine.flash.moe_weight_store.
+
+Targets the per-layer LRU expert cache, pread loading, stats bookkeeping,
+the legacy (manifest-free) raw-byte parsers, and failure handling. All tests
+are hermetic: small synthetic .flashexperts bundles under tmp_path, no GPU
+model loads, no network.
+"""
+
+import json
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from olmlx.engine.flash.moe_bundler import (
+    MoeExpertLayout,
+    bundle_moe_experts,
+)
+from olmlx.engine.flash.moe_weight_store import (
+    ExpertCacheStats,
+    FlashMoeWeightStore,
+)
+from tests.test_flash_moe_bundler import _make_synthetic_moe_weights
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: real bundles built via the bundler, loaded by the store.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fp16_bundle(tmp_path):
+    """Build a non-quantized MoE bundle and return (output_dir, params)."""
+    hidden, inter, experts = 32, 16, 8
+    num_dense, num_moe = 1, 2
+    model_dir = _make_synthetic_moe_weights(
+        hidden, inter, experts, num_moe, num_dense, tmp_path
+    )
+    output_dir = tmp_path / "flash_moe"
+    bundle_moe_experts(model_dir, output_dir)
+    # MoE layers are 1 and 2 (dense layer 0 skipped).
+    return output_dir, hidden, inter, experts
+
+
+@pytest.fixture()
+def quant_bundle(tmp_path):
+    """Build a 4-bit quantized MoE bundle."""
+    hidden, inter, experts = 64, 32, 8
+    num_dense, num_moe = 0, 1
+    model_dir = _make_synthetic_moe_weights(
+        hidden, inter, experts, num_moe, num_dense, tmp_path, quantized=True
+    )
+    output_dir = tmp_path / "flash_moe_q"
+    bundle_moe_experts(model_dir, output_dir)
+    return output_dir, hidden, inter, experts
+
+
+# ---------------------------------------------------------------------------
+# load_experts: hits, misses, stacking, remap.
+# ---------------------------------------------------------------------------
+
+
+def test_load_experts_miss_then_hit_updates_stats(fp16_bundle):
+    output_dir, hidden, inter, experts = fp16_bundle
+    with FlashMoeWeightStore(
+        output_dir, num_io_threads=2, cache_budget_experts=16
+    ) as store:
+        # First call: all 3 are cold misses.
+        loaded = store.load_experts(1, [0, 1, 2])
+        snap1 = store.stats.snapshot()
+        assert snap1["load_calls"] == 1
+        assert snap1["cache_misses"] == 3
+        assert snap1["cache_hits"] == 0
+        assert snap1["load_failures"] == 0
+
+        # Shapes: stacked over the requested experts.
+        assert loaded.gate_weight.shape == (3, inter, hidden)
+        assert loaded.up_weight.shape == (3, inter, hidden)
+        assert loaded.down_weight.shape == (3, hidden, inter)
+        assert loaded.is_quantized is False
+        # fp16 experts carry no scales/biases.
+        assert loaded.gate_scales is None
+
+        # Second call: same experts are warm hits.
+        store.load_experts(1, [0, 1, 2])
+        snap2 = store.stats.snapshot()
+        assert snap2["load_calls"] == 2
+        assert snap2["cache_hits"] == 3
+        assert snap2["cache_misses"] == 3  # unchanged from first call
+        assert store.stats.hit_rate() == pytest.approx(3 / 6)
+
+
+def test_load_experts_partial_hit(fp16_bundle):
+    output_dir, _hidden, _inter, _experts = fp16_bundle
+    with FlashMoeWeightStore(
+        output_dir, num_io_threads=2, cache_budget_experts=16
+    ) as store:
+        store.load_experts(1, [0, 1])  # warm 0, 1
+        store.stats.snapshot()
+        store.load_experts(1, [1, 2, 3])  # 1 hit, 2 misses
+        snap = store.stats.snapshot()
+        assert snap["cache_hits"] == 1
+        assert snap["cache_misses"] == 2 + 2  # first call's 2 + this call's 2
+
+
+def test_remap_lut_and_index_map(fp16_bundle):
+    output_dir, _hidden, _inter, experts = fp16_bundle
+    with FlashMoeWeightStore(
+        output_dir, num_io_threads=2, cache_budget_experts=16
+    ) as store:
+        req = [5, 2, 7]
+        loaded = store.load_experts(1, req)
+        # Index map maps global expert idx -> position in requested order.
+        assert loaded.expert_index_map == {5: 0, 2: 1, 7: 2}
+        lut = np.array(loaded.remap_lut)
+        assert lut.shape == (experts,)
+        assert lut[5] == 0
+        assert lut[2] == 1
+        assert lut[7] == 2
+        # Unused entries carry the sentinel.
+        assert lut[0] == 0xFFFFFFFF
+
+
+def test_load_experts_empty_raises(fp16_bundle):
+    output_dir, *_ = fp16_bundle
+    with FlashMoeWeightStore(output_dir) as store:
+        with pytest.raises(ValueError, match="must not be empty"):
+            store.load_experts(1, [])
+
+
+def test_load_experts_preserves_request_order(fp16_bundle):
+    output_dir, _hidden, _inter, _experts = fp16_bundle
+    with FlashMoeWeightStore(
+        output_dir, num_io_threads=4, cache_budget_experts=16
+    ) as store:
+        # Load each expert individually so we can compare against a reordered
+        # batch load — stacking must follow the *requested* order, not the
+        # completion order of the parallel reads.
+        singles = {
+            i: np.array(store.load_experts(1, [i]).gate_weight[0]) for i in (3, 6, 1)
+        }
+        batch = store.load_experts(1, [6, 1, 3])
+        gw = np.array(batch.gate_weight)
+        assert np.array_equal(gw[0], singles[6])
+        assert np.array_equal(gw[1], singles[1])
+        assert np.array_equal(gw[2], singles[3])
+
+
+# ---------------------------------------------------------------------------
+# Cache eviction with a tiny budget.
+# ---------------------------------------------------------------------------
+
+
+def test_cache_eviction_with_small_budget(fp16_bundle):
+    output_dir, _hidden, _inter, _experts = fp16_bundle
+    # Budget of 2 experts per layer.
+    with FlashMoeWeightStore(
+        output_dir, num_io_threads=2, cache_budget_experts=2
+    ) as store:
+        store.load_experts(1, [0, 1])  # cache now {0, 1}
+        store.load_experts(1, [2])  # inserting 2 evicts LRU (0)
+        # Re-requesting 0 must miss again (it was evicted).
+        store.stats.snapshot()
+        store.load_experts(1, [0])
+        snap = store.stats.snapshot()
+        # 0 evicted -> cold miss again.
+        assert snap["cache_misses"] >= 3
+        # 2 is still resident -> warm hit.
+        store.load_experts(1, [2])
+        assert store.stats.snapshot()["cache_hits"] >= 1
+
+
+def test_cache_is_per_layer(fp16_bundle):
+    output_dir, _hidden, _inter, _experts = fp16_bundle
+    with FlashMoeWeightStore(
+        output_dir, num_io_threads=2, cache_budget_experts=16
+    ) as store:
+        store.load_experts(1, [0])
+        # Same expert index, different layer -> still a miss.
+        store.load_experts(2, [0])
+        snap = store.stats.snapshot()
+        assert snap["cache_misses"] == 2
+        assert snap["cache_hits"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Quantized loading.
+# ---------------------------------------------------------------------------
+
+
+def test_load_quantized_experts(quant_bundle):
+    output_dir, hidden, inter, _experts = quant_bundle
+    with FlashMoeWeightStore(
+        output_dir, num_io_threads=2, cache_budget_experts=16
+    ) as store:
+        loaded = store.load_experts(0, [0, 1])
+        assert loaded.is_quantized is True
+        assert loaded.bits == 4
+        assert loaded.group_size == 32
+        # Packed uint32 weights and float16 scales/biases must be present.
+        assert loaded.gate_weight.dtype == mx.uint32
+        assert loaded.gate_scales is not None
+        assert loaded.gate_biases is not None
+        # Scales group along the input dim: hidden // group_size for gate/up.
+        assert loaded.gate_scales.shape == (2, inter, hidden // 32)
+
+
+# ---------------------------------------------------------------------------
+# Failure path: a read that raises must count failures and re-raise first exc.
+# ---------------------------------------------------------------------------
+
+
+def test_load_failure_counts_and_raises(fp16_bundle, monkeypatch):
+    output_dir, _hidden, _inter, _experts = fp16_bundle
+    with FlashMoeWeightStore(
+        output_dir, num_io_threads=2, cache_budget_experts=16
+    ) as store:
+
+        def boom(layer_idx, expert_idx):
+            raise OSError("simulated SSD read failure")
+
+        monkeypatch.setattr(store, "_read_expert", boom)
+        with pytest.raises(OSError, match="simulated SSD read failure"):
+            store.load_experts(1, [0, 1, 2])
+        snap = store.stats.snapshot()
+        # Every requested-but-missing expert is recorded as a failure.
+        assert snap["load_failures"] == 3
+        assert snap["cache_misses"] == 3
+        assert snap["load_calls"] == 1
+
+
+# ---------------------------------------------------------------------------
+# __init__ failure cleanup when open_fds raises.
+# ---------------------------------------------------------------------------
+
+
+def test_init_open_fds_failure_calls_close(fp16_bundle, monkeypatch):
+    output_dir, *_ = fp16_bundle
+    import olmlx.engine.flash.moe_weight_store as mod
+
+    def fail_open(*_a, **_k):
+        raise OSError("cannot open fds")
+
+    monkeypatch.setattr(mod, "open_fds", fail_open)
+    with pytest.raises(OSError, match="cannot open fds"):
+        FlashMoeWeightStore(output_dir, num_io_threads=2)
+
+
+# ---------------------------------------------------------------------------
+# ExpertCacheStats unit behavior.
+# ---------------------------------------------------------------------------
+
+
+def test_stats_hit_rate_zero_when_empty():
+    stats = ExpertCacheStats()
+    assert stats.hit_rate() == 0.0
+    assert stats.snapshot() == {
+        "load_calls": 0,
+        "cache_hits": 0,
+        "cache_misses": 0,
+        "load_failures": 0,
+    }
+
+
+def test_stats_record_accumulates_and_hit_rate():
+    stats = ExpertCacheStats()
+    stats.record(hits=3, misses=1)
+    stats.record(hits=0, misses=0, failures=2)
+    snap = stats.snapshot()
+    assert snap == {
+        "load_calls": 2,
+        "cache_hits": 3,
+        "cache_misses": 1,
+        "load_failures": 2,
+    }
+    assert stats.hit_rate() == pytest.approx(3 / 4)
+
+
+# ---------------------------------------------------------------------------
+# Legacy (manifest-free) raw-byte parsers, exercised directly.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_float16_expert_roundtrip():
+    hidden, inter = 8, 4
+    rng = np.random.RandomState(0)
+    gate = rng.randn(inter, hidden).astype(np.float16)
+    up = rng.randn(inter, hidden).astype(np.float16)
+    down = rng.randn(hidden, inter).astype(np.float16)
+    raw = gate.tobytes() + up.tobytes() + down.tobytes()
+
+    out = FlashMoeWeightStore._parse_float16_expert(raw, hidden, inter)
+    assert np.array_equal(np.array(out["gate_weight"]), gate)
+    assert np.array_equal(np.array(out["up_weight"]), up)
+    assert np.array_equal(np.array(out["down_weight"]), down)
+    # All scale/bias slots are None for non-quantized.
+    for key in ("gate_scales", "up_biases", "down_bias"):
+        assert out[key] is None
+
+
+def test_parse_quantized_expert_roundtrip():
+    hidden, inter, bits, group_size = 64, 32, 4, 32
+    layout = MoeExpertLayout(
+        layer_idx=0,
+        num_experts=4,
+        hidden_size=hidden,
+        intermediate_size=inter,
+        expert_byte_size=0,
+        file_path=None,
+        offsets=np.zeros(4, dtype=np.uint64),
+        is_quantized=True,
+        bits=bits,
+        group_size=group_size,
+    )
+    gate_packed = hidden * bits // 32
+    down_packed = inter * bits // 32
+    rng = np.random.RandomState(1)
+
+    parts = []
+    expected = {}
+    for proj, out_dim, packed_dim, in_dim in (
+        ("gate", inter, gate_packed, hidden),
+        ("up", inter, gate_packed, hidden),
+        ("down", hidden, down_packed, inter),
+    ):
+        w = rng.randint(0, 2**31, (out_dim, packed_dim)).astype(np.uint32)
+        s_dim = in_dim // group_size
+        s = rng.randn(out_dim, s_dim).astype(np.float16)
+        b = rng.randn(out_dim, s_dim).astype(np.float16)
+        parts += [w.tobytes(), s.tobytes(), b.tobytes()]
+        expected[proj] = (w, s, b)
+
+    raw = b"".join(parts)
+    out = FlashMoeWeightStore._parse_quantized_expert(raw, layout)
+    for proj, (w, s, b) in expected.items():
+        assert np.array_equal(np.array(out[f"{proj}_weight"]), w)
+        assert np.array_equal(np.array(out[f"{proj}_scales"]), s)
+        assert np.array_equal(np.array(out[f"{proj}_biases"]), b)
+        assert out[f"{proj}_bias"] is None
+
+
+def test_parse_expert_with_manifest_fc_alias_and_fill():
+    # fc1/fc2 style (non-gated): fc1 -> up, fc2 -> down, gate missing -> None.
+    hidden, inter = 4, 3
+    rng = np.random.RandomState(2)
+    up = rng.randn(inter, hidden).astype(np.float16)
+    down = rng.randn(hidden, inter).astype(np.float16)
+    raw = up.tobytes() + down.tobytes()
+    manifest = [
+        {
+            "name": "fc1.weight",
+            "shape": [inter, hidden],
+            "dtype": "float16",
+            "nbytes": up.nbytes,
+        },
+        {
+            "name": "fc2.weight",
+            "shape": [hidden, inter],
+            "dtype": "float16",
+            "nbytes": down.nbytes,
+        },
+    ]
+    out = FlashMoeWeightStore._parse_expert_with_manifest(raw, manifest)
+    assert np.array_equal(np.array(out["up_weight"]), up)
+    assert np.array_equal(np.array(out["down_weight"]), down)
+    # gate_* never present in fc1/fc2 -> filled with None.
+    assert out["gate_weight"] is None
+    # Missing scales/biases filled for present projections too.
+    assert out["up_scales"] is None
+    assert out["down_bias"] is None
+
+
+def test_parse_expert_with_manifest_proj_suffix_stripping():
+    # gate_proj.scales -> "gate_scales", verifying _proj suffix stripping.
+    hidden, inter, group_size = 8, 4, 8
+    rng = np.random.RandomState(3)
+    scales = rng.randn(inter, hidden // group_size).astype(np.float16)
+    raw = scales.tobytes()
+    manifest = [
+        {
+            "name": "gate_proj.scales",
+            "shape": [inter, hidden // group_size],
+            "dtype": "float16",
+            "nbytes": scales.nbytes,
+        }
+    ]
+    out = FlashMoeWeightStore._parse_expert_with_manifest(raw, manifest)
+    assert np.array_equal(np.array(out["gate_scales"]), scales)
+    assert out["gate_weight"] is None
+
+
+def test_parse_expert_with_manifest_unsupported_dtype():
+    manifest = [
+        {"name": "gate_proj.weight", "shape": [1], "dtype": "bogus64", "nbytes": 8}
+    ]
+    with pytest.raises(ValueError, match="Unsupported dtype"):
+        FlashMoeWeightStore._parse_expert_with_manifest(b"\x00" * 8, manifest)
+
+
+# ---------------------------------------------------------------------------
+# Legacy _read_expert dispatch (no manifest) — float16 path.
+# ---------------------------------------------------------------------------
+
+
+def test_read_expert_legacy_float16_path(fp16_bundle, monkeypatch):
+    """When a layout has no manifest and the store has no global manifest,
+    _read_expert falls back to _parse_float16_expert."""
+    output_dir, hidden, inter, _experts = fp16_bundle
+    with FlashMoeWeightStore(
+        output_dir, num_io_threads=2, cache_budget_experts=16
+    ) as store:
+        # Strip manifests so the legacy float16 branch is taken.
+        store._manifest = None
+        for layout in store._layouts.values():
+            layout.manifest = None
+            layout.is_quantized = False
+        out = store._read_expert(1, 0)
+        assert np.array(out["gate_weight"]).shape == (inter, hidden)
+        assert out["gate_scales"] is None
+
+
+def test_read_expert_legacy_quantized_path(quant_bundle):
+    """No manifest + is_quantized -> _parse_quantized_expert branch."""
+    output_dir, hidden, inter, _experts = quant_bundle
+    with FlashMoeWeightStore(
+        output_dir, num_io_threads=2, cache_budget_experts=16
+    ) as store:
+        store._manifest = None
+        for layout in store._layouts.values():
+            layout.manifest = None
+        out = store._read_expert(0, 0)
+        assert np.array(out["gate_weight"]).dtype == np.uint32
+        assert np.array(out["gate_scales"]).shape == (inter, hidden // 32)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: close / context manager / __del__.
+# ---------------------------------------------------------------------------
+
+
+def test_close_releases_fds(fp16_bundle):
+    output_dir, *_ = fp16_bundle
+    store = FlashMoeWeightStore(output_dir, num_io_threads=2)
+    fds = dict(store._fds)
+    assert fds  # opened some
+    store.close()
+    # close_fds clears the mapping.
+    assert store._fds == {}
+    # File descriptors are actually closed.
+    import os
+
+    for fd in fds.values():
+        with pytest.raises(OSError):
+            os.fstat(fd)
+
+
+def test_context_manager_enter_returns_self(fp16_bundle):
+    output_dir, *_ = fp16_bundle
+    store = FlashMoeWeightStore(output_dir, num_io_threads=2)
+    with store as ctx:
+        assert ctx is store
+    assert store._fds == {}
+
+
+def test_del_does_not_raise(fp16_bundle):
+    output_dir, *_ = fp16_bundle
+    store = FlashMoeWeightStore(output_dir, num_io_threads=2)
+    # Explicitly invoke the finalizer; must be idempotent / non-raising.
+    store.__del__()
+    assert store._fds == {}
+
+
+# ---------------------------------------------------------------------------
+# quant_mode propagation through the layout config.
+# ---------------------------------------------------------------------------
+
+
+def test_quant_mode_default_affine(fp16_bundle):
+    output_dir, *_ = fp16_bundle
+    # Default quant_mode is "affine" when not specified.
+    layout_cfg = json.loads((output_dir / "flash_moe_layout.json").read_text())
+    assert layout_cfg.get("quant_mode", "affine") == "affine"
+    with FlashMoeWeightStore(output_dir, num_io_threads=2) as store:
+        assert store._quant_mode == "affine"
+        loaded = store.load_experts(1, [0])
+        assert loaded.quant_mode == "affine"

--- a/tests/test_routers_blobs_coverage.py
+++ b/tests/test_routers_blobs_coverage.py
@@ -1,0 +1,327 @@
+"""Regression coverage for olmlx.routers.blobs.
+
+Targets the Ollama /api/blobs HEAD/POST endpoints: digest validation, the
+Content-Length and streamed-size 413 guards, digest-mismatch, the success
+path (201 + on-disk blob), and HEAD presence checks.
+"""
+
+import hashlib
+import types
+from pathlib import Path
+
+import pytest
+
+from olmlx.routers import blobs as blobs_mod
+
+
+def _digest(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+class _FakeStore:
+    """Minimal stand-in for ModelStore exposing models_dir + has_blob."""
+
+    def __init__(self, models_dir: Path):
+        self.models_dir = models_dir
+
+    def has_blob(self, digest: str) -> bool:
+        return (self.models_dir / "blobs" / digest).exists()
+
+
+def _make_request(store, headers, chunks):
+    """Build a fake starlette Request that drives upload_blob's loop directly.
+
+    Calling the endpoint coroutine in-process (rather than through ASGI
+    streaming) lets coverage trace the ``async for chunk in request.stream()``
+    body that the TestClient path leaves untraced.
+    """
+
+    async def stream():
+        for chunk in chunks:
+            yield chunk
+
+    app = types.SimpleNamespace(state=types.SimpleNamespace(model_store=store))
+    return types.SimpleNamespace(app=app, headers=headers, stream=stream)
+
+
+class TestCheckBlob:
+    async def test_head_missing_blob_returns_404(self, app_client):
+        # 64 hex chars but no such blob on disk.
+        digest = "sha256:" + "0" * 64
+        resp = await app_client.head(f"/api/blobs/{digest}")
+        assert resp.status_code == 404
+
+    async def test_head_present_blob_returns_200(self, app_client, mock_store):
+        data = b"present-blob-payload"
+        digest = _digest(data)
+        blobs_dir = mock_store.models_dir / "blobs"
+        blobs_dir.mkdir(parents=True, exist_ok=True)
+        (blobs_dir / digest).write_bytes(data)
+
+        resp = await app_client.head(f"/api/blobs/{digest}")
+        assert resp.status_code == 200
+
+
+class TestUploadDigestValidation:
+    async def test_invalid_digest_format_returns_400(self, app_client):
+        # Missing sha256: prefix / not 64 hex chars.
+        resp = await app_client.post("/api/blobs/not-a-digest", content=b"x")
+        assert resp.status_code == 400
+        assert resp.json() == {"error": "invalid digest format"}
+
+    async def test_uppercase_hex_digest_rejected(self, app_client):
+        # Regex requires lowercase hex; uppercase must be rejected.
+        digest = "sha256:" + "A" * 64
+        resp = await app_client.post(f"/api/blobs/{digest}", content=b"x")
+        assert resp.status_code == 400
+        assert resp.json()["error"] == "invalid digest format"
+
+    async def test_short_hex_digest_rejected(self, app_client):
+        digest = "sha256:" + "0" * 63
+        resp = await app_client.post(f"/api/blobs/{digest}", content=b"x")
+        assert resp.status_code == 400
+
+
+class TestUploadSuccess:
+    async def test_upload_writes_blob_and_returns_201(self, app_client, mock_store):
+        data = b"hello world blob"
+        digest = _digest(data)
+
+        resp = await app_client.post(f"/api/blobs/{digest}", content=data)
+        assert resp.status_code == 201
+
+        # Blob landed under models_dir/blobs/<digest> with exact bytes.
+        blob_path = mock_store.models_dir / "blobs" / digest
+        assert blob_path.exists()
+        assert blob_path.read_bytes() == data
+
+        # And HEAD now reports it present.
+        head = await app_client.head(f"/api/blobs/{digest}")
+        assert head.status_code == 200
+
+    async def test_upload_empty_blob_success(self, app_client, mock_store):
+        data = b""
+        digest = _digest(data)
+
+        resp = await app_client.post(f"/api/blobs/{digest}", content=data)
+        assert resp.status_code == 201
+        assert (mock_store.models_dir / "blobs" / digest).read_bytes() == b""
+
+    async def test_upload_multichunk_blob_success(self, app_client, mock_store):
+        # Large-ish payload so httpx streams it as several chunks, exercising
+        # the async-for accumulation loop more than once.
+        data = b"abc123" * 100_000  # ~600 KB
+        digest = _digest(data)
+
+        resp = await app_client.post(f"/api/blobs/{digest}", content=data)
+        assert resp.status_code == 201
+        assert (mock_store.models_dir / "blobs" / digest).read_bytes() == data
+
+    async def test_blobs_dir_created_when_absent(self, app_client, mock_store):
+        # Upload path must mkdir(parents=True) the blobs dir itself.
+        blobs_dir = mock_store.models_dir / "blobs"
+        assert not blobs_dir.exists()
+
+        data = b"creates the dir"
+        digest = _digest(data)
+        resp = await app_client.post(f"/api/blobs/{digest}", content=data)
+        assert resp.status_code == 201
+        assert blobs_dir.is_dir()
+
+
+class TestUploadDigestMismatch:
+    async def test_digest_mismatch_returns_400_and_no_blob(
+        self, app_client, mock_store
+    ):
+        # Well-formed digest, but the body hashes to something else.
+        claimed = "sha256:" + "1" * 64
+        body = b"this body does not match the claimed digest"
+        resp = await app_client.post(f"/api/blobs/{claimed}", content=body)
+
+        assert resp.status_code == 400
+        assert resp.json() == {"error": "digest mismatch"}
+
+        # Mismatched temp file must be unlinked; nothing left under blobs/.
+        blobs_dir = mock_store.models_dir / "blobs"
+        leftovers = list(blobs_dir.iterdir()) if blobs_dir.exists() else []
+        assert leftovers == []
+
+    async def test_digest_mismatch_leaves_no_partial_named_blob(
+        self, app_client, mock_store
+    ):
+        claimed = "sha256:" + "2" * 64
+        resp = await app_client.post(f"/api/blobs/{claimed}", content=b"abc")
+        assert resp.status_code == 400
+        assert not (mock_store.models_dir / "blobs" / claimed).exists()
+
+
+class TestContentLengthGuard:
+    async def test_content_length_over_limit_returns_413_fast_path(
+        self, app_client, mock_store
+    ):
+        digest = "sha256:" + "3" * 64
+        oversize = blobs_mod.MAX_BLOB_SIZE + 1
+        # Send a small body but lie about Content-Length so the fast-path
+        # rejects before reading the stream.
+        resp = await app_client.post(
+            f"/api/blobs/{digest}",
+            content=b"tiny",
+            headers={"content-length": str(oversize)},
+        )
+        assert resp.status_code == 413
+        assert "blob too large" in resp.json()["error"]
+        # No blobs dir work should have produced a stored blob.
+        assert not (mock_store.models_dir / "blobs" / digest).exists()
+
+    async def test_malformed_content_length_treated_as_zero(
+        self, app_client, mock_store
+    ):
+        # A non-integer Content-Length triggers the ValueError branch (cl=0),
+        # so the upload proceeds normally based on the actual body.
+        data = b"normal payload despite bad header"
+        digest = _digest(data)
+        resp = await app_client.post(
+            f"/api/blobs/{digest}",
+            content=data,
+            headers={"content-length": "not-a-number"},
+        )
+        # httpx may recompute content-length; the key behavior is that a bad
+        # value does not crash and the upload completes.
+        assert resp.status_code == 201
+        assert (mock_store.models_dir / "blobs" / digest).read_bytes() == data
+
+
+class TestStreamedSizeGuard:
+    async def test_streamed_body_over_limit_returns_413(
+        self, app_client, mock_store, monkeypatch
+    ):
+        # Shrink the cap so a modest body trips the streamed-size guard
+        # (received > MAX_BLOB_SIZE) without lying about Content-Length.
+        monkeypatch.setattr(blobs_mod, "MAX_BLOB_SIZE", 8)
+        digest = "sha256:" + "4" * 64
+        resp = await app_client.post(
+            f"/api/blobs/{digest}",
+            content=b"0123456789abcdef",  # 16 bytes > 8
+        )
+        assert resp.status_code == 413
+        assert "blob too large" in resp.json()["error"]
+        # Temp file from the aborted stream must be cleaned up.
+        blobs_dir = mock_store.models_dir / "blobs"
+        leftovers = list(blobs_dir.iterdir()) if blobs_dir.exists() else []
+        assert leftovers == []
+
+
+class TestFdopenFailure:
+    async def test_fdopen_failure_closes_fd_and_propagates(
+        self, app_client, monkeypatch
+    ):
+        # Force os.fdopen to raise so the except branch closes the raw fd and
+        # re-raises (surfaced as a 500 by TestClient with raise_app_exceptions
+        # off). Track that os.close was invoked on the leaked descriptor.
+        closed = []
+        real_close = blobs_mod.os.close
+
+        def fake_close(fd):
+            closed.append(fd)
+            return real_close(fd)
+
+        def boom_fdopen(fd, mode):
+            raise OSError("fdopen failed")
+
+        monkeypatch.setattr(blobs_mod.os, "fdopen", boom_fdopen)
+        monkeypatch.setattr(blobs_mod.os, "close", fake_close)
+
+        digest = "sha256:" + "5" * 64
+        resp = await app_client.post(f"/api/blobs/{digest}", content=b"data")
+
+        assert resp.status_code == 500
+        # The fd opened by mkstemp must have been explicitly closed.
+        assert closed, "expected os.close to run on the orphaned fd"
+
+
+class TestUploadBlobDirect:
+    """Drive the endpoint coroutine in-process to exercise the stream loop."""
+
+    async def test_direct_success_writes_blob_returns_201(self, tmp_path):
+        store = _FakeStore(tmp_path / "models")
+        data = b"direct-path-payload-spanning-chunks"
+        digest = _digest(data)
+        # Split into several chunks to loop multiple times.
+        chunks = [data[i : i + 7] for i in range(0, len(data), 7)]
+
+        resp = await blobs_mod.upload_blob(digest, _make_request(store, {}, chunks))
+        assert resp.status_code == 201
+
+        blob_path = store.models_dir / "blobs" / digest
+        assert blob_path.read_bytes() == data
+
+    async def test_direct_digest_mismatch_returns_400(self, tmp_path):
+        store = _FakeStore(tmp_path / "models")
+        claimed = "sha256:" + "9" * 64
+        resp = await blobs_mod.upload_blob(
+            claimed, _make_request(store, {}, [b"abc", b"def"])
+        )
+        assert resp.status_code == 400
+        assert resp.body == b'{"error":"digest mismatch"}'
+        # Temp file removed; no stored blob.
+        blobs_dir = store.models_dir / "blobs"
+        assert list(blobs_dir.iterdir()) == []
+
+    async def test_direct_streamed_size_limit_returns_413(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(blobs_mod, "MAX_BLOB_SIZE", 4)
+        store = _FakeStore(tmp_path / "models")
+        digest = "sha256:" + "8" * 64
+        resp = await blobs_mod.upload_blob(
+            digest, _make_request(store, {}, [b"12", b"345"])
+        )
+        assert resp.status_code == 413
+        # Aborted temp file cleaned up.
+        blobs_dir = store.models_dir / "blobs"
+        assert list(blobs_dir.iterdir()) == []
+
+    async def test_direct_streamed_413_swallows_unlink_oserror(
+        self, tmp_path, monkeypatch
+    ):
+        # When the over-limit cleanup unlink itself fails, the OSError is
+        # swallowed and a 413 is still returned (lines 62-63).
+        monkeypatch.setattr(blobs_mod, "MAX_BLOB_SIZE", 4)
+        store = _FakeStore(tmp_path / "models")
+
+        def boom_unlink(path):
+            raise OSError("cannot unlink")
+
+        monkeypatch.setattr(blobs_mod.os, "unlink", boom_unlink)
+        digest = "sha256:" + "6" * 64
+        resp = await blobs_mod.upload_blob(
+            digest, _make_request(store, {}, [b"12345678"])
+        )
+        assert resp.status_code == 413
+
+    async def test_direct_content_length_fast_path_413(self, tmp_path):
+        store = _FakeStore(tmp_path / "models")
+        digest = "sha256:" + "7" * 64
+        headers = {"content-length": str(blobs_mod.MAX_BLOB_SIZE + 1)}
+        resp = await blobs_mod.upload_blob(
+            digest, _make_request(store, headers, [b"x"])
+        )
+        assert resp.status_code == 413
+        # Fast-path rejects before creating the blobs dir.
+        assert not (store.models_dir / "blobs").exists()
+
+
+class TestDigestRegex:
+    def test_digest_regex_accepts_canonical_form(self):
+        assert blobs_mod._DIGEST_RE.match("sha256:" + "a" * 64)
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "sha256:" + "a" * 63,
+            "sha256:" + "a" * 65,
+            "sha512:" + "a" * 64,
+            "sha256:" + "g" * 64,
+            "a" * 64,
+        ],
+    )
+    def test_digest_regex_rejects_malformed(self, bad):
+        assert blobs_mod._DIGEST_RE.match(bad) is None

--- a/tests/test_self_speculative_coverage.py
+++ b/tests/test_self_speculative_coverage.py
@@ -1,0 +1,482 @@
+"""Regression coverage for the LayerSkip self-speculative decoder
+(``olmlx.engine.self_speculative.decoder``).
+
+The decoder uses the target model's own early layers as an
+autoregressive draft, then verifies with the full model. These tests
+build stub MLX models (no real weights, no GPU dependence beyond MLX's
+CPU eval) that satisfy the module's path-probing for ``embed_tokens`` /
+``norm`` / ``lm_head`` and the trimmable-KVCache contract, so we can
+drive prefill/step/reset/stats bookkeeping and the constructor guards
+without a real model load.
+
+The single ``step()``/full-generation paths that require a *real* model
+(numerically meaningful acceptance behaviour on production weights) are
+covered structurally here; correctness on real weights is out of scope
+for a hermetic unit test and noted in the summary.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+import olmlx.engine.self_speculative.decoder as ssd
+from olmlx.engine.self_speculative.decoder import (
+    SelfSpeculativeDecoder,
+    _eval_cache,
+    _find_module,
+    _logits,
+)
+
+# Reuse the cache-backed mock layer from the flash-speculative suite so
+# the trimmable-KVCache probe in the constructor passes.
+from tests.test_flash_speculative import MockLayer
+
+
+@pytest.fixture(autouse=True)
+def _seed_mlx_rng():
+    """Pin MLX's global RNG before every test.
+
+    The stub models below initialise their weights randomly, so a few
+    tests (notably the rejection-trim path, which needs the draft to
+    *diverge* from the forced verify token) depend on the RNG state.
+    Without this, the outcome leaks across tests: an earlier test in the
+    full suite can leave the RNG in a state where the draft coincidentally
+    agrees, flipping a rejection into full acceptance. Seeding here makes
+    the file deterministic and order-independent.
+    """
+    mx.random.seed(0)
+
+
+class _SelfSpecModel(nn.Module):
+    """Stub target whose attribute layout matches the decoder's path
+    probing: top-level ``embed_tokens`` / ``norm`` / ``lm_head`` and a
+    ``layers`` list (found by ``get_model_layers`` via ``.layers``).
+
+    ``MockLayer`` writes the input straight into a trimmable ``KVCache``
+    so ``make_prompt_cache`` yields one trimmable cache per layer and the
+    constructor's non-trimmable guard does not fire.
+    """
+
+    def __init__(self, vocab_size: int, hidden_size: int, num_layers: int = 4):
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.embed_tokens = nn.Embedding(vocab_size, hidden_size)
+        self.layers = [MockLayer(hidden_size) for _ in range(num_layers)]
+        self.norm = nn.RMSNorm(hidden_size)
+        self.lm_head = nn.Linear(hidden_size, vocab_size, bias=False)
+
+    def __call__(self, input_ids: mx.array, cache=None):
+        h = self.embed_tokens(input_ids)
+        for i, layer in enumerate(self.layers):
+            h = layer(h, cache=cache[i] if cache is not None else None)
+        return self.lm_head(self.norm(h))
+
+
+class _TiedEmbedModel(nn.Module):
+    """Stub with no ``lm_head`` but an ``embed_tokens`` that exposes
+    ``as_linear`` — exercises the tied-embeddings fallback branch."""
+
+    def __init__(self, vocab_size: int, hidden_size: int, num_layers: int = 3):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(vocab_size, hidden_size)
+        self.layers = [MockLayer(hidden_size) for _ in range(num_layers)]
+        self.norm = nn.RMSNorm(hidden_size)
+
+    def __call__(self, input_ids: mx.array, cache=None):
+        h = self.embed_tokens(input_ids)
+        for i, layer in enumerate(self.layers):
+            h = layer(h, cache=cache[i] if cache is not None else None)
+        # Tied head: project hidden back through the embedding matrix.
+        return self.embed_tokens.as_linear(self.norm(h))
+
+
+@pytest.fixture()
+def model():
+    return _SelfSpecModel(vocab_size=16, hidden_size=8, num_layers=4)
+
+
+@pytest.fixture()
+def decoder(model):
+    return SelfSpeculativeDecoder(
+        target_model=model,
+        num_early_layers=2,
+        num_speculative_tokens=3,
+    )
+
+
+# ----------------------------------------------------------------------
+# Module-level helpers
+# ----------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_find_module_first_path_wins(self):
+        class Holder:
+            pass
+
+        m = Holder()
+        m.embed_tokens = "top"
+        m.model = Holder()
+        m.model.embed_tokens = "nested"
+        paths = (("embed_tokens",), ("model", "embed_tokens"))
+        assert _find_module(m, paths) == "top"
+
+    def test_find_module_falls_through_to_nested(self):
+        class Holder:
+            pass
+
+        m = Holder()
+        m.model = Holder()
+        m.model.embed_tokens = "nested"
+        paths = (("embed_tokens",), ("model", "embed_tokens"))
+        assert _find_module(m, paths) == "nested"
+
+    def test_find_module_returns_none_when_absent(self):
+        class Holder:
+            pass
+
+        assert _find_module(Holder(), (("missing",), ("a", "b"))) is None
+
+    def test_logits_prefers_logits_attr(self):
+        class Out:
+            logits = mx.array([1.0, 2.0])
+
+        assert mx.allclose(_logits(Out()), mx.array([1.0, 2.0]))
+
+    def test_logits_passthrough_when_no_attr(self):
+        arr = mx.array([3.0, 4.0])
+        assert _logits(arr) is arr
+
+
+class TestEvalCache:
+    """Branch coverage for the cache-materialisation helper in this module
+    (a near-copy of speculative._eval_cache). Each supported cache shape
+    must surface its arrays so pass-1 KV state is forced before pass-2."""
+
+    def test_keys_values_as_arrays(self):
+        class C:
+            keys = mx.zeros((2, 2)) + 1.0
+            values = mx.zeros((2, 2)) + 2.0
+
+        # Should not raise; arrays remain valid after eval.
+        _eval_cache([C()])
+        assert mx.allclose(C.keys, mx.ones((2, 2)))
+
+    def test_keys_values_as_lists(self):
+        class C:
+            keys = [mx.zeros((2, 2)) + 1.0, "not-an-array"]
+            values = (mx.zeros((2, 2)) + 2.0,)
+
+        _eval_cache([C()])  # exercises the list/tuple extend branches
+
+    def test_state_branch_when_no_keys_values(self):
+        class C:
+            keys = None
+            values = None
+            state = [mx.zeros((2, 2)) + 3.0, None]
+
+        _eval_cache([C()])  # exercises the .state branch
+
+    def test_dequant_side_buffers(self):
+        class C:
+            keys = None
+            values = None
+            state = None
+            _key_dequant = mx.zeros((2, 2)) + 0.5
+            _value_dequant = mx.zeros((2, 2)) + 0.25
+
+        _eval_cache([C()])  # exercises the dequant-probe branch
+
+    def test_empty_cache_is_noop(self):
+        _eval_cache([])  # arrs stays empty; mx.eval not called
+
+
+# ----------------------------------------------------------------------
+# Constructor / guards
+# ----------------------------------------------------------------------
+
+
+class TestConstructor:
+    def test_init_records_layer_counts_and_modules(self, decoder, model):
+        assert decoder._total_layers == 4
+        assert decoder._N == 2
+        assert decoder._lambda == 3
+        assert decoder._embed is model.embed_tokens
+        assert decoder._norm is model.norm
+        assert decoder._lm_head is model.lm_head
+
+    def test_init_rejects_zero_speculative_tokens(self, model):
+        with pytest.raises(ValueError, match="num_speculative_tokens"):
+            SelfSpeculativeDecoder(model, num_early_layers=2, num_speculative_tokens=0)
+
+    def test_init_rejects_early_layers_below_one(self, model):
+        with pytest.raises(ValueError, match="num_early_layers"):
+            SelfSpeculativeDecoder(model, num_early_layers=0)
+
+    def test_init_rejects_early_layers_at_or_above_total(self, model):
+        # num_early_layers == total_layers is out of [1, total-1].
+        with pytest.raises(ValueError, match="num_early_layers"):
+            SelfSpeculativeDecoder(model, num_early_layers=4)
+
+    def test_init_tied_embedding_fallback_for_lm_head(self):
+        m = _TiedEmbedModel(vocab_size=16, hidden_size=8, num_layers=3)
+        dec = SelfSpeculativeDecoder(m, num_early_layers=1, num_speculative_tokens=2)
+        # Fallback assigned the embedding's as_linear callable as lm_head.
+        # (as_linear is a bound method, so a fresh object per access — assert
+        # behaviour, not identity.)
+        assert callable(dec._lm_head)
+        h = mx.zeros((1, 1, 8))
+        assert dec._lm_head(h).shape == (1, 1, 16)
+        # And the decoder drives end-to-end on a tied-head model.
+        dec.prefill(mx.array([[1, 2, 3]]))
+        accepted, _ = dec.step()
+        assert len(accepted) >= 1
+
+    def test_init_missing_embed_raises(self):
+        class NoEmbed(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = [MockLayer(8) for _ in range(3)]
+                self.norm = nn.RMSNorm(8)
+                self.lm_head = nn.Linear(8, 16, bias=False)
+
+        with pytest.raises(ValueError, match="embed_tokens"):
+            SelfSpeculativeDecoder(NoEmbed(), num_early_layers=1)
+
+    def test_init_missing_norm_raises(self):
+        class NoNorm(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.embed_tokens = nn.Embedding(16, 8)
+                self.layers = [MockLayer(8) for _ in range(3)]
+                self.lm_head = nn.Linear(8, 16, bias=False)
+
+        with pytest.raises(ValueError, match="norm"):
+            SelfSpeculativeDecoder(NoNorm(), num_early_layers=1)
+
+    def test_init_rejects_gdn_hybrid_target(self, model, monkeypatch):
+        # If find_gdn_class reports a GDN layer, the constructor must
+        # refuse the model (ArraysCache RNN-state can't be rolled back).
+        class _FakeGDN:
+            __module__ = "fake.mod"
+            __name__ = "GatedDeltaNet"
+
+        monkeypatch.setattr(ssd, "find_gdn_class", lambda m: _FakeGDN)
+        with pytest.raises(NotImplementedError, match="linear-attention"):
+            SelfSpeculativeDecoder(model, num_early_layers=2)
+
+    def test_init_rejects_non_trimmable_early_cache(self, model, monkeypatch):
+        # A cache whose early entries lack a callable trim() must be
+        # rejected (RotatingKVCache / ChunkedKVCache in issue #343).
+        class _NoTrim:
+            trim = None  # not callable
+
+        monkeypatch.setattr(
+            ssd, "make_prompt_cache", lambda m: [_NoTrim() for _ in range(4)]
+        )
+        with pytest.raises(NotImplementedError, match="non-trimmable"):
+            SelfSpeculativeDecoder(model, num_early_layers=2)
+
+    def test_init_rejects_when_mlx_cache_helpers_unavailable(self, model, monkeypatch):
+        # The module captures make_prompt_cache/trim_prompt_cache at import;
+        # if either is None, construction must raise RuntimeError.
+        monkeypatch.setattr(ssd, "make_prompt_cache", None)
+        with pytest.raises(RuntimeError, match="mlx_lm.models.cache"):
+            SelfSpeculativeDecoder(model, num_early_layers=2)
+
+    def test_init_missing_lm_head_without_tied_raises(self):
+        # embed_tokens without as_linear and no lm_head -> ValueError.
+        class PlainEmbed:
+            pass
+
+        class NoHead(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = [MockLayer(8) for _ in range(3)]
+                self.norm = nn.RMSNorm(8)
+
+            # embed_tokens is a plain object lacking as_linear.
+            embed_tokens = PlainEmbed()
+
+        with pytest.raises(ValueError, match="lm_head"):
+            SelfSpeculativeDecoder(NoHead(), num_early_layers=1)
+
+
+# ----------------------------------------------------------------------
+# Lifecycle: prefill / reset / stats
+# ----------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_prefill_returns_int_token_and_populates_state(self, decoder):
+        prompt = mx.array([[1, 2, 3, 4, 5]])
+        tok = decoder.prefill(prompt)
+        assert isinstance(tok, int)
+        assert 0 <= tok < 16
+        assert decoder._cache is not None
+        # One cache entry per layer.
+        assert len(decoder._cache) == decoder._total_layers
+        assert decoder._prompt_len == 5
+        assert decoder._pending_token == tok
+        assert decoder._last_logit is not None
+
+    def test_prefill_resets_vlm_rope_state(self):
+        # VLM targets (mlx-vlm 0.4.4) cache _position_ids / _rope_deltas;
+        # prefill must clear them so a fresh request starts from scratch.
+        m = _SelfSpecModel(vocab_size=16, hidden_size=8, num_layers=4)
+        m._position_ids = mx.array([[1, 2, 3]])
+        m._rope_deltas = mx.array(5)
+        dec = SelfSpeculativeDecoder(m, num_early_layers=2)
+        dec.prefill(mx.array([[1, 2, 3]]))
+        assert m._position_ids is None
+        assert m._rope_deltas is None
+
+    def test_prefill_single_token_prompt(self, decoder):
+        # Exercises the prompt.shape[1] <= 1 branch in _prefill_last_logit.
+        tok = decoder.prefill(mx.array([[7]]))
+        assert 0 <= tok < 16
+        assert decoder._prompt_len == 1
+
+    def test_prefill_resets_prior_stats(self, decoder):
+        decoder.prefill(mx.array([[1, 2, 3]]))
+        decoder.step()
+        assert decoder._stats_steps == 1
+        # A fresh prefill clears accumulated stats.
+        decoder.prefill(mx.array([[4, 5, 6]]))
+        assert decoder._stats_steps == 0
+        assert decoder._stats_proposed == 0
+        assert decoder._stats_accepted_draft == 0
+
+    def test_reset_clears_all_state(self, decoder):
+        decoder.prefill(mx.array([[1, 2, 3]]))
+        decoder.step()
+        decoder.reset()
+        assert decoder._cache is None
+        assert decoder._last_logit is None
+        assert decoder._pending_token is None
+        assert decoder._prompt_len == 0
+        assert decoder._stats_steps == 0
+        assert decoder._stats_proposed == 0
+        assert decoder._stats_accepted_draft == 0
+
+    def test_close_is_noop(self, decoder):
+        # close() must not raise and must not disturb state.
+        decoder.prefill(mx.array([[1, 2, 3]]))
+        decoder.close()
+        assert decoder._cache is not None
+
+    def test_step_before_prefill_raises(self, decoder):
+        with pytest.raises(AssertionError):
+            decoder.step()
+
+    def test_stats_summary_zero_before_steps(self, decoder):
+        summary = decoder.stats_summary()
+        assert summary["steps"] == 0
+        assert summary["proposed"] == 0
+        assert summary["accepted_draft"] == 0
+        # Division-by-zero guards return 0.0, not NaN/raise.
+        assert summary["acceptance_rate"] == 0.0
+        assert summary["avg_tokens_per_step"] == 0.0
+        assert summary["lambda"] == 3
+
+
+# ----------------------------------------------------------------------
+# step(): bookkeeping and cache-length invariant
+# ----------------------------------------------------------------------
+
+
+class TestStep:
+    def test_step_returns_accepted_and_lambda(self, decoder):
+        decoder.prefill(mx.array([[1, 2, 3]]))
+        accepted, num_draft = decoder.step()
+        assert num_draft == 3  # == lambda
+        assert len(accepted) >= 1  # greedy accept guarantees at least 1
+        assert all(isinstance(t, int) for t in accepted)
+
+    def test_cache_length_invariant_after_step(self, decoder):
+        # After each step the cache holds exactly _prompt_len entries on
+        # every layer (prompt + accepted tokens; pending excluded).
+        decoder.prefill(mx.array([[1, 2, 3, 4]]))
+        accepted, _ = decoder.step()
+        for c in decoder._cache:
+            assert c.offset == decoder._prompt_len
+
+    def test_prompt_len_grows_by_num_accepted(self, decoder):
+        decoder.prefill(mx.array([[1, 2, 3]]))
+        before = decoder._prompt_len
+        accepted, _ = decoder.step()
+        assert decoder._prompt_len == before + len(accepted)
+
+    def test_stats_accumulate_across_steps(self, decoder):
+        decoder.prefill(mx.array([[1, 2, 3]]))
+        decoder.step()
+        decoder.step()
+        assert decoder._stats_steps == 2
+        # proposed grows by lambda each step.
+        assert decoder._stats_proposed == 2 * decoder._lambda
+        summary = decoder.stats_summary()
+        assert summary["steps"] == 2
+        assert summary["avg_tokens_per_step"] >= 1.0
+
+    def test_acceptance_ema_stays_in_unit_range(self, decoder):
+        decoder.prefill(mx.array([[1, 2, 3]]))
+        for _ in range(4):
+            decoder.step()
+            assert 0.0 <= decoder._alpha <= 1.0
+
+    def test_multi_step_keeps_cache_invariant(self, decoder):
+        decoder.prefill(mx.array([[1, 2, 3, 4, 5]]))
+        for _ in range(5):
+            accepted, _ = decoder.step()
+            assert len(accepted) >= 1
+            for c in decoder._cache:
+                assert c.offset == decoder._prompt_len
+
+    def test_pending_token_in_range_after_step(self, decoder):
+        decoder.prefill(mx.array([[1, 2, 3]]))
+        decoder.step()
+        assert isinstance(decoder._pending_token, int)
+        assert 0 <= decoder._pending_token < 16
+
+    def test_rejection_trims_cache_and_keeps_invariant(self):
+        # Force the full-model verify to disagree with the early-layer
+        # draft so >=1 draft token is rejected and the rejection-trim
+        # path (trim_count > 0) runs. The full forward always argmaxes to
+        # a fixed token; the draft loop uses the (untied) lm_head, which
+        # picks something else, guaranteeing a position-0 mismatch.
+        class _DivergeModel(_SelfSpecModel):
+            def __call__(self, input_ids, cache=None):
+                out = super().__call__(input_ids, cache=cache)
+                B, T, V = out.shape
+                forced = mx.zeros((B, T, V))
+                # Pin every verify position to token 0.
+                forced = forced.at[:, :, 0].add(1000.0)
+                return forced
+
+        m = _DivergeModel(vocab_size=16, hidden_size=8, num_layers=4)
+        dec = SelfSpeculativeDecoder(m, num_early_layers=2, num_speculative_tokens=3)
+        dec.prefill(mx.array([[1, 2, 3]]))
+        accepted, num_draft = dec.step()
+        assert num_draft == 3
+        # Verify always picks token 0; the accepted list ends with it.
+        assert accepted[-1] == 0
+        # Cache invariant still holds after a rejection-driven trim.
+        for c in dec._cache:
+            assert c.offset == dec._prompt_len
+        # A rejection means fewer than lambda+1 tokens were accepted.
+        assert len(accepted) <= num_draft
+
+    def test_lambda_one_step(self, model):
+        # Minimal lambda exercises the single-draft loop / trim of 1.
+        dec = SelfSpeculativeDecoder(
+            model, num_early_layers=2, num_speculative_tokens=1
+        )
+        dec.prefill(mx.array([[1, 2, 3]]))
+        accepted, num_draft = dec.step()
+        assert num_draft == 1
+        assert 1 <= len(accepted) <= 2
+        for c in dec._cache:
+            assert c.offset == dec._prompt_len

--- a/tests/test_spectralquant_calibrate_coverage.py
+++ b/tests/test_spectralquant_calibrate_coverage.py
@@ -1,0 +1,792 @@
+"""Regression coverage for olmlx.engine.spectralquant_calibrate.
+
+Exercises the calibration math (covariance, eigendecomposition, effective
+dimensionality, per-head calibration), the save/load round-trip of calibration
+artifacts, and the full `calibrate_model` pipeline with a fully mocked model,
+tokenizer, and helper-function set.  All hermetic: no network, no real model,
+no GPU-only paths, no filesystem outside tmp_path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from mlx_lm.models.cache import KVCache
+
+import olmlx.engine.spectralquant_calibrate as sc
+
+
+# ---------------------------------------------------------------------------
+# Pure math: compute_covariance
+# ---------------------------------------------------------------------------
+
+
+def test_compute_covariance_matches_numpy_population():
+    rng = np.random.default_rng(0)
+    data_np = rng.standard_normal((200, 5)).astype(np.float32)
+    cov = sc.compute_covariance(mx.array(data_np))
+    # Module uses /n (population covariance, not /(n-1)).
+    expected = np.cov(data_np, rowvar=False, bias=True)
+    assert cov.shape == (5, 5)
+    np.testing.assert_allclose(np.array(cov), expected, rtol=1e-3, atol=1e-4)
+
+
+def test_compute_covariance_is_symmetric_and_float32():
+    rng = np.random.default_rng(1)
+    data = mx.array(rng.standard_normal((50, 4)))
+    cov = sc.compute_covariance(data)
+    assert cov.dtype == mx.float32
+    np.testing.assert_allclose(np.array(cov), np.array(cov).T, rtol=1e-5, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Pure math: eigendecompose
+# ---------------------------------------------------------------------------
+
+
+def test_eigendecompose_descending_and_clamped():
+    # Diagonal covariance -> eigenvalues are the diagonal, sorted descending.
+    cov = mx.array(np.diag([2.0, 9.0, 0.5, 4.0]).astype(np.float32))
+    evals, evecs = sc.eigendecompose(cov)
+    ev = np.array(evals)
+    assert evecs.shape == (4, 4)
+    # Descending order.
+    assert np.all(np.diff(ev) <= 1e-5)
+    np.testing.assert_allclose(
+        sorted(ev, reverse=True), [9.0, 4.0, 2.0, 0.5], atol=1e-4
+    )
+
+
+def test_eigendecompose_clamps_negative_eigenvalues():
+    # A matrix with a genuinely negative eigenvalue; clamp to >= 0.
+    cov = mx.array(np.array([[1.0, 0.0], [0.0, -3.0]], dtype=np.float32))
+    evals, _ = sc.eigendecompose(cov)
+    ev = np.array(evals)
+    assert np.all(ev >= 0.0)
+    # The negative one is clamped to 0, positive preserved.
+    np.testing.assert_allclose(sorted(ev), [0.0, 1.0], atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Pure math: compute_d_eff
+# ---------------------------------------------------------------------------
+
+
+def test_compute_d_eff_single_dominant_eigenvalue():
+    # One huge eigenvalue -> participation ratio ~1.
+    evals = mx.array([100.0, 1e-6, 1e-6, 1e-6])
+    assert sc.compute_d_eff(evals) == 1
+
+
+def test_compute_d_eff_uniform_spectrum_equals_dim():
+    # All equal -> d_eff == dimension.
+    evals = mx.array([3.0, 3.0, 3.0, 3.0, 3.0])
+    assert sc.compute_d_eff(evals) == 5
+
+
+def test_compute_d_eff_all_zero_returns_dim():
+    # total_sq < 1e-12 branch returns len(eigenvalues).
+    evals = mx.array([0.0, 0.0, 0.0])
+    assert sc.compute_d_eff(evals) == 3
+
+
+def test_compute_d_eff_clamped_to_at_least_one():
+    evals = mx.array([1e6, 0.0])
+    result = sc.compute_d_eff(evals)
+    assert result >= 1
+
+
+# ---------------------------------------------------------------------------
+# calibrate_head
+# ---------------------------------------------------------------------------
+
+
+def test_calibrate_head_structure_and_shapes():
+    rng = np.random.default_rng(42)
+    head_dim = 8
+    # Anisotropic data so d_eff < head_dim is plausible.
+    base = rng.standard_normal((300, head_dim)).astype(np.float32)
+    base[:, 4:] *= 0.01  # squash tail dims
+    result = sc.calibrate_head(mx.array(base), avg_bits=4)
+
+    assert set(result.keys()) == {
+        "eigenvectors",
+        "d_eff",
+        "codebook_sem",
+        "codebook_tail",
+        "bits_high",
+        "bits_low",
+    }
+    assert result["eigenvectors"].shape == (head_dim, head_dim)
+    assert 1 <= result["d_eff"] <= head_dim
+    assert result["bits_high"] >= result["bits_low"] >= 1
+    # Semantic codebook has 2**bits_high centroids.
+    assert result["codebook_sem"].shape[0] == (1 << result["bits_high"])
+
+
+def test_calibrate_head_full_rank_tail_codebook_is_sentinel():
+    # When d_eff == head_dim, codebook_tail is the [0.0] sentinel.
+    rng = np.random.default_rng(7)
+    head_dim = 4
+    # Isotropic data -> d_eff == head_dim.
+    data = mx.array(rng.standard_normal((500, head_dim)).astype(np.float32))
+    result = sc.calibrate_head(data, avg_bits=4)
+    if result["d_eff"] == head_dim:
+        np.testing.assert_array_equal(np.array(result["codebook_tail"]), [0.0])
+    else:
+        # Anisotropy crept in; tail codebook must then be a real codebook.
+        assert result["codebook_tail"].shape[0] == (1 << result["bits_low"])
+
+
+def test_calibrate_head_respects_avg_bits_budget():
+    rng = np.random.default_rng(3)
+    head_dim = 8
+    data = mx.array(rng.standard_normal((200, head_dim)).astype(np.float32))
+    result = sc.calibrate_head(data, avg_bits=2)
+    d_eff = result["d_eff"]
+    total = d_eff * result["bits_high"] + (head_dim - d_eff) * result["bits_low"]
+    # allocate_bits minimizes |total - head_dim*avg_bits|.
+    assert abs(total - head_dim * 2) <= head_dim  # within a reasonable slack
+
+
+# ---------------------------------------------------------------------------
+# save_calibration / load_calibration round-trip
+# ---------------------------------------------------------------------------
+
+
+def _make_calibration_entry(head_dim=4):
+    eigvecs = mx.array(np.eye(head_dim, dtype=np.float32))
+    return {
+        "eigenvectors": eigvecs,
+        "d_eff": 2,
+        "codebook_sem": mx.array(np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)),
+        "codebook_tail": mx.array(np.array([-0.5, 0.5], dtype=np.float32)),
+        "bits_high": 5,
+        "bits_low": 3,
+    }
+
+
+def test_save_calibration_writes_expected_files(tmp_path):
+    calib = {(0, 0, "key"): _make_calibration_entry()}
+    sc.save_calibration(calib, tmp_path)
+    assert (tmp_path / "spectral_config.json").exists()
+    assert (tmp_path / "calibration.safetensors").exists()
+
+
+def test_save_load_round_trip_preserves_values(tmp_path):
+    calib = {
+        (0, 0, "key"): _make_calibration_entry(),
+        (0, 0, "value"): _make_calibration_entry(),
+        (3, 0, "key"): _make_calibration_entry(),
+    }
+    sc.save_calibration(calib, tmp_path)
+    loaded = sc.load_calibration(tmp_path)
+
+    assert set(loaded.keys()) == set(calib.keys())
+    for key, orig in calib.items():
+        got = loaded[key]
+        assert got["d_eff"] == orig["d_eff"]
+        assert got["bits_high"] == orig["bits_high"]
+        assert got["bits_low"] == orig["bits_low"]
+        np.testing.assert_allclose(
+            np.array(got["eigenvectors"]), np.array(orig["eigenvectors"])
+        )
+        np.testing.assert_allclose(
+            np.array(got["codebook_sem"]), np.array(orig["codebook_sem"])
+        )
+        np.testing.assert_allclose(
+            np.array(got["codebook_tail"]), np.array(orig["codebook_tail"])
+        )
+
+
+def test_save_calibration_creates_nested_output_dir(tmp_path):
+    nested = tmp_path / "a" / "b" / "spectral"
+    sc.save_calibration({(0, 0, "key"): _make_calibration_entry()}, nested)
+    assert (nested / "spectral_config.json").exists()
+
+
+def test_load_calibration_parses_layer_head_kind_from_prefix(tmp_path):
+    calib = {(7, 0, "value"): _make_calibration_entry()}
+    sc.save_calibration(calib, tmp_path)
+    loaded = sc.load_calibration(tmp_path)
+    assert (7, 0, "value") in loaded
+
+
+# ---------------------------------------------------------------------------
+# Helper: _is_attention_cache
+# ---------------------------------------------------------------------------
+
+
+def _kv_cache_with(keys_shape):
+    cache = KVCache()
+    keys = mx.zeros(keys_shape)
+    values = mx.zeros(keys_shape)
+    cache.update_and_fetch(keys, values)
+    return cache
+
+
+def test_is_attention_cache_accepts_valid_kvcache():
+    cache = _kv_cache_with((1, 2, 4, 8))
+    assert sc._is_attention_cache(cache, expected_head_dim=8) is True
+
+
+def test_is_attention_cache_rejects_head_dim_mismatch():
+    cache = _kv_cache_with((1, 2, 4, 8))
+    assert sc._is_attention_cache(cache, expected_head_dim=16) is False
+
+
+def test_is_attention_cache_rejects_too_few_tokens():
+    cache = _kv_cache_with((1, 2, 1, 8))
+    assert sc._is_attention_cache(cache, expected_head_dim=8) is False
+
+
+def test_is_attention_cache_rejects_non_4d_keys():
+    # keys present but ndim != 4 (e.g. a 2D state) -> rejected.
+    class _Bad2DCache(KVCache):
+        @property
+        def state(self):
+            return [mx.zeros((4, 8)), mx.zeros((4, 8))]
+
+    assert sc._is_attention_cache(_Bad2DCache(), expected_head_dim=8) is False
+
+
+def test_is_attention_cache_rejects_non_kvcache():
+    not_a_cache = MagicMock()
+    assert sc._is_attention_cache(not_a_cache, expected_head_dim=8) is False
+
+
+def test_is_attention_cache_rejects_empty_state():
+    # A KVCache subclass whose .state is empty exercises the `not state` guard
+    # without depending on mlx's unpopulated-cache `.state` behavior.
+    class _EmptyStateCache(KVCache):
+        @property
+        def state(self):
+            return []
+
+    assert sc._is_attention_cache(_EmptyStateCache(), expected_head_dim=8) is False
+
+
+def test_is_attention_cache_rejects_one_element_state():
+    # len(state) < 2 guard (keys present but no values).
+    class _OneElemCache(KVCache):
+        @property
+        def state(self):
+            return [mx.zeros((1, 2, 4, 8))]
+
+    assert sc._is_attention_cache(_OneElemCache(), expected_head_dim=8) is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers: config holder resolution / cache owner
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_config_holder_prefers_args_on_inner():
+    inner = MagicMock()
+    inner.args = MagicMock()
+    inner.config = MagicMock()
+    model = MagicMock()
+    assert sc._resolve_config_holder(inner, model) is inner
+
+
+def test_resolve_config_holder_falls_back_to_model_args():
+    inner = MagicMock()
+    inner.args = None
+    model = MagicMock()
+    model.args = MagicMock()
+    assert sc._resolve_config_holder(inner, model) is model
+
+
+def test_resolve_config_holder_uses_config_when_no_args():
+    inner = MagicMock()
+    inner.args = None
+    inner.config = MagicMock()
+    model = MagicMock()
+    model.args = None
+    assert sc._resolve_config_holder(inner, model) is inner
+
+
+def test_resolve_config_holder_raises_when_nothing():
+    inner = MagicMock()
+    inner.args = None
+    inner.config = None
+    model = MagicMock()
+    model.args = None
+    model.config = None
+    with pytest.raises(RuntimeError, match="Cannot detect model configuration"):
+        sc._resolve_config_holder(inner, model)
+
+
+def test_config_namespace_prefers_args():
+    holder = MagicMock()
+    holder.args = "ARGS"
+    assert sc._config_namespace(holder) == "ARGS"
+
+
+def test_config_namespace_falls_back_to_config():
+    holder = MagicMock()
+    holder.args = None
+    holder.config = "CFG"
+    assert sc._config_namespace(holder) == "CFG"
+
+
+def test_config_namespace_raises_when_neither():
+    class Empty:
+        args = None
+        config = None
+
+    with pytest.raises(RuntimeError, match="neither"):
+        sc._config_namespace(Empty())
+
+
+def test_resolve_cache_owner_prefers_model_make_cache():
+    inner = MagicMock(spec=[])  # no make_cache
+    model = MagicMock()
+    model.make_cache = MagicMock()
+    assert sc._resolve_cache_owner(inner, model) is model
+
+
+def test_resolve_cache_owner_falls_back_to_inner():
+    inner = MagicMock()
+    model = MagicMock(spec=[])  # no make_cache attribute
+    assert sc._resolve_cache_owner(inner, model) is inner
+
+
+# ---------------------------------------------------------------------------
+# Error builder
+# ---------------------------------------------------------------------------
+
+
+def test_build_empty_collection_error_with_cause():
+    cause = ValueError("forward boom")
+    err = sc._build_empty_collection_error(cause)
+    assert isinstance(err, RuntimeError)
+    assert err.__cause__ is cause
+    assert err.__suppress_context__ is True
+
+
+def test_build_empty_collection_error_without_cause():
+    err = sc._build_empty_collection_error(None)
+    assert isinstance(err, RuntimeError)
+    assert err.__cause__ is None
+    assert "No attention-layer cache entries" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline: calibrate_model (mocked model/tokenizer/helpers)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBackbone:
+    """Backbone exposing .layers and .args with config fields."""
+
+    def __init__(self, num_layers, n_kv_heads, head_dim):
+        self.layers = [object() for _ in range(num_layers)]
+        args = MagicMock()
+        args.num_key_value_heads = n_kv_heads
+        args.num_attention_heads = n_kv_heads
+        self.args = args
+
+
+class _FakeModel:
+    """Callable model that populates the passed prompt_cache with KV state."""
+
+    def __init__(self, backbone, head_dim, n_kv=None):
+        self._backbone = backbone
+        self._head_dim = head_dim
+        self._n_kv = n_kv if n_kv is not None else backbone.args.num_key_value_heads
+        self.calls = 0
+
+    def __call__(self, input_ids, cache=None):
+        self.calls += 1
+        seq = input_ids.shape[1]
+        n_kv = self._n_kv
+        for entry in cache:
+            keys = mx.ones((1, n_kv, seq, self._head_dim))
+            values = mx.ones((1, n_kv, seq, self._head_dim)) * 2.0
+            entry.update_and_fetch(keys, values)
+
+
+def _patch_helpers(model, tokenizer, head_dim, texts, cache_factory):
+    """Patch the lazily-imported helpers used by calibrate_model."""
+    return [
+        patch(
+            "olmlx.engine.flash.prepare.load_model_with_strict_fallback",
+            return_value=(model, tokenizer),
+        ),
+        patch(
+            "olmlx.engine.flash.prepare._get_backbone",
+            return_value=model._backbone,
+        ),
+        patch(
+            "olmlx.engine.flash.prepare._get_c4_calibration_data",
+            return_value=texts,
+        ),
+        patch(
+            "olmlx.engine.flash.prepare._get_calibration_data",
+            return_value=texts,
+        ),
+        patch(
+            "olmlx.engine.flash.prepare._encode_tokens",
+            side_effect=lambda tok, text: list(range(len(text.split()))),
+        ),
+        patch(
+            "olmlx.engine.turboquant_cache._detect_head_dim",
+            return_value=head_dim,
+        ),
+        patch(
+            "mlx_lm.models.cache.make_prompt_cache",
+            side_effect=cache_factory,
+        ),
+    ]
+
+
+def test_calibrate_model_end_to_end(tmp_path):
+    head_dim = 8
+    num_layers = 2
+    n_kv_heads = 2
+    backbone = _FakeBackbone(num_layers, n_kv_heads, head_dim)
+    model = _FakeModel(backbone, head_dim)
+    tokenizer = MagicMock()
+    # Each text has >= 2 "tokens" after split.
+    texts = ["one two three four five six seven eight nine ten"] * 4
+
+    def cache_factory(_owner):
+        return [KVCache() for _ in range(num_layers)]
+
+    progress = []
+
+    patches = _patch_helpers(model, tokenizer, head_dim, texts, cache_factory)
+    for p in patches:
+        p.start()
+    try:
+        out = sc.calibrate_model(
+            "fake/model",
+            output_dir=tmp_path / "spectral",
+            num_samples=4,
+            progress_callback=lambda desc, frac: progress.append((desc, frac)),
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert out == tmp_path / "spectral"
+    # Forward run once per sample.
+    assert model.calls == len(texts)
+
+    # Artifacts written and loadable.
+    loaded = sc.load_calibration(out)
+    # One key + one value calibration per layer (heads aggregated under head 0).
+    assert (0, 0, "key") in loaded
+    assert (0, 0, "value") in loaded
+    assert (1, 0, "key") in loaded
+    assert len(loaded) == num_layers * 2
+
+    # Metadata merged into spectral_config.json.
+    import json
+
+    cfg = json.loads((out / "spectral_config.json").read_text())
+    assert cfg["meta"]["num_layers"] == num_layers
+    assert cfg["meta"]["n_kv_heads"] == n_kv_heads
+    assert cfg["meta"]["head_dim"] == head_dim
+    assert cfg["meta"]["calibration_dataset"] == "c4"
+    # Progress callback reached completion.
+    assert progress[-1] == ("Done", 1.0)
+
+
+def test_calibrate_model_raises_when_nothing_collected(tmp_path):
+    head_dim = 8
+    num_layers = 1
+    n_kv_heads = 1
+    backbone = _FakeBackbone(num_layers, n_kv_heads, head_dim)
+    model = _FakeModel(backbone, head_dim)
+    tokenizer = MagicMock()
+    # All samples too short (< 2 tokens) -> skipped, nothing collected.
+    texts = ["single", "x", ""]
+
+    def cache_factory(_owner):
+        return [KVCache() for _ in range(num_layers)]
+
+    patches = _patch_helpers(model, tokenizer, head_dim, texts, cache_factory)
+    for p in patches:
+        p.start()
+    try:
+        with pytest.raises(RuntimeError, match="No KV vectors were collected"):
+            sc.calibrate_model(
+                "fake/model",
+                output_dir=tmp_path / "spectral",
+                num_samples=3,
+            )
+    finally:
+        for p in patches:
+            p.stop()
+    # Model never successfully ran a forward with >= 2 tokens.
+    assert model.calls == 0
+
+
+def test_calibrate_model_forward_error_chained_as_cause(tmp_path):
+    head_dim = 8
+    num_layers = 1
+    n_kv_heads = 1
+    backbone = _FakeBackbone(num_layers, n_kv_heads, head_dim)
+
+    class _ExplodingModel(_FakeModel):
+        def __call__(self, input_ids, cache=None):
+            self.calls += 1
+            raise ValueError("forward exploded")
+
+    model = _ExplodingModel(backbone, head_dim)
+    tokenizer = MagicMock()
+    texts = ["one two three four"] * 2
+
+    def cache_factory(_owner):
+        return [KVCache() for _ in range(num_layers)]
+
+    patches = _patch_helpers(model, tokenizer, head_dim, texts, cache_factory)
+    for p in patches:
+        p.start()
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            sc.calibrate_model("fake/model", output_dir=tmp_path / "spectral")
+    finally:
+        for p in patches:
+            p.stop()
+    # The forward-pass ValueError is chained as the cause.
+    assert isinstance(excinfo.value.__cause__, ValueError)
+    assert "forward exploded" in str(excinfo.value.__cause__)
+
+
+def test_calibrate_model_truncates_long_prompts_and_default_output_dir(tmp_path):
+    # Exercise the >512-token truncation path and default output_dir=model/spectral.
+    head_dim = 4
+    num_layers = 1
+    n_kv_heads = 1
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    backbone = _FakeBackbone(num_layers, n_kv_heads, head_dim)
+
+    captured_seq = {}
+
+    class _SeqCapModel(_FakeModel):
+        def __call__(self, input_ids, cache=None):
+            captured_seq["seq"] = input_ids.shape[1]
+            super().__call__(input_ids, cache=cache)
+
+    model = _SeqCapModel(backbone, head_dim)
+    tokenizer = MagicMock()
+    texts = ["w " * 600]  # 600 whitespace tokens after split
+
+    def cache_factory(_owner):
+        return [KVCache() for _ in range(num_layers)]
+
+    patches = _patch_helpers(model, tokenizer, head_dim, texts, cache_factory)
+    for p in patches:
+        p.start()
+    try:
+        out = sc.calibrate_model(str(model_dir), num_samples=1)
+    finally:
+        for p in patches:
+            p.stop()
+    assert out == model_dir / "spectral"
+    # Token list was truncated to 512 before the forward pass.
+    assert captured_seq["seq"] == 512
+
+
+def test_calibrate_model_n_kv_heads_falls_back_to_attention_heads(tmp_path):
+    # num_key_value_heads is None -> falls back to num_attention_heads.
+    head_dim = 4
+    num_layers = 1
+    backbone = _FakeBackbone(num_layers, 3, head_dim)
+    backbone.args.num_key_value_heads = None
+    backbone.args.num_attention_heads = 3
+    model = _FakeModel(backbone, head_dim, n_kv=3)
+    tokenizer = MagicMock()
+    texts = ["one two three four"] * 2
+
+    def cache_factory(_owner):
+        return [KVCache() for _ in range(num_layers)]
+
+    patches = _patch_helpers(model, tokenizer, head_dim, texts, cache_factory)
+    for p in patches:
+        p.start()
+    try:
+        out = sc.calibrate_model("fake/model", output_dir=tmp_path / "s", num_samples=2)
+    finally:
+        for p in patches:
+            p.stop()
+    cfg = __import__("json").loads((out / "spectral_config.json").read_text())
+    assert cfg["meta"]["n_kv_heads"] == 3
+
+
+def test_calibrate_model_skips_non_attention_cache_entries(tmp_path):
+    # A cache entry that is not a valid attention cache is skipped, leaving its
+    # layer with no KV data; the layer is then skipped in calibration.
+    head_dim = 8
+    num_layers = 1
+    n_kv_heads = 1
+    backbone = _FakeBackbone(num_layers, n_kv_heads, head_dim)
+
+    class _NoOpModel(_FakeModel):
+        def __call__(self, input_ids, cache=None):
+            # Populate with a WRONG head_dim so _is_attention_cache rejects it.
+            self.calls += 1
+            seq = input_ids.shape[1]
+            for entry in cache:
+                entry.update_and_fetch(
+                    mx.ones((1, n_kv_heads, seq, head_dim + 4)),
+                    mx.ones((1, n_kv_heads, seq, head_dim + 4)),
+                )
+
+    model = _NoOpModel(backbone, head_dim)
+    tokenizer = MagicMock()
+    texts = ["one two three four"] * 2
+
+    def cache_factory(_owner):
+        return [KVCache() for _ in range(num_layers)]
+
+    patches = _patch_helpers(model, tokenizer, head_dim, texts, cache_factory)
+    for p in patches:
+        p.start()
+    try:
+        with pytest.raises(RuntimeError, match="No KV vectors were collected"):
+            sc.calibrate_model("fake/model", output_dir=tmp_path / "s", num_samples=2)
+    finally:
+        for p in patches:
+            p.stop()
+
+
+def test_calibrate_model_skips_empty_layer_but_calibrates_others(tmp_path):
+    # Two layers: layer 0 gets valid KV (right head_dim), layer 1 gets a
+    # rejected cache (wrong head_dim) -> layer 1 has no chunks and is skipped
+    # in the per-layer calibration loop, but the run still succeeds.
+    head_dim = 8
+    num_layers = 2
+    n_kv_heads = 1
+    backbone = _FakeBackbone(num_layers, n_kv_heads, head_dim)
+
+    class _MixedModel(_FakeModel):
+        def __call__(self, input_ids, cache=None):
+            self.calls += 1
+            seq = input_ids.shape[1]
+            # Layer 0: correct head_dim (accepted).
+            cache[0].update_and_fetch(
+                mx.ones((1, n_kv_heads, seq, head_dim)),
+                mx.ones((1, n_kv_heads, seq, head_dim)),
+            )
+            # Layer 1: wrong head_dim (rejected by _is_attention_cache).
+            cache[1].update_and_fetch(
+                mx.ones((1, n_kv_heads, seq, head_dim + 2)),
+                mx.ones((1, n_kv_heads, seq, head_dim + 2)),
+            )
+
+    model = _MixedModel(backbone, head_dim)
+    tokenizer = MagicMock()
+    texts = ["one two three four"] * 2
+
+    def cache_factory(_owner):
+        return [KVCache() for _ in range(num_layers)]
+
+    patches = _patch_helpers(model, tokenizer, head_dim, texts, cache_factory)
+    for p in patches:
+        p.start()
+    try:
+        out = sc.calibrate_model("fake/model", output_dir=tmp_path / "s", num_samples=2)
+    finally:
+        for p in patches:
+            p.stop()
+    loaded = sc.load_calibration(out)
+    # Only layer 0 was calibrated; layer 1 produced no data and was skipped.
+    assert (0, 0, "key") in loaded
+    assert (1, 0, "key") not in loaded
+
+
+def test_calibrate_model_vlm_fallback_on_value_error(tmp_path):
+    # load_model_with_strict_fallback raises ValueError -> mlx_vlm.load path.
+    head_dim = 4
+    num_layers = 1
+    n_kv_heads = 1
+    backbone = _FakeBackbone(num_layers, n_kv_heads, head_dim)
+    model = _FakeModel(backbone, head_dim)
+    processor = MagicMock()
+    processor.tokenizer = MagicMock()
+    texts = ["one two three four"] * 2
+
+    def cache_factory(_owner):
+        return [KVCache() for _ in range(num_layers)]
+
+    fake_vlm = MagicMock()
+    fake_vlm.load = MagicMock(return_value=(model, processor))
+
+    patches = [
+        patch(
+            "olmlx.engine.flash.prepare.load_model_with_strict_fallback",
+            side_effect=ValueError("not an mlx-lm model"),
+        ),
+        patch("olmlx.engine.flash.prepare._get_backbone", return_value=backbone),
+        patch(
+            "olmlx.engine.flash.prepare._get_c4_calibration_data", return_value=texts
+        ),
+        patch("olmlx.engine.flash.prepare._get_calibration_data", return_value=texts),
+        patch(
+            "olmlx.engine.flash.prepare._encode_tokens",
+            side_effect=lambda tok, text: list(range(len(text.split()))),
+        ),
+        patch("olmlx.engine.turboquant_cache._detect_head_dim", return_value=head_dim),
+        patch("mlx_lm.models.cache.make_prompt_cache", side_effect=cache_factory),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        with patch.dict("sys.modules", {"mlx_vlm": fake_vlm}):
+            out = sc.calibrate_model(
+                "fake/vlm", output_dir=tmp_path / "s", num_samples=2
+            )
+    finally:
+        for p in patches:
+            p.stop()
+    fake_vlm.load.assert_called_once()
+    assert (out / "calibration.safetensors").exists()
+
+
+def test_calibrate_model_synthetic_dataset_branch(tmp_path):
+    head_dim = 4
+    num_layers = 1
+    n_kv_heads = 1
+    backbone = _FakeBackbone(num_layers, n_kv_heads, head_dim)
+    model = _FakeModel(backbone, head_dim)
+    tokenizer = MagicMock()
+    texts = ["alpha beta gamma delta epsilon"] * 3
+
+    def cache_factory(_owner):
+        return [KVCache() for _ in range(num_layers)]
+
+    synthetic_called = {"hit": False}
+
+    def fake_synthetic(n):
+        synthetic_called["hit"] = True
+        return texts
+
+    patches = _patch_helpers(model, tokenizer, head_dim, texts, cache_factory)
+    # Replace synthetic patch with one that records the call.
+    for p in patches:
+        p.start()
+    try:
+        with patch(
+            "olmlx.engine.flash.prepare._get_calibration_data",
+            side_effect=fake_synthetic,
+        ):
+            out = sc.calibrate_model(
+                "fake/model",
+                output_dir=tmp_path / "spectral",
+                num_samples=3,
+                calibration_dataset="synthetic",
+            )
+    finally:
+        for p in patches:
+            p.stop()
+    assert synthetic_called["hit"] is True
+    cfg = __import__("json").loads((out / "spectral_config.json").read_text())
+    assert cfg["meta"]["calibration_dataset"] == "synthetic"

--- a/tests/test_speculative_coverage.py
+++ b/tests/test_speculative_coverage.py
@@ -1,0 +1,498 @@
+"""Regression coverage for olmlx.engine.speculative.
+
+Focus areas (currently-uncovered branches):
+- ``verify_draft_greedy``: accept / first-mismatch / full-acceptance bonus.
+- ``SpeculativeDecoder`` acceptance-rate EMA + stats bookkeeping + reset().
+- ``PromptLookupDecoder`` n-gram lookup (``_lookup_draft``), EMA "skip on
+  no-match" rule, validation guards, prefill/step/reset state.
+
+Hermetic: tiny fake mx-array models/stubs, no real model, no GPU, no I/O.
+pytest runs with asyncio_mode=auto so async tests need no decorator (none here).
+"""
+
+import logging
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from olmlx.engine.speculative import (
+    PromptLookupDecoder,
+    SpeculativeDecoder,
+    verify_draft_greedy,
+)
+from tests.test_flash_speculative import MockModel
+
+
+def _one_hot_logits(tokens: list[int], vocab: int, peak: float = 100.0) -> mx.array:
+    """(len(tokens), vocab) logits whose argmax at row i is tokens[i]."""
+    rows = []
+    for t in tokens:
+        row = mx.zeros((vocab,))
+        row = row.at[t].add(peak)
+        rows.append(row[None, :])
+    return mx.concatenate(rows, axis=0)
+
+
+class _ScriptedTarget(nn.Module):
+    """Target stub whose forward returns argmax-fixed logits.
+
+    For an input ``(1, T)`` it returns ``(1, T, vocab)`` logits where the
+    argmax of every position is taken from ``self.next_tokens`` in order,
+    cycling as needed. This makes ``PromptLookupDecoder.step`` deterministic
+    without any real model maths. It is *not* wired to a KV cache content
+    check — that is irrelevant for the lookup/EMA logic under test — but it
+    still drives ``cache[0].update_and_fetch`` so ``trim_prompt_cache`` works.
+
+    Subclasses ``nn.Module`` so ``find_gdn_class`` (which walks
+    ``named_modules()``) sees a non-hybrid model and returns ``None``.
+    """
+
+    def __init__(self, vocab: int, next_tokens: list[int]):
+        super().__init__()
+        self.vocab = vocab
+        self.next_tokens = next_tokens
+        self._cursor = 0
+        # make_prompt_cache walks model.layers; reuse MockModel's cache-aware
+        # attention by composing one.
+        self._inner = MockModel(vocab, 8, num_layers=1)
+        self.layers = self._inner.layers
+
+    def __call__(self, input_ids, cache=None):
+        # Drive the KV cache so offsets/trim behave like a real forward.
+        if cache is not None:
+            self._inner(input_ids, cache=cache)
+        T = input_ids.shape[1]
+        toks = []
+        for _ in range(T):
+            toks.append(self.next_tokens[self._cursor % len(self.next_tokens)])
+            self._cursor += 1
+        return _one_hot_logits(toks, self.vocab)[None, :, :]
+
+
+# ---------------------------------------------------------------------------
+# verify_draft_greedy
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyDraftGreedy:
+    def test_all_accepted_appends_bonus(self):
+        # target argmax = [5, 6, 7, 9]; draft proposed first three.
+        vocab = 16
+        target = _one_hot_logits([5, 6, 7, 9], vocab)
+        accepted = verify_draft_greedy([5, 6, 7], target)
+        # 3 draft tokens accepted + 1 bonus from the (n+1)th logit row.
+        assert accepted == [5, 6, 7, 9]
+
+    def test_first_mismatch_returns_target_token_and_stops(self):
+        vocab = 16
+        # target argmax = [5, 2, 7, 9]; draft says [5, 6, 7] -> mismatch at i=1.
+        target = _one_hot_logits([5, 2, 7, 9], vocab)
+        accepted = verify_draft_greedy([5, 6, 7], target)
+        # Accept first match (5), then replace mismatch with target's 2, stop.
+        assert accepted == [5, 2]
+
+    def test_immediate_mismatch_returns_single_token(self):
+        vocab = 16
+        target = _one_hot_logits([3, 4, 5, 6], vocab)
+        accepted = verify_draft_greedy([0, 0, 0], target)
+        assert accepted == [3]
+
+    def test_empty_draft_returns_only_bonus(self):
+        vocab = 16
+        # n == 0: loop body never runs; the single (n+1=1) row is the bonus.
+        target = _one_hot_logits([8], vocab)
+        accepted = verify_draft_greedy([], target)
+        assert accepted == [8]
+
+    def test_returns_at_least_one_token_invariant(self):
+        vocab = 8
+        target = _one_hot_logits([7, 7, 7, 7], vocab)
+        for draft in ([], [0], [0, 1, 2]):
+            assert len(verify_draft_greedy(draft, target)) >= 1
+
+
+# ---------------------------------------------------------------------------
+# SpeculativeDecoder acceptance-rate EMA + stats
+# ---------------------------------------------------------------------------
+
+
+def _bare_speculative(lam=4, ema=0.9):
+    """A SpeculativeDecoder without running __init__ (no model wiring).
+
+    Mirrors the style of the existing test_verify_rejects_divergent_tokens.
+    """
+    dec = SpeculativeDecoder.__new__(SpeculativeDecoder)
+    dec._lambda = lam
+    dec._alpha = 0.5
+    dec._alpha_ema = ema
+    return dec
+
+
+class TestAcceptanceRateBookkeeping:
+    def test_full_acceptance_pushes_ema_up(self):
+        dec = _bare_speculative(lam=4, ema=0.9)
+        # num_accepted = lambda + 1 -> all 4 draft accepted -> acceptance 1.0
+        n_draft = dec._update_acceptance_rate(5)
+        assert n_draft == 4  # min(5-1, 4)
+        # alpha = 0.9*0.5 + 0.1*1.0 = 0.55
+        assert dec._alpha == pytest.approx(0.55)
+
+    def test_zero_draft_accepted_pushes_ema_down(self):
+        dec = _bare_speculative(lam=4, ema=0.9)
+        # num_accepted = 1 -> only target's correction token, 0 draft.
+        n_draft = dec._update_acceptance_rate(1)
+        assert n_draft == 0
+        # alpha = 0.9*0.5 + 0.1*0.0 = 0.45
+        assert dec._alpha == pytest.approx(0.45)
+
+    def test_num_accepted_draft_clamped_to_lambda(self):
+        dec = _bare_speculative(lam=3, ema=0.9)
+        # num_accepted=5 would give 4 draft, but lambda=3 clamps it.
+        n_draft = dec._update_acceptance_rate(5)
+        assert n_draft == 3
+
+    def test_update_rejects_zero_accepted(self):
+        dec = _bare_speculative()
+        with pytest.raises(AssertionError):
+            dec._update_acceptance_rate(0)
+
+    def test_stats_summary_empty(self):
+        from tests.test_flash_speculative import MockModel as MM
+
+        dec = SpeculativeDecoder(
+            draft_model=MM(16, 8),
+            target_model=MM(16, 8),
+            num_speculative_tokens=4,
+        )
+        s = dec.stats_summary()
+        # No steps run: acceptance / avg are guarded against div-by-zero.
+        assert s["steps"] == 0
+        assert s["proposed"] == 0
+        assert s["acceptance_rate"] == 0.0
+        assert s["avg_tokens_per_step"] == 0.0
+        assert s["lambda"] == 4
+        dec.close()
+
+    def test_stats_summary_after_steps(self):
+        draft = MockModel(16, 8)
+        target = MockModel(16, 8)
+        # Share weights so draft and target agree -> full acceptance.
+        target.embed.weight = draft.embed.weight
+        target.lm_head.weight = draft.lm_head.weight
+        for i in range(len(draft.layers)):
+            target.layers[i] = draft.layers[i]
+        dec = SpeculativeDecoder(
+            draft_model=draft, target_model=target, num_speculative_tokens=3
+        )
+        dec.prefill(mx.array([[1, 2, 3]]))
+        dec.step()
+        dec.step()
+        s = dec.stats_summary()
+        assert s["steps"] == 2
+        assert s["proposed"] == 6  # 2 steps * lambda 3
+        # avg_tokens_per_step = (accepted_draft + steps) / steps
+        assert s["avg_tokens_per_step"] == pytest.approx((s["accepted_draft"] + 2) / 2)
+        assert s["acceptance_rate"] == pytest.approx(s["accepted_draft"] / 6)
+        dec.close()
+
+
+class TestSpeculativeReset:
+    def test_reset_zeroes_stats_and_state(self):
+        draft = MockModel(16, 8)
+        target = MockModel(16, 8)
+        dec = SpeculativeDecoder(
+            draft_model=draft, target_model=target, num_speculative_tokens=2
+        )
+        dec.prefill(mx.array([[1, 2, 3]]))
+        dec.step()
+        assert dec._stats_steps == 1
+        dec.reset()
+        assert dec._target_cache is None
+        assert dec._draft_cache is None
+        assert dec._cache_seq_len == 0
+        assert dec._last_target_logit is None
+        assert dec._pending_token is None
+        assert dec._stats_steps == 0
+        assert dec._stats_proposed == 0
+        assert dec._stats_accepted_draft == 0
+        dec.close()
+
+    def test_step_before_prefill_raises(self):
+        dec = SpeculativeDecoder(
+            draft_model=MockModel(16, 8),
+            target_model=MockModel(16, 8),
+            num_speculative_tokens=2,
+        )
+        with pytest.raises(AssertionError):
+            dec.step()
+        dec.close()
+
+
+class TestSpeculativeStepIntegration:
+    """Drive prefill+step with independent (non-shared) models so partial
+    rejection and cache-trim bookkeeping in _step_linear get exercised."""
+
+    def test_partial_rejection_trims_and_advances(self):
+        draft = MockModel(16, 8)
+        target = MockModel(16, 8)
+        dec = SpeculativeDecoder(
+            draft_model=draft, target_model=target, num_speculative_tokens=4
+        )
+        dec.prefill(mx.array([[1, 2, 3]]))
+        accepted, num_draft = dec.step()
+        # Independent random weights almost surely reject early, so the
+        # accepted prefix is short but always >= 1 (target correction).
+        assert 1 <= len(accepted) <= 5
+        assert num_draft == 4
+        # Cache offset must equal the new sequence length after trimming.
+        assert dec._target_cache[0].offset == dec._cache_seq_len
+        assert dec._cache_seq_len == 3 + len(accepted)
+        # Stats incremented exactly once.
+        assert dec._stats_steps == 1
+        assert dec._stats_proposed == 4
+        assert 0 <= dec._stats_accepted_draft <= 4
+        dec.close()
+
+    def test_generate_step_updates_stats(self):
+        draft = MockModel(16, 8)
+        target = MockModel(16, 8)
+        dec = SpeculativeDecoder(
+            draft_model=draft, target_model=target, num_speculative_tokens=3
+        )
+        accepted, num_draft = dec.generate_step(mx.array([[1, 2, 3]]))
+        assert len(accepted) >= 1
+        assert num_draft == 3
+        assert dec._stats_steps == 1
+        assert dec._stats_proposed == 3
+        assert 0 <= dec._alpha <= 1.0
+        dec.close()
+
+    def test_draft_generate_cached_length(self):
+        draft = MockModel(16, 8)
+        target = MockModel(16, 8)
+        dec = SpeculativeDecoder(
+            draft_model=draft, target_model=target, num_speculative_tokens=4
+        )
+        dec.prefill(mx.array([[1, 2, 3]]))
+        tokens, ctx = dec._draft_generate_cached(pending_token=2, n=5)
+        assert len(tokens) == 5
+        assert all(0 <= t < 16 for t in tokens)
+        assert ctx == []  # base class returns empty context
+        dec.close()
+
+
+# ---------------------------------------------------------------------------
+# PromptLookupDecoder construction guards
+# ---------------------------------------------------------------------------
+
+
+class TestPLDValidation:
+    def test_rejects_zero_speculative_tokens(self):
+        with pytest.raises(ValueError, match="num_speculative_tokens must be >= 1"):
+            PromptLookupDecoder(MockModel(16, 8), num_speculative_tokens=0)
+
+    def test_rejects_bad_ngram_range(self):
+        with pytest.raises(ValueError, match="Invalid n-gram range"):
+            PromptLookupDecoder(MockModel(16, 8), max_ngram_size=2, min_ngram_size=3)
+
+    def test_rejects_min_ngram_below_one(self):
+        with pytest.raises(ValueError, match="Invalid n-gram range"):
+            PromptLookupDecoder(MockModel(16, 8), min_ngram_size=0)
+
+    def test_rejects_window_smaller_than_max_ngram(self):
+        with pytest.raises(ValueError, match="must be >= max_ngram_size"):
+            PromptLookupDecoder(MockModel(16, 8), max_ngram_size=4, lookup_window=2)
+
+    def test_none_window_is_allowed(self):
+        dec = PromptLookupDecoder(MockModel(16, 8), lookup_window=None)
+        assert dec._lookup_window is None
+        dec.close()
+
+
+# ---------------------------------------------------------------------------
+# PromptLookupDecoder._lookup_draft (n-gram match)
+# ---------------------------------------------------------------------------
+
+
+def _bare_pld(
+    tokens, pending, lam=10, max_ng=3, min_ng=1, window=8192
+) -> PromptLookupDecoder:
+    """A PLD configured for direct _lookup_draft testing (no forward needed)."""
+    dec = PromptLookupDecoder.__new__(PromptLookupDecoder)
+    dec._lambda = lam
+    dec._max_ngram = max_ng
+    dec._min_ngram = min_ng
+    dec._lookup_window = window
+    dec._tokens = list(tokens)
+    dec._pending_token = pending
+    return dec
+
+
+class TestPLDLookupDraft:
+    def test_basic_unigram_match(self):
+        # seq = [..., 5, 6, 7, pending=5]; trailing 1-gram "5" last matched
+        # at index 0, draft = tokens after it = [6, 7].
+        dec = _bare_pld([5, 6, 7], pending=5, max_ng=1, min_ng=1, lam=10)
+        draft = dec._lookup_draft()
+        assert draft == [6, 7]
+
+    def test_longest_ngram_preferred(self):
+        # seq = [1, 2, 3, 9, 1, 2, 3, pending=9]? Build so a 3-gram matches.
+        # tokens=[1,2,3,4,1,2,3], pending=4 -> seq trailing 3-gram is [2,3,4]?
+        # Actually trailing 3-gram = seq[-3:] = [2,3,4]. That occurs only once
+        # so 3-gram fails; fall to 2-gram [3,4] -> not repeated -> 1-gram "4"
+        # matches at index 3 -> draft = [1,2,3]. Verify max-ngram-first walk.
+        dec = _bare_pld([1, 2, 3, 4, 1, 2, 3], pending=4, max_ng=3, min_ng=1)
+        draft = dec._lookup_draft()
+        # 1-gram "4" matched at idx 3, tokens after = [1, 2, 3].
+        assert draft == [1, 2, 3]
+
+    def test_three_gram_match(self):
+        # tokens=[1,2,3,7,8,1,2,3], pending=7 -> trailing 3-gram = [3, ... ]
+        # seq = [1,2,3,7,8,1,2,3,7]; trailing 3-gram = [2,3,7] matches at idx 1
+        # -> draft starts after idx 1+3=4? no. Let's construct deliberately:
+        # seq trailing 3-gram = seq[-3:] = [3, 7] no, len issue. Use explicit.
+        dec = _bare_pld([9, 1, 2, 3, 9, 1, 2], pending=3, max_ng=3, min_ng=1)
+        # seq = [9,1,2,3,9,1,2,3]; trailing 3-gram = [1,2,3] occurs at idx 1.
+        # draft = tokens after idx 1+3=4 => [9,1,2] capped at L-1.
+        draft = dec._lookup_draft()
+        assert draft == [9, 1, 2]
+
+    def test_no_match_returns_empty(self):
+        dec = _bare_pld([1, 2, 3, 4], pending=99, max_ng=3, min_ng=1)
+        assert dec._lookup_draft() == []
+
+    def test_draft_capped_at_lambda(self):
+        # Long repeat so plenty of follow tokens, but lambda caps the draft.
+        body = [5] + list(range(10, 30))
+        # seq = body + body + [pending=5]; unigram "5" match yields up to lambda.
+        dec = _bare_pld(body + body, pending=5, max_ng=1, min_ng=1, lam=3)
+        draft = dec._lookup_draft()
+        assert len(draft) == 3
+
+    def test_pending_excluded_from_draft(self):
+        # The closest match (start = query_start-1) would propose [pending];
+        # draft_end is capped at L-1 so that match yields an empty draft.
+        # seq = [5]; pending=5 -> seq=[5, 5]. unigram "5": query_start=1.
+        # The only candidate start=0 gives draft_start=1, draft_end=
+        # min(1+lam, L-1=1)=1 -> empty (would otherwise propose [pending]).
+        dec = _bare_pld([5], pending=5, max_ng=1, min_ng=1)
+        assert dec._lookup_draft() == []
+
+    def test_short_seq_returns_empty(self):
+        # L < 2 -> early return.
+        dec = _bare_pld([], pending=7, max_ng=3, min_ng=1)
+        assert dec._lookup_draft() == []
+
+    def test_lookup_draft_none_pending_raises(self):
+        dec = _bare_pld([1, 2, 3], pending=None)
+        with pytest.raises(RuntimeError, match="_pending_token=None"):
+            dec._lookup_draft()
+
+
+# ---------------------------------------------------------------------------
+# PromptLookupDecoder prefill / step / EMA via scripted target
+# ---------------------------------------------------------------------------
+
+
+class TestPLDStep:
+    def test_prefill_seeds_tokens_and_returns_token(self):
+        target = _ScriptedTarget(16, next_tokens=[5])
+        dec = PromptLookupDecoder(target, num_speculative_tokens=4)
+        first = dec.prefill(mx.array([[1, 2, 3]]))
+        assert first == 5
+        assert dec._tokens == [1, 2, 3]
+        assert dec._cache_seq_len == 3
+        assert dec._pending_token == 5
+        dec.close()
+
+    def test_prefill_caps_seed_to_window(self):
+        target = _ScriptedTarget(16, next_tokens=[0])
+        dec = PromptLookupDecoder(
+            target, num_speculative_tokens=2, max_ngram_size=2, lookup_window=4
+        )
+        dec.prefill(mx.array([[1, 2, 3, 4, 5, 6, 7]]))
+        # Only the last 4 prompt tokens are seeded into the lookup table.
+        assert dec._tokens == [4, 5, 6, 7]
+        dec.close()
+
+    def test_step_before_prefill_raises(self):
+        dec = PromptLookupDecoder(MockModel(16, 8))
+        with pytest.raises(RuntimeError, match="called before prefill"):
+            dec.step()
+        dec.close()
+
+    def test_step_no_match_does_not_update_ema(self):
+        # pending never appears in history -> no draft -> EMA stays 0.
+        target = _ScriptedTarget(16, next_tokens=[15])
+        dec = PromptLookupDecoder(target, num_speculative_tokens=4)
+        dec.prefill(mx.array([[1, 2, 3]]))  # pending -> 15
+        accepted, num_drafted = dec.step()
+        assert num_drafted == 0
+        assert len(accepted) == 1  # only the target's own next token
+        # EMA untouched (skip-on-no-match rule).
+        assert dec._alpha == 0.0
+        assert dec.stats_summary()["acceptance_rate"] == 0.0
+        dec.close()
+
+    def test_step_with_match_updates_state_and_ema(self):
+        # Build history that makes a unigram match. We control acceptance by
+        # making the target's argmax agree with the drafted tokens.
+        #
+        # prefill prompt = [7, 8, 7] -> _prefill_last_logit runs two passes
+        # consuming 3 scripted slots (cursor 0,1 on [7,8]; cursor 2 on [7]),
+        # so the returned pending = next_tokens[2]. We set that to 8 so that
+        # pending=8 matches the unigram at history index 1 -> draft = [7].
+        # The step() target forward over [pending=8, draft=7] then consumes
+        # next_tokens[3], next_tokens[4]: set to [7, 9] so draft 7 is
+        # accepted and 9 is the bonus.
+        target = _ScriptedTarget(16, next_tokens=[1, 1, 8, 7, 9])
+        dec = PromptLookupDecoder(
+            target, num_speculative_tokens=4, max_ngram_size=1, min_ngram_size=1
+        )
+        first = dec.prefill(mx.array([[7, 8, 7]]))
+        assert first == 8  # pending
+        accepted, num_drafted = dec.step()
+        # draft was [7]; target argmax for [pending=8, draft=7] forward is
+        # [7, 9] -> accept draft 7, bonus 9.
+        assert num_drafted == 1
+        assert accepted == [7, 9]
+        # EMA updated because something was drafted (acceptance 1/1 = 1.0).
+        # alpha = 0.9*0.0 + 0.1*1.0 = 0.1
+        assert dec._alpha == pytest.approx(0.1)
+        # Stats reflect the accepted draft.
+        assert dec._stats_steps == 1
+        assert dec._stats_proposed == 1
+        assert dec._stats_accepted_draft == 1
+        # Pending becomes the bonus token.
+        assert dec._pending_token == 9
+        dec.close()
+
+    def test_reset_clears_pld_state_and_ema(self):
+        target = _ScriptedTarget(16, next_tokens=[3])
+        dec = PromptLookupDecoder(target, num_speculative_tokens=2)
+        dec.prefill(mx.array([[1, 2, 3]]))
+        dec.step()
+        dec.reset()
+        assert dec._target_cache is None
+        assert dec._cache_seq_len == 0
+        assert dec._pending_token is None
+        assert dec._tokens == []
+        assert dec._stats_steps == 0
+        assert dec._alpha == 0.0
+        dec.close()
+
+
+# ---------------------------------------------------------------------------
+# _eval_cache: warning path for unrecognised non-empty cache (extra branch)
+# ---------------------------------------------------------------------------
+
+
+class TestEvalCacheEmpty:
+    def test_empty_cache_list_no_log(self, caplog):
+        from olmlx.engine.speculative import _eval_cache
+
+        with caplog.at_level(logging.ERROR, logger="olmlx.engine.speculative"):
+            _eval_cache([])
+        assert not any("no mx.array entries found" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Adds **~640 hermetic regression tests** across **17 low-coverage modules** (one new `tests/test_*_coverage.py` per module), lifting overall coverage **80% → 86%**. Motivated by a recent run of regressions — these are behavioral tests targeting previously-uncovered branches, not coverage padding.

All tests are deterministic and fully mock model/GPU/network/disk, so they run in CI (no `real_model` marker). Full suite: **4083 passed, 0 failed, 5 skipped**.

## Coverage delta (full-suite, authoritative)

| Module | Before | After |
|---|---|---|
| `engine/self_speculative/decoder` | 0% | **100%** |
| `bench/extended_runner` | 51% | **100%** |
| `chat/mcp_client` | 47% | **100%** |
| `chat/tui` | 56% | **100%** |
| `engine/spectralquant_calibrate` | 47% | **100%** |
| `engine/flash/moe_weight_store` | 72% | **100%** |
| `routers/blobs` | 63% | **100%** |
| `bench/worker` | 36% | **99%** |
| `bench/ifeval_grader` | 47% | **99%** |
| `chat/session` | 79% | **97%** |
| `bench/api_bench` | 54% | **94%** |
| `engine/inference` | 89% | **91%** |
| `chat/builtin_tools` | 69% | **84%** |
| `engine/gdn_rollback` | 71% | **83%** |
| `engine/model_manager` | 79% | **80%** |
| `engine/speculative` | 72% | **73%** |
| `cli.py` | 57% | **63%** |
| **TOTAL** | **80%** | **86%** |

## Bug fix included

The new `chat/session` tests surfaced a **real bug**: `ChatSession._execute_tool_calls` matched the 13-char `"__question__:"` prefix but sliced the payload with `len("__question__")` (12), leaving a stray `:` that made `json.loads` always raise — so the `question` event was **silently never emitted to the UI**. Fixed (1-line), with a regression test asserting the event now fires.

## Notes

- `test_self_speculative_coverage` seeds MLX's RNG per test (autouse fixture) so the random-weight stub models are order-independent — the rejection-trim assertion was otherwise sensitive to RNG state left by earlier tests.
- Out of scope (pre-existing): an unregistered `@pytest.mark.slow` and an un-awaited `_probe_cache_capabilities` coroutine in `test_model_manager.py:6022`.
- `cli.py` (63%) remains the largest headroom; most of the rest is subcommand paths that need a real model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)