### PR TITLE
fix(bench): kill worker process group on timeout to stop orphaned-server RAM leak

### DIFF
--- a/olmlx/bench/runner.py
+++ b/olmlx/bench/runner.py
@@ -6,6 +6,7 @@ import json
 import logging
 import math
 import os
+import signal
 import socket
 import subprocess
 import sys
@@ -62,19 +63,21 @@ def _capture_bench_env() -> dict[str, str]:
     return captured
 
 
-_DEFAULT_WORKER_TIMEOUT = 600.0
+_DEFAULT_WORKER_TIMEOUT = 1800.0
 
 
 def _worker_timeout() -> float:
     """Per-scenario worker kill timeout, in seconds.
 
-    Defaults to 600s — fine for the 7-prompt throughput set. The 50-prompt
-    quality set (especially with thinking on and a high ``--max-tokens``)
-    can run much longer, so it is overridable via
-    ``OLMLX_BENCH_WORKER_TIMEOUT`` rather than hard-failing a long graded run.
+    Defaults to 1800s (30 min). The 7-prompt throughput set finishes in well
+    under that, but the 50-prompt quality set on a mid/large model (especially
+    with thinking on and a high ``--max-tokens``) can run many minutes per
+    scenario — the previous 600s default made those scenarios reliably time out
+    and lose their results. Still overridable via ``OLMLX_BENCH_WORKER_TIMEOUT``
+    for even longer graded runs rather than hard-failing.
 
-    Rejects ``inf`` / ``nan`` (these would silently disable the kill switch
-    in ``subprocess.run``) and warns on unparseable values so an ignored
+    Rejects ``inf`` / ``nan`` (these would silently disable the kill switch in
+    ``communicate(timeout=...)``) and warns on unparseable values so an ignored
     override is diagnosable instead of vanishing into the default.
     """
     raw = os.environ.get("OLMLX_BENCH_WORKER_TIMEOUT", "")
