### PR TITLE
fix(prompt_cache): warn once when byte estimator doesn't recognize a cache layout (#465)

### DIFF
--- a/olmlx/engine/prompt_cache/store.py
+++ b/olmlx/engine/prompt_cache/store.py
@@ -31,6 +31,15 @@ except ImportError:  # pragma: no cover
 
 logger = logging.getLogger(__name__)
 
+# Layer classes the byte estimator failed to size (issue #465). Warned once
+# per class so bytes_in_ram undercounting is visible without log spam.
+_UNSIZED_LAYER_CLASSES: set[type] = set()
+
+# Sentinel distinguishing "no .state attribute" from ".state is None":
+# presence of the attribute means the layer matches the ArraysCache-style
+# sizing strategy even when the state is currently empty.
+_MISSING: Any = object()
+
 
 def _estimate_state_bytes(state: CachedPromptState) -> int:
     """Best-effort byte estimate of a cached state.
@@ -48,7 +57,17 @@ def _estimate_state_bytes(state: CachedPromptState) -> int:
     state-only walk would undercount their snapshot RAM by ~8x at 4-bit
     and ~16x at 2-bit, defeating the ``ram_budget_bytes`` soft-eviction
     guard. Walking ``__dict__`` plus the ``.state`` view (deduped by
-    ``id``) covers both surfaces. Unknown layer types still contribute 0.
+    ``id``) covers both surfaces.
+
+    Unknown layer types still contribute 0, but a layer whose class
+    matches *none* of the sizing strategies (no ``.keys``/``.values``
+    attributes, no ``.state``, no mlx arrays reachable from ``__dict__``)
+    logs a one-time warning per class (issue #465) — otherwise
+    ``bytes_in_ram`` undercounts silently and the RAM budget never fires.
+    Legitimately-empty caches of known layouts (a fresh ``KVCache`` whose
+    ``keys``/``values`` are still ``None``, an ``ArraysCache`` whose
+    ``.state`` is a list of ``None``) do not warn: the attribute presence
+    itself marks the layout as recognized.
     """
     total = 0
     for layer in state.cache or ():
@@ -74,7 +93,14 @@ def _estimate_state_bytes(state: CachedPromptState) -> int:
         stack: list[Any] = []
         if hasattr(layer, "__dict__"):
             stack.extend(vars(layer).values())
-        stack.append(getattr(layer, "state", None))
+        # ``_MISSING`` (not ``None``) so a present-but-empty ``.state``
+        # still counts as a strategy match below. Note ``getattr`` with a
+        # default also swallows a *property* that raises AttributeError —
+        # e.g. a fresh KVCache, whose ``.state`` getter touches
+        # ``self.keys.shape`` while ``keys`` is still None.
+        state_attr = getattr(layer, "state", _MISSING)
+        if state_attr is not _MISSING:
+            stack.append(state_attr)
         while stack:
             item = stack.pop()
             if item is None:
@@ -97,6 +123,23 @@ def _estimate_state_bytes(state: CachedPromptState) -> int:
                     continue
                 seen_ids.add(key)
                 total += nbytes
+        # No sizing strategy matched this layer's class: warn once per
+        # class (issue #465). ``seen_ids`` non-empty means the __dict__ /
+        # .state walk found at least one array, i.e. the layer was sized.
+        if (
+            not seen_ids
+            and state_attr is _MISSING
+            and not hasattr(layer, "keys")
+            and not hasattr(layer, "values")
+        ):
+            layer_cls = type(layer)
+            if layer_cls not in _UNSIZED_LAYER_CLASSES:
+                _UNSIZED_LAYER_CLASSES.add(layer_cls)
+                logger.warning(
+                    "prompt cache byte estimator does not understand %s; "
+                    "RAM budget accounting will undercount",
+                    layer_cls.__name__,
+                )
     return total
 
 

--- a/tests/test_prompt_cache_store_multi.py
+++ b/tests/test_prompt_cache_store_multi.py
@@ -162,3 +162,97 @@ def test_estimate_state_bytes_counts_owned_arrays_outside_state():
     assert nbytes == expected, (
         f"expected {expected} bytes (including dequant side buffers), got {nbytes}"
     )
