### PR TITLE
feat(responses): OpenAI /v1/responses endpoint (#368)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ olmlx/
 ├── routers/
 │   ├── anthropic.py    # /v1/messages — Anthropic Messages API
 │   ├── openai.py       # /v1/chat/completions, /v1/completions, /v1/models, /v1/embeddings
+│   ├── responses.py    # /v1/responses — OpenAI Responses API (state store, semantic SSE)
 │   ├── audio.py        # /v1/audio/transcriptions — Whisper STT
 │   ├── metrics.py      # GET /metrics — Prometheus exposition
 │   └── *.py            # /api/{chat,generate,tags,show,ps,pull,copy,create,delete,embed,blobs,version} (Ollama)
@@ -52,6 +53,7 @@ olmlx/
 ## Key Design Decisions
 
 - **Anthropic router**: Buffers full model output before emitting SSE so `<think>` and `<tool_call>` raw text from Qwen-family models can be split into proper content blocks. Also exposes `/v1/messages/count_tokens`.
+- **Responses router** (`routers/responses.py`): Translation layer over `generate_chat` implementing the OpenAI Responses API (`POST/GET/DELETE /v1/responses`). A bounded-LRU store (`OLMLX_RESPONSES_STORE_MAX`, default 256) holds completed responses; `previous_response_id` replays the stored history and reuses the same `cache_id` for KV cache continuity. `instructions` apply only to the current turn (not propagated via continuation — OpenAI semantics). Built-in tools (`web_search`, `code_interpreter`, `computer_use`) are rejected with 422; function tools and structured output via `text.format` are fully supported. No disk persistence — store is in-memory only.
 - **Thinking toggle**: Resolved per-request to engine's `enable_thinking: bool | None`. Ollama uses native top-level `think` field; OpenAI uses `reasoning_effort` (presence → on) or `chat_template_kwargs.enable_thinking` (authoritative, only clean OFF). Mapping helpers in `routers/common.py`. Omission on `/api/chat` and `/v1/chat/completions` falls back to per-model default (`ModelConfig.enable_thinking`), then engine default. `/api/generate` stays off-by-default and ignores the per-model default.
 - **Structured outputs** (`engine/grammar.py`): JSON-mode / JSON-Schema via xgrammar as an mlx-lm logits processor. Surfaces on OpenAI `response_format` and Ollama `format` (both `/api/chat` and `/api/generate`). Compiled grammars cached per (tokenizer-id, spec-hash). VLM, distributed, and speculative paths skip with a warning — `logits_processors` isn't threaded through any of them.
 - **Tool call parsing**: Qwen `<tool_call>`, Mistral `[TOOL_CALLS]`, Llama 3.x `<function=>`, DeepSeek, MiniMax `<minimax:tool_call>`, bare JSON. `tool_result` blocks → `role: "tool"` messages; `tool_use` blocks → `tool_calls`; thinking blocks in history are skipped.

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -1093,9 +1093,9 @@ curl http://localhost:11434/v1/responses \
 
 **Multi-turn continuation** via `previous_response_id`: pass the `id` of a previous response and the prior conversation history is replayed automatically. The store is bounded in memory (default 256 entries, configurable via `OLMLX_RESPONSES_STORE_MAX`). State is not persisted to disk — the store is cleared on restart.
 
-**Reasoning items**: if the model emits `<think>` tokens, they appear as a `reasoning` output item with `summary` content before the `message` item.
+**Reasoning items**: if the model emits `<think>` tokens, they appear as a `reasoning` output item (with the reasoning text under `content`) before the `message` item.
 
-**Image input**: pass `input_image` items in the `input` array with `image_url` or base64 `source` for VLMs.
+**Image input**: pass `input_image` content parts in a `message` input item for VLMs. The `image_url` field accepts an http(s) URL or a `data:image/...;base64,...` data URI (base64 images are carried inline in `image_url`, not a separate `source` block).
 
 **Not supported**: built-in OpenAI tools (`web_search`, `code_interpreter`, `computer_use`) — these are rejected with HTTP 422.
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -1037,6 +1037,88 @@ response = client.chat.completions.create(
 
 > **Note:** JSON mode appends an instruction to the system prompt. Schema enforcement is not strictly applied — the model is instructed to follow the schema but may deviate.
 
+#### POST /v1/responses
+
+OpenAI [Responses API](https://platform.openai.com/docs/api-reference/responses). Stateful multi-turn conversations with full semantic SSE streaming.
+
+```bash
+curl http://localhost:11434/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3:8b",
+    "input": "What is 2+2?",
+    "instructions": "You are a helpful assistant."
+  }'
+```
+
+**Supported request fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `model` | string | Model name (required) |
+| `input` | string or array | User message text, or array of input items (required) |
+| `instructions` | string | System prompt for this turn |
+| `previous_response_id` | string | ID of a prior response to continue from |
+| `stream` | boolean | Enable SSE streaming with semantic events |
+| `temperature` | float | 0–2 range |
+| `top_p` | float | 0–1 range |
+| `max_output_tokens` | int | Output token limit (default: 512) |
+| `tools` | array | Function tool definitions (`type: "function"`) |
+| `tool_choice` | string/object | `"auto"`, `"none"`, or `{"type":"function","name":"..."}` |
+| `text` | object | `{"format": {"type": "json_object"}}` or `{"format": {"type": "json_schema", "schema": {...}}}` for structured output |
+| `store` | boolean | If `false`, response is not saved (no `previous_response_id` reuse) |
+
+**Non-streaming response:**
+
+```json
+{
+  "id": "resp_abc123",
+  "object": "response",
+  "created_at": 1711100000,
+  "model": "qwen3:8b",
+  "status": "completed",
+  "output": [
+    {
+      "type": "message",
+      "id": "msg_abc123",
+      "role": "assistant",
+      "content": [{"type": "output_text", "text": "4"}]
+    }
+  ],
+  "usage": {"input_tokens": 10, "output_tokens": 3, "total_tokens": 13}
+}
+```
+
+**Streaming** uses Server-Sent Events with semantic event types: `response.created`, `response.output_item.added`, `response.content_part.added`, `response.output_text.delta`, `response.output_text.done`, `response.content_part.done`, `response.output_item.done`, `response.completed`.
+
+**Multi-turn continuation** via `previous_response_id`: pass the `id` of a previous response and the prior conversation history is replayed automatically. The store is bounded in memory (default 256 entries, configurable via `OLMLX_RESPONSES_STORE_MAX`). State is not persisted to disk — the store is cleared on restart.
+
+**Reasoning items**: if the model emits `<think>` tokens, they appear as a `reasoning` output item with `summary` content before the `message` item.
+
+**Image input**: pass `input_image` items in the `input` array with `image_url` or base64 `source` for VLMs.
+
+**Not supported**: built-in OpenAI tools (`web_search`, `code_interpreter`, `computer_use`) — these are rejected with HTTP 422.
+
+#### GET /v1/responses/{id}
+
+Retrieve a stored response by ID:
+
+```bash
+curl http://localhost:11434/v1/responses/resp_abc123
+```
+
+Returns the full response object, or HTTP 404 if the ID is unknown or has been evicted.
+
+#### DELETE /v1/responses/{id}
+
+Delete a stored response:
+
+```bash
+curl -X DELETE http://localhost:11434/v1/responses/resp_abc123
+```
+
+Returns `{"id": "resp_abc123", "object": "response.deleted", "deleted": true}`.
+
 ---
 
 ### Anthropic Messages API

--- a/docs/superpowers/plans/2026-06-07-openai-responses-endpoint.md
+++ b/docs/superpowers/plans/2026-06-07-openai-responses-endpoint.md
@@ -1,0 +1,1800 @@
+# OpenAI `/v1/responses` Endpoint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add OpenAI's `/v1/responses` API to olmlx as a drop-in surface (text, streaming with full semantic events, function tool-calls, `previous_response_id` continuation, reasoning items, image input, structured outputs), implemented as a pure translation layer over the existing `generate_chat` engine.
+
+**Architecture:** A new `routers/responses.py` translates a Responses request into the engine's message-dict format, calls `generate_chat` unchanged, then translates the output back into Responses output-items / SSE events. A bounded-LRU `engine/responses_state.py` holds responses for `previous_response_id` continuation. Mirrors the proven `routers/anthropic.py` buffer-and-split structure. Design doc: `docs/superpowers/specs/2026-06-07-openai-responses-endpoint-design.md`.
+
+**Tech Stack:** FastAPI, Pydantic v2, pytest + httpx `AsyncClient` (autouse MLX mock in `tests/`), the OpenAI Python SDK (for the live test only).
+
+---
+
+## Conventions used in this plan
+
+- All test commands assume the repo root and `uv`. Run a single test with:
+  `uv run pytest tests/test_routers_responses.py::TestClass::test_name -v`
+- Router-level tests patch the engine: `patch("olmlx.routers.responses.generate_chat", ...)`.
+- The `app_client` fixture (in `tests/conftest.py`) provides an httpx `AsyncClient`
+  bound to a real `create_app()` with a mock manager. Reuse it.
+- `TimingStats(prompt_eval_count=N, eval_count=M)` builds usage in tests.
+
+---
+
+## Task 1: Config setting + Pydantic schemas
+
+**Files:**
+- Modify: `olmlx/config.py` (add one setting near the other feature flags, ~line 114)
+- Create: `olmlx/schemas/responses.py`
+- Test: `tests/test_routers_responses.py` (new file — schema validation tests)
+
+- [ ] **Step 1: Add the store-size setting to `config.py`**
+
+In `olmlx/config.py`, inside `class Settings`, near the `prompt_cache_*` block (~line 114), add:
+
+```python
+    # Max number of stored Responses-API responses for previous_response_id
+    # continuation (in-memory LRU; lost on restart).
+    responses_store_max: Annotated[int, Field(gt=0)] = 256
+```
+
+(`Annotated` and `Field` are already imported in `config.py`.)
+
+- [ ] **Step 2: Write the failing schema test**
+
+Create `tests/test_routers_responses.py`:
+
+```python
+"""Tests for olmlx.routers.responses and its schemas."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from olmlx.schemas.responses import ResponsesRequest
+from olmlx.utils.timing import TimingStats
+
+
+class TestResponsesRequestSchema:
+    def test_string_input_accepted(self):
+        req = ResponsesRequest(model="qwen3", input="hello")
+        assert req.input == "hello"
+        assert req.store is True
+        assert req.stream is False
+
+    def test_list_input_accepted(self):
+        req = ResponsesRequest(
+            model="qwen3",
+            input=[{"role": "user", "content": "hi"}],
+        )
+        assert isinstance(req.input, list)
+
+    def test_defaults(self):
+        req = ResponsesRequest(model="qwen3", input="x")
+        assert req.previous_response_id is None
+        assert req.tools is None
+        assert req.max_output_tokens is None
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `uv run pytest tests/test_routers_responses.py::TestResponsesRequestSchema -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'olmlx.schemas.responses'`
+
+- [ ] **Step 4: Implement the schemas**
+
+Create `olmlx/schemas/responses.py`:
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+from olmlx.schemas.common import ModelName
+
+
+class ResponsesRequest(BaseModel):
+    model: ModelName
+    # `input` is either a plain string (one user turn) or a list of input
+    # items (messages / function_call / function_call_output). Items are kept
+    # as freeform dicts and validated during translation (router raises
+    # ValueError -> 400/422 for unknown shapes).
+    input: str | list[dict[str, Any]]
+    instructions: str | None = None
+    stream: bool = False
+    max_output_tokens: int | None = Field(None, ge=1)
+    temperature: float | None = Field(None, ge=0, le=2)
+    top_p: float | None = Field(None, ge=0, le=1)
+    tools: list[dict[str, Any]] | None = None
+    tool_choice: str | dict[str, Any] | None = None
+    previous_response_id: str | None = None
+    store: bool = True
+    reasoning: dict[str, Any] | None = None  # {"effort": "low"|"medium"|"high"}
+    text: dict[str, Any] | None = None       # {"format": {"type": ...}}
+    metadata: dict[str, Any] | None = None
+    seed: int | None = None
+
+    @field_validator("max_output_tokens")
+    @classmethod
+    def _validate_max_tokens(cls, v: int | None) -> int | None:
+        if v is None:
+            return v
+        from olmlx.schemas.common import validate_token_limit
+
+        return validate_token_limit(v, "max_output_tokens")
+
+
+class ResponsesResponse(BaseModel):
+    """Top-level Responses object. Output items and usage are kept as dicts so
+    the router builds them directly; response_model_exclude_none trims absent
+    fields the SDK treats as optional."""
+
+    id: str
+    object: str = "response"
+    created_at: int
+    status: str
+    model: str
+    output: list[dict[str, Any]]
+    usage: dict[str, Any] | None = None
+    previous_response_id: str | None = None
+    incomplete_details: dict[str, Any] | None = None
+    error: dict[str, Any] | None = None
+    instructions: str | None = None
+    max_output_tokens: int | None = None
+    metadata: dict[str, Any] | None = None
+    parallel_tool_calls: bool = True
+    temperature: float | None = None
+    top_p: float | None = None
+    tool_choice: str | dict[str, Any] | None = None
+    tools: list[dict[str, Any]] = Field(default_factory=list)
+```
+
+- [ ] **Step 5: Run the schema test to verify it passes**
+
+Run: `uv run pytest tests/test_routers_responses.py::TestResponsesRequestSchema -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add olmlx/config.py olmlx/schemas/responses.py tests/test_routers_responses.py
+git commit -m "feat(responses): request/response schemas + store-size setting (#368)"
+```
+
+---
+
+## Task 2: Bounded-LRU state store
+
+**Files:**
+- Create: `olmlx/engine/responses_state.py`
+- Test: `tests/test_responses_state.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_responses_state.py`:
+
+```python
+"""Tests for the Responses-API state store."""
+
+from olmlx.engine.responses_state import ResponsesStore
+
+
+def test_put_get_roundtrip():
+    store = ResponsesStore(max_entries=4)
+    store.put("resp_1", {"output_items": [{"a": 1}]})
+    assert store.get("resp_1") == {"output_items": [{"a": 1}]}
+
+
+def test_missing_returns_none():
+    store = ResponsesStore(max_entries=4)
+    assert store.get("nope") is None
+
+
+def test_delete():
+    store = ResponsesStore(max_entries=4)
+    store.put("resp_1", {"x": 1})
+    assert store.delete("resp_1") is True
+    assert store.get("resp_1") is None
+    assert store.delete("resp_1") is False
+
+
+def test_lru_eviction():
+    store = ResponsesStore(max_entries=2)
+    store.put("a", {"v": 1})
+    store.put("b", {"v": 2})
+    store.put("c", {"v": 3})  # evicts "a"
+    assert store.get("a") is None
+    assert store.get("b") == {"v": 2}
+    assert store.get("c") == {"v": 3}
+
+
+def test_get_refreshes_lru():
+    store = ResponsesStore(max_entries=2)
+    store.put("a", {"v": 1})
+    store.put("b", {"v": 2})
+    store.get("a")          # "a" now most-recently used
+    store.put("c", {"v": 3})  # evicts "b", not "a"
+    assert store.get("a") == {"v": 1}
+    assert store.get("b") is None
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run pytest tests/test_responses_state.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'olmlx.engine.responses_state'`
+
+- [ ] **Step 3: Implement the store**
+
+Create `olmlx/engine/responses_state.py`:
+
+```python
+"""In-memory LRU store for Responses-API state (previous_response_id).
+
+Single-user, localhost-only: a bounded OrderedDict keyed by response_id.
+Not persisted; lost on restart. Bounded by OLMLX_RESPONSES_STORE_MAX so it is
+not counted against the memory limit (text-only entries).
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from threading import Lock
+from typing import Any
+
+from olmlx.config import settings
+
+
+class ResponsesStore:
+    def __init__(self, max_entries: int | None = None) -> None:
+        self._max = (
+            max_entries if max_entries is not None else settings.responses_store_max
+        )
+        self._store: OrderedDict[str, dict[str, Any]] = OrderedDict()
+        self._lock = Lock()
+
+    def put(self, response_id: str, entry: dict[str, Any]) -> None:
+        with self._lock:
+            self._store[response_id] = entry
+            self._store.move_to_end(response_id)
+            while len(self._store) > self._max:
+                self._store.popitem(last=False)
+
+    def get(self, response_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            entry = self._store.get(response_id)
+            if entry is not None:
+                self._store.move_to_end(response_id)
+            return entry
+
+    def delete(self, response_id: str) -> bool:
+        with self._lock:
+            return self._store.pop(response_id, None) is not None
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()
+
+
+_store = ResponsesStore()
+
+
+def get_store() -> ResponsesStore:
+    """Return the process-wide Responses store singleton."""
+    return _store
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_responses_state.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/responses_state.py tests/test_responses_state.py
+git commit -m "feat(responses): bounded-LRU state store for previous_response_id (#368)"
+```
+
+---
+
+## Task 3: Translation helpers (tools, input items, options, grammar, reasoning)
+
+**Files:**
+- Create: `olmlx/routers/responses.py` (helpers only this task; endpoint added in Task 4)
+- Test: `tests/test_routers_responses.py` (append `TestTranslation`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_routers_responses.py`:
+
+```python
+from olmlx.routers.responses import (
+    _build_input_messages,
+    _convert_tools,
+    _grammar_from_text_format,
+    _resolve_reasoning,
+)
+
+
+class TestTranslation:
+    def test_string_input(self):
+        msgs = _build_input_messages("hello")
+        assert msgs == [{"role": "user", "content": "hello"}]
+
+    def test_message_item_string_content(self):
+        msgs = _build_input_messages([{"role": "user", "content": "hi"}])
+        assert msgs == [{"role": "user", "content": "hi"}]
+
+    def test_message_item_text_parts(self):
+        msgs = _build_input_messages(
+            [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}]
+        )
+        assert msgs == [{"role": "user", "content": "hi"}]
+
+    def test_message_item_image_part(self):
+        msgs = _build_input_messages(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "describe"},
+                        {"type": "input_image", "image_url": "http://x/y.png"},
+                    ],
+                }
+            ]
+        )
+        assert msgs[0]["content"] == "describe"
+        assert msgs[0]["images"] == ["http://x/y.png"]
+
+    def test_function_call_output_item(self):
+        msgs = _build_input_messages(
+            [{"type": "function_call_output", "call_id": "call_1", "output": "42"}]
+        )
+        assert msgs == [
+            {"role": "tool", "tool_call_id": "call_1", "content": "42"}
+        ]
+
+    def test_function_call_item(self):
+        msgs = _build_input_messages(
+            [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "get_weather",
+                    "arguments": '{"city": "SF"}',
+                }
+            ]
+        )
+        assert msgs[0]["role"] == "assistant"
+        tc = msgs[0]["tool_calls"][0]
+        assert tc["function"]["name"] == "get_weather"
+        assert tc["id"] == "call_1"
+
+    def test_unknown_item_type_raises(self):
+        with pytest.raises(ValueError):
+            _build_input_messages([{"type": "mystery"}])
+
+    def test_convert_function_tool(self):
+        tools = _convert_tools(
+            [
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "description": "d",
+                    "parameters": {"type": "object"},
+                }
+            ]
+        )
+        assert tools[0]["function"]["name"] == "get_weather"
+        assert tools[0]["type"] == "function"
+
+    def test_builtin_tool_rejected(self):
+        with pytest.raises(ValueError):
+            _convert_tools([{"type": "web_search"}])
+
+    def test_grammar_json_object(self):
+        spec = _grammar_from_text_format({"format": {"type": "json_object"}})
+        assert spec is not None
+
+    def test_grammar_none_for_text(self):
+        assert _grammar_from_text_format({"format": {"type": "text"}}) is None
+        assert _grammar_from_text_format(None) is None
+
+    def test_resolve_reasoning_presence(self):
+        assert _resolve_reasoning({"effort": "high"}) is True
+        assert _resolve_reasoning({"effort": "none"}) is False
+        assert _resolve_reasoning(None) is None
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run pytest tests/test_routers_responses.py::TestTranslation -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'olmlx.routers.responses'`
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `olmlx/routers/responses.py`:
+
+```python
+import json
+import logging
+import time
+import uuid
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from olmlx.engine.grammar import parse_response_format
+from olmlx.engine.inference import generate_chat
+from olmlx.engine.responses_state import get_store
+from olmlx.engine.tool_parser import (
+    fill_missing_required_args,
+    parse_model_output,
+    resolve_tool_names,
+)
+from olmlx.routers.common import build_inference_options, resolve_openai_think
+from olmlx.schemas.responses import ResponsesRequest, ResponsesResponse
+from olmlx.utils.images import normalize_image_block
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_BUILTIN_TOOL_TYPES = {"web_search", "code_interpreter", "computer_use", "file_search"}
+
+
+def _make_response_id() -> str:
+    return f"resp_{uuid.uuid4().hex[:24]}"
+
+
+def _make_message_id() -> str:
+    return f"msg_{uuid.uuid4().hex[:24]}"
+
+
+def _make_reasoning_id() -> str:
+    return f"rs_{uuid.uuid4().hex[:24]}"
+
+
+def _make_fc_id() -> str:
+    return f"fc_{uuid.uuid4().hex[:24]}"
+
+
+def _make_call_id() -> str:
+    return f"call_{uuid.uuid4().hex[:24]}"
+
+
+def _message_item_to_engine(item: dict) -> dict:
+    """Convert a Responses `message` input item to an engine message dict."""
+    role = item["role"]
+    content = item.get("content")
+    if isinstance(content, str):
+        return {"role": role, "content": content}
+    texts: list[str] = []
+    images: list[str] = []
+    for part in content or []:
+        if not isinstance(part, dict):
+            continue
+        ptype = part.get("type")
+        if ptype in ("input_text", "text", "output_text"):
+            txt = part.get("text") or ""
+            if txt:
+                texts.append(txt)
+        elif ptype in ("input_image", "image_url"):
+            raw = part.get("image_url")
+            if isinstance(raw, str):
+                block = {"type": "image_url", "image_url": {"url": raw}}
+            else:
+                block = {"type": "image_url", "image_url": raw or {}}
+            images.append(normalize_image_block(block))
+        else:
+            raise ValueError(f"unsupported content part type: {ptype!r}")
+    msg: dict = {"role": role, "content": " ".join(texts)}
+    if images:
+        msg["images"] = images
+    return msg
+
+
+def _build_input_messages(input_data: str | list[dict]) -> list[dict]:
+    """Translate a Responses `input` field into engine message dicts."""
+    if isinstance(input_data, str):
+        return [{"role": "user", "content": input_data}]
+    messages: list[dict] = []
+    for item in input_data:
+        itype = item.get("type")
+        role = item.get("role")
+        if itype in (None, "message") and role is not None:
+            messages.append(_message_item_to_engine(item))
+        elif itype == "function_call":
+            messages.append(
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": item.get("call_id"),
+                            "type": "function",
+                            "function": {
+                                "name": item["name"],
+                                "arguments": item.get("arguments", ""),
+                            },
+                        }
+                    ],
+                }
+            )
+        elif itype == "function_call_output":
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": item.get("call_id"),
+                    "content": item.get("output", ""),
+                }
+            )
+        else:
+            raise ValueError(f"unsupported input item type: {itype!r}")
+    return messages
+
+
+def _convert_tools(tools: list[dict] | None) -> list[dict] | None:
+    """Convert Responses function tools to engine OpenAI-nested format."""
+    if not tools:
+        return None
+    converted: list[dict] = []
+    for t in tools:
+        ttype = t.get("type")
+        if ttype != "function":
+            if ttype in _BUILTIN_TOOL_TYPES:
+                raise ValueError(
+                    f"built-in tool {ttype!r} is not supported; only custom "
+                    "'function' tools are available"
+                )
+            raise ValueError(f"unsupported tool type: {ttype!r}")
+        converted.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": t["name"],
+                    "description": t.get("description", ""),
+                    "parameters": t.get("parameters", {}),
+                },
+            }
+        )
+    return converted
+
+
+def _grammar_from_text_format(text_cfg: dict | None):
+    """Map a Responses `text.format` config to a GrammarSpec (or None)."""
+    fmt = (text_cfg or {}).get("format")
+    if not fmt:
+        return None
+    ftype = fmt.get("type")
+    if ftype in (None, "text"):
+        return None
+    if ftype == "json_object":
+        return parse_response_format({"type": "json_object"})
+    if ftype == "json_schema":
+        return parse_response_format(
+            {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": fmt.get("name", "schema"),
+                    "schema": fmt.get("schema", {}),
+                },
+            }
+        )
+    raise ValueError(f"unsupported text.format type: {ftype!r}")
+
+
+def _resolve_reasoning(reasoning: dict | None) -> bool | None:
+    """Map Responses `reasoning.effort` to the engine enable_thinking flag."""
+    effort = (reasoning or {}).get("effort")
+    return resolve_openai_think(effort, None)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_routers_responses.py::TestTranslation -v`
+Expected: PASS (12 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/routers/responses.py tests/test_routers_responses.py
+git commit -m "feat(responses): request translation helpers (#368)"
+```
+
+---
+
+## Task 4: Non-streaming POST endpoint (text) + router registration
+
+**Files:**
+- Modify: `olmlx/routers/responses.py` (add output builder + POST handler)
+- Modify: `olmlx/app.py` (register router)
+- Test: `tests/test_routers_responses.py` (append `TestNonStreamingText`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_routers_responses.py`:
+
+```python
+class TestNonStreamingText:
+    @pytest.mark.asyncio
+    async def test_text_response_shape(self, app_client):
+        stats = TimingStats(prompt_eval_count=5, eval_count=3)
+        mock_result = {"text": "Hello there.", "done": True, "stats": stats}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "hi", "stream": False},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["object"] == "response"
+        assert data["status"] == "completed"
+        assert data["id"].startswith("resp_")
+        # one message item with one output_text part
+        msg = next(it for it in data["output"] if it["type"] == "message")
+        assert msg["role"] == "assistant"
+        assert msg["content"][0]["type"] == "output_text"
+        assert msg["content"][0]["text"] == "Hello there."
+        assert data["usage"]["input_tokens"] == 5
+        assert data["usage"]["output_tokens"] == 3
+        assert data["usage"]["total_tokens"] == 8
+
+    @pytest.mark.asyncio
+    async def test_timeout_marks_incomplete(self, app_client):
+        mock_result = {
+            "text": "partial",
+            "done": True,
+            "done_reason": "timeout",
+            "stats": TimingStats(),
+        }
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "hi"},
+            )
+        data = resp.json()
+        assert data["status"] == "incomplete"
+        assert data["incomplete_details"]["reason"] == "max_output_tokens"
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run pytest tests/test_routers_responses.py::TestNonStreamingText -v`
+Expected: FAIL with 404 (route not registered) — assertion error on status_code.
+
+- [ ] **Step 3: Build the output builder + POST handler**
+
+Append to `olmlx/routers/responses.py`:
+
+```python
+def _build_output_items(
+    thinking: str, visible_text: str, tool_uses: list[dict]
+) -> list[dict]:
+    """Assemble Responses output items in canonical order."""
+    items: list[dict] = []
+    if thinking:
+        items.append(
+            {
+                "type": "reasoning",
+                "id": _make_reasoning_id(),
+                "summary": [],
+                "content": [{"type": "reasoning_text", "text": thinking}],
+            }
+        )
+    if visible_text:
+        items.append(
+            {
+                "type": "message",
+                "id": _make_message_id(),
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {"type": "output_text", "text": visible_text, "annotations": []}
+                ],
+            }
+        )
+    for tu in tool_uses:
+        items.append(
+            {
+                "type": "function_call",
+                "id": _make_fc_id(),
+                "call_id": _make_call_id(),
+                "name": tu["name"],
+                "arguments": json.dumps(tu.get("input", {})),
+                "status": "completed",
+            }
+        )
+    return items
+
+
+def _usage_dict(stats) -> dict:
+    if stats is None:
+        return {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    prompt = stats.prompt_eval_count
+    completion = stats.eval_count
+    return {
+        "input_tokens": prompt,
+        "output_tokens": completion,
+        "total_tokens": prompt + completion,
+    }
+
+
+def _build_response_object(
+    req: ResponsesRequest,
+    response_id: str,
+    created: int,
+    output_items: list[dict],
+    stats,
+    done_reason: str | None,
+) -> ResponsesResponse:
+    incomplete = None
+    status = "completed"
+    if done_reason == "timeout":
+        status = "incomplete"
+        incomplete = {"reason": "max_output_tokens"}
+    return ResponsesResponse(
+        id=response_id,
+        created_at=created,
+        status=status,
+        model=req.model,
+        output=output_items,
+        usage=_usage_dict(stats),
+        previous_response_id=req.previous_response_id,
+        incomplete_details=incomplete,
+        instructions=req.instructions,
+        max_output_tokens=req.max_output_tokens,
+        metadata=req.metadata,
+        temperature=req.temperature,
+        top_p=req.top_p,
+        tool_choice=req.tool_choice,
+        tools=req.tools or [],
+    )
+
+
+@router.post(
+    "/v1/responses",
+    response_model=ResponsesResponse,
+    response_model_exclude_none=True,
+)
+async def create_response(req: ResponsesRequest, request: Request):
+    manager = request.app.state.model_manager
+    logger.info(
+        "Responses request: model=%s stream=%s tools=%d prev=%s",
+        req.model,
+        req.stream,
+        len(req.tools or []),
+        req.previous_response_id,
+    )
+
+    # --- translate request -> engine inputs (client errors -> 400/422) ---
+    try:
+        messages = _build_input_messages(req.input)
+        tools = _convert_tools(req.tools)
+        grammar_spec = _grammar_from_text_format(req.text)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    if req.instructions:
+        messages.insert(0, {"role": "system", "content": req.instructions})
+
+    options = build_inference_options(
+        temperature=req.temperature, top_p=req.top_p, seed=req.seed
+    )
+    max_tokens = req.max_output_tokens or 512
+    enable_thinking = _resolve_reasoning(req.reasoning)
+    response_id = _make_response_id()
+    created = int(time.time())
+    cache_id = (req.previous_response_id or response_id)[:256]
+
+    result = await generate_chat(
+        manager,
+        req.model,
+        messages,
+        options,
+        tools=tools,
+        stream=False,
+        max_tokens=max_tokens,
+        cache_id=cache_id,
+        enable_thinking=enable_thinking,
+        grammar_spec=grammar_spec,
+    )
+
+    parse_text = result.get("raw_text") or result.get("text", "")
+    thinking, visible_text, tool_uses = parse_model_output(
+        parse_text,
+        bool(tools),
+        thinking_expected=bool(result.get("thinking_expected")),
+    )
+    resolve_tool_names(tool_uses, req.tools)
+    fill_missing_required_args(tool_uses, req.tools)
+
+    output_items = _build_output_items(thinking, visible_text, tool_uses)
+    response = _build_response_object(
+        req, response_id, created, output_items, result.get("stats"),
+        result.get("done_reason"),
+    )
+    return response
+```
+
+- [ ] **Step 4: Register the router in `app.py`**
+
+In `olmlx/app.py`, add the import alongside the other router imports and register it
+after the openai router (~line 400):
+
+```python
+    app.include_router(responses.router)
+```
+
+Add `responses` to the routers import block at the top of `app.py` (find the line
+importing `openai` from `.routers` and add `responses` to it; match the existing
+import style).
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_routers_responses.py::TestNonStreamingText -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add olmlx/routers/responses.py olmlx/app.py tests/test_routers_responses.py
+git commit -m "feat(responses): non-streaming text endpoint + router registration (#368)"
+```
+
+---
+
+## Task 5: Tool calls, reasoning, structured outputs, images (non-streaming)
+
+**Files:**
+- Test: `tests/test_routers_responses.py` (append `TestNonStreamingFeatures`)
+- (No new implementation — these are exercised by Task 3/4 code; this task is the
+  coverage that proves the wiring. If a test fails, fix the helper it exercises.)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_routers_responses.py`:
+
+```python
+class TestNonStreamingFeatures:
+    @pytest.mark.asyncio
+    async def test_function_call_item_emitted(self, app_client):
+        raw = '<tool_call>{"name": "get_weather", "arguments": {"city": "SF"}}</tool_call>'
+        mock_result = {"text": raw, "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": "weather in SF?",
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "get_weather",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                            },
+                        }
+                    ],
+                },
+            )
+        data = resp.json()
+        fc = next(it for it in data["output"] if it["type"] == "function_call")
+        assert fc["name"] == "get_weather"
+        assert json.loads(fc["arguments"]) == {"city": "SF"}
+        assert fc["call_id"].startswith("call_")
+
+    @pytest.mark.asyncio
+    async def test_reasoning_item_from_think(self, app_client):
+        mock_result = {
+            "text": "<think>step one</think>The answer is 42.",
+            "done": True,
+            "stats": TimingStats(),
+            "thinking_expected": True,
+        }
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "q", "reasoning": {"effort": "high"}},
+            )
+        data = resp.json()
+        reasoning = next(it for it in data["output"] if it["type"] == "reasoning")
+        assert "step one" in reasoning["content"][0]["text"]
+        msg = next(it for it in data["output"] if it["type"] == "message")
+        assert msg["content"][0]["text"] == "The answer is 42."
+        assert mock_gen.call_args.kwargs["enable_thinking"] is True
+
+    @pytest.mark.asyncio
+    async def test_structured_output_threads_grammar(self, app_client):
+        mock_result = {"text": "{}", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": "q",
+                    "text": {
+                        "format": {
+                            "type": "json_schema",
+                            "name": "thing",
+                            "schema": {"type": "object"},
+                        }
+                    },
+                },
+            )
+        assert resp.status_code == 200
+        assert mock_gen.call_args.kwargs["grammar_spec"] is not None
+
+    @pytest.mark.asyncio
+    async def test_image_input_threads_images(self, app_client):
+        mock_result = {"text": "a cat", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "input_text", "text": "what is this?"},
+                                {
+                                    "type": "input_image",
+                                    "image_url": "http://x/cat.png",
+                                },
+                            ],
+                        }
+                    ],
+                },
+            )
+        assert resp.status_code == 200
+        sent_messages = mock_gen.call_args.args[2]
+        assert sent_messages[0]["images"] == ["http://x/cat.png"]
+
+    @pytest.mark.asyncio
+    async def test_builtin_tool_rejected_422(self, app_client):
+        resp = await app_client.post(
+            "/v1/responses",
+            json={"model": "qwen3", "input": "q", "tools": [{"type": "web_search"}]},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_unknown_input_item_422(self, app_client):
+        resp = await app_client.post(
+            "/v1/responses",
+            json={"model": "qwen3", "input": [{"type": "mystery"}]},
+        )
+        assert resp.status_code == 422
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `uv run pytest tests/test_routers_responses.py::TestNonStreamingFeatures -v`
+Expected: PASS (6 tests). If any fail, fix the corresponding helper in Task 3/4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_routers_responses.py
+git commit -m "test(responses): non-streaming tool/reasoning/grammar/image coverage (#368)"
+```
+
+---
+
+## Task 6: `previous_response_id` continuation + store write + `store: false`
+
+**Files:**
+- Modify: `olmlx/routers/responses.py` (read prior history, store result, honor `store`)
+- Test: `tests/test_routers_responses.py` (append `TestStateContinuation`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_routers_responses.py`:
+
+```python
+from olmlx.engine.responses_state import get_store
+
+
+class TestStateContinuation:
+    @pytest.fixture(autouse=True)
+    def _clear_store(self):
+        get_store().clear()
+        yield
+        get_store().clear()
+
+    @pytest.mark.asyncio
+    async def test_response_is_stored(self, app_client):
+        mock_result = {"text": "hi", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses", json={"model": "qwen3", "input": "hi"}
+            )
+        rid = resp.json()["id"]
+        assert get_store().get(rid) is not None
+
+    @pytest.mark.asyncio
+    async def test_store_false_skips(self, app_client):
+        mock_result = {"text": "hi", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "hi", "store": False},
+            )
+        rid = resp.json()["id"]
+        assert get_store().get(rid) is None
+
+    @pytest.mark.asyncio
+    async def test_continuation_prepends_history_and_threads_cache_id(self, app_client):
+        # First turn.
+        first = {"text": "Blue.", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = first
+            r1 = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "favorite color?"},
+            )
+        rid = r1.json()["id"]
+
+        # Second turn references the first.
+        second = {"text": "Because.", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = second
+            await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": "why?",
+                    "previous_response_id": rid,
+                },
+            )
+            sent_messages = mock_gen.call_args.args[2]
+            # history (user + assistant) precedes the new user turn
+            roles = [m["role"] for m in sent_messages]
+            assert roles == ["user", "assistant", "user"]
+            assert sent_messages[1]["content"] == "Blue."
+            assert sent_messages[-1]["content"] == "why?"
+            # cache_id is the previous response id (prompt-cache reuse)
+            assert mock_gen.call_args.kwargs["cache_id"] == rid[:256]
+
+    @pytest.mark.asyncio
+    async def test_unknown_previous_id_404(self, app_client):
+        resp = await app_client.post(
+            "/v1/responses",
+            json={"model": "qwen3", "input": "x", "previous_response_id": "resp_nope"},
+        )
+        assert resp.status_code == 404
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run pytest tests/test_routers_responses.py::TestStateContinuation -v`
+Expected: FAIL — continuation/store not implemented (history not prepended; unknown id returns 200; store empty).
+
+- [ ] **Step 3: Implement continuation + storage**
+
+In `olmlx/routers/responses.py`, add a history-reconstruction helper near the other
+helpers:
+
+```python
+def _history_messages_from_store(previous_response_id: str) -> list[dict]:
+    """Rebuild engine messages from a stored response (input + output items)."""
+    entry = get_store().get(previous_response_id)
+    if entry is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"previous_response_id not found: {previous_response_id!r}",
+        )
+    messages = list(entry["input_messages"])
+    for item in entry["output_items"]:
+        itype = item.get("type")
+        if itype == "message":
+            text = "".join(
+                part.get("text", "")
+                for part in item.get("content", [])
+                if part.get("type") == "output_text"
+            )
+            if text:
+                messages.append({"role": "assistant", "content": text})
+        elif itype == "function_call":
+            messages.append(
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": item.get("call_id"),
+                            "type": "function",
+                            "function": {
+                                "name": item["name"],
+                                "arguments": item.get("arguments", ""),
+                            },
+                        }
+                    ],
+                }
+            )
+        # reasoning items are not replayed into prompt history
+    return messages
+```
+
+Then modify `create_response` so the message list includes prior history, and the
+result is stored. Replace the block from `messages = _build_input_messages(req.input)`
+through the `if req.instructions:` insert with:
+
+```python
+    try:
+        new_messages = _build_input_messages(req.input)
+        tools = _convert_tools(req.tools)
+        grammar_spec = _grammar_from_text_format(req.text)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    if req.previous_response_id:
+        messages = _history_messages_from_store(req.previous_response_id)
+        messages.extend(new_messages)
+    else:
+        messages = new_messages
+
+    if req.instructions:
+        messages.insert(0, {"role": "system", "content": req.instructions})
+```
+
+(`_history_messages_from_store` raises `HTTPException(404)` directly, which must NOT
+be wrapped by the `try/except ValueError` above — keep the call outside that block,
+as shown.)
+
+After building `response` (just before `return response`), add storage:
+
+```python
+    if req.store:
+        get_store().put(
+            response_id,
+            {
+                "input_messages": messages,
+                "output_items": output_items,
+                "model": req.model,
+                "previous_response_id": req.previous_response_id,
+                "response": response.model_dump(exclude_none=True),
+            },
+        )
+    return response
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_routers_responses.py::TestStateContinuation -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/routers/responses.py tests/test_routers_responses.py
+git commit -m "feat(responses): previous_response_id continuation + state storage (#368)"
+```
+
+---
+
+## Task 7: Streaming with full semantic events
+
+**Files:**
+- Modify: `olmlx/routers/responses.py` (streaming generator + branch in handler)
+- Test: `tests/test_routers_responses.py` (append `TestStreaming`)
+
+The streaming path buffers `generate_chat` (tool parsing needs the full output, same
+as the chat/anthropic routers), parses once, then replays the assembled items as the
+full semantic event sequence with a monotonic `sequence_number`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_routers_responses.py`:
+
+```python
+def _parse_sse(body: str) -> list[dict]:
+    """Parse an SSE body into a list of {event, data} dicts."""
+    events = []
+    for block in body.strip().split("\n\n"):
+        if not block.strip():
+            continue
+        event = None
+        data = None
+        for line in block.splitlines():
+            if line.startswith("event: "):
+                event = line[len("event: "):]
+            elif line.startswith("data: "):
+                data = json.loads(line[len("data: "):])
+        events.append({"event": event, "data": data})
+    return events
+
+
+class TestStreaming:
+    @pytest.mark.asyncio
+    async def test_text_stream_event_sequence(self, app_client):
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": "Hel", "done": False}
+                yield {"text": "lo", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats(eval_count=2)}
+
+            return gen()
+
+        with patch(
+            "olmlx.routers.responses.generate_chat", side_effect=mock_stream
+        ):
+            resp = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "hi", "stream": True},
+            )
+        assert resp.status_code == 200
+        events = _parse_sse(resp.text)
+        types = [e["event"] for e in events]
+        assert types[0] == "response.created"
+        assert "response.output_text.delta" in types
+        assert types[-1] == "response.completed"
+        # sequence numbers are present and monotonically increasing
+        seqs = [e["data"]["sequence_number"] for e in events]
+        assert seqs == sorted(seqs)
+        # the deltas reconstruct the full text
+        text = "".join(
+            e["data"]["delta"]
+            for e in events
+            if e["event"] == "response.output_text.delta"
+        )
+        assert text == "Hello"
+        # final response object is completed with the message item
+        final = events[-1]["data"]["response"]
+        assert final["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_stream(self, app_client):
+        raw = '<tool_call>{"name": "f", "arguments": {"x": 1}}</tool_call>'
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": raw, "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch(
+            "olmlx.routers.responses.generate_chat", side_effect=mock_stream
+        ):
+            resp = await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": "go",
+                    "stream": True,
+                    "tools": [
+                        {"type": "function", "name": "f", "parameters": {"type": "object"}}
+                    ],
+                },
+            )
+        events = _parse_sse(resp.text)
+        types = [e["event"] for e in events]
+        assert "response.function_call_arguments.delta" in types
+        assert "response.function_call_arguments.done" in types
+        final = events[-1]["data"]["response"]
+        fc = next(it for it in final["output"] if it["type"] == "function_call")
+        assert fc["name"] == "f"
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run pytest tests/test_routers_responses.py::TestStreaming -v`
+Expected: FAIL — streaming branch not implemented (handler ignores `stream`).
+
+- [ ] **Step 3: Implement streaming**
+
+Add to `olmlx/routers/responses.py`. First a small SSE helper near `_make_response_id`:
+
+```python
+def _sse(event: str, data: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+```
+
+Then the streaming generator (place after `_build_response_object`):
+
+```python
+async def _stream_response(
+    result,
+    req: ResponsesRequest,
+    response_id: str,
+    created: int,
+    tools: list[dict] | None,
+    messages: list[dict],
+):
+    """Buffer the engine output, parse once, replay full semantic events."""
+    seq = 0
+
+    def ev(event: str, data: dict) -> str:
+        nonlocal seq
+        payload = {"type": event, "sequence_number": seq, **data}
+        seq += 1
+        return _sse(event, payload)
+
+    def base_response(status: str, output_items: list[dict], stats, done_reason):
+        return _build_response_object(
+            req, response_id, created, output_items, stats, done_reason
+        ).model_dump(exclude_none=True)
+
+    try:
+        # 1. Buffer the engine stream.
+        full_text = ""
+        raw_text = ""
+        done_reason = None
+        thinking_expected = False
+        stats = None
+        async for chunk in result:
+            if chunk.get("cache_info"):
+                continue
+            if "thinking_expected" in chunk:
+                thinking_expected = bool(chunk["thinking_expected"])
+                continue
+            if chunk.get("done"):
+                raw_text = chunk.get("raw_text", raw_text)
+                done_reason = chunk.get("done_reason")
+                stats = chunk.get("stats")
+                break
+            full_text += chunk.get("text", "")
+
+        parse_text = raw_text or full_text
+        thinking, visible_text, tool_uses = parse_model_output(
+            parse_text, bool(tools), thinking_expected=thinking_expected
+        )
+        resolve_tool_names(tool_uses, req.tools)
+        fill_missing_required_args(tool_uses, req.tools)
+        output_items = _build_output_items(thinking, visible_text, tool_uses)
+
+        # 2. created / in_progress
+        in_progress_resp = base_response("in_progress", [], stats, None)
+        in_progress_resp["status"] = "in_progress"
+        yield ev("response.created", {"response": in_progress_resp})
+        yield ev("response.in_progress", {"response": in_progress_resp})
+
+        # 3. Replay each output item through the event envelope.
+        for out_index, item in enumerate(output_items):
+            yield ev(
+                "response.output_item.added",
+                {"output_index": out_index, "item": item},
+            )
+            if item["type"] == "message":
+                part = item["content"][0]
+                yield ev(
+                    "response.content_part.added",
+                    {
+                        "item_id": item["id"],
+                        "output_index": out_index,
+                        "content_index": 0,
+                        "part": {"type": "output_text", "text": "", "annotations": []},
+                    },
+                )
+                yield ev(
+                    "response.output_text.delta",
+                    {
+                        "item_id": item["id"],
+                        "output_index": out_index,
+                        "content_index": 0,
+                        "delta": part["text"],
+                    },
+                )
+                yield ev(
+                    "response.output_text.done",
+                    {
+                        "item_id": item["id"],
+                        "output_index": out_index,
+                        "content_index": 0,
+                        "text": part["text"],
+                    },
+                )
+                yield ev(
+                    "response.content_part.done",
+                    {
+                        "item_id": item["id"],
+                        "output_index": out_index,
+                        "content_index": 0,
+                        "part": part,
+                    },
+                )
+            elif item["type"] == "function_call":
+                yield ev(
+                    "response.function_call_arguments.delta",
+                    {
+                        "item_id": item["id"],
+                        "output_index": out_index,
+                        "delta": item["arguments"],
+                    },
+                )
+                yield ev(
+                    "response.function_call_arguments.done",
+                    {
+                        "item_id": item["id"],
+                        "output_index": out_index,
+                        "arguments": item["arguments"],
+                    },
+                )
+            # reasoning items: added/done only (no text deltas in v1)
+            yield ev(
+                "response.output_item.done",
+                {"output_index": out_index, "item": item},
+            )
+
+        # 4. completed
+        final = base_response("completed", output_items, stats, done_reason)
+        yield ev("response.completed", {"response": final})
+
+        # 5. store (mirrors the non-streaming path)
+        if req.store:
+            get_store().put(
+                response_id,
+                {
+                    "input_messages": messages,
+                    "output_items": output_items,
+                    "model": req.model,
+                    "previous_response_id": req.previous_response_id,
+                    "response": final,
+                },
+            )
+    except Exception as exc:
+        logger.error("Error during Responses streaming: %s", exc, exc_info=True)
+        yield ev(
+            "response.failed",
+            {
+                "response": {
+                    "id": response_id,
+                    "status": "failed",
+                    "error": {
+                        "code": "server_error",
+                        "message": "An internal server error occurred during streaming.",
+                    },
+                }
+            },
+        )
+    finally:
+        await result.aclose()
+```
+
+Now branch in `create_response`. Replace the single `result = await generate_chat(... stream=False ...)` call and everything after it with a stream/non-stream split:
+
+```python
+    if req.stream:
+        result = await generate_chat(
+            manager,
+            req.model,
+            messages,
+            options,
+            tools=tools,
+            stream=True,
+            max_tokens=max_tokens,
+            cache_id=cache_id,
+            enable_thinking=enable_thinking,
+            grammar_spec=grammar_spec,
+        )
+        return StreamingResponse(
+            _stream_response(result, req, response_id, created, tools, messages),
+            media_type="text/event-stream",
+        )
+
+    result = await generate_chat(
+        manager,
+        req.model,
+        messages,
+        options,
+        tools=tools,
+        stream=False,
+        max_tokens=max_tokens,
+        cache_id=cache_id,
+        enable_thinking=enable_thinking,
+        grammar_spec=grammar_spec,
+    )
+    # ... existing non-streaming parse/build/store/return ...
+```
+
+Keep the existing non-streaming parse → `_build_output_items` → `_build_response_object`
+→ store → `return response` code below the `result = await generate_chat(... stream=False ...)`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_routers_responses.py::TestStreaming -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Run the whole file to confirm no regressions**
+
+Run: `uv run pytest tests/test_routers_responses.py -v`
+Expected: PASS (all classes)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add olmlx/routers/responses.py tests/test_routers_responses.py
+git commit -m "feat(responses): streaming with full semantic SSE events (#368)"
+```
+
+---
+
+## Task 8: `GET` / `DELETE /v1/responses/{id}`
+
+**Files:**
+- Modify: `olmlx/routers/responses.py` (two endpoints)
+- Test: `tests/test_routers_responses.py` (append `TestRetrieveDelete`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_routers_responses.py`:
+
+```python
+class TestRetrieveDelete:
+    @pytest.fixture(autouse=True)
+    def _clear_store(self):
+        get_store().clear()
+        yield
+        get_store().clear()
+
+    @pytest.mark.asyncio
+    async def test_get_then_delete_lifecycle(self, app_client):
+        mock_result = {"text": "hi", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            created = await app_client.post(
+                "/v1/responses", json={"model": "qwen3", "input": "hi"}
+            )
+        rid = created.json()["id"]
+
+        got = await app_client.get(f"/v1/responses/{rid}")
+        assert got.status_code == 200
+        assert got.json()["id"] == rid
+
+        deleted = await app_client.delete(f"/v1/responses/{rid}")
+        assert deleted.status_code == 200
+        assert deleted.json()["deleted"] is True
+
+        gone = await app_client.get(f"/v1/responses/{rid}")
+        assert gone.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_unknown_404(self, app_client):
+        resp = await app_client.get("/v1/responses/resp_unknown")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_unknown_404(self, app_client):
+        resp = await app_client.delete("/v1/responses/resp_unknown")
+        assert resp.status_code == 404
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run pytest tests/test_routers_responses.py::TestRetrieveDelete -v`
+Expected: FAIL with 405/404 (routes not defined).
+
+- [ ] **Step 3: Implement the endpoints**
+
+Append to `olmlx/routers/responses.py`:
+
+```python
+@router.get("/v1/responses/{response_id}")
+async def get_response(response_id: str):
+    entry = get_store().get(response_id)
+    if entry is None:
+        raise HTTPException(
+            status_code=404, detail=f"response not found: {response_id!r}"
+        )
+    return entry["response"]
+
+
+@router.delete("/v1/responses/{response_id}")
+async def delete_response(response_id: str):
+    if not get_store().delete(response_id):
+        raise HTTPException(
+            status_code=404, detail=f"response not found: {response_id!r}"
+        )
+    return {"id": response_id, "object": "response.deleted", "deleted": True}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_routers_responses.py::TestRetrieveDelete -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/routers/responses.py tests/test_routers_responses.py
+git commit -m "feat(responses): GET/DELETE /v1/responses/{id} (#368)"
+```
+
+---
+
+## Task 9: Live SDK acceptance test
+
+**Files:**
+- Create: `tests/live/test_responses_sdk.py`
+- Possibly modify: `pyproject.toml` (add `openai` to the test/dev deps if absent)
+
+This is a `real_model` test that drives the actual OpenAI Python SDK against a running
+olmlx, satisfying issue #368's acceptance criteria. It lives in `tests/live/`
+(outside `tests/integration/`) to dodge that directory's autouse MLX mock — the same
+placement convention as `tests/live/test_vlm_tools_images.py`.
+
+- [ ] **Step 1: Confirm the `openai` package is available for tests**
+
+Run: `uv run python -c "import openai; print(openai.__version__)"`
+If it errors, add `openai` to the dev dependency group in `pyproject.toml` and run
+`uv sync --no-editable`. (Check the existing live tests first — they may already
+depend on it.)
+
+- [ ] **Step 2: Write the live test**
+
+Create `tests/live/test_responses_sdk.py`:
+
+```python
+"""Live acceptance test: OpenAI SDK against olmlx /v1/responses (#368).
+
+Marked real_model — requires a real model and a running server fixture. Skipped
+in the default unit run. Mirrors tests/live/test_vlm_tools_images.py placement so
+the integration autouse MLX mock does not apply.
+"""
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.real_model
+
+# NOTE: `live_server_url` and `live_model` are the existing live fixtures used by
+# tests/live/test_vlm_tools_images.py. If they are named differently in
+# tests/live/conftest.py, use those names instead.
+
+
+def _client(base_url):
+    from openai import OpenAI
+
+    return OpenAI(base_url=f"{base_url}/v1", api_key="not-needed")
+
+
+def test_text(live_server_url, live_model):
+    client = _client(live_server_url)
+    resp = client.responses.create(model=live_model, input="Say 'pong'.")
+    assert resp.status == "completed"
+    assert resp.output_text  # SDK convenience accessor
+
+
+def test_streaming_text(live_server_url, live_model):
+    client = _client(live_server_url)
+    chunks = []
+    with client.responses.stream(model=live_model, input="Count: 1 2 3") as stream:
+        for event in stream:
+            if event.type == "response.output_text.delta":
+                chunks.append(event.delta)
+        final = stream.get_final_response()
+    assert "".join(chunks)
+    assert final.status == "completed"
+
+
+def test_tool_use(live_server_url, live_model):
+    client = _client(live_server_url)
+    tools = [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }
+    ]
+    resp = client.responses.create(
+        model=live_model,
+        input="What's the weather in Paris? Use the tool.",
+        tools=tools,
+    )
+    calls = [it for it in resp.output if it.type == "function_call"]
+    assert calls, "expected a function_call output item"
+    assert calls[0].name == "get_weather"
+    json.loads(calls[0].arguments)  # arguments parse as JSON
+```
+
+- [ ] **Step 3: Run the live test (manual / real-model env)**
+
+Run: `uv run pytest tests/live/test_responses_sdk.py -v -m real_model`
+Expected: PASS against a real model. (Skipped in CI default run; run locally with a
+small model loaded.)
+
+If the live fixtures are named differently, inspect `tests/live/conftest.py` and
+adjust the fixture names — do not invent fixtures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/live/test_responses_sdk.py pyproject.toml
+git commit -m "test(responses): live OpenAI SDK acceptance test (#368)"
+```
+
+---
+
+## Task 10: Final verification
+
+- [ ] **Step 1: Run the full responses + state test set**
+
+Run: `uv run pytest tests/test_routers_responses.py tests/test_responses_state.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 2: Run the broader router + app suite for regressions**
+
+Run: `uv run pytest tests/test_routers_openai.py tests/test_routers_anthropic.py tests/test_app.py -q`
+Expected: PASS (no regressions from the `app.py` router registration).
+
+- [ ] **Step 3: Lint + format (project requirement before push)**
+
+Run: `uv run ruff check olmlx tests && uv run ruff format olmlx tests`
+Expected: no errors; formatting clean.
+
+- [ ] **Step 4: Update docs**
+
+Add a short `/v1/responses` entry to the user manual / README where the other OpenAI
+endpoints (`/v1/chat/completions`, `/v1/embeddings`) are documented, noting: supported
+(text, streaming, function tools, `previous_response_id`, reasoning items, image input,
+structured outputs via `text.format`); not supported (built-in tools). Add a one-line
+note to `CLAUDE.md`'s router list under `routers/`.
+
+- [ ] **Step 5: Commit docs**
+
+```bash
+git add -A
+git commit -m "docs(responses): document /v1/responses endpoint (#368)"
+```
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Spec coverage:** text non-stream (T4), streaming full events (T7), function tools
+  (T5, T7), `previous_response_id` + cache_id (T6), reasoning items (T5), image input
+  (T5), structured outputs (T5), state store + `store:false` (T6), GET/DELETE (T8),
+  error paths 400/422/404 (T5, T6, T8), live SDK acceptance (T9). All spec sections map
+  to a task.
+- **404 vs 422 boundary:** unknown `previous_response_id` is a 404 (resource lookup);
+  malformed input items / bad image / built-in tool / bad schema are 422 (request
+  shape). `_history_messages_from_store` raises `HTTPException(404)` and must stay
+  outside the `try/except ValueError` that maps translation errors to 422.
+- **Type consistency:** helper names are stable across tasks — `_build_input_messages`,
+  `_convert_tools`, `_grammar_from_text_format`, `_resolve_reasoning`,
+  `_build_output_items`, `_build_response_object`, `_history_messages_from_store`,
+  `_stream_response`. Store entries always carry `input_messages`, `output_items`,
+  `model`, `previous_response_id`, `response`.
+- **Engine untouched:** every task calls `generate_chat` with the existing keyword
+  signature; no engine edits.
+```

--- a/docs/superpowers/specs/2026-06-07-openai-responses-endpoint-design.md
+++ b/docs/superpowers/specs/2026-06-07-openai-responses-endpoint-design.md
@@ -1,0 +1,193 @@
+# OpenAI `/v1/responses` Endpoint — Design
+
+**Issue:** #368
+**Date:** 2026-06-07
+**Status:** Approved (design)
+
+## Goal
+
+Add OpenAI's newer agentic `/v1/responses` API so olmlx is a drop-in for callers
+that have migrated off `/v1/chat/completions` — notably the OpenAI Agents SDK and
+`client.responses.create()`. The endpoint is a pure request/response *reshaping*
+layer over the existing `generate_chat` engine; the engine and other routers are
+left untouched.
+
+### In scope (v1)
+
+- `POST /v1/responses` — non-streaming and streaming (full semantic SSE events).
+- Function (custom) tool calling.
+- `previous_response_id` state continuation with prompt-cache reuse.
+- Reasoning output items (mapped from `<think>`).
+- Image input (`input_image` content parts) for VLM models.
+- Structured outputs via `text.format` (`json_object` / `json_schema`).
+- `GET /v1/responses/{id}` and `DELETE /v1/responses/{id}`.
+- Honor `store: false` (skip persisting the response).
+
+### Out of scope
+
+- Built-in OpenAI tools (`web_search`, `code_interpreter`, `computer_use`) →
+  rejected with a 400.
+- Disk-persisted state (in-memory only; lost on restart).
+- Distributed-worker / speculative gating changes — inherited from `generate_chat`
+  as-is.
+
+## Approach
+
+**Dedicated translation router** (issue-recommended). A new `routers/responses.py`
+translates a Responses request into the engine's existing message-dict format,
+calls `generate_chat` unchanged, then translates the output back into Responses
+output-items / SSE events. This mirrors the proven `routers/anthropic.py`
+structure (buffer → split `<think>`/tool calls into typed items → emit typed
+events) and keeps each stage independently testable.
+
+Rejected alternatives:
+- *Translate through the chat router* (Responses→chat→engine→chat→Responses):
+  double translation, couples to the chat router's response shape. Fragile.
+- *Extract a shared conversation core* for chat/anthropic/responses: correct
+  long-term but a large refactor touching two working routers — out of scope.
+
+## Files
+
+```
+olmlx/routers/responses.py        # POST /v1/responses (+ GET/DELETE /v1/responses/{id})
+olmlx/schemas/responses.py        # Pydantic request / response / item models
+olmlx/engine/responses_state.py   # bounded-LRU store: response_id -> stored response
+olmlx/app.py                      # app.include_router(responses.router)
+tests/test_routers_responses.py   # unit tests (autouse MLX mock)
+tests/live/test_responses_sdk.py  # real_model live test driving the OpenAI SDK
+```
+
+## Components
+
+### 1. Request translation — `_build_messages(req, store)`
+
+The engine consumes a list of `{role, content, images?, tool_calls?}` dicts (with
+`role: "tool"` for tool results, parsed by `engine/tool_parser.py`). Responses
+`input` maps onto that:
+
+| Responses input                                   | → engine message                                              |
+| ------------------------------------------------- | ------------------------------------------------------------- |
+| `input` as a **string**                           | `{role: "user", content: <str>}`                              |
+| `message` item (`role` + `content` parts)         | `{role, content: <joined input_text>}`; `input_image` parts split into `images` via `normalize_image_block` |
+| `function_call` item (assistant tool call echoed) | `{role: "assistant", tool_calls: [...]}`                      |
+| `function_call_output` item (`call_id`, `output`) | `{role: "tool", tool_call_id: call_id, content: output}`      |
+| top-level `instructions`                          | prepended `{role: "system", content: instructions}`           |
+
+- `content` parts already arrive in Responses spelling (`input_text` / `input_image`);
+  reuse the chat router's `_normalize_multimodal_messages` (it already handles
+  both spellings).
+- If `previous_response_id` is set, fetch the stored entry and reconstruct its
+  `input_items + output_items` into messages, prepended before the new input.
+  Missing id → **404**.
+- Unknown input-item types and built-in tool requests → **400** with a clear
+  message.
+
+### 2. Output construction — non-streaming `_build_response(...)`
+
+Buffer `generate_chat`, run `parse_model_output` (same call the chat/anthropic
+routers use, with `thinking_expected` threading), and build `output[]` in order:
+
+1. `reasoning` item (id `rs_…`) — only if `<think>` text is present.
+2. `message` item (id `msg_…`, `role: "assistant"`) with one `output_text`
+   content part — omitted entirely if visible text is empty.
+3. one `function_call` item (id `fc_…`, `call_id: call_…`, `name`, `arguments`)
+   per parsed tool call.
+
+Top-level fields:
+- `status`: `"completed"`, or `"incomplete"` with
+  `incomplete_details.reason: "max_output_tokens"` when `done_reason == "timeout"`.
+- `usage`: `{input_tokens, output_tokens, total_tokens}` from `TimingStats`
+  (reuse the `OpenAIUsage.from_stats` accounting).
+- `id` (`resp_…`), `object: "response"`, `created_at`, `model`,
+  `previous_response_id`.
+
+### 3. Output construction — streaming `_stream_response(...)`
+
+Full semantic event sequence; every event carries a monotonically increasing
+`sequence_number` and its `type`:
+
+```
+response.created
+response.in_progress
+  per output item:
+    response.output_item.added                { output_index, item }
+    text item:
+      response.content_part.added             { item_id, output_index, content_index, part }
+      response.output_text.delta × N          { item_id, output_index, content_index, delta }
+      response.output_text.done               { item_id, output_index, content_index, text }
+      response.content_part.done              { ...part }
+    function_call item:
+      response.function_call_arguments.delta  { item_id, output_index, ... }
+      response.function_call_arguments.done   { item_id, output_index, arguments }
+    response.output_item.done                 { output_index, item }
+response.completed                            { response: <final assembled object> }
+```
+
+- **No-tools text path:** stream `output_text.delta` live, token by token, with
+  thinking stripped via the existing streaming stripper.
+- **Tools path:** tool calls are only parseable from the complete model output
+  (Qwen-family constraint, same as chat/anthropic). Buffer the full output, parse,
+  then replay reasoning/text/function-call items through the same event envelope —
+  the SDK still receives a well-formed stream.
+- **Reasoning item:** when present, emitted as its own output item before the
+  message item.
+- **Error mid-stream:** emit `response.failed` (generic message, no internal
+  detail leak beyond the local-tool norms) then close; `aclose()` the engine
+  generator in `finally`.
+
+### 4. State store — `engine/responses_state.py`
+
+A bounded `OrderedDict` LRU keyed by `response_id`:
+
+- Value: `{input_items, output_items, model, previous_response_id, created_at}`.
+- Cap: `OLMLX_RESPONSES_STORE_MAX` (default **256**); evict oldest on overflow.
+- `store: false` on the request → do not write.
+- In-memory only; not counted against `OLMLX_MEMORY_LIMIT_FRACTION` (bounded,
+  text-only); lost on restart.
+- `GET /v1/responses/{id}` → stored response object, **404** if absent/evicted.
+- `DELETE /v1/responses/{id}` → remove; **404** if absent.
+
+**Prompt-cache reuse:** pass `cache_id = previous_response_id or <new response id>`
+into `generate_chat`. Consecutive turns then share a KV prefix; the radix prefix
+index (`PrefixCacheIndex`) handles sibling takeover. This satisfies the issue's
+acceptance criterion that a multi-turn `previous_response_id` conversation reuses
+the prompt cache.
+
+## Error handling & edge cases
+
+- Malformed image part → **422** (mirror chat router's `ValueError → 422`).
+- Unknown input-item type → **400**.
+- Built-in tool requested (`type` in `web_search`/`code_interpreter`/`computer_use`)
+  → **400** with a "not supported" message.
+- `previous_response_id` not found → **404**.
+- `text.format` / structured-output schema error → **422** via the existing
+  `parse_response_format`.
+- Grammar/VLM/speculative/distributed gating is inherited from `generate_chat`;
+  no new gates introduced here.
+
+## Testing (TDD — failing tests first)
+
+`tests/test_routers_responses.py`, mirroring `test_routers_openai.py` (autouse MLX
+mock):
+
+- text non-streaming.
+- text streaming — assert event ordering and `sequence_number` monotonicity.
+- function tool-call round-trip: request → `function_call` output item →
+  `function_call_output` continuation request.
+- `previous_response_id` reconstruction + `cache_id` threading into `generate_chat`.
+- reasoning item produced from `<think>` output.
+- image input part split into `images`.
+- structured output via `text.format` (`json_schema`).
+- error paths: 404 unknown id, 422 bad image / bad schema, 400 unknown item / built-in tool.
+- `store: false` skips storage; `GET` then `DELETE` lifecycle (404 after delete).
+
+`tests/live/test_responses_sdk.py` (`real_model`, outside `tests/integration/` to
+dodge its autouse MLX mock): drive the actual OpenAI SDK
+`client.responses.create()` for text, streaming text, and tool use — the issue's
+top-level acceptance criterion.
+
+## Acceptance criteria (from #368)
+
+1. OpenAI SDK `client.responses.create()` works for text, streaming text, and
+   tool use against olmlx.
+2. A multi-turn conversation via `previous_response_id` reuses the prompt cache.

--- a/olmlx/app.py
+++ b/olmlx/app.py
@@ -29,6 +29,7 @@ from olmlx.routers import (
     manage,
     models,
     openai,
+    responses,
     status,
 )
 from olmlx.routers import metrics as metrics_router
@@ -398,6 +399,7 @@ def create_app() -> FastAPI:
     app.include_router(embed.router)
     app.include_router(blobs.router)
     app.include_router(openai.router)
+    app.include_router(responses.router)
     app.include_router(audio.router)
     app.include_router(anthropic.router)
     app.include_router(metrics_router.router)

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -135,6 +135,9 @@ class Settings(BaseSettings):
     # Below this token count, a radix-prefix hit falls back to fresh
     # prefill rather than taking over a near-empty match.
     prompt_cache_radix_min_prefix_tokens: Annotated[int, Field(ge=0)] = 256
+    # Max number of stored Responses-API responses for previous_response_id
+    # continuation (in-memory LRU; lost on restart).
+    responses_store_max: Annotated[int, Field(gt=0)] = 256
     inference_queue_timeout: Annotated[float, Field(gt=0)] | None = 300.0
     inference_timeout: Annotated[float, Field(gt=0)] | None = None
     sync_mode: SyncMode = "full"

--- a/olmlx/engine/responses_state.py
+++ b/olmlx/engine/responses_state.py
@@ -1,0 +1,53 @@
+"""In-memory LRU store for Responses-API state (previous_response_id).
+
+Single-user, localhost-only: a bounded OrderedDict keyed by response_id.
+Not persisted; lost on restart. Bounded by OLMLX_RESPONSES_STORE_MAX so it is
+not counted against the memory limit (text-only entries).
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from threading import Lock
+from typing import Any
+
+from olmlx.config import settings
+
+
+class ResponsesStore:
+    def __init__(self, max_entries: int | None = None) -> None:
+        self._max = (
+            max_entries if max_entries is not None else settings.responses_store_max
+        )
+        self._store: OrderedDict[str, dict[str, Any]] = OrderedDict()
+        self._lock = Lock()
+
+    def put(self, response_id: str, entry: dict[str, Any]) -> None:
+        with self._lock:
+            self._store[response_id] = entry
+            self._store.move_to_end(response_id)
+            while len(self._store) > self._max:
+                self._store.popitem(last=False)
+
+    def get(self, response_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            entry = self._store.get(response_id)
+            if entry is not None:
+                self._store.move_to_end(response_id)
+            return entry
+
+    def delete(self, response_id: str) -> bool:
+        with self._lock:
+            return self._store.pop(response_id, None) is not None
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()
+
+
+_store = ResponsesStore()
+
+
+def get_store() -> ResponsesStore:
+    """Return the process-wide Responses store singleton."""
+    return _store

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -569,3 +569,22 @@ async def create_response(req: ResponsesRequest, request: Request):
             },
         )
     return response
+
+
+@router.get("/v1/responses/{response_id}")
+async def get_response(response_id: str):
+    entry = get_store().get(response_id)
+    if entry is None:
+        raise HTTPException(
+            status_code=404, detail=f"response not found: {response_id!r}"
+        )
+    return entry["response"]
+
+
+@router.delete("/v1/responses/{response_id}")
+async def delete_response(response_id: str):
+    if not get_store().delete(response_id):
+        raise HTTPException(
+            status_code=404, detail=f"response not found: {response_id!r}"
+        )
+    return {"id": response_id, "object": "response.deleted", "deleted": True}

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -4,6 +4,7 @@ import time
 import uuid
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
 
 from olmlx.engine.grammar import GrammarSpec, parse_response_format
 from olmlx.engine.inference import generate_chat
@@ -42,6 +43,10 @@ def _make_fc_id() -> str:
 
 def _make_call_id() -> str:
     return f"call_{uuid.uuid4().hex[:24]}"
+
+
+def _sse(event: str, data: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
 
 
 def _message_item_to_engine(item: dict) -> dict:
@@ -301,6 +306,159 @@ def _build_response_object(
     )
 
 
+async def _stream_response(
+    result,
+    req: ResponsesRequest,
+    response_id: str,
+    created: int,
+    tools: list[dict] | None,
+    conversation: list[dict],
+):
+    """Buffer the engine output, parse once, replay full semantic events."""
+    seq = 0
+
+    def ev(event: str, data: dict) -> str:
+        nonlocal seq
+        payload = {"type": event, "sequence_number": seq, **data}
+        seq += 1
+        return _sse(event, payload)
+
+    def base_response(status: str, output_items: list[dict], stats, done_reason):
+        obj = _build_response_object(
+            req, response_id, created, output_items, stats, done_reason
+        ).model_dump(exclude_none=True)
+        return obj
+
+    try:
+        full_text = ""
+        raw_text = ""
+        done_reason = None
+        thinking_expected = False
+        stats = None
+        async for chunk in result:
+            if chunk.get("cache_info"):
+                continue
+            if "thinking_expected" in chunk:
+                thinking_expected = bool(chunk["thinking_expected"])
+                continue
+            if chunk.get("done"):
+                raw_text = chunk.get("raw_text", raw_text)
+                done_reason = chunk.get("done_reason")
+                stats = chunk.get("stats")
+                break
+            full_text += chunk.get("text", "")
+
+        parse_text = raw_text or full_text
+        thinking, visible_text, tool_uses = parse_model_output(
+            parse_text, bool(tools), thinking_expected=thinking_expected
+        )
+        resolve_tool_names(tool_uses, tools)
+        fill_missing_required_args(tool_uses, tools)
+        output_items = _build_output_items(thinking, visible_text, tool_uses)
+
+        in_progress_resp = base_response("in_progress", [], stats, None)
+        in_progress_resp["status"] = "in_progress"
+        yield ev("response.created", {"response": in_progress_resp})
+        yield ev("response.in_progress", {"response": in_progress_resp})
+
+        for out_index, item in enumerate(output_items):
+            yield ev(
+                "response.output_item.added",
+                {"output_index": out_index, "item": item},
+            )
+            if item["type"] == "message":
+                part = item["content"][0]
+                yield ev(
+                    "response.content_part.added",
+                    {
+                        "item_id": item["id"],
+                        "output_index": out_index,
+                        "content_index": 0,
+                        "part": {"type": "output_text", "text": "", "annotations": []},
+                    },
+                )
+                yield ev(
+                    "response.output_text.delta",
+                    {
+                        "item_id": item["id"],
+                        "output_index": out_index,
+                        "content_index": 0,
+                        "delta": part["text"],
+                    },
+                )
+                yield ev(
+                    "response.output_text.done",
+                    {
+                        "item_id": item["id"],
+                        "output_index": out_index,
+                        "content_index": 0,
+                        "text": part["text"],
+                    },
+                )
+                yield ev(
+                    "response.content_part.done",
+                    {
+                        "item_id": item["id"],
+                        "output_index": out_index,
+                        "content_index": 0,
+                        "part": part,
+                    },
+                )
+            elif item["type"] == "function_call":
+                yield ev(
+                    "response.function_call_arguments.delta",
+                    {
+                        "item_id": item["id"],
+                        "output_index": out_index,
+                        "delta": item["arguments"],
+                    },
+                )
+                yield ev(
+                    "response.function_call_arguments.done",
+                    {
+                        "item_id": item["id"],
+                        "output_index": out_index,
+                        "arguments": item["arguments"],
+                    },
+                )
+            yield ev(
+                "response.output_item.done",
+                {"output_index": out_index, "item": item},
+            )
+
+        final = base_response("completed", output_items, stats, done_reason)
+        yield ev("response.completed", {"response": final})
+
+        if req.store:
+            get_store().put(
+                response_id,
+                {
+                    "input_messages": conversation,
+                    "output_items": output_items,
+                    "model": req.model,
+                    "previous_response_id": req.previous_response_id,
+                    "response": final,
+                },
+            )
+    except Exception as exc:
+        logger.error("Error during Responses streaming: %s", exc, exc_info=True)
+        yield ev(
+            "response.failed",
+            {
+                "response": {
+                    "id": response_id,
+                    "status": "failed",
+                    "error": {
+                        "code": "server_error",
+                        "message": "An internal server error occurred during streaming.",
+                    },
+                }
+            },
+        )
+    finally:
+        await result.aclose()
+
+
 @router.post(
     "/v1/responses",
     response_model=ResponsesResponse,
@@ -348,6 +506,24 @@ async def create_response(req: ResponsesRequest, request: Request):
     response_id = _make_response_id()
     created = int(time.time())
     cache_id = (req.previous_response_id or response_id)[:256]
+
+    if req.stream:
+        result = await generate_chat(
+            manager,
+            req.model,
+            engine_messages,
+            options,
+            tools=tools,
+            stream=True,
+            max_tokens=max_tokens,
+            cache_id=cache_id,
+            enable_thinking=enable_thinking,
+            grammar_spec=grammar_spec,
+        )
+        return StreamingResponse(
+            _stream_response(result, req, response_id, created, tools, conversation),
+            media_type="text/event-stream",
+        )
 
     result = await generate_chat(
         manager,

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -327,6 +327,7 @@ async def _stream_response(
         obj = _build_response_object(
             req, response_id, created, output_items, stats, done_reason
         ).model_dump(exclude_none=True)
+        obj["status"] = status
         return obj
 
     try:
@@ -357,7 +358,6 @@ async def _stream_response(
         output_items = _build_output_items(thinking, visible_text, tool_uses)
 
         in_progress_resp = base_response("in_progress", [], stats, None)
-        in_progress_resp["status"] = "in_progress"
         yield ev("response.created", {"response": in_progress_resp})
         yield ev("response.in_progress", {"response": in_progress_resp})
 
@@ -426,7 +426,8 @@ async def _stream_response(
                 {"output_index": out_index, "item": item},
             )
 
-        final = base_response("completed", output_items, stats, done_reason)
+        final_status = "incomplete" if done_reason == "timeout" else "completed"
+        final = base_response(final_status, output_items, stats, done_reason)
         yield ev("response.completed", {"response": final})
 
         if req.store:

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -4,11 +4,9 @@ import time
 import uuid
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import StreamingResponse
 
 from olmlx.engine.grammar import GrammarSpec, parse_response_format
 from olmlx.engine.inference import generate_chat
-from olmlx.engine.responses_state import get_store
 from olmlx.engine.tool_parser import (
     fill_missing_required_args,
     parse_model_output,
@@ -175,3 +173,156 @@ def _resolve_reasoning(reasoning: dict | None) -> bool | None:
     """Map Responses `reasoning.effort` to the engine enable_thinking flag."""
     effort = (reasoning or {}).get("effort")
     return resolve_openai_think(effort, None)
+
+
+def _build_output_items(
+    thinking: str, visible_text: str, tool_uses: list[dict]
+) -> list[dict]:
+    """Assemble Responses output items in canonical order."""
+    items: list[dict] = []
+    if thinking:
+        items.append(
+            {
+                "type": "reasoning",
+                "id": _make_reasoning_id(),
+                "summary": [],
+                "content": [{"type": "reasoning_text", "text": thinking}],
+            }
+        )
+    if visible_text:
+        items.append(
+            {
+                "type": "message",
+                "id": _make_message_id(),
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {"type": "output_text", "text": visible_text, "annotations": []}
+                ],
+            }
+        )
+    for tu in tool_uses:
+        items.append(
+            {
+                "type": "function_call",
+                "id": _make_fc_id(),
+                "call_id": _make_call_id(),
+                "name": tu["name"],
+                "arguments": json.dumps(tu.get("input", {})),
+                "status": "completed",
+            }
+        )
+    return items
+
+
+def _usage_dict(stats) -> dict:
+    if stats is None:
+        return {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    prompt = stats.prompt_eval_count
+    completion = stats.eval_count
+    return {
+        "input_tokens": prompt,
+        "output_tokens": completion,
+        "total_tokens": prompt + completion,
+    }
+
+
+def _build_response_object(
+    req: ResponsesRequest,
+    response_id: str,
+    created: int,
+    output_items: list[dict],
+    stats,
+    done_reason: str | None,
+) -> ResponsesResponse:
+    incomplete = None
+    status = "completed"
+    if done_reason == "timeout":
+        status = "incomplete"
+        incomplete = {"reason": "max_output_tokens"}
+    return ResponsesResponse(
+        id=response_id,
+        created_at=created,
+        status=status,
+        model=req.model,
+        output=output_items,
+        usage=_usage_dict(stats),
+        previous_response_id=req.previous_response_id,
+        incomplete_details=incomplete,
+        instructions=req.instructions,
+        max_output_tokens=req.max_output_tokens,
+        metadata=req.metadata,
+        parallel_tool_calls=req.parallel_tool_calls,
+        temperature=req.temperature,
+        top_p=req.top_p,
+        tool_choice=req.tool_choice,
+        tools=req.tools or [],
+    )
+
+
+@router.post(
+    "/v1/responses",
+    response_model=ResponsesResponse,
+    response_model_exclude_none=True,
+)
+async def create_response(req: ResponsesRequest, request: Request):
+    manager = request.app.state.model_manager
+    logger.info(
+        "Responses request: model=%s stream=%s tools=%d prev=%s",
+        req.model,
+        req.stream,
+        len(req.tools or []),
+        req.previous_response_id,
+    )
+
+    try:
+        messages = _build_input_messages(req.input)
+        tools = _convert_tools(req.tools)
+        grammar_spec = _grammar_from_text_format(req.text)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    if req.instructions:
+        messages.insert(0, {"role": "system", "content": req.instructions})
+
+    options = build_inference_options(
+        temperature=req.temperature, top_p=req.top_p, seed=req.seed
+    )
+    max_tokens = req.max_output_tokens or 512
+    enable_thinking = _resolve_reasoning(req.reasoning)
+    response_id = _make_response_id()
+    created = int(time.time())
+    cache_id = (req.previous_response_id or response_id)[:256]
+
+    result = await generate_chat(
+        manager,
+        req.model,
+        messages,
+        options,
+        tools=tools,
+        stream=False,
+        max_tokens=max_tokens,
+        cache_id=cache_id,
+        enable_thinking=enable_thinking,
+        grammar_spec=grammar_spec,
+    )
+
+    parse_text = result.get("raw_text") or result.get("text", "")
+    thinking, visible_text, tool_uses = parse_model_output(
+        parse_text,
+        bool(tools),
+        thinking_expected=bool(result.get("thinking_expected")),
+    )
+    resolve_tool_names(tool_uses, tools)
+    fill_missing_required_args(tool_uses, tools)
+
+    output_items = _build_output_items(thinking, visible_text, tool_uses)
+    response = _build_response_object(
+        req,
+        response_id,
+        created,
+        output_items,
+        result.get("stats"),
+        result.get("done_reason"),
+    )
+    return response

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -1,0 +1,171 @@
+import json
+import logging
+import time
+import uuid
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from olmlx.engine.grammar import parse_response_format
+from olmlx.engine.inference import generate_chat
+from olmlx.engine.responses_state import get_store
+from olmlx.engine.tool_parser import (
+    fill_missing_required_args,
+    parse_model_output,
+    resolve_tool_names,
+)
+from olmlx.routers.common import build_inference_options, resolve_openai_think
+from olmlx.schemas.responses import ResponsesRequest, ResponsesResponse
+from olmlx.utils.images import normalize_image_block
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_BUILTIN_TOOL_TYPES = {"web_search", "code_interpreter", "computer_use", "file_search"}
+
+
+def _make_response_id() -> str:
+    return f"resp_{uuid.uuid4().hex[:24]}"
+
+
+def _make_message_id() -> str:
+    return f"msg_{uuid.uuid4().hex[:24]}"
+
+
+def _make_reasoning_id() -> str:
+    return f"rs_{uuid.uuid4().hex[:24]}"
+
+
+def _make_fc_id() -> str:
+    return f"fc_{uuid.uuid4().hex[:24]}"
+
+
+def _make_call_id() -> str:
+    return f"call_{uuid.uuid4().hex[:24]}"
+
+
+def _message_item_to_engine(item: dict) -> dict:
+    """Convert a Responses `message` input item to an engine message dict."""
+    role = item["role"]
+    content = item.get("content")
+    if isinstance(content, str):
+        return {"role": role, "content": content}
+    texts: list[str] = []
+    images: list[str] = []
+    for part in content or []:
+        if not isinstance(part, dict):
+            continue
+        ptype = part.get("type")
+        if ptype in ("input_text", "text", "output_text"):
+            txt = part.get("text") or ""
+            if txt:
+                texts.append(txt)
+        elif ptype in ("input_image", "image_url"):
+            raw = part.get("image_url")
+            if isinstance(raw, str):
+                block = {"type": "image_url", "image_url": {"url": raw}}
+            else:
+                block = {"type": "image_url", "image_url": raw or {}}
+            images.append(normalize_image_block(block))
+        else:
+            raise ValueError(f"unsupported content part type: {ptype!r}")
+    msg: dict = {"role": role, "content": " ".join(texts)}
+    if images:
+        msg["images"] = images
+    return msg
+
+
+def _build_input_messages(input_data: str | list[dict]) -> list[dict]:
+    """Translate a Responses `input` field into engine message dicts."""
+    if isinstance(input_data, str):
+        return [{"role": "user", "content": input_data}]
+    messages: list[dict] = []
+    for item in input_data:
+        itype = item.get("type")
+        role = item.get("role")
+        if itype in (None, "message") and role is not None:
+            messages.append(_message_item_to_engine(item))
+        elif itype == "function_call":
+            messages.append(
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": item.get("call_id"),
+                            "type": "function",
+                            "function": {
+                                "name": item["name"],
+                                "arguments": item.get("arguments", ""),
+                            },
+                        }
+                    ],
+                }
+            )
+        elif itype == "function_call_output":
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": item.get("call_id"),
+                    "content": item.get("output", ""),
+                }
+            )
+        else:
+            raise ValueError(f"unsupported input item type: {itype!r}")
+    return messages
+
+
+def _convert_tools(tools: list[dict] | None) -> list[dict] | None:
+    """Convert Responses function tools to engine OpenAI-nested format."""
+    if not tools:
+        return None
+    converted: list[dict] = []
+    for t in tools:
+        ttype = t.get("type")
+        if ttype != "function":
+            if ttype in _BUILTIN_TOOL_TYPES:
+                raise ValueError(
+                    f"built-in tool {ttype!r} is not supported; only custom "
+                    "'function' tools are available"
+                )
+            raise ValueError(f"unsupported tool type: {ttype!r}")
+        converted.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": t["name"],
+                    "description": t.get("description", ""),
+                    "parameters": t.get("parameters", {}),
+                },
+            }
+        )
+    return converted
+
+
+def _grammar_from_text_format(text_cfg: dict | None):
+    """Map a Responses `text.format` config to a GrammarSpec (or None)."""
+    fmt = (text_cfg or {}).get("format")
+    if not fmt:
+        return None
+    ftype = fmt.get("type")
+    if ftype in (None, "text"):
+        return None
+    if ftype == "json_object":
+        return parse_response_format({"type": "json_object"})
+    if ftype == "json_schema":
+        return parse_response_format(
+            {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": fmt.get("name", "schema"),
+                    "schema": fmt.get("schema", {}),
+                },
+            }
+        )
+    raise ValueError(f"unsupported text.format type: {ftype!r}")
+
+
+def _resolve_reasoning(reasoning: dict | None) -> bool | None:
+    """Map Responses `reasoning.effort` to the engine enable_thinking flag."""
+    effort = (reasoning or {}).get("effort")
+    return resolve_openai_think(effort, None)

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -198,6 +198,7 @@ def _history_messages_from_store(previous_response_id: str) -> list[dict]:
                             "id": item.get("call_id"),
                             "type": "function",
                             "function": {
+                                # `name` is always present: set by _build_output_items invariant.
                                 "name": item["name"],
                                 "arguments": item.get("arguments", ""),
                             },
@@ -323,13 +324,21 @@ async def create_response(req: ResponsesRequest, request: Request):
         raise HTTPException(status_code=422, detail=str(exc))
 
     if req.previous_response_id:
-        messages = _history_messages_from_store(req.previous_response_id)
-        messages.extend(new_messages)
+        conversation = _history_messages_from_store(req.previous_response_id)
+        conversation.extend(new_messages)
     else:
-        messages = new_messages
+        conversation = new_messages
 
+    # Per OpenAI Responses semantics, `instructions` are NOT carried across
+    # previous_response_id — each turn supplies its own. So the system message
+    # is applied only to the engine input and is NOT part of the stored
+    # conversation (which is replayed on the next continuation turn).
+    engine_messages = conversation
     if req.instructions:
-        messages.insert(0, {"role": "system", "content": req.instructions})
+        engine_messages = [
+            {"role": "system", "content": req.instructions},
+            *conversation,
+        ]
 
     options = build_inference_options(
         temperature=req.temperature, top_p=req.top_p, seed=req.seed
@@ -343,7 +352,7 @@ async def create_response(req: ResponsesRequest, request: Request):
     result = await generate_chat(
         manager,
         req.model,
-        messages,
+        engine_messages,
         options,
         tools=tools,
         stream=False,
@@ -375,7 +384,7 @@ async def create_response(req: ResponsesRequest, request: Request):
         get_store().put(
             response_id,
             {
-                "input_messages": messages,
+                "input_messages": conversation,
                 "output_items": output_items,
                 "model": req.model,
                 "previous_response_id": req.previous_response_id,

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -103,7 +103,10 @@ def _build_input_messages(input_data: str | list[dict]) -> list[dict]:
                             "type": "function",
                             "function": {
                                 "name": name,
-                                "arguments": item.get("arguments", ""),
+                                # Default to "{}" (valid JSON), never "" — an
+                                # empty string breaks downstream JSON parsing of
+                                # tool-call arguments.
+                                "arguments": item.get("arguments") or "{}",
                             },
                         }
                     ],
@@ -205,7 +208,7 @@ def _history_messages_from_store(previous_response_id: str) -> list[dict]:
                             "function": {
                                 # `name` is always present: set by _build_output_items invariant.
                                 "name": item["name"],
-                                "arguments": item.get("arguments", ""),
+                                "arguments": item.get("arguments") or "{}",
                             },
                         }
                     ],
@@ -304,6 +307,32 @@ def _build_response_object(
         # The OpenAI SDK requires tool_choice to be non-null; default to "auto".
         tool_choice=req.tool_choice if req.tool_choice is not None else "auto",
         tools=req.tools or [],
+    )
+
+
+def _store_response(
+    req: ResponsesRequest,
+    response_id: str,
+    conversation: list[dict],
+    output_items: list[dict],
+    response_dict: dict,
+) -> None:
+    """Persist a completed response for previous_response_id continuation.
+
+    Shared by the streaming and non-streaming paths so the stored entry shape
+    can't drift between them. No-op when ``store`` is false.
+    """
+    if not req.store:
+        return
+    get_store().put(
+        response_id,
+        {
+            "input_messages": conversation,
+            "output_items": output_items,
+            "model": req.model,
+            "previous_response_id": req.previous_response_id,
+            "response": response_dict,
+        },
     )
 
 
@@ -434,17 +463,7 @@ async def _stream_response(
         final = base_response(final_status, output_items, stats, done_reason)
         yield ev("response.completed", {"response": final})
 
-        if req.store:
-            get_store().put(
-                response_id,
-                {
-                    "input_messages": conversation,
-                    "output_items": output_items,
-                    "model": req.model,
-                    "previous_response_id": req.previous_response_id,
-                    "response": final,
-                },
-            )
+        _store_response(req, response_id, conversation, output_items, final)
     except Exception as exc:
         logger.error("Error during Responses streaming: %s", exc, exc_info=True)
         yield ev(
@@ -461,7 +480,12 @@ async def _stream_response(
             },
         )
     finally:
-        await result.aclose()
+        # Guard cleanup: a raising aclose() (e.g. already-closed generator)
+        # must not propagate out of the finally and truncate the SSE stream.
+        try:
+            await result.aclose()
+        except Exception as exc:
+            logger.warning("Responses stream aclose failed: %s", exc)
 
 
 @router.post(
@@ -561,17 +585,13 @@ async def create_response(req: ResponsesRequest, request: Request):
         result.get("stats"),
         result.get("done_reason"),
     )
-    if req.store:
-        get_store().put(
-            response_id,
-            {
-                "input_messages": conversation,
-                "output_items": output_items,
-                "model": req.model,
-                "previous_response_id": req.previous_response_id,
-                "response": response.model_dump(exclude_none=True),
-            },
-        )
+    _store_response(
+        req,
+        response_id,
+        conversation,
+        output_items,
+        response.model_dump(exclude_none=True),
+    )
     return response
 
 

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from olmlx.engine.grammar import GrammarSpec, parse_response_format
 from olmlx.engine.inference import generate_chat
+from olmlx.engine.responses_state import get_store
 from olmlx.engine.tool_parser import (
     fill_missing_required_args,
     parse_model_output,
@@ -169,6 +170,45 @@ def _grammar_from_text_format(text_cfg: dict | None) -> GrammarSpec | None:
     raise ValueError(f"unsupported text.format type: {ftype!r}")
 
 
+def _history_messages_from_store(previous_response_id: str) -> list[dict]:
+    """Rebuild engine messages from a stored response (input + output items)."""
+    entry = get_store().get(previous_response_id)
+    if entry is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"previous_response_id not found: {previous_response_id!r}",
+        )
+    messages = list(entry["input_messages"])
+    for item in entry["output_items"]:
+        itype = item.get("type")
+        if itype == "message":
+            text = "".join(
+                part.get("text", "")
+                for part in item.get("content", [])
+                if part.get("type") == "output_text"
+            )
+            if text:
+                messages.append({"role": "assistant", "content": text})
+        elif itype == "function_call":
+            messages.append(
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": item.get("call_id"),
+                            "type": "function",
+                            "function": {
+                                "name": item["name"],
+                                "arguments": item.get("arguments", ""),
+                            },
+                        }
+                    ],
+                }
+            )
+        # reasoning items are not replayed into prompt history
+    return messages
+
+
 def _resolve_reasoning(reasoning: dict | None) -> bool | None:
     """Map Responses `reasoning.effort` to the engine enable_thinking flag."""
     effort = (reasoning or {}).get("effort")
@@ -276,11 +316,17 @@ async def create_response(req: ResponsesRequest, request: Request):
     )
 
     try:
-        messages = _build_input_messages(req.input)
+        new_messages = _build_input_messages(req.input)
         tools = _convert_tools(req.tools)
         grammar_spec = _grammar_from_text_format(req.text)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
+
+    if req.previous_response_id:
+        messages = _history_messages_from_store(req.previous_response_id)
+        messages.extend(new_messages)
+    else:
+        messages = new_messages
 
     if req.instructions:
         messages.insert(0, {"role": "system", "content": req.instructions})
@@ -325,4 +371,15 @@ async def create_response(req: ResponsesRequest, request: Request):
         result.get("stats"),
         result.get("done_reason"),
     )
+    if req.store:
+        get_store().put(
+            response_id,
+            {
+                "input_messages": messages,
+                "output_items": output_items,
+                "model": req.model,
+                "previous_response_id": req.previous_response_id,
+                "response": response.model_dump(exclude_none=True),
+            },
+        )
     return response

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -301,7 +301,8 @@ def _build_response_object(
         parallel_tool_calls=req.parallel_tool_calls,
         temperature=req.temperature,
         top_p=req.top_p,
-        tool_choice=req.tool_choice,
+        # The OpenAI SDK requires tool_choice to be non-null; default to "auto".
+        tool_choice=req.tool_choice if req.tool_choice is not None else "auto",
         tools=req.tools or [],
     )
 
@@ -384,6 +385,7 @@ async def _stream_response(
                         "output_index": out_index,
                         "content_index": 0,
                         "delta": part["text"],
+                        "logprobs": [],
                     },
                 )
                 yield ev(
@@ -393,6 +395,7 @@ async def _stream_response(
                         "output_index": out_index,
                         "content_index": 0,
                         "text": part["text"],
+                        "logprobs": [],
                     },
                 )
                 yield ev(
@@ -419,6 +422,7 @@ async def _stream_response(
                         "item_id": item["id"],
                         "output_index": out_index,
                         "arguments": item["arguments"],
+                        "name": item["name"],
                     },
                 )
             yield ev(

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -6,7 +6,7 @@ import uuid
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
-from olmlx.engine.grammar import parse_response_format
+from olmlx.engine.grammar import GrammarSpec, parse_response_format
 from olmlx.engine.inference import generate_chat
 from olmlx.engine.responses_state import get_store
 from olmlx.engine.tool_parser import (
@@ -87,6 +87,9 @@ def _build_input_messages(input_data: str | list[dict]) -> list[dict]:
         if itype in (None, "message") and role is not None:
             messages.append(_message_item_to_engine(item))
         elif itype == "function_call":
+            name = item.get("name")
+            if not name:
+                raise ValueError("function_call item missing 'name'")
             messages.append(
                 {
                     "role": "assistant",
@@ -95,7 +98,7 @@ def _build_input_messages(input_data: str | list[dict]) -> list[dict]:
                             "id": item.get("call_id"),
                             "type": "function",
                             "function": {
-                                "name": item["name"],
+                                "name": name,
                                 "arguments": item.get("arguments", ""),
                             },
                         }
@@ -129,11 +132,14 @@ def _convert_tools(tools: list[dict] | None) -> list[dict] | None:
                     "'function' tools are available"
                 )
             raise ValueError(f"unsupported tool type: {ttype!r}")
+        name = t.get("name")
+        if not name:
+            raise ValueError("function tool missing 'name'")
         converted.append(
             {
                 "type": "function",
                 "function": {
-                    "name": t["name"],
+                    "name": name,
                     "description": t.get("description", ""),
                     "parameters": t.get("parameters", {}),
                 },
@@ -142,7 +148,7 @@ def _convert_tools(tools: list[dict] | None) -> list[dict] | None:
     return converted
 
 
-def _grammar_from_text_format(text_cfg: dict | None):
+def _grammar_from_text_format(text_cfg: dict | None) -> GrammarSpec | None:
     """Map a Responses `text.format` config to a GrammarSpec (or None)."""
     fmt = (text_cfg or {}).get("format")
     if not fmt:

--- a/olmlx/schemas/responses.py
+++ b/olmlx/schemas/responses.py
@@ -28,6 +28,20 @@ class ResponsesRequest(BaseModel):
     metadata: dict[str, Any] | None = None
     seed: int | None = None
 
+    parallel_tool_calls: bool = True
+
+    @field_validator("input")
+    @classmethod
+    def _validate_input_non_empty(
+        cls, v: str | list[dict[str, Any]]
+    ) -> str | list[dict[str, Any]]:
+        if isinstance(v, str):
+            if not v.strip():
+                raise ValueError("input string cannot be empty")
+        elif not v:
+            raise ValueError("input list cannot be empty")
+        return v
+
     @field_validator("max_output_tokens")
     @classmethod
     def _validate_max_tokens(cls, v: int | None) -> int | None:
@@ -56,6 +70,7 @@ class ResponsesResponse(BaseModel):
     instructions: str | None = None
     max_output_tokens: int | None = None
     metadata: dict[str, Any] | None = None
+    # Echoes ResponsesRequest.parallel_tool_calls (set by the router).
     parallel_tool_calls: bool = True
     temperature: float | None = None
     top_p: float | None = None

--- a/olmlx/schemas/responses.py
+++ b/olmlx/schemas/responses.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+from olmlx.schemas.common import ModelName
+
+
+class ResponsesRequest(BaseModel):
+    model: ModelName
+    # `input` is either a plain string (one user turn) or a list of input
+    # items (messages / function_call / function_call_output). Items are kept
+    # as freeform dicts and validated during translation (router raises
+    # ValueError -> 400/422 for unknown shapes).
+    input: str | list[dict[str, Any]]
+    instructions: str | None = None
+    stream: bool = False
+    max_output_tokens: int | None = Field(None, ge=1)
+    temperature: float | None = Field(None, ge=0, le=2)
+    top_p: float | None = Field(None, ge=0, le=1)
+    tools: list[dict[str, Any]] | None = None
+    tool_choice: str | dict[str, Any] | None = None
+    previous_response_id: str | None = None
+    store: bool = True
+    reasoning: dict[str, Any] | None = None  # {"effort": "low"|"medium"|"high"}
+    text: dict[str, Any] | None = None       # {"format": {"type": ...}}
+    metadata: dict[str, Any] | None = None
+    seed: int | None = None
+
+    @field_validator("max_output_tokens")
+    @classmethod
+    def _validate_max_tokens(cls, v: int | None) -> int | None:
+        if v is None:
+            return v
+        from olmlx.schemas.common import validate_token_limit
+
+        return validate_token_limit(v, "max_output_tokens")
+
+
+class ResponsesResponse(BaseModel):
+    """Top-level Responses object. Output items and usage are kept as dicts so
+    the router builds them directly; response_model_exclude_none trims absent
+    fields the SDK treats as optional."""
+
+    id: str
+    object: str = "response"
+    created_at: int
+    status: str
+    model: str
+    output: list[dict[str, Any]]
+    usage: dict[str, Any] | None = None
+    previous_response_id: str | None = None
+    incomplete_details: dict[str, Any] | None = None
+    error: dict[str, Any] | None = None
+    instructions: str | None = None
+    max_output_tokens: int | None = None
+    metadata: dict[str, Any] | None = None
+    parallel_tool_calls: bool = True
+    temperature: float | None = None
+    top_p: float | None = None
+    tool_choice: str | dict[str, Any] | None = None
+    tools: list[dict[str, Any]] = Field(default_factory=list)

--- a/olmlx/schemas/responses.py
+++ b/olmlx/schemas/responses.py
@@ -24,7 +24,7 @@ class ResponsesRequest(BaseModel):
     previous_response_id: str | None = None
     store: bool = True
     reasoning: dict[str, Any] | None = None  # {"effort": "low"|"medium"|"high"}
-    text: dict[str, Any] | None = None       # {"format": {"type": ...}}
+    text: dict[str, Any] | None = None  # {"format": {"type": ...}}
     metadata: dict[str, Any] | None = None
     seed: int | None = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,5 +56,6 @@ dev = [
     "pytest-asyncio>=0.24",
     "pytest-cov>=7.0.0",
     "pyright>=1.1.380",
+    "openai>=1.66",
     "ruff>=0.9",
 ]

--- a/tests/live/test_responses_sdk.py
+++ b/tests/live/test_responses_sdk.py
@@ -1,0 +1,128 @@
+"""Live acceptance test: the real OpenAI SDK against olmlx /v1/responses (#368).
+
+Drives `AsyncOpenAI` over an in-process ASGI transport (no real server) so the
+SDK's own response-schema validation exercises our /v1/responses shapes — the
+acceptance criterion for #368 (SDK works for text, streaming text, tool use).
+
+Outside tests/integration/ on purpose (that package's autouse mock_mlx_primitives
+would replace the real model). real_model; skipped in CI and when the model is
+not downloaded.
+"""
+
+import json
+
+import pytest
+
+from olmlx.config import settings
+
+MODEL = "mlx-community/Qwen3-4B-4bit"
+
+
+def _model_present() -> bool:
+    from olmlx.models.store import _safe_dir_name
+
+    return (settings.models_dir / _safe_dir_name(MODEL) / "config.json").exists()
+
+
+pytestmark = [
+    pytest.mark.real_model,
+    pytest.mark.skipif(
+        not _model_present(),
+        reason=f"{MODEL} not downloaded in {settings.models_dir}",
+    ),
+]
+
+
+@pytest.fixture
+async def sdk_client(tmp_path, monkeypatch):
+    """Real app + ModelManager, exposed via the real OpenAI AsyncOpenAI SDK
+    bound to an in-process ASGI transport."""
+    models_config = tmp_path / "models.json"
+    models_config.write_text(json.dumps({}))
+    aliases_path = tmp_path / "aliases.json"
+    aliases_path.write_text("{}")
+    monkeypatch.setattr("olmlx.config.settings.models_config", models_config)
+    monkeypatch.setattr("olmlx.engine.registry.settings.models_config", models_config)
+
+    from olmlx.engine.model_manager import ModelManager
+    from olmlx.engine.registry import ModelRegistry
+    from olmlx.models.store import ModelStore
+
+    registry = ModelRegistry()
+    registry._aliases_path = aliases_path
+    registry.load()
+    store = ModelStore(registry)
+    manager = ModelManager(registry, store)
+    manager.start_expiry_checker()
+
+    from olmlx.app import create_app
+
+    app = create_app()
+    app.state.registry = registry
+    app.state.model_manager = manager
+    app.state.model_store = store
+
+    import httpx
+    from openai import AsyncOpenAI
+
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    http_client = httpx.AsyncClient(transport=transport, base_url="http://test")
+    client = AsyncOpenAI(
+        base_url="http://test/v1", api_key="not-needed", http_client=http_client
+    )
+    try:
+        yield client
+    finally:
+        await http_client.aclose()
+        await manager.stop()
+
+
+async def test_text(sdk_client):
+    resp = await sdk_client.responses.create(
+        model=MODEL, input="Say the single word: pong.", max_output_tokens=64
+    )
+    assert resp.status in ("completed", "incomplete")
+    assert resp.output_text  # SDK convenience accessor concatenates output_text
+
+
+async def test_streaming_text(sdk_client):
+    chunks = []
+    async with sdk_client.responses.stream(
+        model=MODEL, input="Count to three.", max_output_tokens=64
+    ) as stream:
+        async for event in stream:
+            if event.type == "response.output_text.delta":
+                chunks.append(event.delta)
+        final = await stream.get_final_response()
+    assert "".join(chunks)
+    assert final.status in ("completed", "incomplete")
+
+
+async def test_tool_use(sdk_client):
+    tools = [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get the weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }
+    ]
+    resp = await sdk_client.responses.create(
+        model=MODEL,
+        input="Use the get_weather tool to check the weather in Paris.",
+        tools=tools,
+        max_output_tokens=128,
+    )
+    # The acceptance criterion is that the SDK round-trips our response without
+    # validation errors. A 4B model usually calls the tool here, but we don't
+    # hard-fail on model competence: assert the response validated and, IF a
+    # function_call was produced, its shape is correct.
+    assert resp.status in ("completed", "incomplete")
+    calls = [it for it in resp.output if it.type == "function_call"]
+    for c in calls:
+        assert c.name == "get_weather"
+        json.loads(c.arguments)  # arguments must parse as JSON

--- a/tests/test_responses_state.py
+++ b/tests/test_responses_state.py
@@ -1,0 +1,42 @@
+"""Tests for the Responses-API state store."""
+
+from olmlx.engine.responses_state import ResponsesStore
+
+
+def test_put_get_roundtrip():
+    store = ResponsesStore(max_entries=4)
+    store.put("resp_1", {"output_items": [{"a": 1}]})
+    assert store.get("resp_1") == {"output_items": [{"a": 1}]}
+
+
+def test_missing_returns_none():
+    store = ResponsesStore(max_entries=4)
+    assert store.get("nope") is None
+
+
+def test_delete():
+    store = ResponsesStore(max_entries=4)
+    store.put("resp_1", {"x": 1})
+    assert store.delete("resp_1") is True
+    assert store.get("resp_1") is None
+    assert store.delete("resp_1") is False
+
+
+def test_lru_eviction():
+    store = ResponsesStore(max_entries=2)
+    store.put("a", {"v": 1})
+    store.put("b", {"v": 2})
+    store.put("c", {"v": 3})  # evicts "a"
+    assert store.get("a") is None
+    assert store.get("b") == {"v": 2}
+    assert store.get("c") == {"v": 3}
+
+
+def test_get_refreshes_lru():
+    store = ResponsesStore(max_entries=2)
+    store.put("a", {"v": 1})
+    store.put("b", {"v": 2})
+    store.get("a")  # "a" now most-recently used
+    store.put("c", {"v": 3})  # evicts "b", not "a"
+    assert store.get("a") == {"v": 1}
+    assert store.get("b") is None

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -28,3 +28,10 @@ class TestResponsesRequestSchema:
         assert req.previous_response_id is None
         assert req.tools is None
         assert req.max_output_tokens is None
+
+    def test_empty_input_rejected(self):
+        import pytest
+        with pytest.raises(Exception):
+            ResponsesRequest(model="qwen3", input="")
+        with pytest.raises(Exception):
+            ResponsesRequest(model="qwen3", input=[])

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -140,6 +140,13 @@ class TestTranslation:
         with pytest.raises(ValueError):
             _convert_tools([{"type": "function", "parameters": {}}])
 
+    def test_function_call_missing_arguments_defaults_to_empty_object(self):
+        # A missing/empty arguments must become "{}" (valid JSON), not "".
+        msgs = _build_input_messages(
+            [{"type": "function_call", "call_id": "c1", "name": "f"}]
+        )
+        assert msgs[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+
 
 class TestNonStreamingText:
     @pytest.mark.asyncio

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -614,3 +614,44 @@ class TestStreaming:
         final = events[-1]["data"]["response"]
         assert final["status"] == "incomplete"
         assert final["incomplete_details"]["reason"] == "max_output_tokens"
+
+
+class TestRetrieveDelete:
+    @pytest.fixture(autouse=True)
+    def _clear_store(self):
+        get_store().clear()
+        yield
+        get_store().clear()
+
+    @pytest.mark.asyncio
+    async def test_get_then_delete_lifecycle(self, app_client):
+        mock_result = {"text": "hi", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            created = await app_client.post(
+                "/v1/responses", json={"model": "qwen3", "input": "hi"}
+            )
+        rid = created.json()["id"]
+
+        got = await app_client.get(f"/v1/responses/{rid}")
+        assert got.status_code == 200
+        assert got.json()["id"] == rid
+
+        deleted = await app_client.delete(f"/v1/responses/{rid}")
+        assert deleted.status_code == 200
+        assert deleted.json()["deleted"] is True
+
+        gone = await app_client.get(f"/v1/responses/{rid}")
+        assert gone.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_unknown_404(self, app_client):
+        resp = await app_client.get("/v1/responses/resp_unknown")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_unknown_404(self, app_client):
+        resp = await app_client.delete("/v1/responses/resp_unknown")
+        assert resp.status_code == 404

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -477,3 +477,114 @@ class TestStateContinuation:
             systems = [m for m in sent if m["role"] == "system"]
             assert len(systems) == 1
             assert systems[0]["content"] == "Second."
+
+
+def _parse_sse(body: str) -> list[dict]:
+    """Parse an SSE body into a list of {event, data} dicts."""
+    events = []
+    for block in body.strip().split("\n\n"):
+        if not block.strip():
+            continue
+        event = None
+        data = None
+        for line in block.splitlines():
+            if line.startswith("event: "):
+                event = line[len("event: "):]
+            elif line.startswith("data: "):
+                data = json.loads(line[len("data: "):])
+        events.append({"event": event, "data": data})
+    return events
+
+
+class TestStreaming:
+    @pytest.mark.asyncio
+    async def test_text_stream_event_sequence(self, app_client):
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": "Hel", "done": False}
+                yield {"text": "lo", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats(eval_count=2)}
+
+            return gen()
+
+        with patch(
+            "olmlx.routers.responses.generate_chat", side_effect=mock_stream
+        ):
+            resp = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "hi", "stream": True},
+            )
+        assert resp.status_code == 200
+        events = _parse_sse(resp.text)
+        types = [e["event"] for e in events]
+        assert types[0] == "response.created"
+        assert "response.output_text.delta" in types
+        assert types[-1] == "response.completed"
+        seqs = [e["data"]["sequence_number"] for e in events]
+        assert seqs == sorted(seqs)
+        text = "".join(
+            e["data"]["delta"]
+            for e in events
+            if e["event"] == "response.output_text.delta"
+        )
+        assert text == "Hello"
+        final = events[-1]["data"]["response"]
+        assert final["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_stream(self, app_client):
+        raw = '<tool_call>{"name": "f", "arguments": {"x": 1}}</tool_call>'
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": raw, "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch(
+            "olmlx.routers.responses.generate_chat", side_effect=mock_stream
+        ):
+            resp = await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": "go",
+                    "stream": True,
+                    "tools": [
+                        {"type": "function", "name": "f", "parameters": {"type": "object"}}
+                    ],
+                },
+            )
+        events = _parse_sse(resp.text)
+        types = [e["event"] for e in events]
+        assert "response.function_call_arguments.delta" in types
+        assert "response.function_call_arguments.done" in types
+        final = events[-1]["data"]["response"]
+        fc = next(it for it in final["output"] if it["type"] == "function_call")
+        assert fc["name"] == "f"
+
+    @pytest.mark.asyncio
+    async def test_stream_stores_response(self, app_client):
+        from olmlx.engine.responses_state import get_store
+
+        get_store().clear()
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": "hi", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch(
+            "olmlx.routers.responses.generate_chat", side_effect=mock_stream
+        ):
+            resp = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "hi", "stream": True},
+            )
+        events = _parse_sse(resp.text)
+        rid = events[-1]["data"]["response"]["id"]
+        assert get_store().get(rid) is not None
+        get_store().clear()

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -489,9 +489,9 @@ def _parse_sse(body: str) -> list[dict]:
         data = None
         for line in block.splitlines():
             if line.startswith("event: "):
-                event = line[len("event: "):]
+                event = line[len("event: ") :]
             elif line.startswith("data: "):
-                data = json.loads(line[len("data: "):])
+                data = json.loads(line[len("data: ") :])
         events.append({"event": event, "data": data})
     return events
 
@@ -507,9 +507,7 @@ class TestStreaming:
 
             return gen()
 
-        with patch(
-            "olmlx.routers.responses.generate_chat", side_effect=mock_stream
-        ):
+        with patch("olmlx.routers.responses.generate_chat", side_effect=mock_stream):
             resp = await app_client.post(
                 "/v1/responses",
                 json={"model": "qwen3", "input": "hi", "stream": True},
@@ -542,9 +540,7 @@ class TestStreaming:
 
             return gen()
 
-        with patch(
-            "olmlx.routers.responses.generate_chat", side_effect=mock_stream
-        ):
+        with patch("olmlx.routers.responses.generate_chat", side_effect=mock_stream):
             resp = await app_client.post(
                 "/v1/responses",
                 json={
@@ -552,7 +548,11 @@ class TestStreaming:
                     "input": "go",
                     "stream": True,
                     "tools": [
-                        {"type": "function", "name": "f", "parameters": {"type": "object"}}
+                        {
+                            "type": "function",
+                            "name": "f",
+                            "parameters": {"type": "object"},
+                        }
                     ],
                 },
             )
@@ -577,9 +577,7 @@ class TestStreaming:
 
             return gen()
 
-        with patch(
-            "olmlx.routers.responses.generate_chat", side_effect=mock_stream
-        ):
+        with patch("olmlx.routers.responses.generate_chat", side_effect=mock_stream):
             resp = await app_client.post(
                 "/v1/responses",
                 json={"model": "qwen3", "input": "hi", "stream": True},
@@ -603,9 +601,7 @@ class TestStreaming:
 
             return gen()
 
-        with patch(
-            "olmlx.routers.responses.generate_chat", side_effect=mock_stream
-        ):
+        with patch("olmlx.routers.responses.generate_chat", side_effect=mock_stream):
             resp = await app_client.post(
                 "/v1/responses",
                 json={"model": "qwen3", "input": "hi", "stream": True},
@@ -692,20 +688,14 @@ class TestSDKShapeRegression:
 
             return gen()
 
-        with patch(
-            "olmlx.routers.responses.generate_chat", side_effect=mock_stream
-        ):
+        with patch("olmlx.routers.responses.generate_chat", side_effect=mock_stream):
             resp = await app_client.post(
                 "/v1/responses",
                 json={"model": "qwen3", "input": "hi", "stream": True},
             )
         events = _parse_sse(resp.text)
-        delta = next(
-            e for e in events if e["event"] == "response.output_text.delta"
-        )
-        done = next(
-            e for e in events if e["event"] == "response.output_text.done"
-        )
+        delta = next(e for e in events if e["event"] == "response.output_text.delta")
+        done = next(e for e in events if e["event"] == "response.output_text.done")
         assert delta["data"]["logprobs"] == []
         assert done["data"]["logprobs"] == []
 
@@ -720,9 +710,7 @@ class TestSDKShapeRegression:
 
             return gen()
 
-        with patch(
-            "olmlx.routers.responses.generate_chat", side_effect=mock_stream
-        ):
+        with patch("olmlx.routers.responses.generate_chat", side_effect=mock_stream):
             resp = await app_client.post(
                 "/v1/responses",
                 json={
@@ -730,14 +718,16 @@ class TestSDKShapeRegression:
                     "input": "go",
                     "stream": True,
                     "tools": [
-                        {"type": "function", "name": "f", "parameters": {"type": "object"}}
+                        {
+                            "type": "function",
+                            "name": "f",
+                            "parameters": {"type": "object"},
+                        }
                     ],
                 },
             )
         events = _parse_sse(resp.text)
         done = next(
-            e
-            for e in events
-            if e["event"] == "response.function_call_arguments.done"
+            e for e in events if e["event"] == "response.function_call_arguments.done"
         )
         assert done["data"]["name"] == "f"

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -588,3 +588,29 @@ class TestStreaming:
         rid = events[-1]["data"]["response"]["id"]
         assert get_store().get(rid) is not None
         get_store().clear()
+
+    @pytest.mark.asyncio
+    async def test_stream_timeout_incomplete(self, app_client):
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": "partial", "done": False}
+                yield {
+                    "text": "",
+                    "done": True,
+                    "done_reason": "timeout",
+                    "stats": TimingStats(),
+                }
+
+            return gen()
+
+        with patch(
+            "olmlx.routers.responses.generate_chat", side_effect=mock_stream
+        ):
+            resp = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "hi", "stream": True},
+            )
+        events = _parse_sse(resp.text)
+        final = events[-1]["data"]["response"]
+        assert final["status"] == "incomplete"
+        assert final["incomplete_details"]["reason"] == "max_output_tokens"

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -1,6 +1,5 @@
 """Tests for olmlx.routers.responses and its schemas."""
 
-import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -37,6 +36,7 @@ class TestResponsesRequestSchema:
 
     def test_empty_input_rejected(self):
         import pytest
+
         with pytest.raises(Exception):
             ResponsesRequest(model="qwen3", input="")
         with pytest.raises(Exception):
@@ -77,9 +77,7 @@ class TestTranslation:
         msgs = _build_input_messages(
             [{"type": "function_call_output", "call_id": "call_1", "output": "42"}]
         )
-        assert msgs == [
-            {"role": "tool", "tool_call_id": "call_1", "content": "42"}
-        ]
+        assert msgs == [{"role": "tool", "tool_call_id": "call_1", "content": "42"}]
 
     def test_function_call_item(self):
         msgs = _build_input_messages(
@@ -139,3 +137,50 @@ class TestTranslation:
     def test_function_tool_missing_name_raises(self):
         with pytest.raises(ValueError):
             _convert_tools([{"type": "function", "parameters": {}}])
+
+
+class TestNonStreamingText:
+    @pytest.mark.asyncio
+    async def test_text_response_shape(self, app_client):
+        stats = TimingStats(prompt_eval_count=5, eval_count=3)
+        mock_result = {"text": "Hello there.", "done": True, "stats": stats}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "hi", "stream": False},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["object"] == "response"
+        assert data["status"] == "completed"
+        assert data["id"].startswith("resp_")
+        msg = next(it for it in data["output"] if it["type"] == "message")
+        assert msg["role"] == "assistant"
+        assert msg["content"][0]["type"] == "output_text"
+        assert msg["content"][0]["text"] == "Hello there."
+        assert data["usage"]["input_tokens"] == 5
+        assert data["usage"]["output_tokens"] == 3
+        assert data["usage"]["total_tokens"] == 8
+
+    @pytest.mark.asyncio
+    async def test_timeout_marks_incomplete(self, app_client):
+        mock_result = {
+            "text": "partial",
+            "done": True,
+            "done_reason": "timeout",
+            "stats": TimingStats(),
+        }
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "hi"},
+            )
+        data = resp.json()
+        assert data["status"] == "incomplete"
+        assert data["incomplete_details"]["reason"] == "max_output_tokens"

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -1,5 +1,6 @@
 """Tests for olmlx.routers.responses and its schemas."""
 
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -184,3 +185,128 @@ class TestNonStreamingText:
         data = resp.json()
         assert data["status"] == "incomplete"
         assert data["incomplete_details"]["reason"] == "max_output_tokens"
+
+
+class TestNonStreamingFeatures:
+    @pytest.mark.asyncio
+    async def test_function_call_item_emitted(self, app_client):
+        raw = '<tool_call>{"name": "get_weather", "arguments": {"city": "SF"}}</tool_call>'
+        mock_result = {"text": raw, "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": "weather in SF?",
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "get_weather",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                            },
+                        }
+                    ],
+                },
+            )
+        data = resp.json()
+        fc = next(it for it in data["output"] if it["type"] == "function_call")
+        assert fc["name"] == "get_weather"
+        assert json.loads(fc["arguments"]) == {"city": "SF"}
+        assert fc["call_id"].startswith("call_")
+
+    @pytest.mark.asyncio
+    async def test_reasoning_item_from_think(self, app_client):
+        mock_result = {
+            "text": "<think>step one</think>The answer is 42.",
+            "done": True,
+            "stats": TimingStats(),
+            "thinking_expected": True,
+        }
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "q", "reasoning": {"effort": "high"}},
+            )
+        data = resp.json()
+        reasoning = next(it for it in data["output"] if it["type"] == "reasoning")
+        assert "step one" in reasoning["content"][0]["text"]
+        msg = next(it for it in data["output"] if it["type"] == "message")
+        assert msg["content"][0]["text"] == "The answer is 42."
+        assert mock_gen.call_args.kwargs["enable_thinking"] is True
+
+    @pytest.mark.asyncio
+    async def test_structured_output_threads_grammar(self, app_client):
+        mock_result = {"text": "{}", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": "q",
+                    "text": {
+                        "format": {
+                            "type": "json_schema",
+                            "name": "thing",
+                            "schema": {"type": "object"},
+                        }
+                    },
+                },
+            )
+        assert resp.status_code == 200
+        assert mock_gen.call_args.kwargs["grammar_spec"] is not None
+
+    @pytest.mark.asyncio
+    async def test_image_input_threads_images(self, app_client):
+        mock_result = {"text": "a cat", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "input_text", "text": "what is this?"},
+                                {
+                                    "type": "input_image",
+                                    "image_url": "http://x/cat.png",
+                                },
+                            ],
+                        }
+                    ],
+                },
+            )
+        assert resp.status_code == 200
+        sent_messages = mock_gen.call_args.args[2]
+        assert sent_messages[0]["images"] == ["http://x/cat.png"]
+
+    @pytest.mark.asyncio
+    async def test_builtin_tool_rejected_422(self, app_client):
+        resp = await app_client.post(
+            "/v1/responses",
+            json={"model": "qwen3", "input": "q", "tools": [{"type": "web_search"}]},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_unknown_input_item_422(self, app_client):
+        resp = await app_client.post(
+            "/v1/responses",
+            json={"model": "qwen3", "input": [{"type": "mystery"}]},
+        )
+        assert resp.status_code == 422

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -7,6 +7,12 @@ import pytest
 
 from olmlx.schemas.responses import ResponsesRequest
 from olmlx.utils.timing import TimingStats
+from olmlx.routers.responses import (
+    _build_input_messages,
+    _convert_tools,
+    _grammar_from_text_format,
+    _resolve_reasoning,
+)
 
 
 class TestResponsesRequestSchema:
@@ -35,3 +41,93 @@ class TestResponsesRequestSchema:
             ResponsesRequest(model="qwen3", input="")
         with pytest.raises(Exception):
             ResponsesRequest(model="qwen3", input=[])
+
+
+class TestTranslation:
+    def test_string_input(self):
+        msgs = _build_input_messages("hello")
+        assert msgs == [{"role": "user", "content": "hello"}]
+
+    def test_message_item_string_content(self):
+        msgs = _build_input_messages([{"role": "user", "content": "hi"}])
+        assert msgs == [{"role": "user", "content": "hi"}]
+
+    def test_message_item_text_parts(self):
+        msgs = _build_input_messages(
+            [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}]
+        )
+        assert msgs == [{"role": "user", "content": "hi"}]
+
+    def test_message_item_image_part(self):
+        msgs = _build_input_messages(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "describe"},
+                        {"type": "input_image", "image_url": "http://x/y.png"},
+                    ],
+                }
+            ]
+        )
+        assert msgs[0]["content"] == "describe"
+        assert msgs[0]["images"] == ["http://x/y.png"]
+
+    def test_function_call_output_item(self):
+        msgs = _build_input_messages(
+            [{"type": "function_call_output", "call_id": "call_1", "output": "42"}]
+        )
+        assert msgs == [
+            {"role": "tool", "tool_call_id": "call_1", "content": "42"}
+        ]
+
+    def test_function_call_item(self):
+        msgs = _build_input_messages(
+            [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "get_weather",
+                    "arguments": '{"city": "SF"}',
+                }
+            ]
+        )
+        assert msgs[0]["role"] == "assistant"
+        tc = msgs[0]["tool_calls"][0]
+        assert tc["function"]["name"] == "get_weather"
+        assert tc["id"] == "call_1"
+
+    def test_unknown_item_type_raises(self):
+        with pytest.raises(ValueError):
+            _build_input_messages([{"type": "mystery"}])
+
+    def test_convert_function_tool(self):
+        tools = _convert_tools(
+            [
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "description": "d",
+                    "parameters": {"type": "object"},
+                }
+            ]
+        )
+        assert tools[0]["function"]["name"] == "get_weather"
+        assert tools[0]["type"] == "function"
+
+    def test_builtin_tool_rejected(self):
+        with pytest.raises(ValueError):
+            _convert_tools([{"type": "web_search"}])
+
+    def test_grammar_json_object(self):
+        spec = _grammar_from_text_format({"format": {"type": "json_object"}})
+        assert spec is not None
+
+    def test_grammar_none_for_text(self):
+        assert _grammar_from_text_format({"format": {"type": "text"}}) is None
+        assert _grammar_from_text_format(None) is None
+
+    def test_resolve_reasoning_presence(self):
+        assert _resolve_reasoning({"effort": "high"}) is True
+        assert _resolve_reasoning({"effort": "none"}) is False
+        assert _resolve_reasoning(None) is None

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from olmlx.engine.responses_state import get_store
 from olmlx.schemas.responses import ResponsesRequest
 from olmlx.utils.timing import TimingStats
 from olmlx.routers.responses import (
@@ -310,3 +311,79 @@ class TestNonStreamingFeatures:
             json={"model": "qwen3", "input": [{"type": "mystery"}]},
         )
         assert resp.status_code == 422
+
+
+class TestStateContinuation:
+    @pytest.fixture(autouse=True)
+    def _clear_store(self):
+        get_store().clear()
+        yield
+        get_store().clear()
+
+    @pytest.mark.asyncio
+    async def test_response_is_stored(self, app_client):
+        mock_result = {"text": "hi", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses", json={"model": "qwen3", "input": "hi"}
+            )
+        rid = resp.json()["id"]
+        assert get_store().get(rid) is not None
+
+    @pytest.mark.asyncio
+    async def test_store_false_skips(self, app_client):
+        mock_result = {"text": "hi", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "hi", "store": False},
+            )
+        rid = resp.json()["id"]
+        assert get_store().get(rid) is None
+
+    @pytest.mark.asyncio
+    async def test_continuation_prepends_history_and_threads_cache_id(self, app_client):
+        first = {"text": "Blue.", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = first
+            r1 = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "favorite color?"},
+            )
+        rid = r1.json()["id"]
+
+        second = {"text": "Because.", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = second
+            await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": "why?",
+                    "previous_response_id": rid,
+                },
+            )
+            sent_messages = mock_gen.call_args.args[2]
+            roles = [m["role"] for m in sent_messages]
+            assert roles == ["user", "assistant", "user"]
+            assert sent_messages[1]["content"] == "Blue."
+            assert sent_messages[-1]["content"] == "why?"
+            assert mock_gen.call_args.kwargs["cache_id"] == rid[:256]
+
+    @pytest.mark.asyncio
+    async def test_unknown_previous_id_404(self, app_client):
+        resp = await app_client.post(
+            "/v1/responses",
+            json={"model": "qwen3", "input": "x", "previous_response_id": "resp_nope"},
+        )
+        assert resp.status_code == 404

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -1,0 +1,30 @@
+"""Tests for olmlx.routers.responses and its schemas."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from olmlx.schemas.responses import ResponsesRequest
+from olmlx.utils.timing import TimingStats
+
+
+class TestResponsesRequestSchema:
+    def test_string_input_accepted(self):
+        req = ResponsesRequest(model="qwen3", input="hello")
+        assert req.input == "hello"
+        assert req.store is True
+        assert req.stream is False
+
+    def test_list_input_accepted(self):
+        req = ResponsesRequest(
+            model="qwen3",
+            input=[{"role": "user", "content": "hi"}],
+        )
+        assert isinstance(req.input, list)
+
+    def test_defaults(self):
+        req = ResponsesRequest(model="qwen3", input="x")
+        assert req.previous_response_id is None
+        assert req.tools is None
+        assert req.max_output_tokens is None

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -131,3 +131,11 @@ class TestTranslation:
         assert _resolve_reasoning({"effort": "high"}) is True
         assert _resolve_reasoning({"effort": "none"}) is False
         assert _resolve_reasoning(None) is None
+
+    def test_function_call_missing_name_raises(self):
+        with pytest.raises(ValueError):
+            _build_input_messages([{"type": "function_call", "call_id": "c1"}])
+
+    def test_function_tool_missing_name_raises(self):
+        with pytest.raises(ValueError):
+            _convert_tools([{"type": "function", "parameters": {}}])

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -655,3 +655,89 @@ class TestRetrieveDelete:
     async def test_delete_unknown_404(self, app_client):
         resp = await app_client.delete("/v1/responses/resp_unknown")
         assert resp.status_code == 404
+
+
+class TestSDKShapeRegression:
+    @pytest.mark.asyncio
+    async def test_tool_choice_defaults_to_auto(self, app_client):
+        mock_result = {"text": "hi", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses", json={"model": "qwen3", "input": "hi"}
+            )
+        assert resp.json()["tool_choice"] == "auto"
+
+    @pytest.mark.asyncio
+    async def test_tool_choice_explicit_echoed(self, app_client):
+        mock_result = {"text": "hi", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "hi", "tool_choice": "none"},
+            )
+        assert resp.json()["tool_choice"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_stream_text_events_carry_logprobs(self, app_client):
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": "hi", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch(
+            "olmlx.routers.responses.generate_chat", side_effect=mock_stream
+        ):
+            resp = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "hi", "stream": True},
+            )
+        events = _parse_sse(resp.text)
+        delta = next(
+            e for e in events if e["event"] == "response.output_text.delta"
+        )
+        done = next(
+            e for e in events if e["event"] == "response.output_text.done"
+        )
+        assert delta["data"]["logprobs"] == []
+        assert done["data"]["logprobs"] == []
+
+    @pytest.mark.asyncio
+    async def test_stream_function_call_done_carries_name(self, app_client):
+        raw = '<tool_call>{"name": "f", "arguments": {"x": 1}}</tool_call>'
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": raw, "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch(
+            "olmlx.routers.responses.generate_chat", side_effect=mock_stream
+        ):
+            resp = await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": "go",
+                    "stream": True,
+                    "tools": [
+                        {"type": "function", "name": "f", "parameters": {"type": "object"}}
+                    ],
+                },
+            )
+        events = _parse_sse(resp.text)
+        done = next(
+            e
+            for e in events
+            if e["event"] == "response.function_call_arguments.done"
+        )
+        assert done["data"]["name"] == "f"

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -387,3 +387,93 @@ class TestStateContinuation:
             json={"model": "qwen3", "input": "x", "previous_response_id": "resp_nope"},
         )
         assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_three_turn_chain(self, app_client):
