### PR TITLE
feat: GDN source-hash guard (#468) + real-model smoke CI and unmarked-test guard (#470)

### DIFF
--- a/.github/workflows/real-model-smoke.yml
+++ b/.github/workflows/real-model-smoke.yml
@@ -1,0 +1,39 @@
+name: Real-model smoke
+
+# Nightly real-inference coverage (#470): regular CI mocks MLX and
+# deselects real_model tests, so real-model bugs (e.g. the VLM
+# image-drop, #429) can pass CI silently. This runs a small curated
+# real_model subset on the self-hosted Mac, which caches model
+# downloads between runs. No pull_request trigger → no fork-PR
+# exposure, so the same-repo guard ci.yml uses is not needed here.
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: real-model-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Real-model smoke
+    runs-on: self-hosted
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Report disk and model cache
+        run: |
+          df -h .
+          du -sh ~/.cache/huggingface 2>/dev/null || echo "no HF cache yet"
+      - name: Install dependencies
+        run: uv sync --no-editable
+      - name: Run real-model smoke subset
+        # Per-file pytest processes; tolerates the known SIGBUS-at-
+        # Metal-teardown (exit 138) after a green run. Edit the curated
+        # file list in the script to grow coverage.
+        run: bash scripts/real_model_smoke.sh

--- a/olmlx/engine/gdn_rollback.py
+++ b/olmlx/engine/gdn_rollback.py
@@ -80,6 +80,31 @@ _GATED_DELTA_UPDATE_EXPECTED_PARAMS: tuple[str, ...] = (
 )
 
 
+# **Sync point** (#468): sha256 of the *dedented* ``inspect.getsource``
+# of the upstream functions whose exact behavior this module copies or
+# depends on, as verified against mlx-lm 0.31.2:
+#
+# - ``GatedDeltaNet.__call__`` — ``_capturing_gdn_call`` is a verbatim
+#   copy of it; any upstream edit (even a comment) means the copy must
+#   be re-diffed and re-synced.
+# - ``gated_delta_update`` — ``rollback_autoregressive`` relies on a
+#   documented linearity assumption about this kernel; a change would
+#   not raise, it would silently corrupt the rolled-back state.
+#
+# When bumping mlx-lm: re-diff ``_capturing_gdn_call`` against the new
+# ``GatedDeltaNet.__call__``, re-verify the linearity assumption against
+# the new kernel, then add the new hashes here (a frozenset so one olmlx
+# release can span verified mlx-lm patch releases).
+_VERIFIED_UPSTREAM_SHA256: dict[str, frozenset[str]] = {
+    "GatedDeltaNet.__call__": frozenset(
+        {"bb28b030fb520defc6c059913d5327ef5ba2b4bca63eb6a57e0fabd4bae4cc06"}
+    ),
+    "gated_delta_update": frozenset(
+        {"ffe520f93b13109db81e9a0e4e27446fcf3e6f6f73ea93f93bd35a0b50bf02ce"}
+    ),
+}
+
+
 # Attributes that ``_capturing_gdn_call`` reads off the patched layer.
 # Used by ``_find_gdn_class`` as a structural check so the patch only
 # attaches to a class that actually exposes the GDN interface — a
@@ -214,6 +239,84 @@ def validate_gated_delta_update_signature() -> None:
             "update ``_capturing_gdn_call`` / rollback methods and "
             "``_GATED_DELTA_UPDATE_EXPECTED_PARAMS`` together."
         )