@@ -398,6 +401,29 @@ def run_bench(
     return run
 
 
+def _terminate_process_group(proc: subprocess.Popen) -> None:
+    """Kill the worker's whole process group, reaping any server it spawned.
+
+    The worker is launched with ``start_new_session=True``, so its PID is its
+    own process-group leader and the uvicorn server it spawns inherits that
+    group. Killing the group guarantees the server dies with the worker.
+
+    Without this, a worker killed on timeout (CPython SIGKILLs it on
+    ``TimeoutExpired``, so the worker's own ``finally`` cleanup cannot run)
+    leaves its server orphaned with the model still resident in RAM. Across a
+    multi-scenario / multi-model sweep these orphans accumulate to tens of GB
+    and eventually starve later loads (observed: 61 GB, cascading load failures).
+    """
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
+
+
 def _run_worker(
     model: str,
     scenario: Scenario,
@@ -432,20 +458,37 @@ def _run_worker(
         if max_tokens is not None:
             cmd.extend(["--max-tokens", str(max_tokens)])
 
+        # start_new_session=True: run the worker (and the server it spawns) in a
+        # dedicated process group so _terminate_process_group can reap the whole
+        # tree — see that function for the orphaned-server leak this prevents.
+        proc = subprocess.Popen(
+            cmd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
         try:
-            result = subprocess.run(
-                cmd,
-                env=env,
-                capture_output=True,
-                text=True,
-                timeout=worker_timeout,
-            )
-            if result.returncode != 0:
+            try:
+                _, stderr = proc.communicate(timeout=worker_timeout)
+            except subprocess.TimeoutExpired:
+                return [
+                    PromptResult(
+                        prompt_name="__worker_error__",
+                        category="error",
+                        output_text="",
+                        status_code=0,
+                        error=f"Worker timed out after {worker_timeout:.0f}s",
+                    )
+                ]
+
+            if proc.returncode != 0:
                 logger.error(
                     "Worker failed for %s (exit %d):\n%s",
                     scenario.name,
-                    result.returncode,
-                    result.stderr[-1000:] if result.stderr else "(no stderr)",
+                    proc.returncode,
+                    stderr[-1000:] if stderr else "(no stderr)",
                 )
                 return [
                     PromptResult(
@@ -453,7 +496,7 @@ def _run_worker(
                         category="error",
                         output_text="",
                         status_code=0,
-                        error=f"Worker exited with code {result.returncode}: {result.stderr[-500:] if result.stderr else ''}",
+                        error=f"Worker exited with code {proc.returncode}: {stderr[-500:] if stderr else ''}",
                     )
                 ]
 
@@ -471,16 +514,10 @@ def _run_worker(
             raw = json.loads(results_path.read_text())
             return [PromptResult.from_dict(r) for r in raw]
 
-        except subprocess.TimeoutExpired:
-            return [
-                PromptResult(
-                    prompt_name="__worker_error__",
-                    category="error",
-                    output_text="",
-                    status_code=0,
-                    error=f"Worker timed out after {worker_timeout:.0f}s",
-                )
-            ]
+        finally:
+            # Backstop on every path (timeout, crash, clean exit): ensure the
+            # worker's server child can never outlive this call.
+            _terminate_process_group(proc)
 
 
 def _get_server_port(scenario: Scenario) -> int:

--- a/olmlx/bench/runner.py
+++ b/olmlx/bench/runner.py
@@ -413,6 +413,13 @@ def _terminate_process_group(proc: subprocess.Popen) -> None:
     leaves its server orphaned with the model still resident in RAM. Across a
     multi-scenario / multi-model sweep these orphans accumulate to tens of GB
     and eventually starve later loads (observed: 61 GB, cascading load failures).
+
+    Order matters: ``killpg`` must run *before* ``wait``. The server grandchild
+    inherits the worker's stderr PIPE, so it holds a write end open; killing the
+    whole group first closes every write end, letting the ``waitpid``-only
+    ``wait`` return without blocking on unread pipe data. Do not refactor this to
+    read pipes (e.g. ``communicate``) after the group is gone, and do not narrow
+    the kill to a single PID — either would risk a hang on a surviving server.
     """
     try:
         os.killpg(proc.pid, signal.SIGKILL)
@@ -472,14 +479,22 @@ def _run_worker(
         try:
             try:
                 _, stderr = proc.communicate(timeout=worker_timeout)
-            except subprocess.TimeoutExpired:
+            except subprocess.TimeoutExpired as exc:
+                # communicate() attaches whatever it had drained before the
+                # deadline to the exception — surface its tail so a timed-out
+                # scenario is diagnosable instead of silent. (bytes if the
+                # decoder hadn't run yet; guard for that and for None.)
+                partial = exc.stderr
+                if isinstance(partial, bytes):
+                    partial = partial.decode(errors="replace")
+                tail = f": {partial[-500:]}" if partial else ""
                 return [
                     PromptResult(
                         prompt_name="__worker_error__",
                         category="error",
                         output_text="",
                         status_code=0,
-                        error=f"Worker timed out after {worker_timeout:.0f}s",
+                        error=f"Worker timed out after {worker_timeout:.0f}s{tail}",
                     )
                 ]
 

--- a/tests/test_bench_quality_wiring.py
+++ b/tests/test_bench_quality_wiring.py
@@ -446,33 +446,34 @@ class TestWorkerTimeout:
 
     def test_unset_returns_default(self, monkeypatch):
         monkeypatch.delenv("OLMLX_BENCH_WORKER_TIMEOUT", raising=False)
-        assert _worker_timeout() == 600.0
-
-    def test_positive_value_used(self, monkeypatch):
-        monkeypatch.setenv("OLMLX_BENCH_WORKER_TIMEOUT", "1800")
         assert _worker_timeout() == 1800.0
 
+    def test_positive_value_used(self, monkeypatch):
+        # Distinct from the 1800s default so this proves the override is honored.
+        monkeypatch.setenv("OLMLX_BENCH_WORKER_TIMEOUT", "2400")
+        assert _worker_timeout() == 2400.0
+
     def test_inf_rejected(self, monkeypatch, caplog):
-        # `subprocess.run(timeout=inf)` waits forever — must never get there.
+        # `communicate(timeout=inf)` waits forever — must never get there.
         monkeypatch.setenv("OLMLX_BENCH_WORKER_TIMEOUT", "inf")
         with caplog.at_level("WARNING", logger="olmlx.bench.runner"):
-            assert _worker_timeout() == 600.0
+            assert _worker_timeout() == 1800.0
         assert any("inf" in rec.getMessage().lower() for rec in caplog.records)
 
     def test_nan_rejected(self, monkeypatch):
         monkeypatch.setenv("OLMLX_BENCH_WORKER_TIMEOUT", "nan")
-        assert _worker_timeout() == 600.0
+        assert _worker_timeout() == 1800.0
 
     def test_zero_rejected(self, monkeypatch):
         monkeypatch.setenv("OLMLX_BENCH_WORKER_TIMEOUT", "0")
-        assert _worker_timeout() == 600.0
+        assert _worker_timeout() == 1800.0
 
     def test_negative_rejected(self, monkeypatch):
         monkeypatch.setenv("OLMLX_BENCH_WORKER_TIMEOUT", "-5")
-        assert _worker_timeout() == 600.0
+        assert _worker_timeout() == 1800.0
 
     def test_unparseable_warns(self, monkeypatch, caplog):
         monkeypatch.setenv("OLMLX_BENCH_WORKER_TIMEOUT", "abc")
         with caplog.at_level("WARNING", logger="olmlx.bench.runner"):
-            assert _worker_timeout() == 600.0
+            assert _worker_timeout() == 1800.0
         assert any("abc" in rec.getMessage() for rec in caplog.records)

--- a/tests/test_bench_runner.py
+++ b/tests/test_bench_runner.py
@@ -16,9 +16,44 @@ from olmlx.bench.runner import (
 from olmlx.bench.scenarios import Scenario
 
 
+def _fake_popen_factory(
+    *, results=None, returncode=0, stderr="", timeout=False, captured=None
+):
+    """Build a fake ``subprocess.Popen`` replacement for ``_run_worker`` tests.
+
+    Records the cmd/kwargs into ``captured`` (a dict) and returns a MagicMock
+    proc whose ``communicate`` either returns ``("", stderr)`` or raises
+    ``TimeoutExpired``. Writes ``results`` to the --results-json path on call.
+    """
+    import pathlib
+    import subprocess
+
+    def factory(cmd, **kwargs):
+        if captured is not None:
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+        if results is not None:
+            results_idx = cmd.index("--results-json") + 1
+            pathlib.Path(cmd[results_idx]).write_text(json.dumps(results))
+        proc = MagicMock()
+        proc.pid = 4242
+        proc.returncode = returncode
+        if timeout:
+            proc.communicate.side_effect = subprocess.TimeoutExpired(
+                cmd="worker", timeout=600
+            )
+        else:
+            proc.communicate.return_value = ("", stderr)
+        if captured is not None:
+            captured["proc"] = proc
+        return proc
+
+    return factory
+
+
 class TestRunWorker:
-    def test_worker_success(self, tmp_path, monkeypatch):
-        """Mock subprocess.run to return pre-built results."""
+    def test_worker_success(self):
+        """Mock Popen to return pre-built results."""
         fake_results = [
             {
                 "prompt_name": "factual",
@@ -33,26 +68,15 @@ class TestRunWorker:
             }
         ]
 
-        def fake_subprocess_run(cmd, env, capture_output, text, timeout):
-            # Write results to the path specified in cmd
-            results_idx = cmd.index("--results-json") + 1
-            results_path = cmd[results_idx]
-            import pathlib
-
-            pathlib.Path(results_path).write_text(json.dumps(fake_results))
-
-            class FakeResult:
-                returncode = 0
-                stderr = ""
-                stdout = ""
-
-            return FakeResult()
-
         scenario = Scenario(name="test", description="Test scenario")
         prompts_data = [PROMPTS[0].to_dict()]
 
-        with patch(
-            "olmlx.bench.runner.subprocess.run", side_effect=fake_subprocess_run
+        with (
+            patch(
+                "olmlx.bench.runner.subprocess.Popen",
+                side_effect=_fake_popen_factory(results=fake_results),
+            ),
+            patch("olmlx.bench.runner.os.killpg"),
         ):
             results = _run_worker(
                 "test-model", scenario, prompts_data, None, worker_timeout=600.0
@@ -63,16 +87,35 @@ class TestRunWorker:
         assert results[0].output_text == "Paris."
         assert results[0].tokens_per_second == 10.0
 
+    def test_worker_runs_in_new_session(self):
+        """Worker is launched in its own process group (start_new_session)."""
+        scenario = Scenario(name="test", description="Test")
+        captured: dict = {}
+
+        with (
+            patch(
+                "olmlx.bench.runner.subprocess.Popen",
+                side_effect=_fake_popen_factory(results=[], captured=captured),
+            ),
+            patch("olmlx.bench.runner.os.killpg"),
+        ):
+            _run_worker("model", scenario, [], None, worker_timeout=600.0)
+
+        assert captured["kwargs"].get("start_new_session") is True
+
     def test_worker_failure_returns_error(self):
         """Worker exit code != 0 produces error result."""
         scenario = Scenario(name="test", description="Test")
 
-        class FakeResult:
-            returncode = 1
-            stderr = "ImportError: no module"
-            stdout = ""
-
-        with patch("olmlx.bench.runner.subprocess.run", return_value=FakeResult()):
+        with (
+            patch(
+                "olmlx.bench.runner.subprocess.Popen",
+                side_effect=_fake_popen_factory(
+                    returncode=1, stderr="ImportError: no module"
+                ),
+            ),
+            patch("olmlx.bench.runner.os.killpg"),
+        ):
             results = _run_worker("model", scenario, [], None, worker_timeout=600.0)
 
         assert len(results) == 1
@@ -81,18 +124,65 @@ class TestRunWorker:
 
     def test_worker_timeout_returns_error(self):
         """Worker timeout produces error result."""
-        import subprocess
-
         scenario = Scenario(name="test", description="Test")
 
-        with patch(
-            "olmlx.bench.runner.subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd="test", timeout=600),
+        with (
+            patch(
+                "olmlx.bench.runner.subprocess.Popen",
+                side_effect=_fake_popen_factory(timeout=True),
+            ),
+            patch("olmlx.bench.runner.os.killpg"),
         ):
             results = _run_worker("model", scenario, [], None, worker_timeout=600.0)
 
         assert len(results) == 1
         assert "timed out" in results[0].error.lower()
+
+    def test_worker_timeout_kills_process_group(self):
+        """On timeout, the worker's whole process group is SIGKILLed.
+
+        Regression guard: a timed-out worker must not leave its uvicorn server
+        orphaned (which would keep the model resident in RAM). _run_worker runs
+        the worker in its own session and kills the group on timeout.
+        """
+        scenario = Scenario(name="test", description="Test")
+        captured: dict = {}
+        killpg_calls = []
+
+        with (
+            patch(
+                "olmlx.bench.runner.subprocess.Popen",
+                side_effect=_fake_popen_factory(timeout=True, captured=captured),
+            ),
+            patch(
+                "olmlx.bench.runner.os.killpg",
+                side_effect=lambda pgid, sig: killpg_calls.append((pgid, sig)),
+            ),
+        ):
+            _run_worker("model", scenario, [], None, worker_timeout=600.0)
+
+        # The group led by the worker pid is killed.
+        assert killpg_calls, "expected the worker process group to be killed"
+        assert killpg_calls[0][0] == captured["proc"].pid
+
+    def test_worker_clean_exit_still_reaps_group(self):
+        """Even on a clean exit the process group is reaped (crash backstop)."""
+        scenario = Scenario(name="test", description="Test")
+        killpg_calls = []
+
+        with (
+            patch(
+                "olmlx.bench.runner.subprocess.Popen",
+                side_effect=_fake_popen_factory(results=[]),
+            ),
+            patch(
+                "olmlx.bench.runner.os.killpg",
+                side_effect=lambda pgid, sig: killpg_calls.append((pgid, sig)),
+            ),
+        ):
+            _run_worker("model", scenario, [], None, worker_timeout=600.0)
+
+        assert killpg_calls, "process group should be reaped on every path"
 
     def test_worker_passes_env_overrides(self):
         """Verify env overrides are passed to subprocess."""
@@ -101,50 +191,35 @@ class TestRunWorker:
             description="TurboQuant",
             env_overrides={"OLMLX_KV_CACHE_QUANT": "turboquant:4"},
         )
+        captured: dict = {}
 
-        captured_env = {}
-
-        def capture_run(cmd, env, **kwargs):
-            captured_env.update(env)
-            results_idx = cmd.index("--results-json") + 1
-            import pathlib
-
-            pathlib.Path(cmd[results_idx]).write_text("[]")
-
-            class FakeResult:
-                returncode = 0
-                stderr = ""
-
-            return FakeResult()
-
-        with patch("olmlx.bench.runner.subprocess.run", side_effect=capture_run):
+        with (
+            patch(
+                "olmlx.bench.runner.subprocess.Popen",
+                side_effect=_fake_popen_factory(results=[], captured=captured),
+            ),
+            patch("olmlx.bench.runner.os.killpg"),
+        ):
             _run_worker("model", scenario, [], None, worker_timeout=600.0)
 
-        assert captured_env.get("OLMLX_KV_CACHE_QUANT") == "turboquant:4"
+        assert captured["kwargs"]["env"].get("OLMLX_KV_CACHE_QUANT") == "turboquant:4"
 
     def test_worker_passes_max_tokens(self):
         """Verify --max-tokens is passed when provided."""
         scenario = Scenario(name="test", description="Test")
-        captured_cmd = []
+        captured: dict = {}
 
-        def capture_run(cmd, **kwargs):
-            captured_cmd.extend(cmd)
-            results_idx = cmd.index("--results-json") + 1
-            import pathlib
-
-            pathlib.Path(cmd[results_idx]).write_text("[]")
-
-            class FakeResult:
-                returncode = 0
-                stderr = ""
-
-            return FakeResult()
-
-        with patch("olmlx.bench.runner.subprocess.run", side_effect=capture_run):
+        with (
+            patch(
+                "olmlx.bench.runner.subprocess.Popen",
+                side_effect=_fake_popen_factory(results=[], captured=captured),
+            ),
+            patch("olmlx.bench.runner.os.killpg"),
+        ):
             _run_worker("model", scenario, [], max_tokens=64, worker_timeout=600.0)
 
-        assert "--max-tokens" in captured_cmd
-        assert "64" in captured_cmd
+        assert "--max-tokens" in captured["cmd"]
+        assert "64" in captured["cmd"]
 
 
 class TestRunBench:

--- a/tests/test_bench_runner.py
+++ b/tests/test_bench_runner.py
@@ -17,7 +17,13 @@ from olmlx.bench.scenarios import Scenario
 
 
 def _fake_popen_factory(
-    *, results=None, returncode=0, stderr="", timeout=False, captured=None
+    *,
+    results=None,
+    returncode=0,
+    stderr="",
+    timeout=False,
+    timeout_stderr=None,
+    captured=None,
 ):
     """Build a fake ``subprocess.Popen`` replacement for ``_run_worker`` tests.
 
@@ -39,9 +45,9 @@ def _fake_popen_factory(
         proc.pid = 4242
         proc.returncode = returncode
         if timeout:
-            proc.communicate.side_effect = subprocess.TimeoutExpired(
-                cmd="worker", timeout=600
-            )
+            exc = subprocess.TimeoutExpired(cmd="worker", timeout=600)
+            exc.stderr = timeout_stderr
+            proc.communicate.side_effect = exc
         else:
             proc.communicate.return_value = ("", stderr)
         if captured is not None:
@@ -137,6 +143,25 @@ class TestRunWorker:
 
         assert len(results) == 1
         assert "timed out" in results[0].error.lower()
+
+    def test_worker_timeout_surfaces_partial_stderr(self):
+        """A timed-out worker surfaces the stderr tail communicate() captured."""
+        scenario = Scenario(name="test", description="Test")
+
+        with (
+            patch(
+                "olmlx.bench.runner.subprocess.Popen",
+                side_effect=_fake_popen_factory(
+                    timeout=True, timeout_stderr="boom: model load wedged"
+                ),
+            ),
+            patch("olmlx.bench.runner.os.killpg"),
+        ):
+            results = _run_worker("model", scenario, [], None, worker_timeout=600.0)
+
+        assert len(results) == 1
+        assert "timed out" in results[0].error.lower()
+        assert "model load wedged" in results[0].error
 
     def test_worker_timeout_kills_process_group(self):
         """On timeout, the worker's whole process group is SIGKILLed.


### PR DESCRIPTION
## Problem

Running `olmlx bench run --prompt-set all` across a model ladder drove olmlx RAM to **~61 GB** on a 64 GB machine, with a cascade of scenario failures (by the 8B model, every scenario failed). Throughput on small models was fine, so this looked like a leak under load.

## Root cause (bench harness, not the engine)

`olmlx/bench/runner.py::_run_worker` spawned each scenario via `subprocess.run(..., timeout=worker_timeout)`. The worker itself `Popen`s a uvicorn **server** child. On `worker_timeout`, CPython **SIGKILLs the worker** — uncatchable, so the worker's `finally` block (which would terminate its server) never runs. The **server orphans with the model still resident in RAM**.

57-prompt quality scenarios on ≥4B models exceed the old 600s timeout, so each timeout leaked a server. Orphans are detached, so they accumulate across scenarios *and* across models in the ladder → tens of GB → later loads starve and fail.

Ruled out before fixing:
- **Per-request leak / recent VLM changes** — refuted: a single text server is flat at **0.92 GB across 40 requests**; the VLM prompt-cache/grammar code is gated on `is_vlm` and never touches the text path.

## Fix

- Launch the worker with `start_new_session=True` and reap the **whole process group** (`os.killpg`) in a `finally` on every path (timeout / crash / clean exit), so the server can never outlive the worker. Switched from `subprocess.run` to `Popen` + `communicate(timeout=)` to own the kill.
- Raise the default `OLMLX_BENCH_WORKER_TIMEOUT` **600s → 1800s** — the 50-prompt quality set on mid/large models legitimately runs many minutes per scenario and was reliably timing out (and losing its results) at 600s.

## Verification

- A worker forced to time out mid-generation now leaves **zero** orphaned servers (was: orphan holding the model).
- A 4B `--prompt-set all` stress run with a forced **90s** timeout (deliberately recreating the failure condition) held at **max 1 concurrent server / ~4 GB peak** across many forced timeouts — previously each timeout added ~2.5 GB of permanent orphan.

## Tests

`tests/test_bench_runner.py`: process group is SIGKILLed on timeout, worker runs in its own session, group is reaped on clean exit. `tests/test_bench_quality_wiring.py`: raised-default + override assertions. All bench tests green (`57 passed`).

## Mid-tier quality runs (real large-model confirmation)

Re-ran the mid-tier quality suite (baseline scenario, raised timeout) on this branch. All completed **50/50 prompts, no timeouts, no failures**, with memory bounded the whole time:

| Model | Quality | Throughput | Notes |
|---|---|---|---|
| gemma-4-26b-a4b-it-4bit | 38/40 (95%) | 69.9 tok/s | MoE 4B active |
| Qwen3.5-27B-4bit (dense) | 38/40 (95%) | 15.6 tok/s | dense — slowest decode |
| Qwen3.6-35B-A3B-6bit | 35/40 (88%) | 57.7 tok/s | MoE 3B active, `turboquant:4` KV |

(40 = graded GSM8K+MMLU+HumanEval subset; 10 `code_exec` prompts excluded without `--enable-code-exec`.)

Memory during these three runs: **peak olmlx RSS 27.4 GB** (the 6bit 35B + tq4), **max 1 concurrent server**, **0 orphans** — bounded at a single model's footprint vs. the previous 61 GB cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