+        async def post(json_body):
+            mock_result = {"text": "ok", "done": True, "stats": TimingStats()}
+            with patch(
+                "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+            ) as mock_gen:
+                mock_gen.return_value = mock_result
+                resp = await app_client.post("/v1/responses", json=json_body)
+                return resp.json()["id"], mock_gen
+
+        id1, _ = await post({"model": "qwen3", "input": "one"})
+        id2, _ = await post(
+            {"model": "qwen3", "input": "two", "previous_response_id": id1}
+        )
+
+        mock_result = {"text": "ok", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "three", "previous_response_id": id2},
+            )
+            sent = mock_gen.call_args.args[2]
+            roles = [m["role"] for m in sent]
+            assert roles == ["user", "assistant", "user", "assistant", "user"]
+            contents = [m.get("content") for m in sent]
+            assert contents[0] == "one"
+            assert contents[2] == "two"
+            assert contents[4] == "three"
+
+    @pytest.mark.asyncio
+    async def test_instructions_not_carried_across_turns(self, app_client):
+        # Turn 1 with instructions.
+        mock_result = {"text": "ok", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            r1 = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "hi", "instructions": "Be terse."},
+            )
+        id1 = r1.json()["id"]
+
+        # Turn 2 continuation with NO instructions -> no system message at all.
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "more", "previous_response_id": id1},
+            )
+            sent = mock_gen.call_args.args[2]
+            assert all(m["role"] != "system" for m in sent), sent
+
+    @pytest.mark.asyncio
+    async def test_instructions_replace_not_stack_on_continuation(self, app_client):
+        mock_result = {"text": "ok", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            r1 = await app_client.post(
+                "/v1/responses",
+                json={"model": "qwen3", "input": "hi", "instructions": "First."},
+            )
+        id1 = r1.json()["id"]
+
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": "more",
+                    "previous_response_id": id1,
+                    "instructions": "Second.",
+                },
+            )
+            sent = mock_gen.call_args.args[2]
+            systems = [m for m in sent if m["role"] == "system"]
+            assert len(systems) == 1
+            assert systems[0]["content"] == "Second."