+
+
+def test_estimate_state_bytes_warns_once_for_unrecognized_layout(caplog):
+    """Issue #465: a cache layer class that matches none of the sizing
+    strategies (no .keys/.values, no .state, no mlx arrays reachable from
+    __dict__) silently contributes 0 bytes — bytes_in_ram undercounts and
+    the RAM budget never fires. The estimator must warn once per class so
+    the failure points back at the estimator instead of surfacing later as
+    unexplained Metal memory pressure."""
+    import logging
+
+    import olmlx.engine.prompt_cache.store as store_mod
+    from olmlx.engine.prompt_cache.state import CachedPromptState
+    from olmlx.engine.prompt_cache.store import _estimate_state_bytes
+
+    getattr(store_mod, "_UNSIZED_LAYER_CLASSES", set()).clear()
+
+    class _OpaqueCache:
+        """Future cache layout the estimator does not understand."""
+
+        def __init__(self):
+            self._payload = {"tokens": 128}  # data, but no mlx arrays
+
+    state = CachedPromptState(
+        tokens=[1, 2, 3],
+        cache=[_OpaqueCache(), _OpaqueCache()],
+    )
+    with caplog.at_level(logging.WARNING, logger="olmlx.engine.prompt_cache.store"):
+        assert _estimate_state_bytes(state) == 0
+        # Repeated estimates (and multiple layers) must not spam the log.
+        assert _estimate_state_bytes(state) == 0
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "_OpaqueCache" in r.getMessage()
+    ]
+    assert len(warnings) == 1, (
+        f"expected exactly one warning for _OpaqueCache, got {len(warnings)}"
+    )
+
+
+def test_estimate_state_bytes_warns_per_distinct_unknown_class(caplog):
+    """The once-only suppression is per class, not global: a second unknown
+    layout must still get its own warning."""
+    import logging
+
+    import olmlx.engine.prompt_cache.store as store_mod
+    from olmlx.engine.prompt_cache.state import CachedPromptState
+    from olmlx.engine.prompt_cache.store import _estimate_state_bytes
+
+    getattr(store_mod, "_UNSIZED_LAYER_CLASSES", set()).clear()
+
+    class _OpaqueA:
+        pass
+
+    class _OpaqueB:
+        pass
+
+    state = CachedPromptState(tokens=[1], cache=[_OpaqueA(), _OpaqueB()])
+    with caplog.at_level(logging.WARNING, logger="olmlx.engine.prompt_cache.store"):
+        _estimate_state_bytes(state)
+
+    messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert sum("_OpaqueA" in m for m in messages) == 1
+    assert sum("_OpaqueB" in m for m in messages) == 1
+
+
+def test_estimate_state_bytes_no_warning_for_empty_known_layouts(caplog):
+    """Legitimately-empty caches of *known* layouts must not warn: a fresh
+    KVCache (keys/values are None, .state raises AttributeError until the
+    first update) and an empty ArraysCache (.state is a list of Nones) both
+    contribute 0 bytes but their classes match a sizing strategy."""
+    import logging
+
+    from mlx_lm.models.cache import ArraysCache, KVCache
+
+    import olmlx.engine.prompt_cache.store as store_mod
+    from olmlx.engine.prompt_cache.state import CachedPromptState
+    from olmlx.engine.prompt_cache.store import _estimate_state_bytes
+
+    getattr(store_mod, "_UNSIZED_LAYER_CLASSES", set()).clear()
+
+    state = CachedPromptState(
+        tokens=[1, 2, 3],
+        cache=[KVCache(), ArraysCache(2)],
+    )
+    with caplog.at_level(logging.WARNING, logger="olmlx.engine.prompt_cache.store"):
+        assert _estimate_state_bytes(state) == 0
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == [], (
+        f"empty known layouts must not warn, got: {[r.getMessage() for r in warnings]}"
+    )


### PR DESCRIPTION
## Problem

`_estimate_state_bytes` (`olmlx/engine/prompt_cache/store.py`) sizes cache layers via three strategies: `.keys`/`.values` attributes, a `__dict__` array walk, and a `.state` fallback. A future cache class exposing none of these contributes **0 bytes silently** — `metrics.bytes_in_ram` undercounts, `_enforce_ram_budget` never fires, and the store can blow past `ram_budget_bytes` with the failure surfacing later as Metal memory pressure with no pointer back to the cause.

## Fix

When a layer's class matches *none* of the sizing strategies, emit a `logger.warning` naming the layer class — once per class (module-level `_UNSIZED_LAYER_CLASSES` set) to avoid log spam.

"Matches no strategy" is deliberately distinct from "contributed 0 bytes", so legitimately-empty caches of known layouts stay silent:

- a fresh `KVCache` (keys/values are `None`; its `.state` property raises `AttributeError` while empty) is recognized by the *presence* of the `keys`/`values` attributes;
- an empty `ArraysCache` (`.state` is a list of `None`s) is recognized by the presence of `.state`, distinguished from a missing attribute via a `_MISSING` sentinel instead of the previous `None` default;
- any layer where the `__dict__`/`.state` walk found at least one mlx array was sized, so it never warns.

No sizing behavior changes — the returned byte totals are identical to before. Per the maintainer direction on the issue, this is the minimal log-once fix, not the larger sizing-protocol refactor.

## Testing (TDD)

New tests in `tests/test_prompt_cache_store_multi.py`, written first and confirmed failing for the right reason (no warning emitted) before the fix:

- `test_estimate_state_bytes_warns_once_for_unrecognized_layout` — opaque layer class with no recognized surface warns exactly once across repeated estimates and multiple layers;
- `test_estimate_state_bytes_warns_per_distinct_unknown_class` — suppression is per class, a second unknown layout still gets its own warning;
- `test_estimate_state_bytes_no_warning_for_empty_known_layouts` — real fresh `KVCache` + empty `ArraysCache` contribute 0 bytes without warning.

- `uv run pytest tests/test_prompt_cache_store_multi.py -q` → 12 passed
- `uv run pytest tests/ -k "prompt_cache or store" -q` → 366 passed, 1 skipped
- `uv run ruff check .` / `uv run ruff format .` → clean

Fixes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)