+    # Presence is not enough (#468): ``_capturing_gdn_call`` and the
+    # rollback methods pass some of these positionally, so a reorder
+    # with unchanged names would bind tensors to the wrong parameters
+    # without raising. Compare the leading parameter *order* too (new
+    # trailing parameters with defaults are tolerated — they can't
+    # shift existing positions).
+    actual_order = tuple(sig.parameters)
+    n = len(_GATED_DELTA_UPDATE_EXPECTED_PARAMS)
+    if actual_order[:n] != _GATED_DELTA_UPDATE_EXPECTED_PARAMS:
+        raise RuntimeError(
+            "mlx-lm's ``gated_delta_update`` parameter order changed: "
+            f"expected {_GATED_DELTA_UPDATE_EXPECTED_PARAMS}, got "
+            f"{actual_order[:n]}. A reorder silently misbinds the "
+            "positional arguments in ``_capturing_gdn_call`` / rollback; "
+            "re-verify both against the new mlx-lm and update "
+            "``_GATED_DELTA_UPDATE_EXPECTED_PARAMS``."
+        )
+
+
+def _source_sha256(fn: Any) -> str | None:
+    """sha256 of *fn*'s dedented source, or ``None`` when the source is
+    unavailable (builtins, mocks, frozen installs without .py files).
+    """
+    import hashlib
+    import inspect
+    import textwrap
+
+    try:
+        src = inspect.getsource(fn)
+    except (OSError, TypeError):
+        return None
+    return hashlib.sha256(textwrap.dedent(src).encode()).hexdigest()
+
+
+def validate_gdn_upstream_sources(gdn_cls: type) -> None:
+    """Raise if the upstream sources this module is bit-for-bit coupled
+    to have drifted from the verified copies (#468).
+
+    ``_capturing_gdn_call`` is a verbatim copy of *gdn_cls*'s
+    ``__call__`` and ``rollback_autoregressive`` assumes
+    ``gated_delta_update`` is linear in its recurrent state; neither
+    coupling raises on drift by itself — acceptance degrades or state
+    corrupts silently. Hash the upstream sources at patch-install time
+    and fail loudly instead.
+
+    Only classes that actually come from mlx-lm are checked — test
+    stand-ins and user-defined GDN classes are not governed by the copy.
+    A function whose source can't be introspected is skipped with a
+    warning rather than blocking inference.
+    """
+    checks: list[tuple[str, Any]] = []
+    if getattr(gdn_cls, "__module__", "").startswith("mlx_lm"):
+        checks.append(("GatedDeltaNet.__call__", gdn_cls.__call__))
+    if _gd_mod is not None:
+        checks.append(("gated_delta_update", _gd_mod.gated_delta_update))
+
+    for name, fn in checks:
+        actual = _source_sha256(fn)
+        if actual is None:
+            logger.warning(
+                "validate_gdn_upstream_sources: cannot read the source of "
+                "``%s``; skipping the upstream-drift check.",
+                name,
+            )
+            continue
+        if actual not in _VERIFIED_UPSTREAM_SHA256[name]:
+            raise RuntimeError(
+                f"mlx-lm's ``{name}`` source changed since the GDN "
+                "capture/rollback path was last verified (sha256 "
+                f"{actual} is not in the verified set). The vendored "
+                "copy in ``_capturing_gdn_call`` and the "
+                "``gated_delta_update`` linearity assumption must be "
+                "re-verified against the installed mlx-lm before this "
+                "model can run with speculative rollback: diff the "
+                "upstream functions, re-sync the copy if needed, then "
+                "add the new hash to ``_VERIFIED_UPSTREAM_SHA256`` "
+                "(olmlx/engine/gdn_rollback.py). See issue #468."
+            )
 
 
 def find_gdn_class(model: nn.Module) -> type | None:
@@ -349,6 +452,7 @@ class GDNStateCapture:
                 "GatedDeltaNet state for rollback"
             )
         validate_gated_delta_update_signature()
+        validate_gdn_upstream_sources(gdn_cls)
         self._gdn_cls: type = gdn_cls
         self._active_buffer: GDNBuffer | None = None
         self._orig_call: Any = None