--- a/uv.lock
+++ b/uv.lock
@@ -768,6 +768,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "duckduckgo-search"
 version = "8.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1148,6 +1157,96 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/13/daa722f5765c393576f466378f9dfd29d77c9bed939e0688f96afa3601ea/jiter-0.15.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0f862193b8696249d22ec433e85fd2ab0ad9596bc3e45e6c0bc55e8aeba97be2", size = 310899, upload-time = "2026-05-19T10:07:12.89Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/82/2d2551829b082f4b6d82b9f939b031fb808a10aab1ec0664f82e150bb9a2/jiter-0.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1303d4d68a9b051ea90502402063ecf3807da00ad2affa19ca1ae3b90b3c5f67", size = 314963, upload-time = "2026-05-19T10:07:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0a/8b1a51466f7fe9f31dbe4bc7e0ca848674f9825e0f737b929b97e8c60aa7/jiter-0.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:392b8ab019e5502d08aff85c6272209c24bc2cbe706ea82a56368f524236614a", size = 341730, upload-time = "2026-05-19T10:07:15.869Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/2a/e71dea19822e2e404e83992a08c1d6b9b617bb944f28c9c2fbd85d02c91e/jiter-0.15.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:773b6eb282ce11ee19f05f6b2d4404fa308e5bbd353b0b80a0262caad6db2cd7", size = 366214, upload-time = "2026-05-19T10:07:17.259Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/97e1fa539d124a509a00ab7f669289d1c1d236ecabf12948a18f16c91082/jiter-0.15.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d2c0c44d569ce0f2850f5c926f8caeb5f245fbc84475aeb36efccc2103e6dbd", size = 459527, upload-time = "2026-05-19T10:07:18.741Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7a/4a68d331aef8cf2e2393c14a3aacb635c62aa86071b0229899fb5baaa907/jiter-0.15.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:032396229564bca02440396bd327710719f724f5e7b7e9f7a8eb3faa4a2c2281", size = 375451, upload-time = "2026-05-19T10:07:20.208Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/1c445c2b6f0e30a274dc8082e0c3c7825411cce80d726bccd697c98cc8d3/jiter-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3d37768fce7f88dd2a8c6091f2325dea27d30d30d5c6e7a1c0f0af77723b708", size = 349428, upload-time = "2026-05-19T10:07:22.372Z" },
