### PR TITLE
fix: address actionable code-review findings (#455)

### DIFF
--- a/olmlx/app.py
+++ b/olmlx/app.py
@@ -55,12 +55,10 @@ async def lifespan(app: FastAPI):
     registry.load()
     store = ModelStore(registry)
 
-    # -- Distributed inference --
-    from olmlx.config import settings
-
     if settings.tracing:
         tracing_mod.init_tracing(settings)
 
+    # -- Distributed inference --
     distributed_group = None
     coordinator = None
     distributed_strategy = "tensor"
@@ -138,7 +136,9 @@ async def lifespan(app: FastAPI):
     try:
         metrics_mod.REGISTRY.unregister(app.state.metrics_collector)
     except Exception:
-        pass
+        logger.debug(
+            "Failed to unregister metrics collector during shutdown", exc_info=True
+        )
     if coordinator is not None:
         coordinator.broadcast_shutdown()
         coordinator.close()

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -33,6 +33,40 @@ _MIN_MESSAGES_AFTER_TRUNCATE = 6
 # Emergency truncation target when first pass still exceeds memory
 _MIN_MESSAGES_EMERGENCY_TRUNCATE = 2
 
+
+def _truncate_keep_recent(
+    messages: list[dict], system_idx: int, target_count: int
+) -> list[dict]:
+    """Keep the system message (if any) plus the most recent messages.
+
+    Walk backwards collecting messages until ``target_count`` is reached,
+    then continue back to the next ``user`` message so a turn boundary is
+    never split (no orphan ``tool_result`` or dangling ``tool_call``).
+    ``system_idx`` is 1 when ``messages[0]`` is a system message, else 0.
+    """
+    kept: list[dict] = []
+    if system_idx > 0:
+        kept.append(messages[0])
+
+    recent: list[dict] = []
+    idx = len(messages) - 1
+    while idx >= system_idx:
+        recent.insert(0, messages[idx])
+        idx -= 1
+        if len(recent) >= target_count:
+            # Walk back to the next user message to avoid splitting a turn.
+            while idx >= system_idx:
+                msg = messages[idx]
+                recent.insert(0, msg)
+                idx -= 1
+                if msg.get("role") == "user":
+                    break
+            break
+
+    kept.extend(recent)
+    return kept
+
+
 # Thinking tag constants
 _THINK_OPEN = "<think>"
 _THINK_CLOSE = "</think>"
@@ -425,34 +459,9 @@ class ChatSession:
         original_len = len(self.messages)
 
         # Keep system + N most recent (user, assistant) pairs
-        kept = []
-        if system_idx > 0:
-            kept.append(self.messages[0])  # system message
-
-        # Walk backwards from the end, collecting messages. After hitting
-        # the target count, continue walking back until we reach a clean
-        # turn boundary (a user message) so we never split tool_call /
-        # tool_result pairs or leave orphan tool results.
-        recent = []
-        idx = len(self.messages) - 1
-        while idx >= system_idx:
-            msg = self.messages[idx]
-            recent.insert(0, msg)
-            idx -= 1
-            if len(recent) >= _MIN_MESSAGES_AFTER_TRUNCATE:
-                # Walk back to next user message to avoid splitting a turn
-                while idx >= system_idx:
-                    msg = self.messages[idx]
-                    if msg.get("role") == "user":
-                        recent.insert(0, msg)
-                        idx -= 1
-                        break
-                    recent.insert(0, msg)
-                    idx -= 1
-                break
-
-        kept.extend(recent)
-        self.messages = kept
+        self.messages = _truncate_keep_recent(
+            self.messages, system_idx, _MIN_MESSAGES_AFTER_TRUNCATE
+        )
 
         # Re-verify the truncated history still fits; if not, truncate again
         # but with a shallower target — keep only the last 2 messages.
@@ -467,27 +476,9 @@ class ChatSession:
                 logger.warning(
                     "Truncated history still exceeds memory limit; reducing further"
                 )
-                kept = []
-                if system_idx > 0:
-                    kept.append(self.messages[0])
-                recent = []
-                idx = len(self.messages) - 1
-                while idx >= system_idx:
-                    msg = self.messages[idx]
-                    recent.insert(0, msg)
-                    idx -= 1
-                    if len(recent) >= _MIN_MESSAGES_EMERGENCY_TRUNCATE:
-                        while idx >= system_idx:
-                            msg = self.messages[idx]
-                            if msg.get("role") == "user":
-                                recent.insert(0, msg)
-                                idx -= 1
-                                break
-                            recent.insert(0, msg)
-                            idx -= 1
-                        break
-                kept.extend(recent)
-                self.messages = kept
+                self.messages = _truncate_keep_recent(
+                    self.messages, system_idx, _MIN_MESSAGES_EMERGENCY_TRUNCATE
+                )
 
         if len(self.messages) < original_len:
             self.manager.invalidate_prompt_cache(self.config.model_name, "chat")

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -13,7 +13,10 @@ import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from olmlx.engine.registry import ModelRegistry
 
 from olmlx.config import (
     settings,
@@ -767,7 +770,9 @@ def _apply_serve_overrides(args) -> None:
     _audit_per_model_flash_in_distributed(audit_registry)
 
 
-def _audit_per_model_flash_in_distributed(registry: "Any | None" = None) -> None:
+def _audit_per_model_flash_in_distributed(
+    registry: "ModelRegistry | None" = None,
+) -> None:
     """Audit per-model Flash settings against distributed-mode invariants.
 
     Two failure modes to surface at startup:
@@ -920,7 +925,7 @@ def _models_with_promoted_keys_in_experimental() -> list[str]:
     return bad
 
 
-def _load_registry_for_audit() -> "Any":
+def _load_registry_for_audit() -> "ModelRegistry | None":
     """Load the ModelRegistry once for the startup-audit helpers.
 
     Returns the loaded registry or ``None`` if the load failed.
@@ -965,7 +970,7 @@ def _load_registry_for_audit() -> "Any":
 
 
 def _audit_speculative_config(
-    registry: "Any | None" = None,
+    registry: "ModelRegistry | None" = None,
 ) -> tuple[list[str], list[str], list[str], list[str], bool]:
     """Walk the registry and audit each model's resolved speculative
     config.
@@ -1086,8 +1091,7 @@ def _audit_speculative_config(
             if resolved_flash is not None and resolved_flash.enabled:
                 flash_conflicts.append(name)
             if (
-                mc is not None
-                and mc.resolved_flash_moe().enabled
+                mc.resolved_flash_moe().enabled
                 and strategy in _FLASH_MOE_INCOMPATIBLE_STRATEGIES
             ):
                 dflash_moe_conflicts.append(name)

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -160,6 +160,11 @@ class Settings(BaseSettings):
     inference_timeout: Annotated[float, Field(gt=0)] | None = None
     sync_mode: SyncMode = "full"
     max_tokens_limit: Annotated[int, Field(gt=0)] = 131072
+    # Default generation length when a request omits max_tokens /
+    # num_predict / max_completion_tokens / max_output_tokens. Shared by
+    # every router (Ollama, OpenAI chat/completions, Responses) so the
+    # fallback is configured in one place rather than hardcoded per route.
+    default_max_tokens: Annotated[int, Field(gt=0)] = 512
     cors_origins: list[str] = ["http://localhost:*", "http://127.0.0.1:*"]
     anthropic_models: dict[str, str] = {}
 

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
+from olmlx.config import settings
 from olmlx.engine.grammar import parse_response_format
 from olmlx.engine.inference import generate_chat
 from olmlx.engine.tool_parser import (
@@ -188,7 +189,7 @@ async def chat(req: ChatRequest, request: Request):
     options = req.options.model_dump(exclude_none=True) if req.options else {}
     messages = [m.model_dump(exclude_none=True) for m in req.messages]
     tools = [t.model_dump(exclude_none=True) for t in req.tools] if req.tools else None
-    max_tokens = options.pop("num_predict", 512)
+    max_tokens = options.pop("num_predict", settings.default_max_tokens)
     cache_id = request.headers.get("x-cache-id", "")[:256]
     enable_thinking = resolve_think_flag(req.think)
     try:

--- a/olmlx/routers/generate.py
+++ b/olmlx/routers/generate.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
+from olmlx.config import settings
 from olmlx.engine.grammar import parse_response_format
 from olmlx.engine.inference import generate_completion
 from olmlx.engine.tool_parser import parse_model_output
@@ -24,7 +25,7 @@ async def generate(req: GenerateRequest, request: Request):
     options = req.options.model_dump(exclude_none=True) if req.options else {}
 
     prompt = req.prompt
-    max_tokens = options.pop("num_predict", 512)
+    max_tokens = options.pop("num_predict", settings.default_max_tokens)
     enable_thinking = resolve_think_flag(req.think)
     try:
         grammar_spec = parse_response_format(req.format)

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -1,12 +1,15 @@
+import base64
 import json
 import logging
 import re
+import struct
 import time
 import uuid
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
+from olmlx.config import settings
 from olmlx.engine.grammar import parse_response_format
 from olmlx.engine.inference import (
     INIT_ORPHAN_DETECT_LIMIT,
@@ -393,7 +396,9 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
         else:
             messages.insert(0, {"role": "system", "content": json_prompt})
     options = _build_options(req)
-    max_tokens = req.max_completion_tokens or req.max_tokens or 512
+    max_tokens = (
+        req.max_completion_tokens or req.max_tokens or settings.default_max_tokens
+    )
     chat_id = _make_id()
     created = int(time.time())
     cache_id = request.headers.get("x-cache-id", "")[:256]
@@ -521,7 +526,7 @@ async def openai_completions(req: OpenAICompletionRequest, request: Request):
     manager = request.app.state.model_manager
     options = _build_options(req)
     prompt = req.prompt if isinstance(req.prompt, str) else req.prompt[0]
-    max_tokens = req.max_tokens or 512
+    max_tokens = req.max_tokens or settings.default_max_tokens
     comp_id = f"cmpl-{uuid.uuid4().hex[:8]}"
     created = int(time.time())
 
@@ -595,9 +600,23 @@ async def openai_embeddings(req: OpenAIEmbeddingRequest, request: Request):
     manager = request.app.state.model_manager
     texts = req.input if isinstance(req.input, list) else [req.input]
     embeddings = await generate_embeddings(manager, req.model, texts)
-    data = [
-        OpenAIEmbeddingData(index=i, embedding=emb) for i, emb in enumerate(embeddings)
-    ]
+    if req.encoding_format == "base64":
+        # OpenAI's base64 format packs each embedding as little-endian
+        # float32 bytes, then base64-encodes the result into a string.
+        data = [
+            OpenAIEmbeddingData(
+                index=i,
+                embedding=base64.b64encode(struct.pack(f"<{len(emb)}f", *emb)).decode(
+                    "ascii"
+                ),
+            )
+            for i, emb in enumerate(embeddings)
+        ]
+    else:
+        data = [
+            OpenAIEmbeddingData(index=i, embedding=emb)
+            for i, emb in enumerate(embeddings)
+        ]
     return OpenAIEmbeddingResponse(
         data=data,
         model=req.model,

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -6,6 +6,7 @@ import uuid
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
+from olmlx.config import settings
 from olmlx.engine.grammar import GrammarSpec, parse_response_format
 from olmlx.engine.inference import generate_chat
 from olmlx.engine.responses_state import get_store
@@ -530,7 +531,7 @@ async def create_response(req: ResponsesRequest, request: Request):
     options = build_inference_options(
         temperature=req.temperature, top_p=req.top_p, seed=req.seed
     )
-    max_tokens = req.max_output_tokens or 512
+    max_tokens = req.max_output_tokens or settings.default_max_tokens
     enable_thinking = _resolve_reasoning(req.reasoning)
     response_id = _make_response_id()
     created = int(time.time())

--- a/olmlx/schemas/openai.py
+++ b/olmlx/schemas/openai.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 
 from olmlx.schemas.common import ModelName
 
@@ -65,12 +71,12 @@ class OpenAIChatRequest(BaseModel):
 
     @field_validator("max_tokens", "max_completion_tokens")
     @classmethod
-    def validate_max_tokens(cls, v: int | None) -> int | None:
+    def validate_max_tokens(cls, v: int | None, info: ValidationInfo) -> int | None:
         if v is None:
             return v
         from olmlx.schemas.common import validate_token_limit
 
-        return validate_token_limit(v, "max_tokens")
+        return validate_token_limit(v, info.field_name or "max_tokens")
 
     @field_validator("messages")
     @classmethod
@@ -186,7 +192,7 @@ class OpenAIModelList(BaseModel):
 class OpenAIEmbeddingRequest(BaseModel):
     model: ModelName
     input: str | list[str]
-    encoding_format: str = "float"
+    encoding_format: Literal["float", "base64"] = "float"
 
     @field_validator("input")
     @classmethod
@@ -199,7 +205,9 @@ class OpenAIEmbeddingRequest(BaseModel):
 class OpenAIEmbeddingData(BaseModel):
     object: str = "embedding"
     index: int = 0
-    embedding: list[float]
+    # ``list[float]`` for ``encoding_format="float"`` (default); a base64
+    # string of the little-endian float32 bytes for ``encoding_format="base64"``.
+    embedding: list[float] | str
 
 
 class OpenAIEmbeddingResponse(BaseModel):

--- a/olmlx/utils/streaming.py
+++ b/olmlx/utils/streaming.py
@@ -445,6 +445,14 @@ class CancellableStream:
                         self._queue.put(tok), self._loop
                     ).result(timeout=_QUEUE_PUT_TIMEOUT)
                 except Exception:
+                    # The consumer/event loop is gone (e.g. client disconnect
+                    # mid-stream) or the put timed out. Stop generating; the
+                    # finally block below still runs clean GPU teardown. Logged
+                    # at debug since this is a routine teardown path, not an error.
+                    logger.debug(
+                        "CancellableStream: queue put failed, ending generation",
+                        exc_info=True,
+                    )
                     break
         except Exception as exc:
             tb = traceback.format_exc()

--- a/tests/fixtures/chat_templates/Qwen3.5-27B.jinja
+++ b/tests/fixtures/chat_templates/Qwen3.5-27B.jinja
@@ -1,0 +1,154 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/tests/fixtures/chat_templates/gemma-4-26b-a4b-it.jinja
+++ b/tests/fixtures/chat_templates/gemma-4-26b-a4b-it.jinja
@@ -1,0 +1,363 @@
+{%- macro format_parameters(properties, required, filter_keys=false) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if not filter_keys or key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([]), filter_keys=true) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{%- set ns = namespace(prev_message_type=None) -%}
+{%- set loop_messages = messages -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if (enable_thinking is defined and enable_thinking) or tools or messages[0]['role'] in ['system', 'developer'] -%}
+    {{- '<|turn>system\n' -}}
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking is defined and enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+    {%- if messages[0]['role'] in ['system', 'developer'] -%}
+        {%- if messages[0]['content'] is string -%}
+            {{- messages[0]['content'] | trim -}}
+        {%- elif messages[0]['content'] is sequence -%}
+            {%- for item in messages[0]['content'] -%}
+                {{- item['text'] | trim + ' '-}}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation: suppress duplicate <|turn>model when previous non-tool message was also assistant -#}
+    {%- set prev_nt = namespace(role=None, found=false) -%}
+    {%- if loop.index0 > 0 -%}
+        {%- for j in range(loop.index0 - 1, -1, -1) -%}
+            {%- if not prev_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set prev_nt.role = loop_messages[j]['role'] -%}
+                    {%- set prev_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- set continue_same_model_turn = (role == 'model' and prev_nt.role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- if thinking_text and loop.index0 > ns_turn.last_user_idx and message.get('tool_calls') -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message['tool_calls'] -%}
+                {%- for tool_call in message['tool_calls'] -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is string -%}
+                        {{- function['arguments'] -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message['tool_responses'] -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown'), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') | default('unknown')) -%}
+                        {%- for tc in message['tool_calls'] -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'image' -%}
+                                    {{- '<|image|>' -}}
+                                {%- elif part.get('type') == 'audio' -%}
+                                    {{- '<|audio|>' -}}
+                                {%- elif part.get('type') == 'video' -%}
+                                    {{- '<|video|>' -}}
+                                {%- endif -%}
+                            {%- endfor -%}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- set captured_content -%}
+            {%- if message['content'] is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message['content'] is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item['type'] == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item['type'] == 'image' -%}
+                        {{- '<|image|>' -}}
+                        {%- set ns.prev_message_type = 'image' -%}
+                    {%- elif item['type'] == 'audio' -%}
+                        {{- '<|audio|>' -}}
+                        {%- set ns.prev_message_type = 'audio' -%}
+                    {%- elif item['type'] == 'video' -%}
+                        {{- '<|video|>' -}}
+                        {%- set ns.prev_message_type = 'video' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+            {%- endset -%}
+
+            {{- captured_content -}}
+            {%- set has_content = captured_content | trim | length > 0 -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif not (ns_tr_out.flag and not has_content) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+        {%- if not enable_thinking | default(false) -%}
+            {{- '<|channel>thought\n<channel|>' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endif -%}

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import mlx.core as mx
@@ -1451,13 +1452,12 @@ class TestGemma4TemplateOrdering:
     instructions (with examples) *before* the system prompt.
     """
 
-    GEMMA4_TEMPLATE = (
-        "/Users/daniel/.olmlx/models/"
-        "mlx-community_gemma-4-26b-a4b-it-4bit/chat_template.jinja"
-    )
-    QWEN35_TEMPLATE = (
-        "/Users/daniel/.olmlx/models/mlx-community_Qwen3.5-27B-4bit/chat_template.jinja"
-    )
+    # Vendored chat templates (tests/fixtures/chat_templates/) so the
+    # ordering assertions run in CI. Previously these pointed at
+    # developer-machine model paths, so the whole class silently skipped.
+    _TEMPLATE_DIR = Path(__file__).parent / "fixtures" / "chat_templates"
+    GEMMA4_TEMPLATE = str(_TEMPLATE_DIR / "gemma-4-26b-a4b-it.jinja")
+    QWEN35_TEMPLATE = str(_TEMPLATE_DIR / "Qwen3.5-27B.jinja")
 
     @staticmethod
     def _render(template_path, messages, tools=None, enable_thinking=None):

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -445,6 +445,61 @@ class TestOpenAIRouter:
         assert len(data["data"]) == 2
 
     @pytest.mark.asyncio
+    async def test_embeddings_base64(self, app_client):
+        import base64
+        import struct
+
+        with patch(
+            "olmlx.routers.openai.generate_embeddings", new_callable=AsyncMock
+        ) as mock_emb:
+            mock_emb.return_value = [[0.1, 0.2, 0.3]]
+            resp = await app_client.post(
+                "/v1/embeddings",
+                json={
+                    "model": "qwen3",
+                    "input": "hello world",
+                    "encoding_format": "base64",
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        emb = data["data"][0]["embedding"]
+        assert isinstance(emb, str)
+        decoded = struct.unpack("<3f", base64.b64decode(emb))
+        assert decoded == pytest.approx([0.1, 0.2, 0.3])
+
+    @pytest.mark.asyncio
+    async def test_embeddings_float_encoding_explicit(self, app_client):
+        with patch(
+            "olmlx.routers.openai.generate_embeddings", new_callable=AsyncMock
+        ) as mock_emb:
+            mock_emb.return_value = [[0.1, 0.2, 0.3]]
+            resp = await app_client.post(
+                "/v1/embeddings",
+                json={
+                    "model": "qwen3",
+                    "input": "hello world",
+                    "encoding_format": "float",
+                },
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["embedding"] == [0.1, 0.2, 0.3]
+
+    @pytest.mark.asyncio
+    async def test_embeddings_rejects_invalid_encoding_format(self, app_client):
+        resp = await app_client.post(
+            "/v1/embeddings",
+            json={
+                "model": "qwen3",
+                "input": "hello world",
+                "encoding_format": "bogus",
+            },
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
     async def test_completions_streaming(self, app_client):
         async def mock_stream(*args, **kwargs):
             async def gen():

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -547,6 +547,31 @@ class TestOpenAISchemas:
                 max_completion_tokens=0,
             )
 
+    def test_max_completion_tokens_limit_error_names_correct_field(self):
+        # The "exceeds configured limit" validator covers both max_tokens
+        # and max_completion_tokens; the error must name the field that
+        # actually failed, not always "max_tokens".
+        from olmlx.config import settings
+
+        over_limit = settings.max_tokens_limit + 1
+        with pytest.raises(ValidationError, match="max_completion_tokens"):
+            OpenAIChatRequest(
+                model="test",
+                messages=[OpenAIChatMessage(role="user", content="hi")],
+                max_completion_tokens=over_limit,
+            )
+
+    def test_max_tokens_limit_error_names_correct_field(self):
+        from olmlx.config import settings
+
+        over_limit = settings.max_tokens_limit + 1
+        with pytest.raises(ValidationError, match="max_tokens"):
+            OpenAIChatRequest(
+                model="test",
+                messages=[OpenAIChatMessage(role="user", content="hi")],
+                max_tokens=over_limit,
+            )
+
     def test_chat_request_n_rejects_greater_than_one(self):
         with pytest.raises(ValidationError, match="less than or equal to 1"):
             OpenAIChatRequest(


### PR DESCRIPTION
Implements the maintainer-triaged **fix tier** + **consider** items from the [#455](https://github.com/motsognirr/olmlx/issues/455) review. False-positives (#1, #3, #5, #14, #22, #24) and the framing corrections (#6, #13) are intentionally left alone, and #2 (distributed secret) is deferred to #454.

## Fix tier
- **#12 base64 embeddings** — `/v1/embeddings` now honors `encoding_format`. `Literal["float","base64"]` (422 on anything else); base64 packs each vector as little-endian float32 then base64-encodes it. Previously the field was silently ignored and always returned floats.
- **#11 centralize `max_tokens` default** — new `Settings.default_max_tokens` (512) replaces the 5 hardcoded sites in `chat.py`, `generate.py`, `openai.py` (×2), `responses.py`. Behavior unchanged.
- **#15 wrong field name** — `validate_max_tokens` uses `ValidationInfo.field_name`, so the "exceeds configured limit" error names `max_completion_tokens` when that field fails (was always `max_tokens`).
- **#21** — `cli.py` registry params typed `ModelRegistry` (via `TYPE_CHECKING`) instead of `"Any"`.
- **#25** — drop the always-true `mc is not None` check in the speculative-config audit.
- **#26** — remove the redundant `from olmlx.config import settings` inside `lifespan`.
- **#32** — vendor the real Gemma-4 / Qwen3.5 chat templates to `tests/fixtures/chat_templates/` and repoint `TestGemma4TemplateOrdering`. The 4 ordering tests now **run** in CI (they silently skipped on dev-machine absolute paths).

## Consider
- **#20** — extract the duplicated keep-system-+-walk-back-to-user-boundary logic into `_truncate_keep_recent`; used by both the first and emergency truncation passes.
- **#27 / #7** — `logger.debug(..., exc_info=True)` instead of silently swallowing the metrics-unregister failure (shutdown) and the stream queue-put failure (client disconnect).

## Testing
- TDD for the behavioral changes (base64 embeddings, field-name validation): failing test first, then fix.
- 814 tests pass across the touched suites; `ruff check` clean, `ruff format` applied.

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)