### PR TITLE
fix: minor robustness cleanups (Timer misuse, shard() retry message, voice unlink log, bash ENOENT)

### DIFF
--- a/olmlx/chat/builtin_tools.py
+++ b/olmlx/chat/builtin_tools.py
@@ -1,6 +1,7 @@
 """Built-in tools for the chat client — file system, shell, research, planning."""
 
 import asyncio
+import errno
 import glob as glob_module
 import http.client
 import ipaddress
@@ -402,8 +403,14 @@ async def _handle_bash(args: dict) -> str | ToolError:
             start_new_session=True,
         )
     except OSError as exc:
+        if exc.errno == errno.ENOENT:
+            # The shell binary itself is missing (minimal containers etc.) —
+            # name the real problem instead of a generic spawn failure.
+            message = f"Error running command: shell not found ({exc})"
+        else:
+            message = f"Error running command: {exc}"
         return ToolError(
-            message=f"Error running command: {exc}",
+            message=message,
             tool_name="bash",
             is_user_error=False,
         )

--- a/olmlx/chat/voice/io.py
+++ b/olmlx/chat/voice/io.py
@@ -7,6 +7,7 @@ inference lock, so listen() and speak() never overlap generation.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import re
 
@@ -14,6 +15,8 @@ from olmlx.chat.voice import capture, playback
 from olmlx.engine.inference import generate_speech, generate_transcription
 from olmlx.engine.model_manager import ModelManager
 from olmlx.engine.tts import resolve_voice
+
+logger = logging.getLogger(__name__)
 
 _SENTENCE_RE = re.compile(r".+?(?:[.!?](?:\s+|$)|$)", re.DOTALL)
 
@@ -56,8 +59,8 @@ class VoiceIO:
         finally:
             try:
                 os.unlink(path)
-            except OSError:
-                pass
+            except OSError as exc:
+                logger.debug("Failed to remove recording temp file %s: %s", path, exc)
         return (result.get("text") or "").strip()
 
     async def speak(self, text: str) -> None:

--- a/olmlx/engine/flash/flash_model.py
+++ b/olmlx/engine/flash/flash_model.py
@@ -66,6 +66,7 @@ class FlashModelWrapper(nn.Module):
         # for _-prefixed names).
         object.__setattr__(self, "_model", model)
         object.__setattr__(self, "_sharded", False)
+        object.__setattr__(self, "_shard_failed", False)
         # Surface the weight store so ModelManager can close it on
         # eviction / keep-alive expiry. Without this attribute, the
         # FlashWeightStore's 32-thread ThreadPoolExecutor and per-layer
