### PR TITLE
feat(rerank): /v1/rerank cross-encoder endpoint (#369)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,9 @@ olmlx/
 ├── cli.py              # CLI subcommands (serve, chat, service, models, config, dflash, eagle, flash, spectral)
 ├── chat/               # In-process terminal chat (ChatSession + MCP tool client + Rich TUI)
 ├── engine/
-│   ├── inference.py    # generate_chat, generate_completion, generate_embeddings, generate_transcription
+│   ├── inference.py    # generate_chat, generate_completion, generate_embeddings, generate_transcription, generate_rerank
 │   ├── model_manager.py # Model loading/unloading, keep-alive, LRU eviction
+│   ├── rerank/         # Native MLX XLM-RoBERTa cross-encoder (config + model + weight remaps)
 │   ├── registry.py     # Ollama name → HF repo via models.json
 │   ├── distributed.py  # Multi-machine ring tensor parallelism (TCP sideband)
 │   ├── grammar.py      # xgrammar JSON-mode / JSON-Schema logits processor
@@ -41,6 +42,7 @@ olmlx/
 │   ├── openai.py       # /v1/chat/completions, /v1/completions, /v1/models, /v1/embeddings
 │   ├── responses.py    # /v1/responses — OpenAI Responses API (state store, semantic SSE)
 │   ├── audio.py        # /v1/audio/transcriptions — Whisper STT
+│   ├── rerank.py       # /v1/rerank (+ /rerank) — Cohere-v2 cross-encoder reranking
 │   ├── metrics.py      # GET /metrics — Prometheus exposition
 │   └── *.py            # /api/{chat,generate,tags,show,ps,pull,copy,create,delete,embed,blobs,version} (Ollama)
 ├── schemas/            # Pydantic request/response models per API surface
@@ -92,6 +94,7 @@ olmlx/
   - DFlash precompute (`olmlx dflash precompute`): dump `(input_ids, target_hidden)` shards to skip per-step target forward in subsequent training. Same shards work for both DFlash and EAGLE.
   - EAGLE: `--use-precomputed` only. Pairing is `(h_{t-1}, token_t) → token_{t+1}` (off-by-one collapses bench acceptance to ~1%). `--sample-positions N` (default 256) subsamples vocab projection (~10× speedup, unbiased CE estimator). `iter_precomputed_shards` retries transient `mx.load()` failures (macOS mmap/fd pressure).
 - **Speculative prefetch** (`OLMLX_FLASH_PREFETCH`): Pre-loads neurons from SSD ahead of need. Cross-layer (layer L predicts L+1 from L's pre-MLP hidden, optional dedicated `LookaheadBank`), draft-informed (bulk prefetch for all target layers from draft hiddens). **Prediction synchronous** (MLX `mx.eval` deadlocks under concurrent multi-thread use); only I/O is async via dedicated `ThreadPoolExecutor`. **Prefetcher must be closed before weight store** on model unload (prefetch tasks submit into the store's pool).
+- **Rerank endpoint** (`routers/rerank.py`, #369): `POST /v1/rerank` (+ `/rerank` alias), Cohere-v2 shape (`{model, query, documents, top_n?, max_tokens_per_doc?, return_documents?}` → `{id, results:[{index, relevance_score, document?}], meta}`). Cross-encoder rerankers are a first-class `ModelManager` kind (`reranker`): `_detect_model_kind` matches an `architectures` entry ending in `ForSequenceClassification`; `LoadedModel.is_reranker` guards the LLM-only paths (the cache-capability probe early-returns, like `is_whisper`). The encoder is a native MLX `XLMRobertaCrossEncoder` (`engine/rerank/`): absolute-position (RoBERTa `pad_id+1` offset), post-LN BERT attention, first-token (`<s>`/CLS) classification head, config-driven sizing, dtype-safe `-1e4` mask fill. **Two checkpoint layouts load into one module** via key-inspection remaps (`weights.py`): standard HF (`attention.self.{query,key,value}` — bge-reranker-v2-m3) and flash (`mixer.Wqkv` fused-QKV split + `emb_ln`/`norm1`/`norm2` — jina-reranker-v2). `load_cross_encoder` rejects `num_labels != 1` (multi-label out of scope). `generate_rerank` tokenizes `(query, doc)` pairs (`transformers` tokenizer, `truncation="only_second"` — silent doc-side truncation), micro-batches, `sigmoid` → `[0,1]`, sorts, applies `top_n`; runs under the inference lock with the same trailing `mx.synchronize()` barrier as `generate_embeddings`. No KV cache, speculative, distributed, or streaming for rerankers. Live coverage: `tests/live/test_rerank_real.py` (real_model, bge + jina, incl. a checkpoint-layout gate and a transformers parity check).
 - **Audio transcription**: OpenAI-compatible `/v1/audio/transcriptions` via mlx-whisper. Whisper is a first-class `ModelManager` kind: `_detect_model_kind` matches `model_type == "whisper"` or mlx-whisper dims (`n_mels`/`n_audio_state`); `LoadedModel.is_whisper` guards LLM-only prompt-cache/KV-quant paths. `generate_transcription` injects the managed model into `mlx_whisper.transcribe.ModelHolder` (the module-level singleton — race-free under the serialized lock) and runs transcribe in a worker thread. Formats: `json`, `verbose_json`, `text`, `srt`, `vtt`. `ForceJSONMiddleware` skips `multipart/form-data` so upload boundary survives. **Requires ffmpeg on PATH**. Streaming and diarization out of scope.
 - **Terminal chat**: `olmlx chat` runs in-process via `ModelManager`/`generate_chat()` — no HTTP. Connects to external MCP servers (stdio/SSE) with a full agent loop. MCP config in Claude Desktop format at `~/.olmlx/mcp.json`.
 - **Model load timeout**: `OLMLX_MODEL_LOAD_TIMEOUT` → `ModelLoadTimeoutError` (HTTP 504).

--- a/docs/superpowers/plans/2026-06-08-rerank-endpoint.md
+++ b/docs/superpowers/plans/2026-06-08-rerank-endpoint.md
@@ -1,0 +1,1584 @@
+# `/v1/rerank` Cross-Encoder Endpoint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Cohere-v2-compatible `POST /v1/rerank` endpoint backed by a native MLX XLM-RoBERTa cross-encoder, serving `bge-reranker-v2-m3` and `jina-reranker-v2-base-multilingual`.
+
+**Architecture:** A new `reranker` model kind in `ModelManager`. A pure-MLX `XLMRobertaCrossEncoder` (absolute-position, post-LN BERT attention, first-token classification head) loads from HF safetensors via one of two weight-remap paths (standard HF layout for bge, fused-QKV flash layout for jina), picked by checkpoint-key inspection. A `generate_rerank` engine function tokenizes `(query, doc)` pairs with the model's `transformers` tokenizer (silent doc-side truncation), batch-scores them, sigmoids, sorts, and applies `top_n`. A thin router exposes `/v1/rerank` (+ `/rerank` alias).
+
+**Tech Stack:** MLX / `mlx.nn`, `transformers.AutoTokenizer`, FastAPI, Pydantic v2, pytest. Reference spec: `docs/superpowers/specs/2026-06-08-rerank-endpoint-design.md`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `olmlx/engine/rerank/__init__.py` | Package marker, re-export `XLMRobertaCrossEncoder`, `RerankerConfig`, `load_cross_encoder` |
+| `olmlx/engine/rerank/config.py` | `RerankerConfig` dataclass parsed from HF `config.json` |
+| `olmlx/engine/rerank/model.py` | `XLMRobertaCrossEncoder` nn.Module (embeddings, encoder layers, classification head) |
+| `olmlx/engine/rerank/weights.py` | Key-layout detection + two remap functions (standard / flash), `load_cross_encoder(path)` |
+| `olmlx/schemas/rerank.py` | `RerankRequest`, `RerankResult`, `RerankResponse` |
+| `olmlx/routers/rerank.py` | `POST /v1/rerank` + `POST /rerank` handlers |
+| `olmlx/engine/inference.py` | Add `generate_rerank(...)` |
+| `olmlx/engine/model_manager.py` | `_detect_model_kind` reranker branch; `_load_model` reranker branch; `LoadedModel.is_reranker`; guards |
+| `olmlx/app.py` | Register the router |
+| `CLAUDE.md` | Document endpoint + reranker kind |
+| `tests/test_rerank_model.py` | Unit: encoder math, position offset, both remaps |
+| `tests/test_rerank_schemas.py` | Unit: request/response validation |
+| `tests/test_rerank_engine.py` | Unit: `generate_rerank` (mocked model) — tokenize/truncate/sort/top_n |
+| `tests/test_routers_rerank.py` | Router contract (mocked engine) |
+| `tests/live/test_rerank_real.py` | `real_model` live tests for bge + jina |
+
+---
+
+## Task 1: Reranker config dataclass
+
+**Files:**
+- Create: `olmlx/engine/rerank/__init__.py`
+- Create: `olmlx/engine/rerank/config.py`
+- Test: `tests/test_rerank_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_rerank_model.py
+from olmlx.engine.rerank.config import RerankerConfig
+
+
+def test_rerankerconfig_from_dict_bge():
+    raw = {
+        "architectures": ["XLMRobertaForSequenceClassification"],
+        "hidden_size": 1024,
+        "num_hidden_layers": 24,
+        "num_attention_heads": 16,
+        "intermediate_size": 4096,
+        "max_position_embeddings": 8194,
+        "vocab_size": 250002,
+        "type_vocab_size": 1,
+        "layer_norm_eps": 1e-5,
+        "pad_token_id": 1,
+        "hidden_act": "gelu",
+        "id2label": {"0": "LABEL_0"},
+    }
+    cfg = RerankerConfig.from_dict(raw)
+    assert cfg.hidden_size == 1024
+    assert cfg.num_hidden_layers == 24
+    assert cfg.num_attention_heads == 16
+    assert cfg.intermediate_size == 4096
+    assert cfg.max_position_embeddings == 8194
+    assert cfg.vocab_size == 250002
+    assert cfg.type_vocab_size == 1
+    assert cfg.pad_token_id == 1
+    assert cfg.num_labels == 1
+    assert cfg.head_dim == 64
+
+
+def test_rerankerconfig_num_labels_from_num_labels_key():
+    raw = {
+        "hidden_size": 768, "num_hidden_layers": 12, "num_attention_heads": 12,
+        "intermediate_size": 3072, "max_position_embeddings": 1026,
+        "vocab_size": 250002, "type_vocab_size": 1, "layer_norm_eps": 1e-5,
+        "pad_token_id": 1, "num_labels": 1,
+    }
+    cfg = RerankerConfig.from_dict(raw)
+    assert cfg.num_labels == 1
+    assert cfg.head_dim == 64
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_rerank_model.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'olmlx.engine.rerank'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# olmlx/engine/rerank/__init__.py
+"""Native MLX cross-encoder reranker (XLM-RoBERTa family). Issue #369."""
+
+from olmlx.engine.rerank.config import RerankerConfig
+
+__all__ = ["RerankerConfig"]
+```
+
+```python
+# olmlx/engine/rerank/config.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RerankerConfig:
+    """Sizing parameters parsed from an XLM-RoBERTa cross-encoder config.json."""
+
+    hidden_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    intermediate_size: int
+    max_position_embeddings: int
+    vocab_size: int
+    type_vocab_size: int
+    layer_norm_eps: float
+    pad_token_id: int
+    num_labels: int
+    hidden_act: str = "gelu"
+
+    @property
+    def head_dim(self) -> int:
+        return self.hidden_size // self.num_attention_heads
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> RerankerConfig:
+        num_labels = raw.get("num_labels")
+        if num_labels is None:
+            id2label = raw.get("id2label") or {"0": "LABEL_0"}
+            num_labels = len(id2label)
+        return cls(
+            hidden_size=int(raw["hidden_size"]),
+            num_hidden_layers=int(raw["num_hidden_layers"]),
+            num_attention_heads=int(raw["num_attention_heads"]),
+            intermediate_size=int(raw["intermediate_size"]),
+            max_position_embeddings=int(raw["max_position_embeddings"]),
+            vocab_size=int(raw["vocab_size"]),
+            type_vocab_size=int(raw.get("type_vocab_size", 1)),
+            layer_norm_eps=float(raw.get("layer_norm_eps", 1e-5)),
+            pad_token_id=int(raw.get("pad_token_id", 1)),
+            num_labels=int(num_labels),
+            hidden_act=str(raw.get("hidden_act", "gelu")),
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_rerank_model.py -q`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/rerank/__init__.py olmlx/engine/rerank/config.py tests/test_rerank_model.py
+git commit -m "feat(rerank): RerankerConfig parsed from HF config.json (#369)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Encoder module — embeddings + RoBERTa position offset
+
+**Files:**
+- Create: `olmlx/engine/rerank/model.py`
+- Test: `tests/test_rerank_model.py`
+
+This task builds only the embedding stage and the position-id helper so we can pin the
+RoBERTa offset behavior before the full forward exists.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_rerank_model.py
+import mlx.core as mx
+from olmlx.engine.rerank.model import roberta_position_ids
+
+
+def test_roberta_position_ids_offset_no_padding():
+    # pad_token_id=1; a fully-real sequence -> positions start at 2
+    input_ids = mx.array([[5, 6, 7, 8]])
+    pos = roberta_position_ids(input_ids, pad_token_id=1)
+    assert pos.tolist() == [[2, 3, 4, 5]]
+
+
+def test_roberta_position_ids_offset_with_padding():
+    # trailing pad tokens (id=1) keep position == pad_token_id (1)
+    input_ids = mx.array([[5, 6, 1, 1]])
+    pos = roberta_position_ids(input_ids, pad_token_id=1)
+    assert pos.tolist() == [[2, 3, 1, 1]]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_rerank_model.py::test_roberta_position_ids_offset_no_padding -q`
+Expected: FAIL — `ImportError: cannot import name 'roberta_position_ids'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# olmlx/engine/rerank/model.py
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from olmlx.engine.rerank.config import RerankerConfig
+
+
+def roberta_position_ids(input_ids: mx.array, pad_token_id: int) -> mx.array:
+    """Position ids with the RoBERTa offset.
+
+    Mirrors transformers' ``create_position_ids_from_input_ids``:
+    ``position_ids = cumsum(mask) * mask + pad_token_id`` where
+    ``mask = (input_ids != pad_token_id)``. The first real token therefore
+    gets position ``pad_token_id + 1`` (== 2 for XLM-RoBERTa), which is why
+    the position-embedding table is sized ``max_seq + pad_token_id + 1``.
+    """
+    mask = (input_ids != pad_token_id).astype(mx.int32)
+    incremental = mx.cumsum(mask, axis=1) * mask
+    return incremental + pad_token_id
+
+
+class XLMRobertaEmbeddings(nn.Module):
+    def __init__(self, config: RerankerConfig):
+        super().__init__()
+        self.pad_token_id = config.pad_token_id
+        self.word_embeddings = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.position_embeddings = nn.Embedding(
+            config.max_position_embeddings, config.hidden_size
+        )
+        self.token_type_embeddings = nn.Embedding(
+            config.type_vocab_size, config.hidden_size
+        )
+        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+    def __call__(self, input_ids: mx.array) -> mx.array:
+        pos_ids = roberta_position_ids(input_ids, self.pad_token_id)
+        words = self.word_embeddings(input_ids)
+        positions = self.position_embeddings(pos_ids)
+        # token_type_ids are all zero (type_vocab_size == 1); add row-0 bias.
+        token_type = self.token_type_embeddings(mx.zeros_like(input_ids))
+        return self.LayerNorm(words + positions + token_type)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_rerank_model.py -q`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/rerank/model.py tests/test_rerank_model.py
+git commit -m "feat(rerank): XLM-RoBERTa embeddings + RoBERTa position offset (#369)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Encoder layer + full forward + classification head
+
+**Files:**
+- Modify: `olmlx/engine/rerank/model.py`
+- Test: `tests/test_rerank_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_rerank_model.py
+from olmlx.engine.rerank.model import XLMRobertaCrossEncoder
+
+
+def _tiny_config() -> RerankerConfig:
+    return RerankerConfig(
+        hidden_size=16, num_hidden_layers=2, num_attention_heads=2,
+        intermediate_size=32, max_position_embeddings=32, vocab_size=50,
+        type_vocab_size=1, layer_norm_eps=1e-5, pad_token_id=1, num_labels=1,
+    )
+
+
+def test_cross_encoder_forward_shape():
+    cfg = _tiny_config()
+    model = XLMRobertaCrossEncoder(cfg)
+    input_ids = mx.array([[5, 6, 7, 2], [5, 6, 1, 1]])  # 2nd row padded
+    attention_mask = mx.array([[1, 1, 1, 1], [1, 1, 0, 0]])
+    logits = model(input_ids, attention_mask)
+    mx.eval(logits)
+    assert logits.shape == (2, 1)
+
+
+def test_cross_encoder_padding_invariance():
+    # Scoring a sequence must not change when extra pad tokens are appended,
+    # because the attention mask zeroes them out.
+    cfg = _tiny_config()
+    model = XLMRobertaCrossEncoder(cfg)
+    short_ids = mx.array([[5, 6, 7, 2]])
+    short_mask = mx.array([[1, 1, 1, 1]])
+    padded_ids = mx.array([[5, 6, 7, 2, 1, 1]])
+    padded_mask = mx.array([[1, 1, 1, 1, 0, 0]])
+    a = model(short_ids, short_mask)
+    b = model(padded_ids, padded_mask)
+    mx.eval(a, b)
+    assert abs(float(a[0, 0]) - float(b[0, 0])) < 1e-4
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_rerank_model.py::test_cross_encoder_forward_shape -q`
+Expected: FAIL — `ImportError: cannot import name 'XLMRobertaCrossEncoder'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `olmlx/engine/rerank/model.py`:
+
+```python
+class XLMRobertaSelfAttention(nn.Module):
+    def __init__(self, config: RerankerConfig):
+        super().__init__()
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.scale = self.head_dim**-0.5
+        h = config.hidden_size
+        self.query = nn.Linear(h, h)
+        self.key = nn.Linear(h, h)
+        self.value = nn.Linear(h, h)
+
+    def __call__(self, x: mx.array, additive_mask: mx.array) -> mx.array:
+        b, s, _ = x.shape
+        q = self.query(x).reshape(b, s, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+        k = self.key(x).reshape(b, s, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+        v = self.value(x).reshape(b, s, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+        scores = (q @ k.transpose(0, 1, 3, 2)) * self.scale
+        scores = scores + additive_mask  # [b, 1, 1, s] broadcast
+        weights = mx.softmax(scores, axis=-1)
+        out = weights @ v  # [b, heads, s, head_dim]
+        return out.transpose(0, 2, 1, 3).reshape(b, s, -1)
+
+
+class XLMRobertaLayer(nn.Module):
+    def __init__(self, config: RerankerConfig):
+        super().__init__()
+        h = config.hidden_size
+        self.attention_self = XLMRobertaSelfAttention(config)
+        self.attention_output_dense = nn.Linear(h, h)
+        self.attention_output_norm = nn.LayerNorm(h, eps=config.layer_norm_eps)
+        self.intermediate_dense = nn.Linear(h, config.intermediate_size)
+        self.output_dense = nn.Linear(config.intermediate_size, h)
+        self.output_norm = nn.LayerNorm(h, eps=config.layer_norm_eps)
+
+    def __call__(self, x: mx.array, additive_mask: mx.array) -> mx.array:
+        attn = self.attention_self(x, additive_mask)
+        x = self.attention_output_norm(self.attention_output_dense(attn) + x)
+        inter = nn.gelu(self.intermediate_dense(x))
+        x = self.output_norm(self.output_dense(inter) + x)
+        return x
+
+
+class XLMRobertaClassificationHead(nn.Module):
+    def __init__(self, config: RerankerConfig):
+        super().__init__()
+        self.dense = nn.Linear(config.hidden_size, config.hidden_size)
+        self.out_proj = nn.Linear(config.hidden_size, config.num_labels)
+
+    def __call__(self, features: mx.array) -> mx.array:
+        x = features[:, 0, :]  # first token (<s> / CLS)
+        x = mx.tanh(self.dense(x))
+        return self.out_proj(x)
+
+
+class XLMRobertaCrossEncoder(nn.Module):
+    def __init__(self, config: RerankerConfig):
+        super().__init__()
+        self.config = config
+        self.embeddings = XLMRobertaEmbeddings(config)
+        self.layers = [XLMRobertaLayer(config) for _ in range(config.num_hidden_layers)]
+        self.classifier = XLMRobertaClassificationHead(config)
+
+    def __call__(self, input_ids: mx.array, attention_mask: mx.array) -> mx.array:
+        # additive mask: keep -> 0, pad -> -inf, shaped [b, 1, 1, s]
+        additive = (1.0 - attention_mask.astype(mx.float32))[:, None, None, :] * -1e9
+        x = self.embeddings(input_ids)
+        for layer in self.layers:
+            x = layer(x, additive)
+        return self.classifier(x)
+```
+
+Note on attribute naming: this module uses **flat** attribute names
+(`attention_self`, `attention_output_dense`, …) so the weight-remap functions in Task 4
+can target them directly without nested container modules. The remap is the single source
+of truth mapping HF/flash checkpoint keys to these names.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_rerank_model.py -q`
+Expected: PASS (6 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/rerank/model.py tests/test_rerank_model.py
+git commit -m "feat(rerank): XLM-RoBERTa encoder layers + classification head (#369)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Weight loading — layout detection + two remaps
+
+**Files:**
+- Create: `olmlx/engine/rerank/weights.py`
+- Modify: `olmlx/engine/rerank/__init__.py`
+- Test: `tests/test_rerank_model.py`
+
+`detect_layout(keys)` returns `"flash"` when any key contains `mixer.Wqkv` or `emb_ln`,
+else `"standard"`. `remap_standard` / `remap_flash` translate a HF state dict (numpy
+arrays) into a flat `{our_attr_path: mx.array}` dict matching the module in Task 3.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_rerank_model.py
+import numpy as np
+from olmlx.engine.rerank.weights import detect_layout, remap_standard, remap_flash
+
+
+def test_detect_layout():
+    assert detect_layout(["roberta.encoder.layer.0.attention.self.query.weight"]) == "standard"
+    assert detect_layout(["roberta.encoder.layers.0.mixer.Wqkv.weight"]) == "flash"
+    assert detect_layout(["roberta.emb_ln.weight"]) == "flash"
+
+
+def test_remap_standard_keys():
+    cfg = _tiny_config()
+    h = cfg.hidden_size
+    sd = {
+        "roberta.embeddings.word_embeddings.weight": np.zeros((cfg.vocab_size, h), np.float32),
+        "roberta.embeddings.position_embeddings.weight": np.zeros((cfg.max_position_embeddings, h), np.float32),
+        "roberta.embeddings.token_type_embeddings.weight": np.zeros((cfg.type_vocab_size, h), np.float32),
+        "roberta.embeddings.LayerNorm.weight": np.ones((h,), np.float32),
+        "roberta.embeddings.LayerNorm.bias": np.zeros((h,), np.float32),
+        "classifier.dense.weight": np.zeros((h, h), np.float32),
+        "classifier.dense.bias": np.zeros((h,), np.float32),
+        "classifier.out_proj.weight": np.zeros((1, h), np.float32),
+        "classifier.out_proj.bias": np.zeros((1,), np.float32),
+    }
+    for i in range(cfg.num_hidden_layers):
+        p = f"roberta.encoder.layer.{i}."
+        for proj in ("query", "key", "value"):
+            sd[f"{p}attention.self.{proj}.weight"] = np.zeros((h, h), np.float32)
+            sd[f"{p}attention.self.{proj}.bias"] = np.zeros((h,), np.float32)
+        sd[f"{p}attention.output.dense.weight"] = np.zeros((h, h), np.float32)
+        sd[f"{p}attention.output.dense.bias"] = np.zeros((h,), np.float32)
+        sd[f"{p}attention.output.LayerNorm.weight"] = np.ones((h,), np.float32)
+        sd[f"{p}attention.output.LayerNorm.bias"] = np.zeros((h,), np.float32)
+        sd[f"{p}intermediate.dense.weight"] = np.zeros((cfg.intermediate_size, h), np.float32)
+        sd[f"{p}intermediate.dense.bias"] = np.zeros((cfg.intermediate_size,), np.float32)
+        sd[f"{p}output.dense.weight"] = np.zeros((h, cfg.intermediate_size), np.float32)
+        sd[f"{p}output.dense.bias"] = np.zeros((h,), np.float32)
+        sd[f"{p}output.LayerNorm.weight"] = np.ones((h,), np.float32)
+        sd[f"{p}output.LayerNorm.bias"] = np.zeros((h,), np.float32)
+    flat = remap_standard(sd, cfg)
+    model = XLMRobertaCrossEncoder(cfg)
+    model.load_weights(list(flat.items()))  # raises if any key/shape mismatches
+    mx.eval(model.parameters())
+
+
+def test_remap_flash_splits_fused_qkv():
+    cfg = _tiny_config()
+    h = cfg.hidden_size
+    # Fused QKV: rows [q | k | v] each h.
+    wqkv = np.arange(3 * h * h, dtype=np.float32).reshape(3 * h, h)
+    bqkv = np.arange(3 * h, dtype=np.float32)
+    sd = {
+        "roberta.embeddings.word_embeddings.weight": np.zeros((cfg.vocab_size, h), np.float32),
+        "roberta.embeddings.position_embeddings.weight": np.zeros((cfg.max_position_embeddings, h), np.float32),
+        "roberta.embeddings.token_type_embeddings.weight": np.zeros((cfg.type_vocab_size, h), np.float32),
+        "roberta.emb_ln.weight": np.ones((h,), np.float32),
+        "roberta.emb_ln.bias": np.zeros((h,), np.float32),
+        "classifier.dense.weight": np.zeros((h, h), np.float32),
+        "classifier.dense.bias": np.zeros((h,), np.float32),
+        "classifier.out_proj.weight": np.zeros((1, h), np.float32),
+        "classifier.out_proj.bias": np.zeros((1,), np.float32),
+    }
+    for i in range(cfg.num_hidden_layers):
+        p = f"roberta.encoder.layers.{i}."
+        sd[f"{p}mixer.Wqkv.weight"] = wqkv.copy()
+        sd[f"{p}mixer.Wqkv.bias"] = bqkv.copy()
+        sd[f"{p}mixer.out_proj.weight"] = np.zeros((h, h), np.float32)
+        sd[f"{p}mixer.out_proj.bias"] = np.zeros((h,), np.float32)
+        sd[f"{p}norm1.weight"] = np.ones((h,), np.float32)
+        sd[f"{p}norm1.bias"] = np.zeros((h,), np.float32)
+        sd[f"{p}mlp.fc1.weight"] = np.zeros((cfg.intermediate_size, h), np.float32)
+        sd[f"{p}mlp.fc1.bias"] = np.zeros((cfg.intermediate_size,), np.float32)
+        sd[f"{p}mlp.fc2.weight"] = np.zeros((h, cfg.intermediate_size), np.float32)
+        sd[f"{p}mlp.fc2.bias"] = np.zeros((h,), np.float32)
+        sd[f"{p}norm2.weight"] = np.ones((h,), np.float32)
+        sd[f"{p}norm2.bias"] = np.zeros((h,), np.float32)
+    flat = remap_flash(sd, cfg)
+    # Q slice is the first h rows of the fused matrix.
+    assert np.allclose(np.array(flat["layers.0.attention_self.query.weight"]), wqkv[:h])
+    assert np.allclose(np.array(flat["layers.0.attention_self.key.weight"]), wqkv[h:2 * h])
+    assert np.allclose(np.array(flat["layers.0.attention_self.value.weight"]), wqkv[2 * h:])
+    model = XLMRobertaCrossEncoder(cfg)
+    model.load_weights(list(flat.items()))
+    mx.eval(model.parameters())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_rerank_model.py::test_detect_layout -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'olmlx.engine.rerank.weights'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# olmlx/engine/rerank/weights.py
+from __future__ import annotations
+
+import glob
+import json
+import os
+from typing import Any
+
+import mlx.core as mx
+import numpy as np
+
+from olmlx.engine.rerank.config import RerankerConfig
+from olmlx.engine.rerank.model import XLMRobertaCrossEncoder
+
+
+def detect_layout(keys: list[str]) -> str:
+    for k in keys:
+        if "mixer.Wqkv" in k or "emb_ln" in k:
+            return "flash"
+    return "standard"
+
+
+def _emb_and_head(sd: dict[str, Any], emb_ln_prefix: str) -> dict[str, np.ndarray]:
+    e = "roberta.embeddings."
+    return {
+        "embeddings.word_embeddings.weight": sd[f"{e}word_embeddings.weight"],
+        "embeddings.position_embeddings.weight": sd[f"{e}position_embeddings.weight"],
+        "embeddings.token_type_embeddings.weight": sd[f"{e}token_type_embeddings.weight"],
+        "embeddings.LayerNorm.weight": sd[f"{emb_ln_prefix}.weight"],
+        "embeddings.LayerNorm.bias": sd[f"{emb_ln_prefix}.bias"],
+        "classifier.dense.weight": sd["classifier.dense.weight"],
+        "classifier.dense.bias": sd["classifier.dense.bias"],
+        "classifier.out_proj.weight": sd["classifier.out_proj.weight"],
+        "classifier.out_proj.bias": sd["classifier.out_proj.bias"],
+    }
+
+
+def remap_standard(sd: dict[str, Any], cfg: RerankerConfig) -> dict[str, mx.array]:
+    out = _emb_and_head(sd, "roberta.embeddings.LayerNorm")
+    for i in range(cfg.num_hidden_layers):
+        p = f"roberta.encoder.layer.{i}."
+        q = f"layers.{i}."
+        for proj in ("query", "key", "value"):
+            out[f"{q}attention_self.{proj}.weight"] = sd[f"{p}attention.self.{proj}.weight"]
+            out[f"{q}attention_self.{proj}.bias"] = sd[f"{p}attention.self.{proj}.bias"]
+        out[f"{q}attention_output_dense.weight"] = sd[f"{p}attention.output.dense.weight"]
+        out[f"{q}attention_output_dense.bias"] = sd[f"{p}attention.output.dense.bias"]
+        out[f"{q}attention_output_norm.weight"] = sd[f"{p}attention.output.LayerNorm.weight"]
+        out[f"{q}attention_output_norm.bias"] = sd[f"{p}attention.output.LayerNorm.bias"]
+        out[f"{q}intermediate_dense.weight"] = sd[f"{p}intermediate.dense.weight"]
+        out[f"{q}intermediate_dense.bias"] = sd[f"{p}intermediate.dense.bias"]
+        out[f"{q}output_dense.weight"] = sd[f"{p}output.dense.weight"]
+        out[f"{q}output_dense.bias"] = sd[f"{p}output.dense.bias"]
+        out[f"{q}output_norm.weight"] = sd[f"{p}output.LayerNorm.weight"]
+        out[f"{q}output_norm.bias"] = sd[f"{p}output.LayerNorm.bias"]
+    return {k: mx.array(np.asarray(v)) for k, v in out.items()}
+
+
+def remap_flash(sd: dict[str, Any], cfg: RerankerConfig) -> dict[str, mx.array]:
+    h = cfg.hidden_size
+    out = _emb_and_head(sd, "roberta.emb_ln")
+    for i in range(cfg.num_hidden_layers):
+        p = f"roberta.encoder.layers.{i}."
+        q = f"layers.{i}."
+        wqkv = np.asarray(sd[f"{p}mixer.Wqkv.weight"])
+        bqkv = np.asarray(sd[f"{p}mixer.Wqkv.bias"])
+        out[f"{q}attention_self.query.weight"] = wqkv[:h]
+        out[f"{q}attention_self.key.weight"] = wqkv[h : 2 * h]
+        out[f"{q}attention_self.value.weight"] = wqkv[2 * h :]
+        out[f"{q}attention_self.query.bias"] = bqkv[:h]
+        out[f"{q}attention_self.key.bias"] = bqkv[h : 2 * h]
+        out[f"{q}attention_self.value.bias"] = bqkv[2 * h :]
+        out[f"{q}attention_output_dense.weight"] = sd[f"{p}mixer.out_proj.weight"]
+        out[f"{q}attention_output_dense.bias"] = sd[f"{p}mixer.out_proj.bias"]
+        out[f"{q}attention_output_norm.weight"] = sd[f"{p}norm1.weight"]
+        out[f"{q}attention_output_norm.bias"] = sd[f"{p}norm1.bias"]
+        out[f"{q}intermediate_dense.weight"] = sd[f"{p}mlp.fc1.weight"]
+        out[f"{q}intermediate_dense.bias"] = sd[f"{p}mlp.fc1.bias"]
+        out[f"{q}output_dense.weight"] = sd[f"{p}mlp.fc2.weight"]
+        out[f"{q}output_dense.bias"] = sd[f"{p}mlp.fc2.bias"]
+        out[f"{q}output_norm.weight"] = sd[f"{p}norm2.weight"]
+        out[f"{q}output_norm.bias"] = sd[f"{p}norm2.bias"]
+    return {k: mx.array(np.asarray(v)) for k, v in out.items()}
+
+
+def _load_state_dict(path: str) -> dict[str, np.ndarray]:
+    files = sorted(glob.glob(os.path.join(path, "*.safetensors")))
+    if not files:
+        raise FileNotFoundError(f"no .safetensors weights in {path}")
+    sd: dict[str, np.ndarray] = {}
+    for f in files:
+        sd.update(mx.load(f))  # mx.load returns {name: mx.array}
+    return sd
+
+
+def load_cross_encoder(path: str) -> XLMRobertaCrossEncoder:
+    """Build an XLMRobertaCrossEncoder from a local model directory."""
+    with open(os.path.join(path, "config.json")) as fh:
+        cfg = RerankerConfig.from_dict(json.load(fh))
+    sd = _load_state_dict(path)
+    layout = detect_layout(list(sd.keys()))
+    flat = remap_flash(sd, cfg) if layout == "flash" else remap_standard(sd, cfg)
+    model = XLMRobertaCrossEncoder(cfg)
+    model.load_weights(list(flat.items()))
+    model.eval()
+    mx.eval(model.parameters())
+    return model
+```
+
+Add to `olmlx/engine/rerank/__init__.py`:
+
+```python
+from olmlx.engine.rerank.model import XLMRobertaCrossEncoder
+from olmlx.engine.rerank.weights import detect_layout, load_cross_encoder
+
+__all__ = [
+    "RerankerConfig",
+    "XLMRobertaCrossEncoder",
+    "detect_layout",
+    "load_cross_encoder",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_rerank_model.py -q`
+Expected: PASS (9 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/rerank/ tests/test_rerank_model.py
+git commit -m "feat(rerank): weight loader with standard + flash (fused-QKV) remaps (#369)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Request/response schemas
+
+**Files:**
+- Create: `olmlx/schemas/rerank.py`
+- Test: `tests/test_rerank_schemas.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_rerank_schemas.py
+import pytest
+from pydantic import ValidationError
+
+from olmlx.schemas.rerank import RerankRequest, RerankResponse, RerankResult
+
+
+def test_rerank_request_defaults():
+    req = RerankRequest(model="bge-reranker", query="q", documents=["a", "b"])
+    assert req.top_n is None
+    assert req.max_tokens_per_doc == 4096
+    assert req.return_documents is False
+
+
+def test_rerank_request_rejects_empty_documents():
+    with pytest.raises(ValidationError):
+        RerankRequest(model="m", query="q", documents=[])
+
+
+def test_rerank_request_rejects_empty_query():
+    with pytest.raises(ValidationError):
+        RerankRequest(model="m", query="  ", documents=["a"])
+
+
+def test_rerank_request_rejects_nonpositive_top_n():
+    with pytest.raises(ValidationError):
+        RerankRequest(model="m", query="q", documents=["a"], top_n=0)
+
+
+def test_rerank_response_shape():
+    resp = RerankResponse(
+        id="rerank-xyz",
+        results=[RerankResult(index=1, relevance_score=0.9)],
+        meta={"api_version": {"version": "2"}},
+    )
+    dumped = resp.model_dump()
+    assert dumped["results"][0]["index"] == 1
+    assert dumped["results"][0]["relevance_score"] == 0.9
+    assert "document" not in dumped["results"][0] or dumped["results"][0]["document"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_rerank_schemas.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'olmlx.schemas.rerank'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# olmlx/schemas/rerank.py
+from __future__ import annotations
+
+from pydantic import BaseModel, field_validator
+
+from olmlx.schemas.common import ModelName, validate_non_empty_text_input
+
+
+class RerankRequest(BaseModel):
+    model: ModelName
+    query: str
+    documents: list[str]
+    top_n: int | None = None
+    max_tokens_per_doc: int = 4096
+    return_documents: bool = False
+    keep_alive: int | str | None = None
+
+    @field_validator("query")
+    @classmethod
+    def _query_non_empty(cls, v: str) -> str:
+        return validate_non_empty_text_input(v, "query")
+
+    @field_validator("documents")
+    @classmethod
+    def _documents_non_empty(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("documents must be a non-empty list")
+        return v
+
+    @field_validator("top_n")
+    @classmethod
+    def _top_n_positive(cls, v: int | None) -> int | None:
+        if v is not None and v <= 0:
+            raise ValueError("top_n must be a positive integer")
+        return v
+
+
+class RerankResult(BaseModel):
+    index: int
+    relevance_score: float
+    document: str | None = None
+
+
+class RerankResponse(BaseModel):
+    id: str
+    results: list[RerankResult]
+    meta: dict = {}
+```
+
+Confirm `validate_non_empty_text_input` accepts a plain `str` (it is used for the
+embeddings `prompt` field). If its signature differs, adapt the call.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_rerank_schemas.py -q`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/schemas/rerank.py tests/test_rerank_schemas.py
+git commit -m "feat(rerank): Cohere-v2 request/response schemas (#369)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `LoadedModel.is_reranker` + kind detection
+
+**Files:**
+- Modify: `olmlx/engine/model_manager.py`
+- Test: `tests/test_rerank_manager.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_rerank_manager.py
+import json
+
+from olmlx.engine.model_manager import ModelManager
+
+
+def _write_config(tmp_path, store_dir, hf_path, config):
+    d = store_dir / hf_path
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "config.json").write_text(json.dumps(config))
+    return d
+
+
+def test_detect_model_kind_reranker(tmp_path, monkeypatch):
+    mgr = ModelManager()
+    cfg = {
+        "architectures": ["XLMRobertaForSequenceClassification"],
+        "model_type": "xlm-roberta",
+        "hidden_size": 1024, "num_hidden_layers": 24,
+        "num_attention_heads": 16, "intermediate_size": 4096,
+        "max_position_embeddings": 8194, "vocab_size": 250002,
+        "type_vocab_size": 1, "pad_token_id": 1,
+    }
+
+    # Force _detect_model_kind to read this config (monkeypatch the loader's
+    # config fetch). Simplest: patch _read_config_for_kind if present, else
+    # write into a fake store. Use the store hook the manager already exposes.
+    monkeypatch.setattr(
+        mgr, "_load_config_json", lambda hf: cfg, raising=False
+    )
+    # Fallback: if the manager has no such helper, this test documents the
+    # expected return given the architecture marker; adapt to the real seam
+    # discovered while implementing (see Step 3).
+    assert _kind_for_config(cfg) == "reranker"
+
+
+def _kind_for_config(cfg):
+    from olmlx.engine.model_manager import _is_cross_encoder_config
+
+    return "reranker" if _is_cross_encoder_config(cfg) else "other"
+```
+
+Note: the exact monkeypatch seam depends on how `_detect_model_kind` reads config (it
+reads `config.json` from the local store or HF hub — see `model_manager.py:1683`). The
+testable unit extracted here is a pure helper `_is_cross_encoder_config(config: dict)`,
+which `_detect_model_kind` calls. Test the helper directly; the branch wiring is covered
+by the live test in Task 10.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_rerank_manager.py -q`
+Expected: FAIL — `ImportError: cannot import name '_is_cross_encoder_config'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `olmlx/engine/model_manager.py`, add a module-level helper near the other detection
+code:
+
+```python
+def _is_cross_encoder_config(config: dict) -> bool:
+    """True for an XLM-RoBERTa-family sequence-classification reranker."""
+    archs = config.get("architectures") or []
+    return any(
+        isinstance(a, str) and a.endswith("ForSequenceClassification") for a in archs
+    )
+```
+
+In `_detect_model_kind`, after the whisper check and before the VLM/text resolution
+(around `model_manager.py:1718`, right after the `if not model_type: return "unknown"`
+guard — but the reranker check must run even when `model_type` is set, so place it
+immediately after the whisper block at ~line 1716):
+
+```python
+        if _is_cross_encoder_config(config):
+            return "reranker"
+```
+
+Add the field to `LoadedModel` (after `is_whisper`, `model_manager.py:479`):
+
+```python
+    is_reranker: bool = False
+```
+
+At the `LoadedModel(...)` construction site (`model_manager.py:1456`), add:
+
+```python
+                        is_reranker=(_model_kind == "reranker"),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_rerank_manager.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Run the broader manager suite for regressions**
+
+Run: `uv run pytest tests/test_model_manager*.py -q`
+Expected: PASS (no regressions)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add olmlx/engine/model_manager.py tests/test_rerank_manager.py
+git commit -m "feat(rerank): detect reranker kind + LoadedModel.is_reranker (#369)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `_load_model` reranker branch + LLM-only-path guards
+
+**Files:**
+- Modify: `olmlx/engine/model_manager.py`
+- Test: covered by Task 10 live test (loading requires real weights); add a guard unit test
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_rerank_manager.py
+from olmlx.engine.model_manager import LoadedModel
+
+
+def test_is_reranker_guards_skip_llm_paths():
+    # A reranker LoadedModel must report is_reranker and must not be treated as
+    # an embedding/LLM target by the kv-quant / prompt-cache guards.
+    lm = LoadedModel(name="bge", hf_path="bge", model=object(), tokenizer=object(),
+                     is_reranker=True)
+    assert lm.is_reranker is True
+    # Mirror the is_whisper guard contract: rerankers carry no KV cache.
+    assert lm.kv_cache_quant is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_rerank_manager.py::test_is_reranker_guards_skip_llm_paths -q`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'is_reranker'`
+(if Task 6's field was not yet present) OR PASS the constructor but the test asserts the
+guard contract — if it fails on the kv_cache_quant assertion, proceed to Step 3.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `_load_model`, in the kind-dispatch block (after the `kind == "vlm"` branch, near
+`model_manager.py:3512`), add a reranker branch:
+
+```python
+        if kind == "reranker":
+            from transformers import AutoTokenizer
+
+            from olmlx.engine.rerank import load_cross_encoder
+
+            model = load_cross_encoder(load_path)
+            tokenizer = AutoTokenizer.from_pretrained(load_path)
+            # No chat template, no speculative, no KV cache for a cross-encoder.
+            return model, tokenizer, False, TemplateCaps(), None
+```
+
+In `ensure_loaded`, where `_model_kind` gates whisper KV-quant (`model_manager.py:1100`),
+extend the guard so rerankers also skip KV-cache quant / spectral calibration:
+
+```python
+                _model_kind = self._detect_model_kind(hf_path)
+                if _model_kind in ("whisper", "reranker"):
+                    kv_cache_quant = None
+```
+
+Audit the LLM-only paths that branch on `is_whisper` and add `or lm.is_reranker` where a
+cross-encoder must be excluded (it has no KV cache and no generation):
+`model_manager.py:809`, `:824`, `:2100`. For each, change `if lm.is_whisper:` /
+`if not lm.is_whisper:` to include `is_reranker` with the same polarity as whisper.
+Verify by reading each site — the intent is "skip prompt-cache / KV-cache / generation
+bookkeeping for non-LLM models".
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_rerank_manager.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/model_manager.py tests/test_rerank_manager.py
+git commit -m "feat(rerank): _load_model reranker branch + is_reranker guards (#369)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: `generate_rerank` engine function
+
+**Files:**
+- Modify: `olmlx/engine/inference.py`
+- Test: `tests/test_rerank_engine.py`
+
+`generate_rerank` mirrors `generate_embeddings` (inference lock, pinned ref, trailing
+`mx.synchronize()`), but scores `(query, doc)` pairs and returns a Cohere-shaped dict.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_rerank_engine.py
+import mlx.core as mx
+import pytest
+
+from olmlx.engine.inference import _build_rerank_results, _score_pairs
+
+
+class _FakeTokenizer:
+    model_max_length = 512
+
+    def __call__(self, query, documents, truncation, max_length, padding,
+                 return_tensors=None):
+        # Return numpy-like dict; one row per document.
+        import numpy as np
+        n = len(documents)
+        ids = np.ones((n, 4), dtype=np.int64) * 5
+        mask = np.ones((n, 4), dtype=np.int64)
+        return {"input_ids": ids, "attention_mask": mask}
+
+
+class _FakeModel:
+    def __init__(self, scores):
+        self._scores = scores
+        self.calls = 0
+
+    def __call__(self, input_ids, attention_mask):
+        b = input_ids.shape[0]
+        out = self._scores[self.calls : self.calls + b]
+        self.calls += b
+        return mx.array(out).reshape(b, 1)
+
+
+def test_score_pairs_sigmoid_and_order():
+    # Raw logits -> sigmoid; higher logit -> higher score.
+    model = _FakeModel([2.0, -2.0, 0.0])
+    scores = _score_pairs(
+        model, _FakeTokenizer(), "q", ["a", "b", "c"],
+        max_tokens_per_doc=256, batch_size=8,
+    )
+    assert len(scores) == 3
+    assert scores[0] > scores[2] > scores[1]
+    assert all(0.0 <= s <= 1.0 for s in scores)
+
+
+def test_build_rerank_results_top_n_and_sort():
+    results = _build_rerank_results(
+        scores=[0.1, 0.9, 0.5], documents=["a", "b", "c"],
+        top_n=2, return_documents=False,
+    )
+    assert [r["index"] for r in results] == [1, 2]
+    assert results[0]["relevance_score"] == 0.9
+    assert "document" not in results[0] or results[0]["document"] is None
+
+
+def test_build_rerank_results_return_documents():
+    results = _build_rerank_results(
+        scores=[0.1, 0.9], documents=["a", "b"], top_n=None,
+        return_documents=True,
+    )
+    assert results[0]["document"] == "b"
+
+
+def test_build_rerank_results_top_n_clamped():
+    results = _build_rerank_results(
+        scores=[0.1, 0.9], documents=["a", "b"], top_n=10,
+        return_documents=False,
+    )
+    assert len(results) == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_rerank_engine.py -q`
+Expected: FAIL — `ImportError: cannot import name '_score_pairs'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `olmlx/engine/inference.py` (near `generate_embeddings`):
+
+```python
+def _score_pairs(
+    model,
+    tokenizer,
+    query: str,
+    documents: list[str],
+    *,
+    max_tokens_per_doc: int,
+    batch_size: int = 32,
+) -> list[float]:
+    """Tokenize (query, doc) pairs, batch-score, sigmoid -> [0,1] scores."""
+    import numpy as np
+
+    model_max = int(getattr(tokenizer, "model_max_length", 512) or 512)
+    # transformers sometimes reports a sentinel (very large) model_max_length.
+    if model_max > 100_000:
+        model_max = 512
+    max_len = min(max_tokens_per_doc, model_max)
+
+    scores: list[float] = []
+    for start in range(0, len(documents), batch_size):
+        chunk = documents[start : start + batch_size]
+        enc = tokenizer(
+            [query] * len(chunk),
+            chunk,
+            truncation="only_second",
+            max_length=max_len,
+            padding=True,
+            return_tensors="np",
+        )
+        input_ids = mx.array(np.asarray(enc["input_ids"]).astype(np.int32))
+        attn = mx.array(np.asarray(enc["attention_mask"]).astype(np.int32))
+        logits = model(input_ids, attn)  # [b, 1]
+        probs = mx.sigmoid(logits[:, 0])
+        mx.eval(probs)
+        scores.extend(float(x) for x in probs.tolist())
+    return scores
+
+
+def _build_rerank_results(
+    *,
+    scores: list[float],
+    documents: list[str],
+    top_n: int | None,
+    return_documents: bool,
+) -> list[dict]:
+    order = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)
+    if top_n is not None:
+        order = order[: min(top_n, len(order))]
+    results: list[dict] = []
+    for idx in order:
+        item: dict = {"index": idx, "relevance_score": scores[idx]}
+        if return_documents:
+            item["document"] = documents[idx]
+        results.append(item)
+    return results
+
+
+async def generate_rerank(
+    manager: ModelManager,
+    model_name: str,
+    query: str,
+    documents: list[str],
+    *,
+    top_n: int | None = None,
+    max_tokens_per_doc: int = 4096,
+    return_documents: bool = False,
+    keep_alive: int | str | None = None,
+) -> dict:
+    """Score documents against a query with a cross-encoder reranker (#369)."""
+    lm = await manager.ensure_loaded(model_name, keep_alive, pin=True)
+    try:
+        if not getattr(lm, "is_reranker", False):
+            raise ValueError(
+                f"Model '{model_name}' is not a reranker. /v1/rerank requires "
+                "an XLM-RoBERTa cross-encoder (e.g. bge-reranker-v2-m3)."
+            )
+        async with _inference_locked(
+            lm.inference_queue_timeout, sync_mode=lm.sync_mode
+        ):
+            with (
+                _tracing.span(
+                    "inference",
+                    model=lm.name,
+                    surface=surface_var.get(),
+                    strategy="none",
+                ),
+                _inference_ref(lm, keep_alive=keep_alive, adopt=True),
+            ):
+                scores = _score_pairs(
+                    lm.model,
+                    lm.text_tokenizer,
+                    query,
+                    documents,
+                    max_tokens_per_doc=max_tokens_per_doc,
+                )
+                results = _build_rerank_results(
+                    scores=scores,
+                    documents=documents,
+                    top_n=top_n,
+                    return_documents=return_documents,
+                )
+                # Same sync_mode="none" barrier rationale as generate_embeddings.
+                try:
+                    mx.synchronize()
+                except Exception:
+                    logger.warning(
+                        "rerank post-compute sync failed — next inference may crash",
+                        exc_info=True,
+                    )
+                return {"results": results}
+    finally:
+        lm.release_ref()
+```
+
+Confirm `lm.text_tokenizer` returns the `transformers` tokenizer for a reranker (it is set
+from the `_load_model` return). If reranker tokenizers surface under a different attribute,
+use `lm.tokenizer`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_rerank_engine.py -q`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/inference.py tests/test_rerank_engine.py
+git commit -m "feat(rerank): generate_rerank engine function (#369)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Router + app registration
+
+**Files:**
+- Create: `olmlx/routers/rerank.py`
+- Modify: `olmlx/app.py:22-35` (imports), `:399` (registration)
+- Test: `tests/test_routers_rerank.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_routers_rerank.py
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class TestRerankRouter:
+    @pytest.mark.asyncio
+    async def test_rerank_v1(self, app_client):
+        with patch(
+            "olmlx.routers.rerank.generate_rerank", new_callable=AsyncMock
+        ) as mock:
+            mock.return_value = {
+                "results": [
+                    {"index": 1, "relevance_score": 0.92},
+                    {"index": 0, "relevance_score": 0.10},
+                ]
+            }
+            resp = await app_client.post(
+                "/v1/rerank",
+                json={
+                    "model": "bge-reranker",
+                    "query": "what is mlx",
+                    "documents": ["unrelated", "mlx is an array framework"],
+                    "top_n": 2,
+                },
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["results"][0]["index"] == 1
+        assert data["results"][0]["relevance_score"] == 0.92
+        assert data["id"].startswith("rerank-")
+        assert data["meta"]["api_version"]["version"] == "2"
+
+    @pytest.mark.asyncio
+    async def test_rerank_alias(self, app_client):
+        with patch(
+            "olmlx.routers.rerank.generate_rerank", new_callable=AsyncMock
+        ) as mock:
+            mock.return_value = {"results": []}
+            resp = await app_client.post(
+                "/rerank",
+                json={"model": "m", "query": "q", "documents": ["a"]},
+            )
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_rerank_rejects_empty_documents(self, app_client):
+        resp = await app_client.post(
+            "/v1/rerank",
+            json={"model": "m", "query": "q", "documents": []},
+        )
+        assert resp.status_code == 422
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_routers_rerank.py -q`
+Expected: FAIL — 404 (route not registered) / import error
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# olmlx/routers/rerank.py
+import uuid
+
+from fastapi import APIRouter, Request
+
+from olmlx.engine.inference import generate_rerank
+from olmlx.schemas.rerank import RerankRequest, RerankResponse, RerankResult
+
+router = APIRouter()
+
+
+async def _rerank(req: RerankRequest, request: Request) -> RerankResponse:
+    manager = request.app.state.model_manager
+    out = await generate_rerank(
+        manager,
+        req.model,
+        req.query,
+        req.documents,
+        top_n=req.top_n,
+        max_tokens_per_doc=req.max_tokens_per_doc,
+        return_documents=req.return_documents,
+        keep_alive=req.keep_alive,
+    )
+    return RerankResponse(
+        id=f"rerank-{uuid.uuid4().hex}",
+        results=[RerankResult(**r) for r in out["results"]],
+        meta={"api_version": {"version": "2"}},
+    )
+
+
+@router.post("/v1/rerank", response_model=RerankResponse)
+async def rerank_v1(req: RerankRequest, request: Request) -> RerankResponse:
+    return await _rerank(req, request)
+
+
+@router.post("/rerank", response_model=RerankResponse)
+async def rerank_alias(req: RerankRequest, request: Request) -> RerankResponse:
+    return await _rerank(req, request)
+```
+
+In `olmlx/app.py`, add `rerank` to the routers import block (`app.py:22`) and register it
+alongside the others (after `embed.router`, `app.py:399`):
+
+```python
+    app.include_router(rerank.router)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_routers_rerank.py -q`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Run the app-wiring test**
+
+Run: `uv run pytest tests/test_app.py -q`
+Expected: PASS (router registration doesn't break app construction)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add olmlx/routers/rerank.py olmlx/app.py tests/test_routers_rerank.py
+git commit -m "feat(rerank): /v1/rerank router (+ /rerank alias) (#369)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Live tests against real models (bge + jina)
+
+**Files:**
+- Create: `tests/live/test_rerank_real.py`
+- Reference: `tests/live/` patterns and the `real_model` marker (`tests/integration/conftest.py:147-161`)
+
+These download real weights. Mark `real_model` and `slow`; keep them outside
+`tests/integration/` so the autouse MLX mock doesn't apply (per CLAUDE.md).
+
+- [ ] **Step 1: Write the discovery test (asserts real checkpoint key layout)**
+
+```python
+# tests/live/test_rerank_real.py
+import pytest
+
+pytestmark = [pytest.mark.real_model, pytest.mark.slow]
+
+BGE = "BAAI/bge-reranker-v2-m3"
+JINA = "jinaai/jina-reranker-v2-base-multilingual"
+
+
+def _local_dir(repo: str) -> str:
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(repo)
+
+
+@pytest.mark.parametrize("repo,expected", [(BGE, "standard"), (JINA, "flash")])
+def test_checkpoint_layout_matches_expectation(repo, expected):
+    import glob
+    import os
+
+    import mlx.core as mx
+
+    from olmlx.engine.rerank.weights import detect_layout
+
+    path = _local_dir(repo)
+    files = sorted(glob.glob(os.path.join(path, "*.safetensors")))
+    keys: list[str] = []
+    for f in files:
+        keys.extend(mx.load(f).keys())
+    assert detect_layout(keys) == expected, (
+        f"{repo}: detected {detect_layout(keys)} (sample keys: {keys[:8]})"
+    )
+```
+
+- [ ] **Step 2: Run the discovery test**
+
+Run: `uv run pytest tests/live/test_rerank_real.py -m real_model -q`
+Expected: PASS. **If jina's keys differ from the assumed flash layout**, the assertion
+prints sample keys — update `detect_layout` / `remap_flash` in Task 4 to the real strings,
+re-run, then continue.
+
+- [ ] **Step 3: Write the ranking + reference-parity test**
+
+```python
+# add to tests/live/test_rerank_real.py
+@pytest.mark.parametrize("repo", [BGE, JINA])
+def test_load_and_rank(repo):
+    import mlx.core as mx
+    import numpy as np
+    from transformers import AutoTokenizer
+
+    from olmlx.engine.inference import _build_rerank_results, _score_pairs
+    from olmlx.engine.rerank.weights import load_cross_encoder
+
+    path = _local_dir(repo)
+    model = load_cross_encoder(path)
+    tok = AutoTokenizer.from_pretrained(path)
+
+    query = "What is the capital of France?"
+    docs = [
+        "The capital of France is Paris.",
+        "Bananas are a good source of potassium.",
+    ]
+    scores = _score_pairs(model, tok, query, docs, max_tokens_per_doc=512)
+    results = _build_rerank_results(
+        scores=scores, documents=docs, top_n=None, return_documents=False
+    )
+    assert results[0]["index"] == 0  # the relevant doc ranks first
+    assert scores[0] > scores[1]
+
+
+def test_batch_of_100_documents():
+    from transformers import AutoTokenizer
+
+    from olmlx.engine.inference import _score_pairs
+    from olmlx.engine.rerank.weights import load_cross_encoder
+
+    path = _local_dir(BGE)
+    model = load_cross_encoder(path)
+    tok = AutoTokenizer.from_pretrained(path)
+    docs = [f"document number {i} about various topics" for i in range(100)]
+    scores = _score_pairs(model, tok, "find the relevant document", docs,
+                          max_tokens_per_doc=256)
+    assert len(scores) == 100
+```
+
+- [ ] **Step 4: Add a transformers reference-parity check (bge only)**
+
+```python
+# add to tests/live/test_rerank_real.py
+def test_parity_against_transformers_reference():
+    import numpy as np
+    import torch
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+    from olmlx.engine.inference import _score_pairs
+    from olmlx.engine.rerank.weights import load_cross_encoder
+
+    pytest.importorskip("torch")
+    path = _local_dir(BGE)
+    tok = AutoTokenizer.from_pretrained(path)
+    query = "What is MLX?"
+    docs = ["MLX is an array framework for Apple silicon.", "I like sandwiches."]
+
+    ours = _score_pairs(load_cross_encoder(path), tok, query, docs,
+                        max_tokens_per_doc=512)
+
+    ref_model = AutoModelForSequenceClassification.from_pretrained(path).eval()
+    with torch.no_grad():
+        enc = tok([query, query], docs, padding=True, truncation="only_second",
+                  max_length=512, return_tensors="pt")
+        ref_logits = ref_model(**enc).logits.squeeze(-1)
+        ref = torch.sigmoid(ref_logits).tolist()
+
+    assert np.allclose(np.array(ours), np.array(ref), atol=1e-2), (ours, ref)
+```
+
+`torch`/`transformers` reference model is `importorskip`-guarded so the suite skips
+cleanly where torch isn't installed.
+
+- [ ] **Step 5: Run the live suite**
+
+Run: `uv run pytest tests/live/test_rerank_real.py -m real_model -q`
+Expected: PASS (or SKIP for the torch-parity test if torch absent). Investigate any
+ranking failure before proceeding.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/live/test_rerank_real.py
+git commit -m "test(rerank): live bge + jina ranking, layout, and parity checks (#369)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Documentation + final verification
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Reference: full test suite
+
+- [ ] **Step 1: Document the endpoint in CLAUDE.md**
+
+Add under "Project Structure" (routers list): a line for `routers/rerank.py`. Add a bullet
+under "Key Design Decisions":
+
+```markdown
+- **Rerank endpoint** (`routers/rerank.py`, #369): `POST /v1/rerank` (+ `/rerank` alias),
+  Cohere-v2 shape. Cross-encoder rerankers are a first-class `ModelManager` kind
+  (`reranker`): `_detect_model_kind` matches an `architectures` entry ending in
+  `ForSequenceClassification`; `LoadedModel.is_reranker` guards the LLM-only prompt-cache /
+  KV-quant / generation paths (like `is_whisper`). The encoder is a native MLX
+  `XLMRobertaCrossEncoder` (`engine/rerank/`): absolute-position, post-LN BERT attention,
+  first-token classification head, config-driven sizing. Two checkpoint layouts load into
+  the same module via key-inspection remaps — standard HF (`attention.self.{query,key,
+  value}`, bge) and flash (`mixer.Wqkv` fused QKV + `emb_ln`/`norm1`/`norm2`, jina).
+  `generate_rerank` tokenizes `(query, doc)` pairs (`transformers` tokenizer,
+  `truncation="only_second"` — silent doc-side truncation), batch-scores, `sigmoid` →
+  `[0,1]`, sorts, applies `top_n`. No KV cache, speculative, distributed, or streaming for
+  rerankers. Live coverage: `tests/live/test_rerank_real.py` (real_model, bge + jina).
+```
+
+- [ ] **Step 2: Run the full focused test set**
+
+Run:
+```bash
+uv run pytest tests/test_rerank_model.py tests/test_rerank_schemas.py \
+  tests/test_rerank_engine.py tests/test_routers_rerank.py \
+  tests/test_rerank_manager.py tests/test_app.py -q
+```
+Expected: PASS (all)
+
+- [ ] **Step 3: Lint**
+
+Run: `uv run ruff check olmlx/engine/rerank olmlx/routers/rerank.py olmlx/schemas/rerank.py olmlx/engine/inference.py olmlx/engine/model_manager.py tests/test_rerank_*.py tests/live/test_rerank_real.py && uv run ruff format --check olmlx/engine/rerank olmlx/routers/rerank.py olmlx/schemas/rerank.py`
+Expected: no errors (run `ruff format` to fix formatting if the check fails)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(rerank): document /v1/rerank endpoint and reranker kind (#369)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 5: Push and open PR** (only when the user asks — per project git policy)
+
+```bash
+git push -u origin feat/rerank-endpoint
+gh pr create --fill --base main
+```
+
+---
+
+## Self-Review notes (for the implementer)
+
+- **Spec coverage**: kind detection (T6), native MLX encoder (T2/T3), two weight layouts
+  (T4), loader + guards (T6/T7), `generate_rerank` truncation/sort/top_n (T8), schemas
+  (T5), router + alias (T9), tests incl. live bge+jina + parity (T10), docs (T11). All
+  spec sections map to a task.
+- **Uncertain seam — jina flash key strings**: the exact `mixer.Wqkv`/`norm1`/`emb_ln`
+  strings are inferred from flash-attn conventions. Task 10 Step 1/2 is a hard
+  validation gate that prints the real keys and forces a Task-4 fix before the rest of
+  the live suite runs. Do not skip it.
+- **Uncertain seam — `_detect_model_kind` config-read path**: Task 6 extracts a pure
+  helper (`_is_cross_encoder_config`) to keep the unit test independent of the
+  store/hub config-fetch plumbing; wire the helper into the real `_detect_model_kind`
+  branch and rely on Task 10 for end-to-end coverage.
+- **`text_tokenizer` vs `tokenizer`**: confirmed steps in T8 to verify the attribute the
+  reranker tokenizer lands on; adapt if needed.
+- **GELU variant**: bge/jina use `hidden_act: "gelu"` (exact erf GELU). `nn.gelu` is the
+  exact form — correct. (If a future model specifies `gelu_new`/`gelu_pytorch_tanh`, branch
+  on `cfg.hidden_act`.)

--- a/docs/superpowers/specs/2026-06-08-rerank-endpoint-design.md
+++ b/docs/superpowers/specs/2026-06-08-rerank-endpoint-design.md
@@ -16,7 +16,7 @@ run a second tool.
 | Decision | Choice |
 |----------|--------|
 | Model backend | **Native MLX XLM-RoBERTa** — no new runtime deps, pure MLX/Metal |
-| Model coverage | **Generic config-driven** cross-encoder (absolute *and* rotary position embeddings) to cover bge + jina + future XLM-RoBERTa-family rerankers |
+| Model coverage | **Generic config-driven** XLM-RoBERTa cross-encoder covering bge + jina + future family members. Both targets use absolute position embeddings + post-LN BERT attention; they differ only in **checkpoint weight layout** (see below), not math. |
 | API shape | **Cohere v2** rerank contract (`/v1/rerank`), drop-in for the Cohere SDK via `base_url` |
 | Long-document handling | **Silent truncation** (Cohere default) — truncate document side, preserve full query |
 
@@ -38,18 +38,35 @@ config-driven decision.
 
 ### 2. Native MLX encoder — `olmlx/engine/rerank/model.py`
 
-`XLMRobertaCrossEncoder(nn.Module)`, fully config-driven:
+`XLMRobertaCrossEncoder(nn.Module)` — **one** architecture for both targets (verified
+against jina's modeling source: it is *not* rotary), config-driven sizing:
 
-- **Embeddings**: word + position + token_type, followed by LayerNorm. The config's
-  `position_embedding_type` selects **absolute** (bge) vs **rotary** (jina) — the single
-  branch that covers both target architectures.
+- **Embeddings**: word + position + token_type, followed by LayerNorm. **Absolute**
+  position ids with the RoBERTa offset (`position_ids = cumsum(mask) * mask + pad_id`,
+  so the first real token is position `pad_id + 1 = 2`; this is why
+  `max_position_embeddings` is `8194 = 8192 + 2` for bge, `1026 = 1024 + 2` for jina).
+  `token_type_ids` are all zero (`type_vocab_size == 1`) but the learned row-0 bias is
+  still added.
 - **Encoder**: `num_hidden_layers` post-LN transformer blocks (self-attention + GELU
   FFN), sized from config (`hidden_size`, `num_attention_heads`, `intermediate_size`).
-- **Classification head**: project the first token's hidden state to a single relevance
-  logit (`num_labels == 1`).
-- **Weights**: load from HF safetensors via a key-remap table (HF `xlm-roberta.*` naming
-  → our module names). Forward signature: `(input_ids, attention_mask) -> [batch, 1]`
-  logits.
+- **Classification head** (`XLMRobertaClassificationHead`): take the **first token**
+  (`features[:, 0, :]`) → `dense` → tanh → `out_proj` → single relevance logit
+  (`num_labels == 1`). This is the `classifier`, *not* the base-model `pooler`.
+- **Forward**: `(input_ids, attention_mask) -> [batch, 1]` logits.
+
+**Two weight layouts, same module** (loader picks by key inspection, not model name):
+
+- **Standard HF (bge)**: `roberta.encoder.layer.{i}.attention.self.{query,key,value}`,
+  `attention.output.dense`/`LayerNorm`, `intermediate.dense`, `output.dense`/`LayerNorm`,
+  `embeddings.LayerNorm`, `classifier.{dense,out_proj}`.
+- **Flash (jina)**: flash-attention module naming —
+  `roberta.encoder.layers.{i}.mixer.Wqkv` (**fused** QKV, split into q/k/v on load),
+  `mixer.out_proj`, `mlp.fc1`/`fc2`, `norm1` (post-attention LN), `norm2` (post-MLP LN),
+  `emb_ln` (embedding LayerNorm). Post-LN math identical to bge.
+
+A discovery/validation test asserts each target's actual key set before its remap is
+trusted (jina's exact strings are inferred from the flash-attn conventions, not yet seen
+against the real checkpoint).
 
 ### 3. Loader + `LoadedModel`
 
@@ -112,20 +129,26 @@ routers.
 
 ### 7. Tests (TDD — write failing first)
 
-- **Unit (model)**: encoder forward parity against a tiny saved fixture; weight-remap
-  correctness; absolute vs rotary position-embedding branch.
+- **Unit (model)**: encoder forward parity against a tiny saved fixture; RoBERTa
+  position-id offset; both weight-remap paths (standard + fused-QKV flash split).
+- **Discovery**: assert the real checkpoint key set for bge (standard) and jina (flash)
+  before trusting each remap.
 - **Unit (engine)**: pair tokenization + `only_second` truncation; sigmoid scoring; sort +
   `top_n` clamp; empty-documents → empty results; non-reranker model → ValueError.
 - **Router**: Cohere v2 response shape; `return_documents` toggle; 422 on malformed
   request (empty documents, non-positive `top_n`).
 - **Live (`real_model`, outside `tests/integration/` to dodge the autouse MLX mock)**:
-  `bge-reranker-v2-m3` ranks a known-relevant document above an irrelevant one; smoke-test
-  scoring a batch of 100 documents.
+  `bge-reranker-v2-m3` (standard layout) **and** `jina-reranker-v2-base-multilingual`
+  (flash layout) each rank a known-relevant document above an irrelevant one; smoke-test
+  scoring a batch of 100 documents. Cross-check the top score against the HF/transformers
+  reference to within tolerance for at least one model.
 
 ## Out of scope (v1)
 
 - Document objects / `rank_fields` (string documents only).
 - Multi-label classification heads (`num_labels > 1`).
+- Rotary-position cross-encoders (neither target uses them; the encoder stays
+  absolute-position only until a real rotary reranker appears).
 - Streaming, distributed, and flash paths for rerankers.
 - Billed-units accounting in `meta`.
 

--- a/docs/superpowers/specs/2026-06-08-rerank-endpoint-design.md
+++ b/docs/superpowers/specs/2026-06-08-rerank-endpoint-design.md
@@ -1,0 +1,142 @@
+# `/v1/rerank` — Cross-encoder reranking endpoint
+
+**Issue:** #369
+**Date:** 2026-06-08
+**Status:** Approved, ready for implementation planning
+
+## Why
+
+The standard RAG pipeline is embed → retrieve top-k → **rerank** → LLM. olmlx already
+serves embeddings and manages model lifecycle; cross-encoder rerankers slot in as a
+natural pairing. Without rerank, callers either skip it (retrieval-quality drop) or
+run a second tool.
+
+## Decisions (locked)
+
+| Decision | Choice |
+|----------|--------|
+| Model backend | **Native MLX XLM-RoBERTa** — no new runtime deps, pure MLX/Metal |
+| Model coverage | **Generic config-driven** cross-encoder (absolute *and* rotary position embeddings) to cover bge + jina + future XLM-RoBERTa-family rerankers |
+| API shape | **Cohere v2** rerank contract (`/v1/rerank`), drop-in for the Cohere SDK via `base_url` |
+| Long-document handling | **Silent truncation** (Cohere default) — truncate document side, preserve full query |
+
+## Acceptance criteria (from issue)
+
+- `bge-reranker-v2-m3` and `jina-reranker-v2-base-multilingual` load and serve.
+- Compatible with the Cohere SDK request shape.
+- A batch of 100 documents scores on M3 in reasonable time.
+
+## Architecture
+
+### 1. New model kind: `reranker`
+
+Extend `ModelManager._detect_model_kind` to return `"reranker"` when `config.json`'s
+`architectures` entry ends in `ForSequenceClassification` (XLM-RoBERTa cross-encoder
+family). Checked **before** the generic text path and after whisper/VLM detection.
+Generic discriminator rather than a hardcoded model allowlist, per the generic
+config-driven decision.
+
+### 2. Native MLX encoder — `olmlx/engine/rerank/model.py`
+
+`XLMRobertaCrossEncoder(nn.Module)`, fully config-driven:
+
+- **Embeddings**: word + position + token_type, followed by LayerNorm. The config's
+  `position_embedding_type` selects **absolute** (bge) vs **rotary** (jina) — the single
+  branch that covers both target architectures.
+- **Encoder**: `num_hidden_layers` post-LN transformer blocks (self-attention + GELU
+  FFN), sized from config (`hidden_size`, `num_attention_heads`, `intermediate_size`).
+- **Classification head**: project the first token's hidden state to a single relevance
+  logit (`num_labels == 1`).
+- **Weights**: load from HF safetensors via a key-remap table (HF `xlm-roberta.*` naming
+  → our module names). Forward signature: `(input_ids, attention_mask) -> [batch, 1]`
+  logits.
+
+### 3. Loader + `LoadedModel`
+
+- Add `is_reranker: bool = False` to `LoadedModel` (mirrors `is_whisper`).
+- New `kind == "reranker"` branch in `_load_model`: build the encoder from config, load
+  weights, return `(model, tokenizer, is_vlm=False, TemplateCaps(), decoder=None)` and
+  set `is_reranker=True` at `LoadedModel` construction.
+- Tokenizer loaded via `transformers.AutoTokenizer` (transformers + sentencepiece already
+  present). XLM-RoBERTa uses a SentencePiece tokenizer.
+- `is_reranker` guards the LLM-only paths (prompt cache, KV-quant, speculative,
+  embeddings) exactly as `is_whisper` does today.
+- `ensure_loaded` / keep-alive / LRU eviction / memory check all work unchanged — the
+  reranker is a managed model like any other.
+
+### 4. Engine: `generate_rerank(...)` — `olmlx/engine/inference.py`
+
+```
+async def generate_rerank(
+    manager, model_name, query, documents,
+    *, top_n=None, max_tokens_per_doc=4096, return_documents=False,
+    keep_alive=None,
+) -> dict
+```
+
+Runs under `_inference_locked` + a tracing `inference` span (strategy `"none"`), pinned
+ref, mirroring `generate_embeddings`:
+
+1. Reject non-reranker models with a clear `ValueError` (→ HTTP 400), like
+   `generate_transcription` does for non-whisper.
+2. For each `(query, doc)` pair, encode with
+   `tokenizer(query, doc, truncation="only_second",
+   max_length=min(max_tokens_per_doc, model_max))` → silent doc-side truncation,
+   full query preserved.
+3. **Micro-batch**: pad to the longest sequence in the batch, build the attention mask,
+   run the encoder forward in bounded batches (cap peak activation memory), collect
+   logits, apply `sigmoid` → `relevance_score ∈ [0, 1]`.
+4. Sort by score descending, apply `top_n` (clamp to `len(documents)`), build the
+   results list. Include `document` text only when `return_documents=True`.
+5. Trailing `mx.synchronize()` barrier — same `sync_mode="none"` lock-boundary concern
+   documented in `generate_embeddings`.
+
+Edge cases: empty `documents` → empty `results`; `top_n` larger than the list → clamp;
+`top_n <= 0` → 422 at the schema layer.
+
+### 5. Schemas — `olmlx/schemas/rerank.py`
+
+- `RerankRequest`: `model: ModelName`, `query: str`, `documents: list[str]`,
+  `top_n: int | None = None`, `max_tokens_per_doc: int = 4096`,
+  `return_documents: bool = False`, `keep_alive: int | str | None = None`.
+  Validators: non-empty `query`, non-empty `documents`, `top_n` positive when present.
+- `RerankResult`: `index: int`, `relevance_score: float`, `document: str | None = None`.
+- `RerankResponse`: `id: str`, `results: list[RerankResult]`,
+  `meta: dict` (`{"api_version": {"version": "2"}}`; billed-units omitted for a local tool).
+
+### 6. Router — `olmlx/routers/rerank.py`
+
+`POST /v1/rerank` → `generate_rerank` → `RerankResponse`. Plus a `POST /rerank` alias for
+Jina/TEI-style clients (cheap, same handler). Registered in `app.py` alongside the other
+routers.
+
+### 7. Tests (TDD — write failing first)
+
+- **Unit (model)**: encoder forward parity against a tiny saved fixture; weight-remap
+  correctness; absolute vs rotary position-embedding branch.
+- **Unit (engine)**: pair tokenization + `only_second` truncation; sigmoid scoring; sort +
+  `top_n` clamp; empty-documents → empty results; non-reranker model → ValueError.
+- **Router**: Cohere v2 response shape; `return_documents` toggle; 422 on malformed
+  request (empty documents, non-positive `top_n`).
+- **Live (`real_model`, outside `tests/integration/` to dodge the autouse MLX mock)**:
+  `bge-reranker-v2-m3` ranks a known-relevant document above an irrelevant one; smoke-test
+  scoring a batch of 100 documents.
+
+## Out of scope (v1)
+
+- Document objects / `rank_fields` (string documents only).
+- Multi-label classification heads (`num_labels > 1`).
+- Streaming, distributed, and flash paths for rerankers.
+- Billed-units accounting in `meta`.
+
+## Files
+
+- new `olmlx/engine/rerank/__init__.py`, `olmlx/engine/rerank/model.py`
+- new `olmlx/schemas/rerank.py`
+- new `olmlx/routers/rerank.py`
+- `olmlx/engine/inference.py` — add `generate_rerank`
+- `olmlx/engine/model_manager.py` — `_detect_model_kind` reranker branch, `_load_model`
+  reranker branch, `LoadedModel.is_reranker`, `is_reranker` guards on LLM-only paths
+- `olmlx/app.py` — register the router
+- `CLAUDE.md` — document the endpoint + reranker model kind under Key Design Decisions
+- tests under `tests/` (+ a live test outside `tests/integration/`)

--- a/olmlx/app.py
+++ b/olmlx/app.py
@@ -29,6 +29,7 @@ from olmlx.routers import (
     manage,
     models,
     openai,
+    rerank,
     responses,
     status,
 )
@@ -397,6 +398,7 @@ def create_app() -> FastAPI:
     app.include_router(models.router)
     app.include_router(manage.router)
     app.include_router(embed.router)
+    app.include_router(rerank.router)
     app.include_router(blobs.router)
     app.include_router(openai.router)
     app.include_router(responses.router)

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -4900,7 +4900,9 @@ def _score_pairs(
         )
         input_ids = mx.array(np.asarray(enc["input_ids"]).astype(np.int32))
         attn = mx.array(np.asarray(enc["attention_mask"]).astype(np.int32))
-        logits = model(input_ids, attn)  # [b, 1]
+        logits = model(input_ids, attn)  # [b, 1] (num_labels == 1)
+        # Single relevance logit -> probability. Assumes num_labels == 1
+        # (enforced at load by load_cross_encoder); column 0 is the score.
         probs = mx.sigmoid(logits[:, 0])
         mx.eval(probs)
         scores.extend(float(x) for x in probs.tolist())
@@ -4978,7 +4980,7 @@ async def generate_rerank(
                     mx.synchronize()
                 except Exception:
                     logger.warning(
-                        "rerank post-compute sync failed — next inference may crash",
+                        "rerank post-compute sync failed — next inference will crash",
                         exc_info=True,
                     )
                 return {"results": results}

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -4905,7 +4905,12 @@ def _score_pairs(
         # (enforced at load by load_cross_encoder); column 0 is the score.
         probs = mx.sigmoid(logits[:, 0])
         mx.eval(probs)
-        scores.extend(float(x) for x in probs.tolist())
+        # probs is 1-D (one score per doc) so tolist() is a list; the isinstance
+        # guard also narrows mlx's union return type for the type checker.
+        batch_scores = probs.tolist()
+        if not isinstance(batch_scores, list):
+            batch_scores = [batch_scores]
+        scores.extend(float(x) for x in batch_scores)
     return scores
 
 

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -4869,6 +4869,123 @@ async def generate_embeddings(
         lm.release_ref()
 
 
+def _score_pairs(
+    model,
+    tokenizer,
+    query: str,
+    documents: list[str],
+    *,
+    max_tokens_per_doc: int,
+    batch_size: int = 32,
+) -> list[float]:
+    """Tokenize (query, doc) pairs, batch-score, sigmoid -> [0,1] scores."""
+    import numpy as np
+
+    model_max = int(getattr(tokenizer, "model_max_length", 512) or 512)
+    # transformers sometimes reports a sentinel (very large) model_max_length.
+    if model_max > 100_000:
+        model_max = 512
+    max_len = min(max_tokens_per_doc, model_max)
+
+    scores: list[float] = []
+    for start in range(0, len(documents), batch_size):
+        chunk = documents[start : start + batch_size]
+        enc = tokenizer(
+            [query] * len(chunk),
+            chunk,
+            truncation="only_second",
+            max_length=max_len,
+            padding=True,
+            return_tensors="np",
+        )
+        input_ids = mx.array(np.asarray(enc["input_ids"]).astype(np.int32))
+        attn = mx.array(np.asarray(enc["attention_mask"]).astype(np.int32))
+        logits = model(input_ids, attn)  # [b, 1]
+        probs = mx.sigmoid(logits[:, 0])
+        mx.eval(probs)
+        scores.extend(float(x) for x in probs.tolist())
+    return scores
+
+
+def _build_rerank_results(
+    *,
+    scores: list[float],
+    documents: list[str],
+    top_n: int | None,
+    return_documents: bool,
+) -> list[dict]:
+    order = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)
+    if top_n is not None:
+        order = order[: min(top_n, len(order))]
+    results: list[dict] = []
+    for idx in order:
+        item: dict = {"index": idx, "relevance_score": scores[idx]}
+        if return_documents:
+            item["document"] = documents[idx]
+        results.append(item)
+    return results
+
+
+async def generate_rerank(
+    manager: ModelManager,
+    model_name: str,
+    query: str,
+    documents: list[str],
+    *,
+    top_n: int | None = None,
+    max_tokens_per_doc: int = 4096,
+    return_documents: bool = False,
+    keep_alive: int | str | None = None,
+) -> dict:
+    """Score documents against a query with a cross-encoder reranker (#369)."""
+    lm = await manager.ensure_loaded(model_name, keep_alive, pin=True)
+    try:
+        if not getattr(lm, "is_reranker", False):
+            raise ValueError(
+                f"Model '{model_name}' is not a reranker. /v1/rerank requires "
+                "an XLM-RoBERTa cross-encoder (e.g. bge-reranker-v2-m3)."
+            )
+        async with _inference_locked(
+            lm.inference_queue_timeout, sync_mode=lm.sync_mode
+        ):
+            with (
+                _tracing.span(
+                    "inference",
+                    model=lm.name,
+                    surface=surface_var.get(),
+                    strategy="none",
+                ),
+                _inference_ref(lm, keep_alive=keep_alive, adopt=True),
+            ):
+                scores = _score_pairs(
+                    lm.model,
+                    lm.text_tokenizer,
+                    query,
+                    documents,
+                    max_tokens_per_doc=max_tokens_per_doc,
+                )
+                results = _build_rerank_results(
+                    scores=scores,
+                    documents=documents,
+                    top_n=top_n,
+                    return_documents=return_documents,
+                )
+                # Load-bearing when sync_mode="none": same rationale as
+                # generate_embeddings — this is the only Metal barrier before
+                # the lock is released. Suppress+log so caller still gets
+                # results; Metal error surfaces on the next inference.
+                try:
+                    mx.synchronize()
+                except Exception:
+                    logger.warning(
+                        "rerank post-compute sync failed — next inference may crash",
+                        exc_info=True,
+                    )
+                return {"results": results}
+    finally:
+        lm.release_ref()
+
+
 async def generate_transcription(
     manager: ModelManager,
     model_name: str,

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2110,8 +2110,9 @@ class ModelManager:
         TurboQuant/Spectral factories would otherwise pull calibration data
         off disk on every model load only to throw the result away.
         """
-        if lm.is_whisper:
-            # Whisper has no LLM-style prompt cache; nothing to probe.
+        if lm.is_whisper or lm.is_reranker:
+            # Whisper / cross-encoder rerankers have no LLM-style prompt cache;
+            # nothing to probe.
             return
         try:
             from mlx_lm.models.cache import make_prompt_cache
@@ -3521,6 +3522,18 @@ class ModelManager:
 
             model = whisper_loader.load_model(load_path, dtype=mx.float16)
             return model, None, False, TemplateCaps(), None
+
+        if kind == "reranker":
+            # Cross-encoder reranker (#369): native MLX XLM-RoBERTa loaded from
+            # safetensors; tokenizer via transformers. No chat template, no
+            # speculative decoder, no KV cache.
+            from transformers import AutoTokenizer
+
+            from olmlx.engine.rerank import load_cross_encoder
+
+            model = load_cross_encoder(load_path)
+            tokenizer = AutoTokenizer.from_pretrained(load_path)
+            return model, tokenizer, False, TemplateCaps(), None
 
         if kind == "vlm":
             # VLM detected — load with mlx-vlm directly

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -589,11 +589,19 @@ class LoadedModel:
 
 
 def _is_cross_encoder_config(config: dict) -> bool:
-    """True for an XLM-RoBERTa-family sequence-classification reranker (#369)."""
+    """True for an XLM-RoBERTa-family sequence-classification reranker (#369).
+
+    Requires both a ``*ForSequenceClassification`` architecture AND a
+    roberta-family ``model_type`` — the encoder and weight remaps only support
+    XLM-RoBERTa/RoBERTa, so a plain BERT/DistilBERT text classifier must NOT be
+    routed here (it would otherwise be detected as a reranker and fail at load).
+    """
     archs = config.get("architectures") or []
-    return any(
+    if not any(
         isinstance(a, str) and a.endswith("ForSequenceClassification") for a in archs
-    )
+    ):
+        return False
+    return "roberta" in (config.get("model_type") or "").lower()
 
 
 def parse_keep_alive(value: str | int) -> float | None:

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -477,6 +477,7 @@ class LoadedModel:
     is_flash: bool = False
     is_flash_moe: bool = False
     is_whisper: bool = False
+    is_reranker: bool = False
     speculative_decoder: Any = None
     weight_store: Any = None
     template_caps: TemplateCaps = field(default_factory=TemplateCaps)
@@ -585,6 +586,14 @@ class LoadedModel:
         if self.is_vlm and hasattr(tok, "tokenizer"):
             return tok.tokenizer
         return tok
+
+
+def _is_cross_encoder_config(config: dict) -> bool:
+    """True for an XLM-RoBERTa-family sequence-classification reranker (#369)."""
+    archs = config.get("architectures") or []
+    return any(
+        isinstance(a, str) and a.endswith("ForSequenceClassification") for a in archs
+    )
 
 
 def parse_keep_alive(value: str | int) -> float | None:
@@ -1098,7 +1107,7 @@ class ModelManager:
                 # Whisper models (issue #366) have no LLM KV cache — never
                 # apply KV-cache quantization / spectral calibration to them.
                 _model_kind = self._detect_model_kind(hf_path)
-                if _model_kind == "whisper":
+                if _model_kind in ("whisper", "reranker"):
                     kv_cache_quant = None
                 flash_moe_config = model_config.resolved_flash_moe()
 
@@ -1454,6 +1463,7 @@ class ModelManager:
                         is_flash=is_flash,
                         is_flash_moe=is_flash_moe,
                         is_whisper=(_model_kind == "whisper"),
+                        is_reranker=(_model_kind == "reranker"),
                         speculative_decoder=_spec_decoder,
                         weight_store=_weight_store,
                         template_caps=caps,
@@ -1714,6 +1724,9 @@ class ModelManager:
             "n_mels" in config and "n_audio_state" in config
         ):
             return "whisper"
+
+        if _is_cross_encoder_config(config):
+            return "reranker"
 
         if not model_type:
             return "unknown"

--- a/olmlx/engine/rerank/__init__.py
+++ b/olmlx/engine/rerank/__init__.py
@@ -1,5 +1,12 @@
 """Native MLX cross-encoder reranker (XLM-RoBERTa family). Issue #369."""
 
 from olmlx.engine.rerank.config import RerankerConfig
+from olmlx.engine.rerank.model import XLMRobertaCrossEncoder
+from olmlx.engine.rerank.weights import detect_layout, load_cross_encoder
 
-__all__ = ["RerankerConfig"]
+__all__ = [
+    "RerankerConfig",
+    "XLMRobertaCrossEncoder",
+    "detect_layout",
+    "load_cross_encoder",
+]

--- a/olmlx/engine/rerank/__init__.py
+++ b/olmlx/engine/rerank/__init__.py
@@ -1,0 +1,5 @@
+"""Native MLX cross-encoder reranker (XLM-RoBERTa family). Issue #369."""
+
+from olmlx.engine.rerank.config import RerankerConfig
+
+__all__ = ["RerankerConfig"]

--- a/olmlx/engine/rerank/config.py
+++ b/olmlx/engine/rerank/config.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RerankerConfig:
+    """Sizing parameters parsed from an XLM-RoBERTa cross-encoder config.json."""
+
+    hidden_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    intermediate_size: int
+    max_position_embeddings: int
+    vocab_size: int
+    type_vocab_size: int
+    layer_norm_eps: float
+    pad_token_id: int
+    num_labels: int
+    hidden_act: str = "gelu"
+
+    @property
+    def head_dim(self) -> int:
+        return self.hidden_size // self.num_attention_heads
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> RerankerConfig:
+        num_labels = raw.get("num_labels")
+        if num_labels is None:
+            id2label = raw.get("id2label") or {"0": "LABEL_0"}
+            num_labels = len(id2label)
+        return cls(
+            hidden_size=int(raw["hidden_size"]),
+            num_hidden_layers=int(raw["num_hidden_layers"]),
+            num_attention_heads=int(raw["num_attention_heads"]),
+            intermediate_size=int(raw["intermediate_size"]),
+            max_position_embeddings=int(raw["max_position_embeddings"]),
+            vocab_size=int(raw["vocab_size"]),
+            type_vocab_size=int(raw.get("type_vocab_size", 1)),
+            layer_norm_eps=float(raw.get("layer_norm_eps", 1e-5)),
+            pad_token_id=int(raw.get("pad_token_id", 1)),
+            num_labels=int(num_labels),
+            hidden_act=str(raw.get("hidden_act", "gelu")),
+        )

--- a/olmlx/engine/rerank/config.py
+++ b/olmlx/engine/rerank/config.py
@@ -28,8 +28,8 @@ class RerankerConfig:
     def from_dict(cls, raw: dict[str, Any]) -> RerankerConfig:
         num_labels = raw.get("num_labels")
         if num_labels is None:
-            id2label = raw.get("id2label") or {"0": "LABEL_0"}
-            num_labels = len(id2label)
+            id2label = raw.get("id2label")
+            num_labels = len(id2label) if id2label is not None else 1
         return cls(
             hidden_size=int(raw["hidden_size"]),
             num_hidden_layers=int(raw["num_hidden_layers"]),

--- a/olmlx/engine/rerank/model.py
+++ b/olmlx/engine/rerank/model.py
@@ -43,3 +43,86 @@ class XLMRobertaEmbeddings(nn.Module):
         # avoiding a full [batch, seq, hidden] gather.
         token_type = self.token_type_embeddings(mx.array([0]))
         return self.LayerNorm(words + positions + token_type)
+
+
+class XLMRobertaSelfAttention(nn.Module):
+    def __init__(self, config: RerankerConfig):
+        super().__init__()
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.scale = self.head_dim**-0.5
+        h = config.hidden_size
+        self.query = nn.Linear(h, h)
+        self.key = nn.Linear(h, h)
+        self.value = nn.Linear(h, h)
+
+    def __call__(self, x: mx.array, additive_mask: mx.array) -> mx.array:
+        b, s, _ = x.shape
+        q = (
+            self.query(x)
+            .reshape(b, s, self.num_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        k = (
+            self.key(x)
+            .reshape(b, s, self.num_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        v = (
+            self.value(x)
+            .reshape(b, s, self.num_heads, self.head_dim)
+            .transpose(0, 2, 1, 3)
+        )
+        scores = (q @ k.transpose(0, 1, 3, 2)) * self.scale
+        scores = scores + additive_mask  # [b, 1, 1, s] broadcast
+        weights = mx.softmax(scores, axis=-1)
+        out = weights @ v  # [b, heads, s, head_dim]
+        return out.transpose(0, 2, 1, 3).reshape(b, s, -1)
+
+
+class XLMRobertaLayer(nn.Module):
+    def __init__(self, config: RerankerConfig):
+        super().__init__()
+        h = config.hidden_size
+        self.attention_self = XLMRobertaSelfAttention(config)
+        self.attention_output_dense = nn.Linear(h, h)
+        self.attention_output_norm = nn.LayerNorm(h, eps=config.layer_norm_eps)
+        self.intermediate_dense = nn.Linear(h, config.intermediate_size)
+        self.output_dense = nn.Linear(config.intermediate_size, h)
+        self.output_norm = nn.LayerNorm(h, eps=config.layer_norm_eps)
+
+    def __call__(self, x: mx.array, additive_mask: mx.array) -> mx.array:
+        attn = self.attention_self(x, additive_mask)
+        x = self.attention_output_norm(self.attention_output_dense(attn) + x)
+        inter = nn.gelu(self.intermediate_dense(x))
+        x = self.output_norm(self.output_dense(inter) + x)
+        return x
+
+
+class XLMRobertaClassificationHead(nn.Module):
+    def __init__(self, config: RerankerConfig):
+        super().__init__()
+        self.dense = nn.Linear(config.hidden_size, config.hidden_size)
+        self.out_proj = nn.Linear(config.hidden_size, config.num_labels)
+
+    def __call__(self, features: mx.array) -> mx.array:
+        x = features[:, 0, :]  # first token (<s> / CLS)
+        x = mx.tanh(self.dense(x))
+        return self.out_proj(x)
+
+
+class XLMRobertaCrossEncoder(nn.Module):
+    def __init__(self, config: RerankerConfig):
+        super().__init__()
+        self.config = config
+        self.embeddings = XLMRobertaEmbeddings(config)
+        self.layers = [XLMRobertaLayer(config) for _ in range(config.num_hidden_layers)]
+        self.classifier = XLMRobertaClassificationHead(config)
+
+    def __call__(self, input_ids: mx.array, attention_mask: mx.array) -> mx.array:
+        # additive mask: keep -> 0, pad -> -inf, shaped [b, 1, 1, s]
+        additive = (1.0 - attention_mask.astype(mx.float32))[:, None, None, :] * -1e9
+        x = self.embeddings(input_ids)
+        for layer in self.layers:
+            x = layer(x, additive)
+        return self.classifier(x)

--- a/olmlx/engine/rerank/model.py
+++ b/olmlx/engine/rerank/model.py
@@ -5,6 +5,32 @@ import mlx.nn as nn
 
 from olmlx.engine.rerank.config import RerankerConfig
 
+# Additive attention-mask fill. -1e4 (not -1e9) so the value survives a cast to
+# float16/bfloat16 without saturating to -inf — a fully-masked softmax row would
+# then yield NaN instead of ~0. -1e4 still drives masked softmax weights to 0.
+_MASK_FILL = -1.0e4
+
+
+def _resolve_activation(hidden_act: str):
+    """Map an HF ``hidden_act`` string to an MLX activation function.
+
+    bge/jina rerankers use exact-erf ``gelu``; the tanh-approximation aliases are
+    mapped too. Unknown activations raise rather than silently using GELU.
+    """
+    table = {
+        "gelu": nn.gelu,
+        "gelu_new": nn.gelu_approx,
+        "gelu_pytorch_tanh": nn.gelu_approx,
+        "relu": nn.relu,
+    }
+    try:
+        return table[hidden_act]
+    except KeyError:
+        raise ValueError(
+            f"unsupported hidden_act {hidden_act!r} for reranker "
+            f"(supported: {sorted(table)})"
+        ) from None
+
 
 def roberta_position_ids(input_ids: mx.array, pad_token_id: int) -> mx.array:
     """Position ids with the RoBERTa offset.
@@ -90,11 +116,12 @@ class XLMRobertaLayer(nn.Module):
         self.intermediate_dense = nn.Linear(h, config.intermediate_size)
         self.output_dense = nn.Linear(config.intermediate_size, h)
         self.output_norm = nn.LayerNorm(h, eps=config.layer_norm_eps)
+        self.activation = _resolve_activation(config.hidden_act)
 
     def __call__(self, x: mx.array, additive_mask: mx.array) -> mx.array:
         attn = self.attention_self(x, additive_mask)
         x = self.attention_output_norm(self.attention_output_dense(attn) + x)
-        inter = nn.gelu(self.intermediate_dense(x))
+        inter = self.activation(self.intermediate_dense(x))
         x = self.output_norm(self.output_dense(inter) + x)
         return x
 
@@ -114,14 +141,16 @@ class XLMRobertaClassificationHead(nn.Module):
 class XLMRobertaCrossEncoder(nn.Module):
     def __init__(self, config: RerankerConfig):
         super().__init__()
-        self.config = config
+        self.config = config  # retained for introspection (HF-style)
         self.embeddings = XLMRobertaEmbeddings(config)
         self.layers = [XLMRobertaLayer(config) for _ in range(config.num_hidden_layers)]
         self.classifier = XLMRobertaClassificationHead(config)
 
     def __call__(self, input_ids: mx.array, attention_mask: mx.array) -> mx.array:
-        # additive mask: keep -> 0, pad -> -inf, shaped [b, 1, 1, s]
-        additive = (1.0 - attention_mask.astype(mx.float32))[:, None, None, :] * -1e9
+        # additive mask: keep -> 0, pad -> _MASK_FILL, shaped [b, 1, 1, s]
+        additive = (1.0 - attention_mask.astype(mx.float32))[
+            :, None, None, :
+        ] * _MASK_FILL
         x = self.embeddings(input_ids)
         for layer in self.layers:
             x = layer(x, additive)

--- a/olmlx/engine/rerank/model.py
+++ b/olmlx/engine/rerank/model.py
@@ -31,12 +31,15 @@ class XLMRobertaEmbeddings(nn.Module):
         self.token_type_embeddings = nn.Embedding(
             config.type_vocab_size, config.hidden_size
         )
+        # PascalCase matches the HF checkpoint weight key (embeddings.LayerNorm).
         self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
 
     def __call__(self, input_ids: mx.array) -> mx.array:
         pos_ids = roberta_position_ids(input_ids, self.pad_token_id)
         words = self.word_embeddings(input_ids)
         positions = self.position_embeddings(pos_ids)
-        # token_type_ids are all zero (type_vocab_size == 1); add row-0 bias.
-        token_type = self.token_type_embeddings(mx.zeros_like(input_ids))
+        # token_type_ids are all zero (type_vocab_size == 1): embed token-type 0
+        # once as a [1, hidden] row and let it broadcast across batch/sequence,
+        # avoiding a full [batch, seq, hidden] gather.
+        token_type = self.token_type_embeddings(mx.array([0]))
         return self.LayerNorm(words + positions + token_type)

--- a/olmlx/engine/rerank/model.py
+++ b/olmlx/engine/rerank/model.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from olmlx.engine.rerank.config import RerankerConfig
+
+
+def roberta_position_ids(input_ids: mx.array, pad_token_id: int) -> mx.array:
+    """Position ids with the RoBERTa offset.
+
+    Mirrors transformers' ``create_position_ids_from_input_ids``:
+    ``position_ids = cumsum(mask) * mask + pad_token_id`` where
+    ``mask = (input_ids != pad_token_id)``. The first real token therefore
+    gets position ``pad_token_id + 1`` (== 2 for XLM-RoBERTa), which is why
+    the position-embedding table is sized ``max_seq + pad_token_id + 1``.
+    """
+    mask = (input_ids != pad_token_id).astype(mx.int32)
+    incremental = mx.cumsum(mask, axis=1) * mask
+    return incremental + pad_token_id
+
+
+class XLMRobertaEmbeddings(nn.Module):
+    def __init__(self, config: RerankerConfig):
+        super().__init__()
+        self.pad_token_id = config.pad_token_id
+        self.word_embeddings = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.position_embeddings = nn.Embedding(
+            config.max_position_embeddings, config.hidden_size
+        )
+        self.token_type_embeddings = nn.Embedding(
+            config.type_vocab_size, config.hidden_size
+        )
+        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+    def __call__(self, input_ids: mx.array) -> mx.array:
+        pos_ids = roberta_position_ids(input_ids, self.pad_token_id)
+        words = self.word_embeddings(input_ids)
+        positions = self.position_embeddings(pos_ids)
+        # token_type_ids are all zero (type_vocab_size == 1); add row-0 bias.
+        token_type = self.token_type_embeddings(mx.zeros_like(input_ids))
+        return self.LayerNorm(words + positions + token_type)

--- a/olmlx/engine/rerank/weights.py
+++ b/olmlx/engine/rerank/weights.py
@@ -126,7 +126,9 @@ def _load_state_dict(path: str) -> dict[str, mx.array]:
         raise FileNotFoundError(f"no .safetensors weights in {path}")
     sd: dict[str, mx.array] = {}
     for f in files:
-        sd.update(mx.load(f))  # mx.load returns {name: mx.array}
+        loaded = mx.load(f)  # a .safetensors file loads as {name: mx.array}
+        if isinstance(loaded, dict):
+            sd.update(loaded)
     return sd
 
 

--- a/olmlx/engine/rerank/weights.py
+++ b/olmlx/engine/rerank/weights.py
@@ -128,6 +128,14 @@ def load_cross_encoder(path: str) -> XLMRobertaCrossEncoder:
     """Build an XLMRobertaCrossEncoder from a local model directory."""
     with open(os.path.join(path, "config.json")) as fh:
         cfg = RerankerConfig.from_dict(json.load(fh))
+    if cfg.num_labels != 1:
+        # The engine reads a single relevance logit (column 0). Multi-label
+        # heads are out of scope (#369) — fail loudly rather than silently
+        # producing inverted/garbage rankings.
+        raise ValueError(
+            f"reranker has num_labels={cfg.num_labels}; only single-label "
+            "cross-encoders (num_labels == 1) are supported"
+        )
     sd = _load_state_dict(path)
     layout = detect_layout(list(sd.keys()))
     flat = remap_flash(sd, cfg) if layout == "flash" else remap_standard(sd, cfg)

--- a/olmlx/engine/rerank/weights.py
+++ b/olmlx/engine/rerank/weights.py
@@ -6,10 +6,16 @@ import os
 from typing import Any
 
 import mlx.core as mx
-import numpy as np
 
 from olmlx.engine.rerank.config import RerankerConfig
 from olmlx.engine.rerank.model import XLMRobertaCrossEncoder
+
+
+def _to_f32(v: Any) -> mx.array:
+    """Coerce a numpy array or mx.array (any dtype, incl. bfloat16) to an
+    mx.array in float32. Staying in mx avoids numpy, which has no bfloat16
+    dtype and raises on ``np.asarray`` of a bf16 mx.array (jina ships bf16)."""
+    return mx.array(v).astype(mx.float32)
 
 
 def detect_layout(keys: list[str]) -> str:
@@ -76,7 +82,7 @@ def remap_standard(sd: dict[str, Any], cfg: RerankerConfig) -> dict[str, mx.arra
             out[f"{q}output_norm.bias"] = sd[f"{p}output.LayerNorm.bias"]
     except KeyError as exc:
         raise _missing_key_error("standard", exc) from exc
-    return {k: mx.array(np.asarray(v)) for k, v in out.items()}
+    return {k: _to_f32(v) for k, v in out.items()}
 
 
 def remap_flash(sd: dict[str, Any], cfg: RerankerConfig) -> dict[str, mx.array]:
@@ -86,8 +92,8 @@ def remap_flash(sd: dict[str, Any], cfg: RerankerConfig) -> dict[str, mx.array]:
         for i in range(cfg.num_hidden_layers):
             p = f"roberta.encoder.layers.{i}."
             q = f"layers.{i}."
-            wqkv = np.asarray(sd[f"{p}mixer.Wqkv.weight"])
-            bqkv = np.asarray(sd[f"{p}mixer.Wqkv.bias"])
+            wqkv = sd[f"{p}mixer.Wqkv.weight"]
+            bqkv = sd[f"{p}mixer.Wqkv.bias"]
             if wqkv.shape[0] != 3 * h:
                 raise ValueError(
                     f"layer {i}: expected fused Wqkv rows == 3 * hidden_size "
@@ -111,7 +117,7 @@ def remap_flash(sd: dict[str, Any], cfg: RerankerConfig) -> dict[str, mx.array]:
             out[f"{q}output_norm.bias"] = sd[f"{p}norm2.bias"]
     except KeyError as exc:
         raise _missing_key_error("flash", exc) from exc
-    return {k: mx.array(np.asarray(v)) for k, v in out.items()}
+    return {k: _to_f32(v) for k, v in out.items()}
 
 
 def _load_state_dict(path: str) -> dict[str, mx.array]:

--- a/olmlx/engine/rerank/weights.py
+++ b/olmlx/engine/rerank/weights.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import glob
+import json
+import os
+from typing import Any
+
+import mlx.core as mx
+import numpy as np
+
+from olmlx.engine.rerank.config import RerankerConfig
+from olmlx.engine.rerank.model import XLMRobertaCrossEncoder
+
+
+def detect_layout(keys: list[str]) -> str:
+    for k in keys:
+        if "mixer.Wqkv" in k or "emb_ln" in k:
+            return "flash"
+    return "standard"
+
+
+def _emb_and_head(sd: dict[str, Any], emb_ln_prefix: str) -> dict[str, np.ndarray]:
+    e = "roberta.embeddings."
+    return {
+        "embeddings.word_embeddings.weight": sd[f"{e}word_embeddings.weight"],
+        "embeddings.position_embeddings.weight": sd[f"{e}position_embeddings.weight"],
+        "embeddings.token_type_embeddings.weight": sd[
+            f"{e}token_type_embeddings.weight"
+        ],
+        "embeddings.LayerNorm.weight": sd[f"{emb_ln_prefix}.weight"],
+        "embeddings.LayerNorm.bias": sd[f"{emb_ln_prefix}.bias"],
+        "classifier.dense.weight": sd["classifier.dense.weight"],
+        "classifier.dense.bias": sd["classifier.dense.bias"],
+        "classifier.out_proj.weight": sd["classifier.out_proj.weight"],
+        "classifier.out_proj.bias": sd["classifier.out_proj.bias"],
+    }
+
+
+def remap_standard(sd: dict[str, Any], cfg: RerankerConfig) -> dict[str, mx.array]:
+    out = _emb_and_head(sd, "roberta.embeddings.LayerNorm")
+    for i in range(cfg.num_hidden_layers):
+        p = f"roberta.encoder.layer.{i}."
+        q = f"layers.{i}."
+        for proj in ("query", "key", "value"):
+            out[f"{q}attention_self.{proj}.weight"] = sd[
+                f"{p}attention.self.{proj}.weight"
+            ]
+            out[f"{q}attention_self.{proj}.bias"] = sd[f"{p}attention.self.{proj}.bias"]
+        out[f"{q}attention_output_dense.weight"] = sd[
+            f"{p}attention.output.dense.weight"
+        ]
+        out[f"{q}attention_output_dense.bias"] = sd[f"{p}attention.output.dense.bias"]
+        out[f"{q}attention_output_norm.weight"] = sd[
+            f"{p}attention.output.LayerNorm.weight"
+        ]
+        out[f"{q}attention_output_norm.bias"] = sd[
+            f"{p}attention.output.LayerNorm.bias"
+        ]
+        out[f"{q}intermediate_dense.weight"] = sd[f"{p}intermediate.dense.weight"]
+        out[f"{q}intermediate_dense.bias"] = sd[f"{p}intermediate.dense.bias"]
+        out[f"{q}output_dense.weight"] = sd[f"{p}output.dense.weight"]
+        out[f"{q}output_dense.bias"] = sd[f"{p}output.dense.bias"]
+        out[f"{q}output_norm.weight"] = sd[f"{p}output.LayerNorm.weight"]
+        out[f"{q}output_norm.bias"] = sd[f"{p}output.LayerNorm.bias"]
+    return {k: mx.array(np.asarray(v)) for k, v in out.items()}
+
+
+def remap_flash(sd: dict[str, Any], cfg: RerankerConfig) -> dict[str, mx.array]:
+    h = cfg.hidden_size
+    out = _emb_and_head(sd, "roberta.emb_ln")
+    for i in range(cfg.num_hidden_layers):
+        p = f"roberta.encoder.layers.{i}."
+        q = f"layers.{i}."
+        wqkv = np.asarray(sd[f"{p}mixer.Wqkv.weight"])
+        bqkv = np.asarray(sd[f"{p}mixer.Wqkv.bias"])
+        out[f"{q}attention_self.query.weight"] = wqkv[:h]
+        out[f"{q}attention_self.key.weight"] = wqkv[h : 2 * h]
+        out[f"{q}attention_self.value.weight"] = wqkv[2 * h :]
+        out[f"{q}attention_self.query.bias"] = bqkv[:h]
+        out[f"{q}attention_self.key.bias"] = bqkv[h : 2 * h]
+        out[f"{q}attention_self.value.bias"] = bqkv[2 * h :]
+        out[f"{q}attention_output_dense.weight"] = sd[f"{p}mixer.out_proj.weight"]
+        out[f"{q}attention_output_dense.bias"] = sd[f"{p}mixer.out_proj.bias"]
+        out[f"{q}attention_output_norm.weight"] = sd[f"{p}norm1.weight"]
+        out[f"{q}attention_output_norm.bias"] = sd[f"{p}norm1.bias"]
+        out[f"{q}intermediate_dense.weight"] = sd[f"{p}mlp.fc1.weight"]
+        out[f"{q}intermediate_dense.bias"] = sd[f"{p}mlp.fc1.bias"]
+        out[f"{q}output_dense.weight"] = sd[f"{p}mlp.fc2.weight"]
+        out[f"{q}output_dense.bias"] = sd[f"{p}mlp.fc2.bias"]
+        out[f"{q}output_norm.weight"] = sd[f"{p}norm2.weight"]
+        out[f"{q}output_norm.bias"] = sd[f"{p}norm2.bias"]
+    return {k: mx.array(np.asarray(v)) for k, v in out.items()}
+
+
+def _load_state_dict(path: str) -> dict[str, mx.array]:
+    files = sorted(glob.glob(os.path.join(path, "*.safetensors")))
+    if not files:
+        raise FileNotFoundError(f"no .safetensors weights in {path}")
+    sd: dict[str, mx.array] = {}
+    for f in files:
+        sd.update(mx.load(f))  # mx.load returns {name: mx.array}
+    return sd
+
+
+def load_cross_encoder(path: str) -> XLMRobertaCrossEncoder:
+    """Build an XLMRobertaCrossEncoder from a local model directory."""
+    with open(os.path.join(path, "config.json")) as fh:
+        cfg = RerankerConfig.from_dict(json.load(fh))
+    sd = _load_state_dict(path)
+    layout = detect_layout(list(sd.keys()))
+    flat = remap_flash(sd, cfg) if layout == "flash" else remap_standard(sd, cfg)
+    model = XLMRobertaCrossEncoder(cfg)
+    model.load_weights(list(flat.items()))
+    model.eval()
+    mx.eval(model.parameters())
+    return model

--- a/olmlx/engine/rerank/weights.py
+++ b/olmlx/engine/rerank/weights.py
@@ -19,7 +19,7 @@ def detect_layout(keys: list[str]) -> str:
     return "standard"
 
 
-def _emb_and_head(sd: dict[str, Any], emb_ln_prefix: str) -> dict[str, np.ndarray]:
+def _emb_and_head(sd: dict[str, Any], emb_ln_prefix: str) -> dict[str, Any]:
     e = "roberta.embeddings."
     return {
         "embeddings.word_embeddings.weight": sd[f"{e}word_embeddings.weight"],
@@ -36,59 +36,81 @@ def _emb_and_head(sd: dict[str, Any], emb_ln_prefix: str) -> dict[str, np.ndarra
     }
 
 
+def _missing_key_error(layout: str, exc: KeyError) -> KeyError:
+    return KeyError(
+        f"{layout}-layout checkpoint is missing expected key {exc} "
+        "(was the wrong layout detected?)"
+    )
+
+
 def remap_standard(sd: dict[str, Any], cfg: RerankerConfig) -> dict[str, mx.array]:
-    out = _emb_and_head(sd, "roberta.embeddings.LayerNorm")
-    for i in range(cfg.num_hidden_layers):
-        p = f"roberta.encoder.layer.{i}."
-        q = f"layers.{i}."
-        for proj in ("query", "key", "value"):
-            out[f"{q}attention_self.{proj}.weight"] = sd[
-                f"{p}attention.self.{proj}.weight"
+    try:
+        out = _emb_and_head(sd, "roberta.embeddings.LayerNorm")
+        for i in range(cfg.num_hidden_layers):
+            p = f"roberta.encoder.layer.{i}."
+            q = f"layers.{i}."
+            for proj in ("query", "key", "value"):
+                out[f"{q}attention_self.{proj}.weight"] = sd[
+                    f"{p}attention.self.{proj}.weight"
+                ]
+                out[f"{q}attention_self.{proj}.bias"] = sd[
+                    f"{p}attention.self.{proj}.bias"
+                ]
+            out[f"{q}attention_output_dense.weight"] = sd[
+                f"{p}attention.output.dense.weight"
             ]
-            out[f"{q}attention_self.{proj}.bias"] = sd[f"{p}attention.self.{proj}.bias"]
-        out[f"{q}attention_output_dense.weight"] = sd[
-            f"{p}attention.output.dense.weight"
-        ]
-        out[f"{q}attention_output_dense.bias"] = sd[f"{p}attention.output.dense.bias"]
-        out[f"{q}attention_output_norm.weight"] = sd[
-            f"{p}attention.output.LayerNorm.weight"
-        ]
-        out[f"{q}attention_output_norm.bias"] = sd[
-            f"{p}attention.output.LayerNorm.bias"
-        ]
-        out[f"{q}intermediate_dense.weight"] = sd[f"{p}intermediate.dense.weight"]
-        out[f"{q}intermediate_dense.bias"] = sd[f"{p}intermediate.dense.bias"]
-        out[f"{q}output_dense.weight"] = sd[f"{p}output.dense.weight"]
-        out[f"{q}output_dense.bias"] = sd[f"{p}output.dense.bias"]
-        out[f"{q}output_norm.weight"] = sd[f"{p}output.LayerNorm.weight"]
-        out[f"{q}output_norm.bias"] = sd[f"{p}output.LayerNorm.bias"]
+            out[f"{q}attention_output_dense.bias"] = sd[
+                f"{p}attention.output.dense.bias"
+            ]
+            out[f"{q}attention_output_norm.weight"] = sd[
+                f"{p}attention.output.LayerNorm.weight"
+            ]
+            out[f"{q}attention_output_norm.bias"] = sd[
+                f"{p}attention.output.LayerNorm.bias"
+            ]
+            out[f"{q}intermediate_dense.weight"] = sd[f"{p}intermediate.dense.weight"]
+            out[f"{q}intermediate_dense.bias"] = sd[f"{p}intermediate.dense.bias"]
+            out[f"{q}output_dense.weight"] = sd[f"{p}output.dense.weight"]
+            out[f"{q}output_dense.bias"] = sd[f"{p}output.dense.bias"]
+            out[f"{q}output_norm.weight"] = sd[f"{p}output.LayerNorm.weight"]
+            out[f"{q}output_norm.bias"] = sd[f"{p}output.LayerNorm.bias"]
+    except KeyError as exc:
+        raise _missing_key_error("standard", exc) from exc
     return {k: mx.array(np.asarray(v)) for k, v in out.items()}
 
 
 def remap_flash(sd: dict[str, Any], cfg: RerankerConfig) -> dict[str, mx.array]:
     h = cfg.hidden_size
-    out = _emb_and_head(sd, "roberta.emb_ln")
-    for i in range(cfg.num_hidden_layers):
-        p = f"roberta.encoder.layers.{i}."
-        q = f"layers.{i}."
-        wqkv = np.asarray(sd[f"{p}mixer.Wqkv.weight"])
-        bqkv = np.asarray(sd[f"{p}mixer.Wqkv.bias"])
-        out[f"{q}attention_self.query.weight"] = wqkv[:h]
-        out[f"{q}attention_self.key.weight"] = wqkv[h : 2 * h]
-        out[f"{q}attention_self.value.weight"] = wqkv[2 * h :]
-        out[f"{q}attention_self.query.bias"] = bqkv[:h]
-        out[f"{q}attention_self.key.bias"] = bqkv[h : 2 * h]
-        out[f"{q}attention_self.value.bias"] = bqkv[2 * h :]
-        out[f"{q}attention_output_dense.weight"] = sd[f"{p}mixer.out_proj.weight"]
-        out[f"{q}attention_output_dense.bias"] = sd[f"{p}mixer.out_proj.bias"]
-        out[f"{q}attention_output_norm.weight"] = sd[f"{p}norm1.weight"]
-        out[f"{q}attention_output_norm.bias"] = sd[f"{p}norm1.bias"]
-        out[f"{q}intermediate_dense.weight"] = sd[f"{p}mlp.fc1.weight"]
-        out[f"{q}intermediate_dense.bias"] = sd[f"{p}mlp.fc1.bias"]
-        out[f"{q}output_dense.weight"] = sd[f"{p}mlp.fc2.weight"]
-        out[f"{q}output_dense.bias"] = sd[f"{p}mlp.fc2.bias"]
-        out[f"{q}output_norm.weight"] = sd[f"{p}norm2.weight"]
-        out[f"{q}output_norm.bias"] = sd[f"{p}norm2.bias"]
+    try:
+        out = _emb_and_head(sd, "roberta.emb_ln")
+        for i in range(cfg.num_hidden_layers):
+            p = f"roberta.encoder.layers.{i}."
+            q = f"layers.{i}."
+            wqkv = np.asarray(sd[f"{p}mixer.Wqkv.weight"])
+            bqkv = np.asarray(sd[f"{p}mixer.Wqkv.bias"])
+            if wqkv.shape[0] != 3 * h:
+                raise ValueError(
+                    f"layer {i}: expected fused Wqkv rows == 3 * hidden_size "
+                    f"({3 * h}), got {wqkv.shape[0]}"
+                )
+            out[f"{q}attention_self.query.weight"] = wqkv[:h]
+            out[f"{q}attention_self.key.weight"] = wqkv[h : 2 * h]
+            out[f"{q}attention_self.value.weight"] = wqkv[2 * h :]
+            out[f"{q}attention_self.query.bias"] = bqkv[:h]
+            out[f"{q}attention_self.key.bias"] = bqkv[h : 2 * h]
+            out[f"{q}attention_self.value.bias"] = bqkv[2 * h :]
+            out[f"{q}attention_output_dense.weight"] = sd[f"{p}mixer.out_proj.weight"]
+            out[f"{q}attention_output_dense.bias"] = sd[f"{p}mixer.out_proj.bias"]
+            out[f"{q}attention_output_norm.weight"] = sd[f"{p}norm1.weight"]
+            out[f"{q}attention_output_norm.bias"] = sd[f"{p}norm1.bias"]
+            out[f"{q}intermediate_dense.weight"] = sd[f"{p}mlp.fc1.weight"]
+            out[f"{q}intermediate_dense.bias"] = sd[f"{p}mlp.fc1.bias"]
+            out[f"{q}output_dense.weight"] = sd[f"{p}mlp.fc2.weight"]
+            out[f"{q}output_dense.bias"] = sd[f"{p}mlp.fc2.bias"]
+            out[f"{q}output_norm.weight"] = sd[f"{p}norm2.weight"]
+            out[f"{q}output_norm.bias"] = sd[f"{p}norm2.bias"]
+    except KeyError as exc:
+        raise _missing_key_error("flash", exc) from exc
     return {k: mx.array(np.asarray(v)) for k, v in out.items()}
 
 

--- a/olmlx/routers/rerank.py
+++ b/olmlx/routers/rerank.py
@@ -1,0 +1,37 @@
+import uuid
+
+from fastapi import APIRouter, Request
+
+from olmlx.engine.inference import generate_rerank
+from olmlx.schemas.rerank import RerankRequest, RerankResponse, RerankResult
+
+router = APIRouter()
+
+
+async def _rerank(req: RerankRequest, request: Request) -> RerankResponse:
+    manager = request.app.state.model_manager
+    out = await generate_rerank(
+        manager,
+        req.model,
+        req.query,
+        req.documents,
+        top_n=req.top_n,
+        max_tokens_per_doc=req.max_tokens_per_doc,
+        return_documents=req.return_documents,
+        keep_alive=req.keep_alive,
+    )
+    return RerankResponse(
+        id=f"rerank-{uuid.uuid4().hex}",
+        results=[RerankResult(**r) for r in out["results"]],
+        meta={"api_version": {"version": "2"}},
+    )
+
+
+@router.post("/v1/rerank", response_model=RerankResponse)
+async def rerank_v1(req: RerankRequest, request: Request) -> RerankResponse:
+    return await _rerank(req, request)
+
+
+@router.post("/rerank", response_model=RerankResponse)
+async def rerank_alias(req: RerankRequest, request: Request) -> RerankResponse:
+    return await _rerank(req, request)

--- a/olmlx/schemas/rerank.py
+++ b/olmlx/schemas/rerank.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, field_validator
+
+from olmlx.schemas.common import ModelName, validate_non_empty_text_input
+
+
+class RerankRequest(BaseModel):
+    model: ModelName
+    query: str
+    documents: list[str]
+    top_n: int | None = None
+    max_tokens_per_doc: int = 4096
+    return_documents: bool = False
+    keep_alive: int | str | None = None
+
+    @field_validator("query")
+    @classmethod
+    def _query_non_empty(cls, v: str) -> str:
+        validate_non_empty_text_input(v, "query")
+        if not v.strip():
+            raise ValueError("query cannot be blank")
+        return v
+
+    @field_validator("documents")
+    @classmethod
+    def _documents_non_empty(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("documents must be a non-empty list")
+        return v
+
+    @field_validator("top_n")
+    @classmethod
+    def _top_n_positive(cls, v: int | None) -> int | None:
+        if v is not None and v <= 0:
+            raise ValueError("top_n must be a positive integer")
+        return v
+
+
+class RerankResult(BaseModel):
+    index: int
+    relevance_score: float
+    document: str | None = None
+
+
+class RerankResponse(BaseModel):
+    id: str
+    results: list[RerankResult]
+    meta: dict = {}

--- a/olmlx/schemas/rerank.py
+++ b/olmlx/schemas/rerank.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, field_validator
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
 
 from olmlx.schemas.common import ModelName, validate_non_empty_text_input
 
@@ -10,28 +12,27 @@ class RerankRequest(BaseModel):
     query: str
     documents: list[str]
     top_n: int | None = None
-    max_tokens_per_doc: int = 4096
+    max_tokens_per_doc: int = Field(default=4096, gt=0)
     return_documents: bool = False
     keep_alive: int | str | None = None
 
     @field_validator("query")
     @classmethod
-    def _query_non_empty(cls, v: str) -> str:
-        validate_non_empty_text_input(v, "query")
+    def validate_query_non_empty(cls, v: str) -> str:
+        # Reject empty and whitespace-only queries (a blank query can't rank).
         if not v.strip():
-            raise ValueError("query cannot be blank")
+            raise ValueError("query cannot be empty or blank")
         return v
 
     @field_validator("documents")
     @classmethod
-    def _documents_non_empty(cls, v: list[str]) -> list[str]:
-        if not v:
-            raise ValueError("documents must be a non-empty list")
-        return v
+    def validate_documents_non_empty(cls, v: list[str]) -> list[str]:
+        # Rejects an empty list or any empty-string document (matches embed).
+        return validate_non_empty_text_input(v, "documents")
 
     @field_validator("top_n")
     @classmethod
-    def _top_n_positive(cls, v: int | None) -> int | None:
+    def validate_top_n_positive(cls, v: int | None) -> int | None:
         if v is not None and v <= 0:
             raise ValueError("top_n must be a positive integer")
         return v
@@ -46,4 +47,4 @@ class RerankResult(BaseModel):
 class RerankResponse(BaseModel):
     id: str
     results: list[RerankResult]
-    meta: dict = {}
+    meta: dict[str, Any] = {}

--- a/tests/live/test_rerank_real.py
+++ b/tests/live/test_rerank_real.py
@@ -21,7 +21,7 @@ JINA = "jinaai/jina-reranker-v2-base-multilingual"
 def _local_dir_or_skip(repo: str) -> str:
     """Return the local snapshot dir for an already-cached repo, else skip."""
     from huggingface_hub import snapshot_download
-    from huggingface_hub.utils import LocalEntryNotFoundError
+    from huggingface_hub.errors import LocalEntryNotFoundError
 
     try:
         return snapshot_download(repo, local_files_only=True)

--- a/tests/live/test_rerank_real.py
+++ b/tests/live/test_rerank_real.py
@@ -25,7 +25,7 @@ def _local_dir_or_skip(repo: str) -> str:
 
     try:
         return snapshot_download(repo, local_files_only=True)
-    except (LocalEntryNotFoundError, FileNotFoundError, OSError):
+    except LocalEntryNotFoundError:
         pytest.skip(f"{repo} not downloaded; skipping live rerank test")
 
 
@@ -33,11 +33,14 @@ def _safetensors_keys(path: str) -> list[str]:
     import glob
     import os
 
-    import mlx.core as mx
+    from safetensors import safe_open
 
+    # Header-only read — avoids materializing ~2.3 GB of weights just to
+    # inspect the key names for layout detection.
     keys: list[str] = []
     for f in sorted(glob.glob(os.path.join(path, "*.safetensors"))):
-        keys.extend(mx.load(f).keys())
+        with safe_open(f, framework="numpy") as st:
+            keys.extend(st.keys())
     return keys
 
 
@@ -76,6 +79,9 @@ def test_load_and_rank(repo):
 
 
 def test_batch_of_100_documents():
+    # Throughput / no-crash check: scores a 100-doc batch (multiple internal
+    # micro-batches) and confirms the count and that scores are valid
+    # probabilities. Not a ranking-quality assertion.
     from transformers import AutoTokenizer
 
     from olmlx.engine.inference import _score_pairs

--- a/tests/live/test_rerank_real.py
+++ b/tests/live/test_rerank_real.py
@@ -1,0 +1,125 @@
+"""Live cross-encoder rerank tests against real models (#369).
+
+Covers BOTH target checkpoint layouts:
+  * BAAI/bge-reranker-v2-m3            -> standard XLM-RoBERTa key layout
+  * jinaai/jina-reranker-v2-base-multilingual -> flash (fused-Wqkv) layout
+
+This is the validation gate for remap_flash: it asserts jina's real checkpoint
+keys match the layout our weight loader infers. Skips cleanly when a model is
+not already downloaded (no forced multi-GB pull). Lives outside
+tests/integration/ to avoid that package's autouse MLX mock.
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.real_model]
+
+BGE = "BAAI/bge-reranker-v2-m3"
+JINA = "jinaai/jina-reranker-v2-base-multilingual"
+
+
+def _local_dir_or_skip(repo: str) -> str:
+    """Return the local snapshot dir for an already-cached repo, else skip."""
+    from huggingface_hub import snapshot_download
+    from huggingface_hub.utils import LocalEntryNotFoundError
+
+    try:
+        return snapshot_download(repo, local_files_only=True)
+    except (LocalEntryNotFoundError, FileNotFoundError, OSError):
+        pytest.skip(f"{repo} not downloaded; skipping live rerank test")
+
+
+def _safetensors_keys(path: str) -> list[str]:
+    import glob
+    import os
+
+    import mlx.core as mx
+
+    keys: list[str] = []
+    for f in sorted(glob.glob(os.path.join(path, "*.safetensors"))):
+        keys.extend(mx.load(f).keys())
+    return keys
+
+
+@pytest.mark.parametrize("repo,expected", [(BGE, "standard"), (JINA, "flash")])
+def test_checkpoint_layout_matches_expectation(repo, expected):
+    from olmlx.engine.rerank.weights import detect_layout
+
+    path = _local_dir_or_skip(repo)
+    keys = _safetensors_keys(path)
+    got = detect_layout(keys)
+    assert got == expected, f"{repo}: detected {got}; sample keys: {keys[:8]}"
+
+
+@pytest.mark.parametrize("repo", [BGE, JINA])
+def test_load_and_rank(repo):
+    from transformers import AutoTokenizer
+
+    from olmlx.engine.inference import _build_rerank_results, _score_pairs
+    from olmlx.engine.rerank.weights import load_cross_encoder
+
+    path = _local_dir_or_skip(repo)
+    model = load_cross_encoder(path)
+    tok = AutoTokenizer.from_pretrained(path)
+
+    query = "What is the capital of France?"
+    docs = [
+        "The capital of France is Paris.",
+        "Bananas are a good source of potassium.",
+    ]
+    scores = _score_pairs(model, tok, query, docs, max_tokens_per_doc=512)
+    results = _build_rerank_results(
+        scores=scores, documents=docs, top_n=None, return_documents=False
+    )
+    assert results[0]["index"] == 0  # the relevant doc ranks first
+    assert scores[0] > scores[1]
+
+
+def test_batch_of_100_documents():
+    from transformers import AutoTokenizer
+
+    from olmlx.engine.inference import _score_pairs
+    from olmlx.engine.rerank.weights import load_cross_encoder
+
+    path = _local_dir_or_skip(BGE)
+    model = load_cross_encoder(path)
+    tok = AutoTokenizer.from_pretrained(path)
+    docs = [f"document number {i} about various topics" for i in range(100)]
+    scores = _score_pairs(
+        model, tok, "find the relevant document", docs, max_tokens_per_doc=256
+    )
+    assert len(scores) == 100
+    assert all(0.0 <= s <= 1.0 for s in scores)
+
+
+def test_parity_against_transformers_reference():
+    pytest.importorskip("torch")
+    import numpy as np
+    import torch
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+    from olmlx.engine.inference import _score_pairs
+    from olmlx.engine.rerank.weights import load_cross_encoder
+
+    path = _local_dir_or_skip(BGE)
+    tok = AutoTokenizer.from_pretrained(path)
+    query = "What is MLX?"
+    docs = ["MLX is an array framework for Apple silicon.", "I like sandwiches."]
+
+    ours = _score_pairs(
+        load_cross_encoder(path), tok, query, docs, max_tokens_per_doc=512
+    )
+
+    ref_model = AutoModelForSequenceClassification.from_pretrained(path).eval()
+    with torch.no_grad():
+        enc = tok(
+            [query, query],
+            docs,
+            padding=True,
+            truncation="only_second",
+            max_length=512,
+            return_tensors="pt",
+        )
+        ref = torch.sigmoid(ref_model(**enc).logits.squeeze(-1)).tolist()
+
+    assert np.allclose(np.array(ours), np.array(ref), atol=1e-2), (ours, ref)

--- a/tests/test_rerank_engine.py
+++ b/tests/test_rerank_engine.py
@@ -4,13 +4,16 @@ from olmlx.engine.inference import _build_rerank_results, _score_pairs
 
 
 class _FakeTokenizer:
-    model_max_length = 512
+    def __init__(self, model_max_length=512):
+        self.model_max_length = model_max_length
+        self.seen_max_length = None
 
     def __call__(
         self, query, documents, truncation, max_length, padding, return_tensors=None
     ):
         import numpy as np
 
+        self.seen_max_length = max_length
         n = len(documents)
         ids = np.ones((n, 4), dtype=np.int64) * 5
         mask = np.ones((n, 4), dtype=np.int64)
@@ -44,6 +47,35 @@ def test_score_pairs_sigmoid_and_order():
     assert all(0.0 <= s <= 1.0 for s in scores)
 
 
+def test_score_pairs_multi_batch_preserves_order():
+    # 5 docs with batch_size=2 spans 3 batches; scores must stay in doc order.
+    model = _FakeModel([3.0, -3.0, 1.0, -1.0, 0.0])
+    scores = _score_pairs(
+        model,
+        _FakeTokenizer(),
+        "q",
+        ["a", "b", "c", "d", "e"],
+        max_tokens_per_doc=256,
+        batch_size=2,
+    )
+    assert len(scores) == 5
+    assert model.calls == 5
+    # Monotonic in the input logits: 3 > 1 > 0 > -1 > -3.
+    assert scores[0] > scores[2] > scores[4] > scores[3] > scores[1]
+
+
+def test_score_pairs_clamps_sentinel_model_max_length():
+    # transformers reports a huge sentinel; max_length must clamp to 512, then
+    # be further bounded by max_tokens_per_doc.
+    tok = _FakeTokenizer(model_max_length=1_000_000_019)
+    _score_pairs(_FakeModel([0.0]), tok, "q", ["a"], max_tokens_per_doc=4096)
+    assert tok.seen_max_length == 512
+
+    tok2 = _FakeTokenizer(model_max_length=512)
+    _score_pairs(_FakeModel([0.0]), tok2, "q", ["a"], max_tokens_per_doc=128)
+    assert tok2.seen_max_length == 128
+
+
 def test_build_rerank_results_top_n_and_sort():
     results = _build_rerank_results(
         scores=[0.1, 0.9, 0.5],
@@ -53,7 +85,7 @@ def test_build_rerank_results_top_n_and_sort():
     )
     assert [r["index"] for r in results] == [1, 2]
     assert results[0]["relevance_score"] == 0.9
-    assert "document" not in results[0] or results[0]["document"] is None
+    assert "document" not in results[0]
 
 
 def test_build_rerank_results_return_documents():

--- a/tests/test_rerank_engine.py
+++ b/tests/test_rerank_engine.py
@@ -1,0 +1,76 @@
+import mlx.core as mx
+
+from olmlx.engine.inference import _build_rerank_results, _score_pairs
+
+
+class _FakeTokenizer:
+    model_max_length = 512
+
+    def __call__(
+        self, query, documents, truncation, max_length, padding, return_tensors=None
+    ):
+        import numpy as np
+
+        n = len(documents)
+        ids = np.ones((n, 4), dtype=np.int64) * 5
+        mask = np.ones((n, 4), dtype=np.int64)
+        return {"input_ids": ids, "attention_mask": mask}
+
+
+class _FakeModel:
+    def __init__(self, scores):
+        self._scores = scores
+        self.calls = 0
+
+    def __call__(self, input_ids, attention_mask):
+        b = input_ids.shape[0]
+        out = self._scores[self.calls : self.calls + b]
+        self.calls += b
+        return mx.array(out).reshape(b, 1)
+
+
+def test_score_pairs_sigmoid_and_order():
+    model = _FakeModel([2.0, -2.0, 0.0])
+    scores = _score_pairs(
+        model,
+        _FakeTokenizer(),
+        "q",
+        ["a", "b", "c"],
+        max_tokens_per_doc=256,
+        batch_size=8,
+    )
+    assert len(scores) == 3
+    assert scores[0] > scores[2] > scores[1]
+    assert all(0.0 <= s <= 1.0 for s in scores)
+
+
+def test_build_rerank_results_top_n_and_sort():
+    results = _build_rerank_results(
+        scores=[0.1, 0.9, 0.5],
+        documents=["a", "b", "c"],
+        top_n=2,
+        return_documents=False,
+    )
+    assert [r["index"] for r in results] == [1, 2]
+    assert results[0]["relevance_score"] == 0.9
+    assert "document" not in results[0] or results[0]["document"] is None
+
+
+def test_build_rerank_results_return_documents():
+    results = _build_rerank_results(
+        scores=[0.1, 0.9],
+        documents=["a", "b"],
+        top_n=None,
+        return_documents=True,
+    )
+    assert results[0]["document"] == "b"
+
+
+def test_build_rerank_results_top_n_clamped():
+    results = _build_rerank_results(
+        scores=[0.1, 0.9],
+        documents=["a", "b"],
+        top_n=10,
+        return_documents=False,
+    )
+    assert len(results) == 2

--- a/tests/test_rerank_load.py
+++ b/tests/test_rerank_load.py
@@ -1,0 +1,50 @@
+import pytest
+
+from olmlx.engine.model_manager import LoadedModel, ModelManager
+
+
+@pytest.mark.asyncio
+async def test_probe_cache_capabilities_skips_reranker(registry):
+    # A reranker has no LLM prompt cache; the probe must early-return without
+    # touching mlx-lm's make_prompt_cache and must leave persistence off.
+    mgr = ModelManager(registry)
+    lm = LoadedModel(
+        name="bge",
+        hf_path="bge",
+        model=object(),
+        tokenizer=object(),
+        is_reranker=True,
+    )
+    await mgr._probe_cache_capabilities(lm)  # must not raise
+    assert lm.supports_cache_persistence is False
+    assert lm.uses_checkpoint_persistence is False
+
+
+def test_load_model_reranker_branch(registry, monkeypatch, tmp_path):
+    # The reranker branch builds the encoder via load_cross_encoder and the
+    # tokenizer via transformers.AutoTokenizer, returning the standard
+    # (model, tokenizer, is_vlm=False, caps, decoder=None) tuple.
+    import olmlx.engine.model_manager as mm
+
+    sentinel_model = object()
+    sentinel_tok = object()
+
+    monkeypatch.setattr(
+        mm.ModelManager, "_detect_model_kind", lambda self, hf: "reranker"
+    )
+    monkeypatch.setattr(
+        "olmlx.engine.rerank.load_cross_encoder", lambda path: sentinel_model
+    )
+    import transformers
+
+    monkeypatch.setattr(
+        transformers.AutoTokenizer, "from_pretrained", lambda path, **kw: sentinel_tok
+    )
+
+    mgr = ModelManager(registry)
+    model, tokenizer, is_vlm, caps, decoder = mgr._load_model(str(tmp_path))
+
+    assert model is sentinel_model
+    assert tokenizer is sentinel_tok
+    assert is_vlm is False
+    assert decoder is None

--- a/tests/test_rerank_load.py
+++ b/tests/test_rerank_load.py
@@ -1,12 +1,14 @@
-import pytest
+from unittest.mock import patch
 
 from olmlx.engine.model_manager import LoadedModel, ModelManager
 
 
-@pytest.mark.asyncio
 async def test_probe_cache_capabilities_skips_reranker(registry):
-    # A reranker has no LLM prompt cache; the probe must early-return without
-    # touching mlx-lm's make_prompt_cache and must leave persistence off.
+    # A reranker has no LLM prompt cache; the probe must early-return BEFORE
+    # touching mlx-lm's make_prompt_cache, and leave persistence off. Patching
+    # make_prompt_cache and asserting it's never called proves the guard
+    # short-circuited the body (the persistence flags default to False, so they
+    # alone wouldn't catch a regression that ran the probe).
     mgr = ModelManager(registry)
     lm = LoadedModel(
         name="bge",
@@ -15,7 +17,9 @@ async def test_probe_cache_capabilities_skips_reranker(registry):
         tokenizer=object(),
         is_reranker=True,
     )
-    await mgr._probe_cache_capabilities(lm)  # must not raise
+    with patch("mlx_lm.models.cache.make_prompt_cache") as mock_make:
+        await mgr._probe_cache_capabilities(lm)  # must not raise
+    mock_make.assert_not_called()
     assert lm.supports_cache_persistence is False
     assert lm.uses_checkpoint_persistence is False
 

--- a/tests/test_rerank_manager.py
+++ b/tests/test_rerank_manager.py
@@ -1,0 +1,30 @@
+from olmlx.engine.model_manager import LoadedModel, _is_cross_encoder_config
+
+
+def test_is_cross_encoder_config_true_for_sequence_classification():
+    cfg = {
+        "architectures": ["XLMRobertaForSequenceClassification"],
+        "model_type": "xlm-roberta",
+    }
+    assert _is_cross_encoder_config(cfg) is True
+
+
+def test_is_cross_encoder_config_false_for_plain_lm():
+    cfg = {"architectures": ["Qwen2ForCausalLM"], "model_type": "qwen2"}
+    assert _is_cross_encoder_config(cfg) is False
+
+
+def test_is_cross_encoder_config_false_when_no_architectures():
+    assert _is_cross_encoder_config({"model_type": "bert"}) is False
+
+
+def test_loaded_model_is_reranker_field_defaults_false():
+    lm = LoadedModel(name="m", hf_path="m", model=object(), tokenizer=object())
+    assert lm.is_reranker is False
+
+
+def test_loaded_model_accepts_is_reranker():
+    lm = LoadedModel(
+        name="bge", hf_path="bge", model=object(), tokenizer=object(), is_reranker=True
+    )
+    assert lm.is_reranker is True

--- a/tests/test_rerank_manager.py
+++ b/tests/test_rerank_manager.py
@@ -18,6 +18,18 @@ def test_is_cross_encoder_config_false_when_no_architectures():
     assert _is_cross_encoder_config({"model_type": "bert"}) is False
 
 
+def test_is_cross_encoder_config_false_for_non_roberta_classifier():
+    # A plain BERT/DistilBERT text classifier ends in ForSequenceClassification
+    # but is NOT a supported reranker — the encoder only handles XLM-RoBERTa.
+    cfg = {"architectures": ["BertForSequenceClassification"], "model_type": "bert"}
+    assert _is_cross_encoder_config(cfg) is False
+
+
+def test_is_cross_encoder_config_true_for_roberta_family():
+    cfg = {"architectures": ["RobertaForSequenceClassification"], "model_type": "roberta"}
+    assert _is_cross_encoder_config(cfg) is True
+
+
 def test_loaded_model_is_reranker_field_defaults_false():
     lm = LoadedModel(name="m", hf_path="m", model=object(), tokenizer=object())
     assert lm.is_reranker is False

--- a/tests/test_rerank_manager.py
+++ b/tests/test_rerank_manager.py
@@ -26,7 +26,10 @@ def test_is_cross_encoder_config_false_for_non_roberta_classifier():
 
 
 def test_is_cross_encoder_config_true_for_roberta_family():
-    cfg = {"architectures": ["RobertaForSequenceClassification"], "model_type": "roberta"}
+    cfg = {
+        "architectures": ["RobertaForSequenceClassification"],
+        "model_type": "roberta",
+    }
     assert _is_cross_encoder_config(cfg) is True
 
 

--- a/tests/test_rerank_model.py
+++ b/tests/test_rerank_model.py
@@ -229,6 +229,52 @@ def test_remap_flash_splits_fused_qkv():
     mx.eval(model.parameters())
 
 
+def test_remap_flash_handles_bfloat16_weights():
+    # jina-reranker-v2 ships bfloat16 weights; mx.load returns bf16 mx.arrays.
+    # numpy has no bf16 dtype, so the remap must stay in mx-land (not route
+    # through np.asarray) and cast to float32 for uniform compute. Regression
+    # for the live-test crash on the real jina checkpoint.
+    cfg = _tiny_config()
+    h = cfg.hidden_size
+
+    def bf16(*shape):
+        return mx.zeros(shape, dtype=mx.bfloat16)
+
+    sd = {
+        "roberta.embeddings.word_embeddings.weight": bf16(cfg.vocab_size, h),
+        "roberta.embeddings.position_embeddings.weight": bf16(
+            cfg.max_position_embeddings, h
+        ),
+        "roberta.embeddings.token_type_embeddings.weight": bf16(cfg.type_vocab_size, h),
+        "roberta.emb_ln.weight": bf16(h),
+        "roberta.emb_ln.bias": bf16(h),
+        "classifier.dense.weight": bf16(h, h),
+        "classifier.dense.bias": bf16(h),
+        "classifier.out_proj.weight": bf16(1, h),
+        "classifier.out_proj.bias": bf16(1),
+    }
+    for i in range(cfg.num_hidden_layers):
+        p = f"roberta.encoder.layers.{i}."
+        sd[f"{p}mixer.Wqkv.weight"] = bf16(3 * h, h)
+        sd[f"{p}mixer.Wqkv.bias"] = bf16(3 * h)
+        sd[f"{p}mixer.out_proj.weight"] = bf16(h, h)
+        sd[f"{p}mixer.out_proj.bias"] = bf16(h)
+        sd[f"{p}norm1.weight"] = bf16(h)
+        sd[f"{p}norm1.bias"] = bf16(h)
+        sd[f"{p}mlp.fc1.weight"] = bf16(cfg.intermediate_size, h)
+        sd[f"{p}mlp.fc1.bias"] = bf16(cfg.intermediate_size)
+        sd[f"{p}mlp.fc2.weight"] = bf16(h, cfg.intermediate_size)
+        sd[f"{p}mlp.fc2.bias"] = bf16(h)
+        sd[f"{p}norm2.weight"] = bf16(h)
+        sd[f"{p}norm2.bias"] = bf16(h)
+    flat = remap_flash(sd, cfg)  # must not raise on bf16
+    # Weights are upcast to float32 for uniform compute.
+    assert flat["layers.0.attention_self.query.weight"].dtype == mx.float32
+    model = XLMRobertaCrossEncoder(cfg)
+    model.load_weights(list(flat.items()))
+    mx.eval(model.parameters())
+
+
 def test_load_cross_encoder_rejects_multilabel(tmp_path):
     import json
 

--- a/tests/test_rerank_model.py
+++ b/tests/test_rerank_model.py
@@ -27,6 +27,7 @@ def test_rerankerconfig_from_dict_bge():
     assert cfg.pad_token_id == 1
     assert cfg.num_labels == 1
     assert cfg.head_dim == 64
+    assert cfg.hidden_act == "gelu"
 
 
 def test_rerankerconfig_num_labels_from_num_labels_key():
@@ -45,3 +46,4 @@ def test_rerankerconfig_num_labels_from_num_labels_key():
     cfg = RerankerConfig.from_dict(raw)
     assert cfg.num_labels == 1
     assert cfg.head_dim == 64
+    assert cfg.hidden_act == "gelu"  # default applied when key absent

--- a/tests/test_rerank_model.py
+++ b/tests/test_rerank_model.py
@@ -1,4 +1,5 @@
 import mlx.core as mx
+import numpy as np
 
 from olmlx.engine.rerank.config import RerankerConfig
 from olmlx.engine.rerank.model import (
@@ -6,6 +7,7 @@ from olmlx.engine.rerank.model import (
     XLMRobertaEmbeddings,
     roberta_position_ids,
 )
+from olmlx.engine.rerank.weights import detect_layout, remap_flash, remap_standard
 
 
 def test_rerankerconfig_from_dict_bge():
@@ -118,3 +120,108 @@ def test_cross_encoder_padding_invariance():
     b = model(padded_ids, padded_mask)
     mx.eval(a, b)
     assert abs(float(a[0, 0]) - float(b[0, 0])) < 1e-5
+
+
+def test_detect_layout():
+    assert (
+        detect_layout(["roberta.encoder.layer.0.attention.self.query.weight"])
+        == "standard"
+    )
+    assert detect_layout(["roberta.encoder.layers.0.mixer.Wqkv.weight"]) == "flash"
+    assert detect_layout(["roberta.emb_ln.weight"]) == "flash"
+
+
+def test_remap_standard_keys():
+    cfg = _tiny_config()
+    h = cfg.hidden_size
+    sd = {
+        "roberta.embeddings.word_embeddings.weight": np.zeros(
+            (cfg.vocab_size, h), np.float32
+        ),
+        "roberta.embeddings.position_embeddings.weight": np.zeros(
+            (cfg.max_position_embeddings, h), np.float32
+        ),
+        "roberta.embeddings.token_type_embeddings.weight": np.zeros(
+            (cfg.type_vocab_size, h), np.float32
+        ),
+        "roberta.embeddings.LayerNorm.weight": np.ones((h,), np.float32),
+        "roberta.embeddings.LayerNorm.bias": np.zeros((h,), np.float32),
+        "classifier.dense.weight": np.zeros((h, h), np.float32),
+        "classifier.dense.bias": np.zeros((h,), np.float32),
+        "classifier.out_proj.weight": np.zeros((1, h), np.float32),
+        "classifier.out_proj.bias": np.zeros((1,), np.float32),
+    }
+    for i in range(cfg.num_hidden_layers):
+        p = f"roberta.encoder.layer.{i}."
+        for proj in ("query", "key", "value"):
+            sd[f"{p}attention.self.{proj}.weight"] = np.zeros((h, h), np.float32)
+            sd[f"{p}attention.self.{proj}.bias"] = np.zeros((h,), np.float32)
+        sd[f"{p}attention.output.dense.weight"] = np.zeros((h, h), np.float32)
+        sd[f"{p}attention.output.dense.bias"] = np.zeros((h,), np.float32)
+        sd[f"{p}attention.output.LayerNorm.weight"] = np.ones((h,), np.float32)
+        sd[f"{p}attention.output.LayerNorm.bias"] = np.zeros((h,), np.float32)
+        sd[f"{p}intermediate.dense.weight"] = np.zeros(
+            (cfg.intermediate_size, h), np.float32
+        )
+        sd[f"{p}intermediate.dense.bias"] = np.zeros(
+            (cfg.intermediate_size,), np.float32
+        )
+        sd[f"{p}output.dense.weight"] = np.zeros((h, cfg.intermediate_size), np.float32)
+        sd[f"{p}output.dense.bias"] = np.zeros((h,), np.float32)
+        sd[f"{p}output.LayerNorm.weight"] = np.ones((h,), np.float32)
+        sd[f"{p}output.LayerNorm.bias"] = np.zeros((h,), np.float32)
+    flat = remap_standard(sd, cfg)
+    model = XLMRobertaCrossEncoder(cfg)
+    model.load_weights(list(flat.items()))  # raises if any key/shape mismatches
+    mx.eval(model.parameters())
+
+
+def test_remap_flash_splits_fused_qkv():
+    cfg = _tiny_config()
+    h = cfg.hidden_size
+    # Fused QKV: rows [q | k | v] each h.
+    wqkv = np.arange(3 * h * h, dtype=np.float32).reshape(3 * h, h)
+    bqkv = np.arange(3 * h, dtype=np.float32)
+    sd = {
+        "roberta.embeddings.word_embeddings.weight": np.zeros(
+            (cfg.vocab_size, h), np.float32
+        ),
+        "roberta.embeddings.position_embeddings.weight": np.zeros(
+            (cfg.max_position_embeddings, h), np.float32
+        ),
+        "roberta.embeddings.token_type_embeddings.weight": np.zeros(
+            (cfg.type_vocab_size, h), np.float32
+        ),
+        "roberta.emb_ln.weight": np.ones((h,), np.float32),
+        "roberta.emb_ln.bias": np.zeros((h,), np.float32),
+        "classifier.dense.weight": np.zeros((h, h), np.float32),
+        "classifier.dense.bias": np.zeros((h,), np.float32),
+        "classifier.out_proj.weight": np.zeros((1, h), np.float32),
+        "classifier.out_proj.bias": np.zeros((1,), np.float32),
+    }
+    for i in range(cfg.num_hidden_layers):
+        p = f"roberta.encoder.layers.{i}."
+        sd[f"{p}mixer.Wqkv.weight"] = wqkv.copy()
+        sd[f"{p}mixer.Wqkv.bias"] = bqkv.copy()
+        sd[f"{p}mixer.out_proj.weight"] = np.zeros((h, h), np.float32)
+        sd[f"{p}mixer.out_proj.bias"] = np.zeros((h,), np.float32)
+        sd[f"{p}norm1.weight"] = np.ones((h,), np.float32)
+        sd[f"{p}norm1.bias"] = np.zeros((h,), np.float32)
+        sd[f"{p}mlp.fc1.weight"] = np.zeros((cfg.intermediate_size, h), np.float32)
+        sd[f"{p}mlp.fc1.bias"] = np.zeros((cfg.intermediate_size,), np.float32)
+        sd[f"{p}mlp.fc2.weight"] = np.zeros((h, cfg.intermediate_size), np.float32)
+        sd[f"{p}mlp.fc2.bias"] = np.zeros((h,), np.float32)
+        sd[f"{p}norm2.weight"] = np.ones((h,), np.float32)
+        sd[f"{p}norm2.bias"] = np.zeros((h,), np.float32)
+    flat = remap_flash(sd, cfg)
+    # Q slice is the first h rows of the fused matrix.
+    assert np.allclose(np.array(flat["layers.0.attention_self.query.weight"]), wqkv[:h])
+    assert np.allclose(
+        np.array(flat["layers.0.attention_self.key.weight"]), wqkv[h : 2 * h]
+    )
+    assert np.allclose(
+        np.array(flat["layers.0.attention_self.value.weight"]), wqkv[2 * h :]
+    )
+    model = XLMRobertaCrossEncoder(cfg)
+    model.load_weights(list(flat.items()))
+    mx.eval(model.parameters())

--- a/tests/test_rerank_model.py
+++ b/tests/test_rerank_model.py
@@ -227,3 +227,32 @@ def test_remap_flash_splits_fused_qkv():
     model = XLMRobertaCrossEncoder(cfg)
     model.load_weights(list(flat.items()))
     mx.eval(model.parameters())
+
+
+def test_load_cross_encoder_rejects_multilabel(tmp_path):
+    import json
+
+    import pytest
+
+    from olmlx.engine.rerank.weights import load_cross_encoder
+
+    # num_labels=2 is out of scope (#369); load must fail loudly before reading
+    # any weights.
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "architectures": ["XLMRobertaForSequenceClassification"],
+                "hidden_size": 16,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 2,
+                "intermediate_size": 32,
+                "max_position_embeddings": 32,
+                "vocab_size": 50,
+                "type_vocab_size": 1,
+                "pad_token_id": 1,
+                "num_labels": 2,
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="num_labels"):
+        load_cross_encoder(str(tmp_path))

--- a/tests/test_rerank_model.py
+++ b/tests/test_rerank_model.py
@@ -129,6 +129,8 @@ def test_detect_layout():
     )
     assert detect_layout(["roberta.encoder.layers.0.mixer.Wqkv.weight"]) == "flash"
     assert detect_layout(["roberta.emb_ln.weight"]) == "flash"
+    # Unrecognised keys fall back to standard (the deliberate default).
+    assert detect_layout(["some.unknown.key"]) == "standard"
 
 
 def test_remap_standard_keys():

--- a/tests/test_rerank_model.py
+++ b/tests/test_rerank_model.py
@@ -102,6 +102,7 @@ def test_cross_encoder_forward_shape():
     logits = model(input_ids, attention_mask)
     mx.eval(logits)
     assert logits.shape == (2, 1)
+    assert not bool(mx.any(mx.isnan(logits)))  # masking must not produce NaN
 
 
 def test_cross_encoder_padding_invariance():
@@ -116,4 +117,4 @@ def test_cross_encoder_padding_invariance():
     a = model(short_ids, short_mask)
     b = model(padded_ids, padded_mask)
     mx.eval(a, b)
-    assert abs(float(a[0, 0]) - float(b[0, 0])) < 1e-4
+    assert abs(float(a[0, 0]) - float(b[0, 0])) < 1e-5

--- a/tests/test_rerank_model.py
+++ b/tests/test_rerank_model.py
@@ -1,7 +1,7 @@
 import mlx.core as mx
 
 from olmlx.engine.rerank.config import RerankerConfig
-from olmlx.engine.rerank.model import roberta_position_ids
+from olmlx.engine.rerank.model import XLMRobertaEmbeddings, roberta_position_ids
 
 
 def test_rerankerconfig_from_dict_bge():
@@ -64,3 +64,23 @@ def test_roberta_position_ids_offset_with_padding():
     input_ids = mx.array([[5, 6, 1, 1]])
     pos = roberta_position_ids(input_ids, pad_token_id=1)
     assert pos.tolist() == [[2, 3, 1, 1]]
+
+
+def test_embeddings_output_shape():
+    cfg = RerankerConfig(
+        hidden_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        intermediate_size=32,
+        max_position_embeddings=32,
+        vocab_size=50,
+        type_vocab_size=1,
+        layer_norm_eps=1e-5,
+        pad_token_id=1,
+        num_labels=1,
+    )
+    emb = XLMRobertaEmbeddings(cfg)
+    input_ids = mx.array([[5, 6, 7, 2], [5, 6, 1, 1]])
+    out = emb(input_ids)
+    mx.eval(out)
+    assert out.shape == (2, 4, cfg.hidden_size)

--- a/tests/test_rerank_model.py
+++ b/tests/test_rerank_model.py
@@ -1,7 +1,11 @@
 import mlx.core as mx
 
 from olmlx.engine.rerank.config import RerankerConfig
-from olmlx.engine.rerank.model import XLMRobertaEmbeddings, roberta_position_ids
+from olmlx.engine.rerank.model import (
+    XLMRobertaCrossEncoder,
+    XLMRobertaEmbeddings,
+    roberta_position_ids,
+)
 
 
 def test_rerankerconfig_from_dict_bge():
@@ -66,8 +70,8 @@ def test_roberta_position_ids_offset_with_padding():
     assert pos.tolist() == [[2, 3, 1, 1]]
 
 
-def test_embeddings_output_shape():
-    cfg = RerankerConfig(
+def _tiny_config() -> RerankerConfig:
+    return RerankerConfig(
         hidden_size=16,
         num_hidden_layers=2,
         num_attention_heads=2,
@@ -79,8 +83,37 @@ def test_embeddings_output_shape():
         pad_token_id=1,
         num_labels=1,
     )
+
+
+def test_embeddings_output_shape():
+    cfg = _tiny_config()
     emb = XLMRobertaEmbeddings(cfg)
     input_ids = mx.array([[5, 6, 7, 2], [5, 6, 1, 1]])
     out = emb(input_ids)
     mx.eval(out)
     assert out.shape == (2, 4, cfg.hidden_size)
+
+
+def test_cross_encoder_forward_shape():
+    cfg = _tiny_config()
+    model = XLMRobertaCrossEncoder(cfg)
+    input_ids = mx.array([[5, 6, 7, 2], [5, 6, 1, 1]])  # 2nd row padded
+    attention_mask = mx.array([[1, 1, 1, 1], [1, 1, 0, 0]])
+    logits = model(input_ids, attention_mask)
+    mx.eval(logits)
+    assert logits.shape == (2, 1)
+
+
+def test_cross_encoder_padding_invariance():
+    # Scoring a sequence must not change when extra pad tokens are appended,
+    # because the attention mask zeroes them out.
+    cfg = _tiny_config()
+    model = XLMRobertaCrossEncoder(cfg)
+    short_ids = mx.array([[5, 6, 7, 2]])
+    short_mask = mx.array([[1, 1, 1, 1]])
+    padded_ids = mx.array([[5, 6, 7, 2, 1, 1]])
+    padded_mask = mx.array([[1, 1, 1, 1, 0, 0]])
+    a = model(short_ids, short_mask)
+    b = model(padded_ids, padded_mask)
+    mx.eval(a, b)
+    assert abs(float(a[0, 0]) - float(b[0, 0])) < 1e-4

--- a/tests/test_rerank_model.py
+++ b/tests/test_rerank_model.py
@@ -1,4 +1,7 @@
+import mlx.core as mx
+
 from olmlx.engine.rerank.config import RerankerConfig
+from olmlx.engine.rerank.model import roberta_position_ids
 
 
 def test_rerankerconfig_from_dict_bge():
@@ -47,3 +50,17 @@ def test_rerankerconfig_num_labels_from_num_labels_key():
     assert cfg.num_labels == 1
     assert cfg.head_dim == 64
     assert cfg.hidden_act == "gelu"  # default applied when key absent
+
+
+def test_roberta_position_ids_offset_no_padding():
+    # pad_token_id=1; a fully-real sequence -> positions start at 2
+    input_ids = mx.array([[5, 6, 7, 8]])
+    pos = roberta_position_ids(input_ids, pad_token_id=1)
+    assert pos.tolist() == [[2, 3, 4, 5]]
+
+
+def test_roberta_position_ids_offset_with_padding():
+    # trailing pad tokens (id=1) keep position == pad_token_id (1)
+    input_ids = mx.array([[5, 6, 1, 1]])
+    pos = roberta_position_ids(input_ids, pad_token_id=1)
+    assert pos.tolist() == [[2, 3, 1, 1]]

--- a/tests/test_rerank_model.py
+++ b/tests/test_rerank_model.py
@@ -1,0 +1,47 @@
+from olmlx.engine.rerank.config import RerankerConfig
+
+
+def test_rerankerconfig_from_dict_bge():
+    raw = {
+        "architectures": ["XLMRobertaForSequenceClassification"],
+        "hidden_size": 1024,
+        "num_hidden_layers": 24,
+        "num_attention_heads": 16,
+        "intermediate_size": 4096,
+        "max_position_embeddings": 8194,
+        "vocab_size": 250002,
+        "type_vocab_size": 1,
+        "layer_norm_eps": 1e-5,
+        "pad_token_id": 1,
+        "hidden_act": "gelu",
+        "id2label": {"0": "LABEL_0"},
+    }
+    cfg = RerankerConfig.from_dict(raw)
+    assert cfg.hidden_size == 1024
+    assert cfg.num_hidden_layers == 24
+    assert cfg.num_attention_heads == 16
+    assert cfg.intermediate_size == 4096
+    assert cfg.max_position_embeddings == 8194
+    assert cfg.vocab_size == 250002
+    assert cfg.type_vocab_size == 1
+    assert cfg.pad_token_id == 1
+    assert cfg.num_labels == 1
+    assert cfg.head_dim == 64
+
+
+def test_rerankerconfig_num_labels_from_num_labels_key():
+    raw = {
+        "hidden_size": 768,
+        "num_hidden_layers": 12,
+        "num_attention_heads": 12,
+        "intermediate_size": 3072,
+        "max_position_embeddings": 1026,
+        "vocab_size": 250002,
+        "type_vocab_size": 1,
+        "layer_norm_eps": 1e-5,
+        "pad_token_id": 1,
+        "num_labels": 1,
+    }
+    cfg = RerankerConfig.from_dict(raw)
+    assert cfg.num_labels == 1
+    assert cfg.head_dim == 64

--- a/tests/test_rerank_schemas.py
+++ b/tests/test_rerank_schemas.py
@@ -1,0 +1,41 @@
+import pytest
+from pydantic import ValidationError
+
+from olmlx.schemas.rerank import RerankRequest, RerankResponse, RerankResult
+
+
+def test_rerank_request_defaults():
+    req = RerankRequest(model="bge-reranker", query="q", documents=["a", "b"])
+    assert req.top_n is None
+    assert req.max_tokens_per_doc == 4096
+    assert req.return_documents is False
+
+
+def test_rerank_request_rejects_empty_documents():
+    with pytest.raises(ValidationError):
+        RerankRequest(model="m", query="q", documents=[])
+
+
+def test_rerank_request_rejects_empty_query():
+    with pytest.raises(ValidationError):
+        RerankRequest(model="m", query="  ", documents=["a"])
+
+
+def test_rerank_request_rejects_nonpositive_top_n():
+    with pytest.raises(ValidationError):
+        RerankRequest(model="m", query="q", documents=["a"], top_n=0)
+
+
+def test_rerank_response_shape():
+    resp = RerankResponse(
+        id="rerank-xyz",
+        results=[RerankResult(index=1, relevance_score=0.9)],
+        meta={"api_version": {"version": "2"}},
+    )
+    dumped = resp.model_dump()
+    assert dumped["results"][0]["index"] == 1
+    assert dumped["results"][0]["relevance_score"] == 0.9
+    assert (
+        "document" not in dumped["results"][0]
+        or dumped["results"][0]["document"] is None
+    )

--- a/tests/test_rerank_schemas.py
+++ b/tests/test_rerank_schemas.py
@@ -16,9 +16,19 @@ def test_rerank_request_rejects_empty_documents():
         RerankRequest(model="m", query="q", documents=[])
 
 
-def test_rerank_request_rejects_empty_query():
+def test_rerank_request_rejects_empty_documents_with_blank_element():
+    with pytest.raises(ValidationError):
+        RerankRequest(model="m", query="q", documents=["a", ""])
+
+
+def test_rerank_request_rejects_blank_query():
     with pytest.raises(ValidationError):
         RerankRequest(model="m", query="  ", documents=["a"])
+
+
+def test_rerank_request_rejects_empty_query():
+    with pytest.raises(ValidationError):
+        RerankRequest(model="m", query="", documents=["a"])
 
 
 def test_rerank_request_rejects_nonpositive_top_n():
@@ -35,7 +45,5 @@ def test_rerank_response_shape():
     dumped = resp.model_dump()
     assert dumped["results"][0]["index"] == 1
     assert dumped["results"][0]["relevance_score"] == 0.9
-    assert (
-        "document" not in dumped["results"][0]
-        or dumped["results"][0]["document"] is None
-    )
+    # document defaults to None when not requested.
+    assert dumped["results"][0]["document"] is None

--- a/tests/test_routers_rerank.py
+++ b/tests/test_routers_rerank.py
@@ -42,6 +42,27 @@ class TestRerankRouter:
                 json={"model": "m", "query": "q", "documents": ["a"]},
             )
         assert resp.status_code == 200
+        assert resp.json()["id"].startswith("rerank-")
+
+    @pytest.mark.asyncio
+    async def test_rerank_returns_documents_when_requested(self, app_client):
+        with patch(
+            "olmlx.routers.rerank.generate_rerank", new_callable=AsyncMock
+        ) as mock:
+            mock.return_value = {
+                "results": [{"index": 0, "relevance_score": 0.7, "document": "a"}]
+            }
+            resp = await app_client.post(
+                "/v1/rerank",
+                json={
+                    "model": "m",
+                    "query": "q",
+                    "documents": ["a"],
+                    "return_documents": True,
+                },
+            )
+        assert resp.status_code == 200
+        assert resp.json()["results"][0]["document"] == "a"
 
     @pytest.mark.asyncio
     async def test_rerank_rejects_empty_documents(self, app_client):
@@ -50,3 +71,18 @@ class TestRerankRouter:
             json={"model": "m", "query": "q", "documents": []},
         )
         assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_rerank_non_reranker_model_returns_400(self, app_client):
+        # generate_rerank raises ValueError for a non-reranker model; the
+        # app-level ValueError handler must turn it into a clean HTTP 400.
+        with patch(
+            "olmlx.routers.rerank.generate_rerank", new_callable=AsyncMock
+        ) as mock:
+            mock.side_effect = ValueError("Model 'qwen3' is not a reranker.")
+            resp = await app_client.post(
+                "/v1/rerank",
+                json={"model": "qwen3", "query": "q", "documents": ["a"]},
+            )
+        assert resp.status_code == 400
+        assert "not a reranker" in resp.text

--- a/tests/test_routers_rerank.py
+++ b/tests/test_routers_rerank.py
@@ -1,0 +1,52 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class TestRerankRouter:
+    @pytest.mark.asyncio
+    async def test_rerank_v1(self, app_client):
+        with patch(
+            "olmlx.routers.rerank.generate_rerank", new_callable=AsyncMock
+        ) as mock:
+            mock.return_value = {
+                "results": [
+                    {"index": 1, "relevance_score": 0.92},
+                    {"index": 0, "relevance_score": 0.10},
+                ]
+            }
+            resp = await app_client.post(
+                "/v1/rerank",
+                json={
+                    "model": "bge-reranker",
+                    "query": "what is mlx",
+                    "documents": ["unrelated", "mlx is an array framework"],
+                    "top_n": 2,
+                },
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["results"][0]["index"] == 1
+        assert data["results"][0]["relevance_score"] == 0.92
+        assert data["id"].startswith("rerank-")
+        assert data["meta"]["api_version"]["version"] == "2"
+
+    @pytest.mark.asyncio
+    async def test_rerank_alias(self, app_client):
+        with patch(
+            "olmlx.routers.rerank.generate_rerank", new_callable=AsyncMock
+        ) as mock:
+            mock.return_value = {"results": []}
+            resp = await app_client.post(
+                "/rerank",
+                json={"model": "m", "query": "q", "documents": ["a"]},
+            )
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_rerank_rejects_empty_documents(self, app_client):
+        resp = await app_client.post(
+            "/v1/rerank",
+            json={"model": "m", "query": "q", "documents": []},
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Adds a Cohere-v2-compatible `POST /v1/rerank` (+ `/rerank` alias) backed by a **native MLX XLM-RoBERTa cross-encoder** — no new runtime deps, pure MLX/Metal. Serves `bge-reranker-v2-m3` (standard HF layout) and `jina-reranker-v2-base-multilingual` (flash fused-QKV layout) through the same encoder, with the weight layout chosen by checkpoint-key inspection. Closes #369.

- **`engine/rerank/`** — `RerankerConfig` (parsed from `config.json`), `XLMRobertaCrossEncoder` (absolute-position with RoBERTa offset, post-LN BERT attention, first-token/CLS classification head, dtype-safe `-1e4` mask fill), and `weights.py` with two key-remaps onto one flat-named module (`load_cross_encoder` strict-loads; rejects `num_labels != 1`).
- **`engine/inference.py`** — `generate_rerank` (+ pure `_score_pairs`/`_build_rerank_results`): tokenizes `(query, doc)` pairs with `truncation="only_second"` (silent doc-side truncation), micro-batches, `sigmoid` → `[0,1]`, sorts, applies `top_n`; runs under the inference lock with the same trailing `mx.synchronize()` barrier as `generate_embeddings`.
- **`ModelManager`** — new `reranker` kind (`_detect_model_kind` matches `*ForSequenceClassification`); `LoadedModel.is_reranker` fences off the LLM-only cache/KV-quant paths, mirroring `is_whisper`.
- **`routers/rerank.py` + `schemas/rerank.py`** — Cohere-v2 request/response, registered in `app.py`. Non-reranker model → `ValueError` → HTTP 400.
- Design spec + implementation plan under `docs/superpowers/`; CLAUDE.md updated.

Out of scope (per spec): document objects/`rank_fields`, multi-label heads, rotary cross-encoders, streaming/distributed/flash for rerankers.

## Test Plan

- [x] Unit: config parse, RoBERTa position offset, encoder forward + padding-invariance, both weight remaps (incl. fused-QKV split), schemas, kind detection, `_load_model` branch + cache-probe guard, `generate_rerank` helpers (sigmoid/sort/top_n/multi-batch/sentinel clamp), router contract (200 / 422 / 400 / `return_documents`). 68 passed.
- [x] Regression: `-k "inference or model_manager or embed"` → 759 passed; `test_app.py` → 32 passed. ruff clean.
- [ ] **Live validation (needs models downloaded):** `uv run pytest tests/live/test_rerank_real.py` — exercises the real bge (standard) + jina (flash) checkpoints: a checkpoint-layout gate (validates the inferred jina fused-QKV key names), relevant-doc-ranks-first, a 100-doc batch, and a transformers/torch parity check. **These skip in CI; run locally with both models present before merge** — the jina flash remap is inferred from flash-attn conventions and this is its verification gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)