+    { url = "https://files.pythonhosted.org/packages/00/94/e20d38984fc17a636371bffd2ae0f698124fdc8e75ef969cd2da6ba7cea7/jiter-0.15.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:2c9cb907439d20bd0c7d7565ca01ee52234203208433749bae5b516907526928", size = 355405, upload-time = "2026-05-19T10:07:23.916Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/4d09f814779d0ea80a28ed8e4c6662ec9a4a8ecef0ac52190ebac6262d14/jiter-0.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9100ddbec09741cc66feb0fc6773f8bdbd0e3c345689368f260082ff85dcc0cd", size = 393688, upload-time = "2026-05-19T10:07:25.854Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9d/8eb5d4fb8bf7e93a75964a5da71a75c67c864baf7fa3f98598187b3c7e57/jiter-0.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ae1b0d82ac2d987f9ea512b1c9adfcc71a28de3dea3a6039b54d76cffda9901e", size = 520853, upload-time = "2026-05-19T10:07:27.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2c/5e07874e59e623a943a0acf1552a80d05b70f31b402287a8fc6d7ec634c7/jiter-0.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8020c99ec13a7db2b6f96cbe82ef4721c88b426a4892f27478044af0284615ef", size = 551016, upload-time = "2026-05-19T10:07:28.846Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/d2d34422143474cadc15b60d482b1c35683dbc5c63c24346ddd0df09bcaf/jiter-0.15.0-cp311-cp311-win32.whl", hash = "sha256:42bfb257930800cf43e7c62c832402c704ab60797c992faf88d20e903eac8f32", size = 209518, upload-time = "2026-05-19T10:07:30.431Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/7d/52778b930e5cc3e52a37d950b1c10494244308b4329b25a0ff0d88303a81/jiter-0.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:860a74063284a2ae9bfedd694f299cc2c68e2696c5f3d440cc9d18bb81b9dd04", size = 200565, upload-time = "2026-05-19T10:07:32.125Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4f/d9b4067feb69b3fa6eb0488e1b59e2ad5b463fe39f59e527eab2aca00bb0/jiter-0.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:37a10c377ce3a4a85f4a67f28b7afe093154cde77eaf248a72e856aa08b4d865", size = 195488, upload-time = "2026-05-19T10:07:33.846Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
+    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/43/1fc62172aa98b50a7de9a25554060db510f85c89cfbed0dfe13e1907a139/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:411fa4dfa5a7ae3d11491027ffb9beadec3996010a986862db70d91abba1c750", size = 305585, upload-time = "2026-05-19T10:09:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c4/dd58fcd9e2df83666e5c1c1347bef58ce919cd8efc3ffa38aeea62ce493b/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:2b0074e2f56eb2dacca1689760fd2852a068f85a0547a157b82cb4cafeb6768b", size = 306936, upload-time = "2026-05-19T10:09:37.435Z" },
+    { url = "https://files.pythonhosted.org/packages/39/86/b695e16f1180c07f43ea98e73ecd21cf63fa2e1b0c1103739013784d11ae/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:913d02d29c9606643418d9ccfc3b72492ab25a6bf7889934e09a3490f8d3438b", size = 342453, upload-time = "2026-05-19T10:09:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/34/56/55d76614af37fe3f22a3347d1e410d2a15da581997cb2da499a625000bb5/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b15d3ec9b0449c40e85319bdb4caa8b77ab526e74f5532ed94bec15e2f66822c", size = 345606, upload-time = "2026-05-19T10:09:40.727Z" },
+    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
 ]
 
 [[package]]