@@ -154,10 +155,13 @@ class FlashModelWrapper(nn.Module):
         all_sum, so every rank feeds identical input to FlashMLP.
         """
         if self._sharded:
-            raise RuntimeError(
-                "shard() has already been called or failed mid-loop — "
-                "model is in an indeterminate state, reload to retry"
-            )
+            if self._shard_failed:
+                raise RuntimeError(
+                    "shard() failed mid-mutation — attention weights are "
+                    "partially sharded; discard this instance and reload "
+                    "the model"
+                )
+            raise RuntimeError("shard() has already been called")
         if group is None:
             raise ValueError("shard() requires an explicit distributed group")
         from mlx.nn.layers.distributed import shard_linear
@@ -196,23 +200,29 @@ class FlashModelWrapper(nn.Module):
             )
 
         # Mark sharded before mutation so a mid-loop failure still prevents
-        # a second shard() call on a partially-mutated model.
+        # a second shard() call on a partially-mutated model; _shard_failed
+        # distinguishes that case so the retry error doesn't claim a prior
+        # success.
         object.__setattr__(self, "_sharded", True)
-        # Shard projections first; update head counts in a second pass so
-        # a shard_linear failure doesn't leave some layers with halved heads.
-        for layer in self._model.layers:
-            if not hasattr(layer, "self_attn"):
-                continue
-            attn = layer.self_attn
-            attn.q_proj = shard_linear(attn.q_proj, "all-to-sharded", group=group)
-            attn.k_proj = shard_linear(attn.k_proj, "all-to-sharded", group=group)
-            attn.v_proj = shard_linear(attn.v_proj, "all-to-sharded", group=group)
-            attn.o_proj = shard_linear(attn.o_proj, "sharded-to-all", group=group)
-        for layer in self._model.layers:
-            if not hasattr(layer, "self_attn"):
-                continue
-            layer.self_attn.n_heads //= N
-            layer.self_attn.n_kv_heads //= N
+        try:
+            # Shard projections first; update head counts in a second pass so
+            # a shard_linear failure doesn't leave some layers with halved heads.
+            for layer in self._model.layers:
+                if not hasattr(layer, "self_attn"):
+                    continue
+                attn = layer.self_attn
+                attn.q_proj = shard_linear(attn.q_proj, "all-to-sharded", group=group)
+                attn.k_proj = shard_linear(attn.k_proj, "all-to-sharded", group=group)
+                attn.v_proj = shard_linear(attn.v_proj, "all-to-sharded", group=group)
+                attn.o_proj = shard_linear(attn.o_proj, "sharded-to-all", group=group)
+            for layer in self._model.layers:
+                if not hasattr(layer, "self_attn"):
+                    continue
+                layer.self_attn.n_heads //= N
+                layer.self_attn.n_kv_heads //= N
+        except BaseException:
+            object.__setattr__(self, "_shard_failed", True)
+            raise
         logger.info(
             "Sharded %d attention layers (MLP handled by Flash SSD)",
             attn_layer_count,

--- a/olmlx/utils/timing.py
+++ b/olmlx/utils/timing.py
@@ -26,8 +26,8 @@ class Timer:
     """Nanosecond timer context manager."""
 
     def __init__(self):
-        self._start: int = 0
-        self._end: int = 0
+        self._start: int | None = None
+        self._end: int | None = None
 
     def __enter__(self):
         self._start = time.perf_counter_ns()
@@ -38,4 +38,12 @@ class Timer:
 
     @property
     def duration_ns(self) -> int:
+        # Fail loudly on misuse — a silent 0 would flow into TimingStats
+        # and Prometheus as a plausible-looking measurement.
+        if self._start is None:
+            raise RuntimeError("Timer was never entered; duration_ns is undefined")
+        if self._end is None:
+            raise RuntimeError(
+                "Timer was entered but not exited; duration_ns is undefined"
+            )
         return self._end - self._start

--- a/tests/test_builtin_tools_coverage.py
+++ b/tests/test_builtin_tools_coverage.py
@@ -447,3 +447,19 @@ class TestBashBranches:
         assert result.tool_name == "bash"
         assert "Error running command" in result.message
         assert result.is_user_error is False
+
+    @pytest.mark.asyncio
+    async def test_bash_spawn_enoent_names_missing_shell(self, manager):
+        """ENOENT means the shell binary itself is missing — say so explicitly
+        instead of the generic spawn-failure message."""
+        import errno
+
+        with patch(
+            "olmlx.chat.builtin_tools.asyncio.create_subprocess_shell",
+            side_effect=OSError(errno.ENOENT, "No such file or directory"),
+        ):
+            result = await manager.call_tool("bash", {"command": "echo hi"})
+        assert isinstance(result, ToolError)
+        assert result.tool_name == "bash"
+        assert "shell not found" in result.message
+        assert result.is_user_error is False

--- a/tests/test_flash_mlp.py
+++ b/tests/test_flash_mlp.py
@@ -491,12 +491,34 @@ class TestFlashModelWrapperShard:
             wrapper.shard(FakeGroup(rank=0, size=8))
 
     def test_shard_raises_if_called_twice(self, wrapper_setup):
-        """shard() must raise RuntimeError if called a second time."""
+        """A retry after a *successful* shard() must say so — not claim a
+        mid-loop failure that never happened."""
         from olmlx.engine.pre_shard import FakeGroup
 
         wrapper, *_ = wrapper_setup
         wrapper.shard(FakeGroup(rank=0, size=2))
-        with pytest.raises(RuntimeError, match="already been called|indeterminate"):
+        with pytest.raises(RuntimeError, match="already been called") as excinfo:
+            wrapper.shard(FakeGroup(rank=0, size=2))
+        assert "failed" not in str(excinfo.value)
+
+    def test_shard_retry_after_midloop_failure_says_reload(self, wrapper_setup):
+        """A retry after shard() died mid-mutation must say the model is
+        partially sharded and needs a reload, not 'already been called'."""
+        from unittest.mock import patch
+
+        from olmlx.engine.pre_shard import FakeGroup
+
+        wrapper, *_ = wrapper_setup
+        with (
+            patch(
+                "mlx.nn.layers.distributed.shard_linear",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            wrapper.shard(FakeGroup(rank=0, size=2))
+
+        with pytest.raises(RuntimeError, match="failed mid-mutation.*reload"):
             wrapper.shard(FakeGroup(rank=0, size=2))
 
     def test_shard_requires_group(self, wrapper_setup):

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -2,6 +2,8 @@
 
 import time
 
+import pytest
+
 from olmlx.utils.timing import Timer, TimingStats
 
 
@@ -60,8 +62,15 @@ class TestTimer:
         assert result is timer
         timer.__exit__(None, None, None)
 
-    def test_initial_values(self):
+    def test_duration_before_enter_raises(self):
+        """A never-entered timer must fail loudly, not report 0 ns."""
         t = Timer()
-        assert t._start == 0
-        assert t._end == 0
-        assert t.duration_ns == 0
+        with pytest.raises(RuntimeError, match="never entered"):
+            t.duration_ns
+
+    def test_duration_before_exit_raises(self):
+        """Reading duration inside the with-block is misuse, not 'now - start'."""
+        t = Timer()
+        t.__enter__()
+        with pytest.raises(RuntimeError, match="not exited"):
+            t.duration_ns

--- a/tests/test_voice_io.py
+++ b/tests/test_voice_io.py
@@ -42,6 +42,31 @@ async def test_listen_records_and_transcribes(mock_manager):
     unlink.assert_called_once_with("/tmp/x.wav")
 
 
+@pytest.mark.asyncio
+async def test_listen_unlink_oserror_is_logged_not_raised(mock_manager, caplog):
+    """A failed temp-file cleanup must not clobber a successful transcription."""
+    import logging
+
+    vio = VoiceIO(
+        manager=mock_manager,
+        stt_model="whisper",
+        tts_model="kokoro",
+        voice="af_heart",
+    )
+    with (
+        patch("olmlx.chat.voice.io.capture.record_to_wav", return_value="/tmp/x.wav"),
+        patch("olmlx.chat.voice.io.os.unlink", side_effect=OSError("gone")),
+        patch(
+            "olmlx.chat.voice.io.generate_transcription",
+            new=AsyncMock(return_value={"text": "hello"}),
+        ),
+        caplog.at_level(logging.DEBUG, logger="olmlx.chat.voice.io"),
+    ):
+        text = await vio.listen()
+    assert text == "hello"
+    assert any("/tmp/x.wav" in r.getMessage() for r in caplog.records)
+
+
 def _fake_speech_stream(segments):
     """Return a callable producing a fresh async generator of ``segments``.
 