--- a/scripts/real_model_smoke.sh
+++ b/scripts/real_model_smoke.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Real-model smoke runner (#470).
+#
+# Runs each test file in its own pytest process so a SIGBUS at Metal
+# teardown (exit 138 = 128 + SIGBUS, seen after an all-green run) kills
+# only that file's process instead of poisoning the whole batch. A file
+# counts as passed when pytest exits 0, or when it exits 138 *after*
+# printing an all-green summary (the known teardown crash). Anything
+# else fails the run.
+#
+# Usage: scripts/real_model_smoke.sh [test-file ...]
+# With no arguments, runs the curated default subset below.
+set -u
+
+FILES=("$@")
+if [ ${#FILES[@]} -eq 0 ]; then
+  FILES=(
+    # Text model end-to-end (tiny: Qwen2.5-0.5B-4bit).
+    tests/integration/test_real_model.py
+    # OpenAI Responses API over a real model (Qwen3-4B-4bit).
+    tests/live/test_responses_sdk.py
+    # VLM + prompt cache + grammar (gemma-4-26B-A4B-4bit).
+    tests/live/test_vlm_cache_grammar.py
+    # Speculative: real MTP draft-head download + strict weight load.
+    tests/test_mtp_loader.py
+  )
+fi
+
+overall=0
+results=()
+for f in "${FILES[@]}"; do
+  echo "::group::${f}"
+  log=$(mktemp)
+  uv run pytest "$f" -m real_model -q 2>&1 | tee "$log"
+  code=${PIPESTATUS[0]}
+  echo "::endgroup::"
+  if [ "$code" -eq 0 ]; then
+    results+=("PASS ${f}")
+  elif [ "$code" -eq 138 ] \
+      && grep -qE '[0-9]+ passed' "$log" \
+      && ! grep -qE '[0-9]+ (failed|error)' "$log"; then
+    # Tests were green; the process died afterwards in Metal teardown.
+    results+=("PASS (teardown SIGBUS, exit 138) ${f}")
+  else
+    results+=("FAIL (exit ${code}) ${f}")
+    overall=1
+  fi
+  rm -f "$log"
+done
+
+echo
+echo "=== real-model smoke summary ==="
+printf '%s\n' "${results[@]}"
+exit "$overall"

--- a/scripts/real_model_smoke.sh
+++ b/scripts/real_model_smoke.sh
@@ -34,8 +34,14 @@ for f in "${FILES[@]}"; do
   uv run pytest "$f" -m real_model -q 2>&1 | tee "$log"
   code=${PIPESTATUS[0]}
   echo "::endgroup::"
-  if [ "$code" -eq 0 ]; then
+  if [ "$code" -eq 0 ] && grep -qE '[0-9]+ passed' "$log"; then
     results+=("PASS ${f}")
+  elif [ "$code" -eq 0 ]; then
+    # Exit 0 but nothing actually ran (everything skipped — e.g. the
+    # model wasn't downloadable). Silent zero coverage must not read
+    # as a green smoke run.
+    results+=("FAIL (exit 0 but no tests ran — all skipped?) ${f}")
+    overall=1
   elif [ "$code" -eq 138 ] \
       && grep -qE '[0-9]+ passed' "$log" \
       && ! grep -qE '[0-9]+ (failed|error)' "$log"; then

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,10 +27,19 @@ def block_real_model_loads(request, monkeypatch):
     that let the VLM image-drop bug through (#429). Guarded seams:
     ``mlx_lm.load``, ``mlx_vlm.load`` (every olmlx text/VLM load goes
     through them; both modules are already imported transitively) and
-    ``huggingface_hub.snapshot_download`` (every fresh download,
-    including whisper/TTS pulls — olmlx resolves it at call time via
-    function-local imports). Cached whisper/TTS weights are *not*
-    covered; importing ``mlx_audio`` here would drag in spaCy.
+    ``huggingface_hub.snapshot_download`` (every fresh weight download
+    — olmlx resolves it at call time via function-local imports).
+    Cached whisper/TTS weights are *not* covered; importing
+    ``mlx_audio`` here would drag in spaCy.
+
+    The single-file metadata fetches (``hf_hub_download`` for
+    config.json / chat templates, ``model_info`` for model cards) get
+    softer treatment: every production call site wraps them in a
+    designed ``except Exception`` fallback, and dozens of unit tests
+    exercise exactly those fallbacks — previously via a *real* network
+    404 per test. Those entry points raise ``LocalEntryNotFoundError``
+    (what genuine offline mode raises) instead of failing the test, so
+    fallback tests stay meaningful, deterministic, and offline.
 
     Tests marked ``real_model`` get the real entry points; the
     integration suite's ``mock_mlx_primitives`` layers its mocks over
@@ -55,12 +64,35 @@ def block_real_model_loads(request, monkeypatch):
         _fail._olmlx_real_model_guard = True
         return _fail
 
+    def _offline(entry: str):
+        from huggingface_hub.errors import LocalEntryNotFoundError
+
+        def _raise(*_args, **_kwargs):
+            raise LocalEntryNotFoundError(
+                f"{entry} blocked by the olmlx real-model guard (no "
+                "@pytest.mark.real_model on this test); raising the "
+                "offline-mode error so designed fallbacks engage."
+            )
+
+        _raise._olmlx_real_model_guard = True
+        return _raise
+
     monkeypatch.setattr(mlx_lm, "load", _blocked("mlx_lm.load"))
     monkeypatch.setattr(mlx_vlm, "load", _blocked("mlx_vlm.load"))
     monkeypatch.setattr(
         huggingface_hub,
         "snapshot_download",
         _blocked("huggingface_hub.snapshot_download"),
+    )
+    monkeypatch.setattr(
+        huggingface_hub,
+        "hf_hub_download",
+        _offline("huggingface_hub.hf_hub_download"),
+    )
+    monkeypatch.setattr(
+        huggingface_hub,
+        "model_info",
+        _offline("huggingface_hub.model_info"),
     )
     yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,9 @@
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+import huggingface_hub
+import mlx_lm
+import mlx_vlm
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -11,6 +14,55 @@ from olmlx.engine.model_manager import LoadedModel, ModelManager
 from olmlx.engine.registry import ModelRegistry
 from olmlx.engine.template_caps import TemplateCaps
 from olmlx.models.store import ModelStore
+
+
+@pytest.fixture(autouse=True)
+def block_real_model_loads(request, monkeypatch):
+    """Fail any test that reaches a real model-loading entry point
+    without ``@pytest.mark.real_model`` (#470).
+
+    CI deselects ``-m "not real_model"`` and the integration suite
+    autouse-mocks MLX, so a forgotten marker either downloads gigabytes
+    in CI or silently passes against a mock — the false-positive gap
+    that let the VLM image-drop bug through (#429). Guarded seams:
+    ``mlx_lm.load``, ``mlx_vlm.load`` (every olmlx text/VLM load goes
+    through them; both modules are already imported transitively) and
+    ``huggingface_hub.snapshot_download`` (every fresh download,
+    including whisper/TTS pulls — olmlx resolves it at call time via
+    function-local imports). Cached whisper/TTS weights are *not*
+    covered; importing ``mlx_audio`` here would drag in spaCy.
+
+    Tests marked ``real_model`` get the real entry points; the
+    integration suite's ``mock_mlx_primitives`` layers its mocks over
+    this guard (inner fixture wins during the test, unwinds cleanly).
+    """
+    if request.node.get_closest_marker("real_model"):
+        yield
+        return
+
+    def _blocked(entry: str):
+        def _fail(*_args, **_kwargs):
+            pytest.fail(
+                f"{entry} was called by a test without "
+                "@pytest.mark.real_model. Loading or downloading real "
+                "models must be opted into via the marker so CI "
+                "(-m 'not real_model') deselects it; otherwise the "
+                "integration MLX mock can turn a real-model bug into a "
+                "silent pass. Add @pytest.mark.real_model (and put live "
+                "coverage under tests/live/), or mock the load."
+            )
+
+        _fail._olmlx_real_model_guard = True
+        return _fail
+
+    monkeypatch.setattr(mlx_lm, "load", _blocked("mlx_lm.load"))
+    monkeypatch.setattr(mlx_vlm, "load", _blocked("mlx_vlm.load"))
+    monkeypatch.setattr(
+        huggingface_hub,
+        "snapshot_download",
+        _blocked("huggingface_hub.snapshot_download"),
+    )
+    yield
 
 
 def make_error_stream(chunks, error_msg="GPU error"):

--- a/tests/test_extended_runner_coverage.py
+++ b/tests/test_extended_runner_coverage.py
@@ -470,8 +470,15 @@ class TestRunModelOrchestration:
         # t_start=0, then deadline check returns increasing time. With
         # per_model_timeout=10 and deadline=10, the 2nd loop check at t=20
         # has remaining<=0 → breakout after 1 prompt.
-        times = iter([0.0, 1.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0])
-        monkeypatch.setattr(er.time, "monotonic", lambda: next(times))
+        #
+        # ``er.time`` is the global ``time`` module, so this patch leaks
+        # to *every* monotonic caller during the test (asyncio, fixture
+        # teardown). Repeat the last value once exhausted — a bare
+        # ``next(times)`` raised StopIteration out of unrelated yield
+        # fixtures whenever a conftest change perturbed the call count.
+        times = [0.0, 1.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0]
+        times_iter = iter(times)
+        monkeypatch.setattr(er.time, "monotonic", lambda: next(times_iter, times[-1]))
 
         async def fake_drive(client, model, prompt, suite):
             return PromptResult(prompt.name, prompt.category, suite, True, 1.0, "", "")

--- a/tests/test_gdn_rollback_coverage.py
+++ b/tests/test_gdn_rollback_coverage.py
@@ -377,6 +377,89 @@ class TestValidateSignature:
             with pytest.raises(RuntimeError, match="Cannot introspect"):
                 validate_gated_delta_update_signature()
 
+    def test_raises_on_reordered_params(self):
+        """#468: a presence-only check accepts a reordering that breaks
+        the positional call in ``_capturing_gdn_call``/rollback. The
+        probe must compare order, not just the set of names.
+        """
+        fake_mod = MagicMock()
+
+        # Same names as upstream, ``q`` and ``k`` swapped.
+        def _reordered(k, q, v, a, b, A_log, dt_bias, state, mask, use_kernel):
+            return None
+
+        fake_mod.gated_delta_update = _reordered
+        with patch.object(gr, "_gd_mod", fake_mod):
+            with pytest.raises(RuntimeError, match="order"):
+                validate_gated_delta_update_signature()
+
+
+# ---------------------------------------------------------------------------
+# validate_gdn_upstream_sources (#468 follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUpstreamSources:
+    """Source-hash guard: an out-of-sync vendored ``GatedDeltaNet.__call__``
+    copy (or a changed ``gated_delta_update`` kernel) must fail at patch
+    time instead of silently degrading acceptance / corrupting state.
+    """
+
+    @staticmethod
+    def _real_gdn_cls():
+        from mlx_lm.models.qwen3_5 import GatedDeltaNet as RealGDN
+
+        return RealGDN
+
+    def test_passes_with_real_mlx_lm(self):
+        # The verified-hash table must match the installed (pinned) mlx-lm.
+        gr.validate_gdn_upstream_sources(self._real_gdn_cls())
+
+    def test_raises_on_drifted_gdn_call_source(self):
+        stale = dict(gr._VERIFIED_UPSTREAM_SHA256)
+        stale["GatedDeltaNet.__call__"] = frozenset({"0" * 64})
+        with patch.object(gr, "_VERIFIED_UPSTREAM_SHA256", stale):
+            with pytest.raises(RuntimeError, match="GatedDeltaNet.__call__"):
+                gr.validate_gdn_upstream_sources(self._real_gdn_cls())
+
+    def test_raises_on_drifted_gated_delta_update_source(self):
+        stale = dict(gr._VERIFIED_UPSTREAM_SHA256)
+        stale["gated_delta_update"] = frozenset({"0" * 64})
+        with patch.object(gr, "_VERIFIED_UPSTREAM_SHA256", stale):
+            with pytest.raises(RuntimeError, match="gated_delta_update"):
+                gr.validate_gdn_upstream_sources(self._real_gdn_cls())
+
+    def test_skips_non_mlx_lm_classes(self):
+        # The contract is with upstream mlx-lm; hand-built stand-ins
+        # (this file's fake ``GatedDeltaNet``) are exempt from the class
+        # hash even with a poisoned table.
+        stale = dict(gr._VERIFIED_UPSTREAM_SHA256)
+        stale["GatedDeltaNet.__call__"] = frozenset({"0" * 64})
+        with patch.object(gr, "_VERIFIED_UPSTREAM_SHA256", stale):
+            gr.validate_gdn_upstream_sources(GatedDeltaNet)
+
+    def test_skips_uninspectable_gated_delta_update(self):
+        # A MagicMock module (as other tests install) has no source —
+        # skip with a warning rather than blocking inference.
+        fake_mod = MagicMock()
+        with patch.object(gr, "_gd_mod", fake_mod):
+            gr.validate_gdn_upstream_sources(GatedDeltaNet)
+
+    def test_capture_init_validates_sources(self):
+        # The guard must run before the patch is installed, and a
+        # failed construction must leave the lock free.
+        stale = dict(gr._VERIFIED_UPSTREAM_SHA256)
+        stale["GatedDeltaNet.__call__"] = frozenset({"0" * 64})
+        real_cls = self._real_gdn_cls()
+        orig_call = real_cls.__call__
+        with patch.object(gr, "_VERIFIED_UPSTREAM_SHA256", stale):
+            with pytest.raises(RuntimeError, match="GatedDeltaNet.__call__"):
+                GDNStateCapture(real_cls)
+        assert real_cls.__call__ is orig_call  # never patched
+        # Lock free → a capture on the fake class still installs.
+        cap = GDNStateCapture(GatedDeltaNet)
+        cap.close()
+
 
 # ---------------------------------------------------------------------------
 # Patch lifecycle: __init__ / _patch / close / __del__ / for_model

--- a/tests/test_inference_checkpoint_drive.py
+++ b/tests/test_inference_checkpoint_drive.py
@@ -606,6 +606,7 @@ def test_tokenize_segmented_chat_returns_empty_segment_for_unrecognised_shape():
 
 
 @pytest.mark.slow
+@pytest.mark.real_model
 def test_tokenize_segmented_chat_real_qwen3_5_template():
     """Real-template test: Qwen3.5 chat template should produce one
     segment per message, with token boundaries at <|im_end|> positions."""

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -5992,6 +5992,13 @@ class TestWhisperLoad:
     def test_load_model_whisper_branch(self, tmp_path, registry, mock_store):
         manager = ModelManager(registry, mock_store)
         fake_whisper = MagicMock()
+        # Pre-create the local model dir so ensure_downloaded() takes the
+        # is_downloaded() short-circuit. Without it this test reached the
+        # real ``snapshot_download("test/whisper")`` over the network
+        # (caught by the real-model guard, #470).
+        local_dir = mock_store.local_path("test/whisper")
+        local_dir.mkdir(parents=True)
+        (local_dir / "config.json").write_text("{}")
         with (
             patch.object(manager, "_detect_model_kind", return_value="whisper"),
             patch(

--- a/tests/test_mtp_loader.py
+++ b/tests/test_mtp_loader.py
@@ -17,10 +17,14 @@ def _head_dir() -> Path | None:
         return None
 
 
-@pytest.mark.skipif(_head_dir() is None, reason="MTP head not downloadable")
+# real_model (#470): downloads and loads the real MTP head. The skip
+# decision lives inside the test (not a ``skipif`` expression) so
+# collection never touches the network.
+@pytest.mark.real_model
 def test_load_mtp_draft_strict_no_leftover_keys():
     path = _head_dir()
-    assert path is not None  # guarded by skipif above; narrows for the type checker
+    if path is None:
+        pytest.skip("MTP head not downloadable")
     cfg = MTPConfig.from_dict(json.loads((path / "config.json").read_text()))
     draft = load_mtp_draft(path, cfg)
     assert isinstance(draft, MTPDraftModel)
@@ -39,10 +43,11 @@ def _moe_head_dir() -> Path | None:
         return None
 
 
-@pytest.mark.skipif(_moe_head_dir() is None, reason="MoE MTP head not downloadable")
+@pytest.mark.real_model
 def test_load_mtp_draft_moe_strict():
     path = _moe_head_dir()
-    assert path is not None
+    if path is None:
+        pytest.skip("MoE MTP head not downloadable")
     cfg = MTPConfig.from_dict(json.loads((path / "config.json").read_text()))
     assert cfg.is_moe
     draft = load_mtp_draft(path, cfg)

--- a/tests/test_real_model_guard.py
+++ b/tests/test_real_model_guard.py
@@ -29,6 +29,23 @@ class TestRealModelGuard:
         with pytest.raises(pytest.fail.Exception, match="real_model"):
             huggingface_hub.snapshot_download("olmlx-tests/no-such-repo")
 
+    def test_hf_hub_download_raises_offline_error_without_marker(self):
+        # Metadata fetches (config.json, chat templates) have designed
+        # except-Exception fallbacks at every production call site, so
+        # the guard raises the offline-mode error instead of failing
+        # the test — fallback tests stay meaningful without a real
+        # network 404 per test.
+        from huggingface_hub.errors import LocalEntryNotFoundError
+
+        with pytest.raises(LocalEntryNotFoundError, match="real-model guard"):
+            huggingface_hub.hf_hub_download("olmlx-tests/no-such-repo", "config.json")
+
+    def test_model_info_raises_offline_error_without_marker(self):
+        from huggingface_hub.errors import LocalEntryNotFoundError
+
+        with pytest.raises(LocalEntryNotFoundError, match="real-model guard"):
+            huggingface_hub.model_info("olmlx-tests/no-such-repo")
+
     def test_guard_is_installed_for_unmarked_tests(self):
         # The patched callables are tagged so this test (and humans
         # debugging a confusing failure) can tell guard from real.

--- a/tests/test_real_model_guard.py
+++ b/tests/test_real_model_guard.py
@@ -1,0 +1,49 @@
+"""Tests for the unmarked-real-model guard (#470).
+
+CI deselects ``-m "not real_model"`` and the integration suite autouse-mocks
+MLX, so a test that loads a real model *without* the marker either downloads
+gigabytes in CI or silently passes against a mock (a false positive — the
+exact gap that let the VLM image-drop bug through, #429). The autouse guard
+in ``tests/conftest.py`` patches the real loading/downloading entry points
+to fail the offending test with an actionable message.
+"""
+
+import huggingface_hub
+import mlx_lm
+import mlx_vlm
+import pytest
+
+
+class TestRealModelGuard:
+    def test_mlx_lm_load_blocked_without_marker(self, tmp_path):
+        with pytest.raises(pytest.fail.Exception, match="real_model"):
+            mlx_lm.load(str(tmp_path / "no-such-model"))
+
+    def test_mlx_vlm_load_blocked_without_marker(self, tmp_path):
+        with pytest.raises(pytest.fail.Exception, match="real_model"):
+            mlx_vlm.load(str(tmp_path / "no-such-model"))
+
+    def test_snapshot_download_blocked_without_marker(self):
+        # Nonexistent repo id: if the guard ever regresses, this fails
+        # fast on a 404 instead of downloading a real model.
+        with pytest.raises(pytest.fail.Exception, match="real_model"):
+            huggingface_hub.snapshot_download("olmlx-tests/no-such-repo")
+
+    def test_guard_is_installed_for_unmarked_tests(self):
+        # The patched callables are tagged so this test (and humans
+        # debugging a confusing failure) can tell guard from real.
+        assert getattr(mlx_lm.load, "_olmlx_real_model_guard", False)
+        assert getattr(mlx_vlm.load, "_olmlx_real_model_guard", False)
+        assert getattr(
+            huggingface_hub.snapshot_download, "_olmlx_real_model_guard", False
+        )
+
+    @pytest.mark.real_model
+    def test_marked_test_bypasses_guard(self):
+        # Deselected in CI; validates locally that the marker restores
+        # the real entry points.
+        assert not getattr(mlx_lm.load, "_olmlx_real_model_guard", False)
+        assert not getattr(mlx_vlm.load, "_olmlx_real_model_guard", False)
+        assert not getattr(
+            huggingface_hub.snapshot_download, "_olmlx_real_model_guard", False
+        )


### PR DESCRIPTION
Completes the remainders of #468 and #470 (the pins and fork-PR guard landed in #475).

## #468 — fail loudly when upstream drifts from the verified GDN copy

- **`validate_gdn_upstream_sources()`** (`engine/gdn_rollback.py`): at patch-install time, sha256 the dedented source of the upstream `GatedDeltaNet.__call__` (which `_capturing_gdn_call` copies verbatim) and `gated_delta_update` (whose linearity the rollback depends on) against a verified-hash table. A drifted upstream now raises with re-verification instructions instead of silently degrading acceptance or corrupting draft cache state. Test stand-ins (non-`mlx_lm` classes) and uninspectable callables are exempt.
- **Order-aware signature probe**: `validate_gated_delta_update_signature()` now compares leading parameter *order*, not just presence — a reorder with unchanged names would misbind the positional call without raising. New trailing defaulted params remain tolerated.

Closes #468

## #470 — close the zero-real-inference CI gap

- **Nightly real-model smoke** (`.github/workflows/real-model-smoke.yml` + `scripts/real_model_smoke.sh`): scheduled (03:00 UTC) + `workflow_dispatch` on the self-hosted Mac. Each curated file runs in its own pytest process; exit 138 after an all-green summary (the known SIGBUS-at-Metal-teardown) counts as pass, anything else fails. Curated subset: tiny text model (`Qwen2.5-0.5B`), Responses API over a real model, VLM cache+grammar (Gemma 4), MTP head load. The list is a plain array in the script — grow it by editing.
- **Unmarked-test guard** (`tests/conftest.py`, autouse): any test reaching `mlx_lm.load`, `mlx_vlm.load`, or `huggingface_hub.snapshot_download` without `@pytest.mark.real_model` now fails with an actionable message. Cached whisper/TTS loads aren't covered (importing `mlx_audio` would drag in spaCy); fresh downloads of any kind are.

The guard immediately caught three real offenders (fixed here):
1. `test_mtp_loader.py` downloaded MTP heads at **collection time** (inside `skipif` expressions) and loaded real weights unmarked → marked `real_model`, downloads moved inside the test bodies so collection never touches the network.
2. `test_tokenize_segmented_chat_real_qwen3_5_template` loaded a real 0.8B model unmarked → marked `real_model`.
3. `test_load_model_whisper_branch` made a live network call to `snapshot_download("test/whisper")` → the local model dir is now pre-created so `ensure_downloaded()` short-circuits.

Plus one robustness fix the guard exposed: `test_per_model_timeout_breaks_loop_and_marks_timed_out` patched the global `time.monotonic` with a finite iterator, so any conftest change perturbing the call count raised `StopIteration` out of unrelated yield fixtures — the fake clock now repeats its last value.

Closes #470

## Verification

- TDD: guard tests and GDN-validation tests written first and watched failing (the source-hash tests fail with a poisoned hash table; the guard tests failed by actually reaching the network pre-implementation)
- `uv run pytest -m "not real_model"`: 4437 passed, 3 skipped
- `uv run pyright`: 0 errors
- `ruff check` + `ruff format`: clean
- `scripts/real_model_smoke.sh tests/test_real_model_guard.py`: PASS (script classification logic exercised end-to-end)

Note for the first nightly run: the curated VLM file needs `gemma-4-26B-A4B-it-4bit` (~15 GB) on the runner — if the Mac Mini's disk can't hold it, drop that line from the script's default list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)