@@ -2194,6 +2293,7 @@ dev = [
     { name = "datasets" },
     { name = "httpx" },
     { name = "matplotlib" },
+    { name = "openai" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "pyright" },
@@ -2232,6 +2332,7 @@ dev = [
     { name = "datasets", specifier = ">=3.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "matplotlib", specifier = ">=3.9" },
+    { name = "openai", specifier = ">=1.66" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27" },
     { name = "opentelemetry-sdk", specifier = ">=1.27" },
     { name = "pyright", specifier = ">=1.1.380" },
@@ -2239,6 +2340,25 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.9" },
+]
+
+[[package]]
+name = "openai"
+version = "2.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/a6/5815fe2e2aca74b36c650d1bd43b69827cee568073d0d2d9b6fc5aaac80c/openai-2.41.0.tar.gz", hash = "sha256:db5c362acd6604b84f076abbefa66826ea4b46ecba2954ed866e6a149a1352c0", size = 783525, upload-time = "2026-06-03T22:39:40.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/51/d82bb424e8aa372190c5233253a2ceb399a778747d18b42cff487411e663/openai-2.41.0-py3-none-any.whl", hash = "sha256:20cc7952e8501c7e5773dd2ef7be437bae9cb549044902e1041a83a54516e375", size = 1353378, upload-time = "2026-06-03T22:39:38.964Z" },
 ]
 
 [[package]]
@@ -3496,6 +3616,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds the OpenAI **Responses API** (`/v1/responses`) as a drop-in surface, implemented as a pure translation layer over the existing `generate_chat` engine (engine untouched), mirroring the Anthropic router's buffer-and-split structure. Closes #368.

**Endpoints**
- `POST /v1/responses` — non-streaming **and** streaming with the full OpenAI semantic SSE event sequence (`response.created` → `output_item.added` → `content_part.added` → `output_text.delta`×N → … → `response.completed`), monotonic `sequence_number` on every event.
- `GET /v1/responses/{id}` / `DELETE /v1/responses/{id}` — retrieve/delete stored responses.

**Capabilities**
- Function (custom) tool calling — buffered parse, replayed through `function_call_arguments.delta/.done`.
- `previous_response_id` continuation via a bounded-LRU in-memory store (`OLMLX_RESPONSES_STORE_MAX`, default 256); threads `cache_id` for prompt-cache reuse. `instructions` apply per-turn (not carried across continuation — OpenAI semantics). Honors `store: false`.
- Reasoning items (from model `<think>`), image input (`input_image`), structured outputs via `text.format` (json_object / json_schema).
- Built-in tools (`web_search`/`code_interpreter`/`computer_use`) rejected with 4xx; malformed input → 422; unknown `previous_response_id` → 404.

**Files**: new `routers/responses.py`, `schemas/responses.py`, `engine/responses_state.py`; `config.py` + `app.py` wiring; docs in `USER_MANUAL.md` + `CLAUDE.md`. Design/plan under `docs/superpowers/`.

## Test Plan
- [x] 49 unit tests (`tests/test_routers_responses.py`, `tests/test_responses_state.py`) — autouse MLX mock; cover non-streaming/streaming shapes, SSE event order + `sequence_number` monotonicity, tools, reasoning, images, structured outputs, continuation (incl. 3-turn chain + instructions-not-carried), store lifecycle, 422/404 paths, and regression coverage for SDK-required fields (`tool_choice`, `logprobs`, function-call `name`).
- [x] Live OpenAI-SDK acceptance test (`tests/live/test_responses_sdk.py`, `real_model`, CI-skipped) — drives the real `AsyncOpenAI` SDK over in-process ASGI against Qwen3-4B; text, streaming, tool use all pass. This surfaced 3 real response-shape bugs (now fixed + regression-covered).
- [x] No regressions: `test_routers_openai` + `test_routers_anthropic` (206) and `test_app` (32) pass; `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)