### PR DESCRIPTION
Closes #472 — four small, low-severity items from the 2026-06-09 full-repo review. TDD: each fix has a test that failed before the change.

## Changes

1. **`utils/timing.py` `Timer`** — `_start`/`_end` initialize to `None` instead of `0`, and `duration_ns` raises `RuntimeError` on a never-entered or un-exited timer. Previously a misused timer silently reported 0 ns, which would flow into `TimingStats` and Prometheus as a plausible-looking measurement. All existing callers (`inference.py`, `routers/embed.py`) read `duration_ns` after the `with` block, so correct use is unaffected; the old `test_initial_values` test (which asserted the silent-zero behavior) is replaced by two misuse tests.

2. **`engine/flash/flash_model.py` `shard()`** — a new `_shard_failed` flag distinguishes "shard already succeeded" from "shard died mid-mutation". The retry error after a mid-loop failure now says the model is partially sharded and must be discarded/reloaded; a retry after success keeps a plain "already been called" message. The fail-closed behavior (never allow a second shard attempt on a partially-mutated model) is unchanged — `except BaseException` so even a KeyboardInterrupt mid-loop marks the instance failed.

3. **`chat/voice/io.py` `listen()`** — the recording temp-file unlink failure is logged at debug level instead of swallowed with a bare `pass` (the `OSError` guard itself already existed; this adds the observability the issue asked for, mirroring the `materialize_audio` cleanup pattern).

4. **`chat/builtin_tools.py` bash handler** — a spawn `OSError` with `errno.ENOENT` now reports "shell not found" explicitly instead of the generic spawn-failure message, which helps on minimal environments where `/bin/sh` is missing.

## Testing

- New tests: 2 Timer misuse tests, 1 shard mid-mutation-retry test (+ tightened the success-retry test to reject the old conflated message), 1 voice unlink-OSError logging test, 1 bash ENOENT test.
- `pytest tests/test_timing.py tests/test_voice_io.py tests/test_voice_cli.py tests/test_builtin_tools.py tests/test_builtin_tools_coverage.py tests/test_flash_mlp.py tests/test_flash_integration.py tests/test_metrics.py tests/test_routers_embed.py tests/test_streaming.py tests/integration -m "not real_model"` — all green.
- `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)