### PR TITLE
fix(dflash): document sliding-draft offset invariant (#453)

### DIFF
--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -469,19 +469,25 @@ class DFlashDecoder:
         if ft_idx is not None:
             draft_offset = self._draft_cache[ft_idx].offset
             target_offset = self._prompt_size + self._n_generated - 1
-            # If the draft model has sliding-window attention layers and
-            # the prompt exceeds the sliding window, the first draft
-            # step advances ``cache.offset`` by ``skip + S`` (see
-            # ``DFlashAttention.__call__``).  If ALL draft tokens from
-            # that first step are rejected, ``self._n_generated`` stays
-            # at 1 (the prefill token) while the draft cache offset is
-            # ``prompt_size``, and the next step's check trips.  This is
-            # an extremely narrow window (requires a sliding-window draft
-            # *and* 0-for-block_size acceptance on the first step) and no
-            # known draft model hits it today.
-            # FIXME: undo the ``cache.offset += skip`` pre-advance on
-            # rejection rollback so the draft cache offset stays correct
-            # across steps even in this edge case.
+            # Sliding-window draft layers do NOT desync this check, even
+            # on full rejection (gh#453 conjectured they would). When a
+            # sliding layer's context exceeds its window,
+            # ``DFlashAttention.__call__`` truncates ``x_ctx`` to ``keep
+            # = window - 1`` tokens and pre-advances ``cache.offset +=
+            # skip`` for the dropped positions. The subsequent
+            # ``RotatingKVCache.update_and_fetch`` then advances offset
+            # by the *post-truncation* count (``keep``), so the net
+            # advance is ``skip + keep == S`` — identical to a
+            # full-attention layer. The skipped positions are real
+            # (evicted from the window), so the pre-advance is correct
+            # and is deliberately NOT rolled back on rejection: undoing
+            # it would apply wrong RoPE positions to later context
+            # writes. This check runs on a full-attention layer (which
+            # never skips), whose offset therefore always equals
+            # ``prompt_size + n_generated - 1`` by construction. The
+            # guard remains a fail-stop against future bookkeeping bugs.
+            # Locked by ``test_sliding_draft_offset_stays_in_lockstep_
+            # on_full_rejection``.
             if draft_offset != target_offset:
                 msg = (
                     f"DFlash internal invariant violated: draft cache offset "

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -992,6 +992,7 @@ class TestDFlashDecoder:
         decoder.prefill(mx.array([list(range(1, prompt_len + 1))]))
         sliding_idx, ft_idx = 0, 1
 
+        saw_full_rejection = False
         for _ in range(6):
             # The offset guard fires DURING step() and checks the draft
             # offset against ``prompt_size + n_generated - 1`` using the
@@ -1000,19 +1001,28 @@ class TestDFlashDecoder:
             n_gen_entry = decoder._n_generated
             # No RuntimeError from the offset invariant guard.
             accepted, _ = decoder.step()
-            # Random weights ⇒ the draft never matches the target ⇒ only
-            # the bonus token is accepted (the 0-for-block_size case).
-            assert len(accepted) == 1
+            if len(accepted) == 1:
+                saw_full_rejection = True  # 0-for-block_size, the issue's case
             sliding_off = decoder._draft_cache[sliding_idx].offset
             ft_off = decoder._draft_cache[ft_idx].offset
-            # The sliding-layer offset stays in lockstep with the
-            # full-attention layer (the gh#453 invariant) and matches the
-            # value the in-step guard validated against.
+            # The gh#453 invariant: the sliding-layer offset stays in
+            # lockstep with the full-attention layer and matches the value
+            # the in-step guard validated against. This holds for ANY
+            # acceptance count — it is acceptance-independent — so it does
+            # not rely on the random weights producing a particular accept
+            # pattern.
             assert sliding_off == ft_off == decoder._prompt_size + n_gen_entry - 1
+
+        # The issue is specifically about 0-for-block_size acceptance; the
+        # random weights here drive the draft into full rejection, so assert
+        # we actually exercised that regime (a soft aggregate check rather
+        # than a brittle per-step equality on the accept count).
+        assert saw_full_rejection
 
         # Confirm the skip actually fired: the sliding cache holds at most
         # ``keep`` physical tokens yet its offset ran far past that — proof
-        # the pre-advance happened (otherwise the test proves nothing).
+        # the pre-advance happened (otherwise the test proves nothing). This
+        # is deterministic: step 1 always feeds S = prompt_size > window - 1.
         sliding_cache = decoder._draft_cache[sliding_idx]
         assert sliding_cache.keys.shape[2] <= window - 1
         assert sliding_cache.offset > window - 1

--- a/tests/test_dflash.py
+++ b/tests/test_dflash.py
@@ -945,6 +945,78 @@ class TestDFlashDecoder:
         assert stats["proposed"] == 2
         assert stats["lambda"] == 2
 
+    def test_sliding_draft_offset_stays_in_lockstep_on_full_rejection(self):
+        """Regression for gh#453.
+
+        The issue conjectured that a sliding-window draft layer's
+        ``cache.offset += skip`` pre-advance (in ``DFlashAttention``)
+        is never rolled back on full rejection, desyncing the draft
+        cache offset and tripping the full-attention invariant check in
+        ``step()``.
+
+        It cannot: ``RotatingKVCache.update_and_fetch`` advances
+        ``offset`` by the *post-truncation* token count (``keep``), and
+        the layer already truncated ``x_ctx`` to ``keep`` tokens before
+        the write, so the net advance is ``skip + keep == S`` — exactly
+        the same advance a full-attention layer makes. The skipped
+        positions are real (evicted from the window), so the advance is
+        correct and must NOT be undone on rollback.
+
+        This drives the exact scenario from the issue — sliding+full
+        draft, prompt longer than the window, full rejection on every
+        step (random weights guarantee draft/target tokens disagree) —
+        and asserts the sliding-layer draft cache offset stays in
+        lockstep with the full-attention layer's and with
+        ``prompt_size + n_generated - 1`` across steps, with no
+        ``RuntimeError``. Subtracting ``skip`` on rollback (the issue's
+        suggested "fix") would break the lockstep assertion.
+        """
+        mx.random.seed(0)
+        vocab_size, hidden_size = 32, 16
+        window = 4  # keep = window - 1 = 3
+        prompt_len = 12  # >> window so the skip pre-advance fires on step 1
+
+        target = _Target(vocab_size, hidden_size, num_layers=4)
+        cfg = _make_draft_config(
+            vocab_size,
+            hidden_size,
+            target_layer_ids=[1, 3],
+            num_hidden_layers=2,
+            sliding_window=window,
+            layer_types=("sliding_attention", "full_attention"),
+            block_size=4,
+        )
+        draft = DFlashDraftModel(cfg)
+        decoder = DFlashDecoder(target, draft, cfg, block_size=4)
+
+        decoder.prefill(mx.array([list(range(1, prompt_len + 1))]))
+        sliding_idx, ft_idx = 0, 1
+
+        for _ in range(6):
+            # The offset guard fires DURING step() and checks the draft
+            # offset against ``prompt_size + n_generated - 1`` using the
+            # *entry* value of ``_n_generated`` (before the post-step
+            # increment), so snapshot it now.
+            n_gen_entry = decoder._n_generated
+            # No RuntimeError from the offset invariant guard.
+            accepted, _ = decoder.step()
+            # Random weights ⇒ the draft never matches the target ⇒ only
+            # the bonus token is accepted (the 0-for-block_size case).
+            assert len(accepted) == 1
+            sliding_off = decoder._draft_cache[sliding_idx].offset
+            ft_off = decoder._draft_cache[ft_idx].offset
+            # The sliding-layer offset stays in lockstep with the
+            # full-attention layer (the gh#453 invariant) and matches the
+            # value the in-step guard validated against.
+            assert sliding_off == ft_off == decoder._prompt_size + n_gen_entry - 1
+
+        # Confirm the skip actually fired: the sliding cache holds at most
+        # ``keep`` physical tokens yet its offset ran far past that — proof
+        # the pre-advance happened (otherwise the test proves nothing).
+        sliding_cache = decoder._draft_cache[sliding_idx]
+        assert sliding_cache.keys.shape[2] <= window - 1
+        assert sliding_cache.offset > window - 1
+
 
 # ---------------------------------------------------------------------------
 # Migration / config routing


### PR DESCRIPTION
Closes #453.

## TL;DR

Issue #453 reported a latent bug: a sliding-window DFlash draft layer's `cache.offset += skip` pre-advance is supposedly never rolled back on full rejection, desyncing the draft KV-cache offset and tripping the full-attention invariant guard in `DFlashDecoder.step()`. **It turns out this can't happen** — the offset accounting is already correct. This PR removes the misleading FIXME, documents *why* the invariant holds, and adds a regression test that locks it.

## Root cause of the false alarm

The issue assumed `RotatingKVCache.update_and_fetch` advances `offset` by the original context length `S`, making the total advance `skip + S` (a double-count). It doesn't — it advances by the **post-truncation** count (`keep`):

```python
# mlx_lm RotatingKVCache._update_concat / _update_in_place
self.offset += keys.shape[2]   # keys already truncated to `keep`
```

`DFlashAttention.__call__` truncates `x_ctx` to `keep = window - 1` tokens *before* the write, so the net advance is `skip + keep == S` — identical to a full-attention layer. The skipped positions are real (evicted from the sliding window), so the pre-advance is correct and must **not** be undone. The issue's suggested fix (subtract `skip` on rollback) would apply wrong RoPE positions to later context writes — i.e. it would *introduce* a bug.

The invariant guard runs on a full-attention layer, which never skips, so its offset always equals `prompt_size + n_generated - 1` by construction.

## Verification

Drove the exact scenario from the issue — sliding+full draft, prompt (12) longer than the window (4), full rejection (0-for-block_size) on every step — through the real `prefill`/`step` path:

- The guard never fires.
- The sliding-layer offset stays in **exact lockstep** with the full-attention layer's at every step.

The new test has teeth: applying the issue's proposed rollback turns it red (`assert 11 == 12`).

## Changes

- `olmlx/engine/dflash/decoder.py` — replace the misleading FIXME with an accurate explanation of why the invariant holds by construction. The fail-stop guard stays (still valuable against future bookkeeping bugs).
- `tests/test_dflash.py` — add `test_sliding_draft_offset_stays_in_lockstep_on_full_rejection`.

All 52 dflash tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)