### PR TITLE
refactor(chat): extract per-turn streaming + parse step from send_message (#480)

### DIFF
--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -202,6 +202,18 @@ ChatEvent = (
 )
 
 
+class _TurnStreamResult(TypedDict):
+    """Out-of-band results from ``_stream_one_turn``.
+
+    Filled in place by the helper because an async generator cannot
+    return values.
+    """
+
+    full_text: str
+    thinking_expected: bool
+    repetition_stopped: bool
+
+
 class ThinkingTracker:
     """Tracks <think> tag boundaries during streaming generation.
 
@@ -904,6 +916,97 @@ class ChatSession:
             # (agent loop) handle recovery and track consecutive failures.
             return
 
+    async def _stream_one_turn(
+        self,
+        *,
+        options: dict[str, Any],
+        mcp_tools: list[dict] | None,
+        implicit_thinking: bool,
+        template_has_thinking: bool,
+        result: _TurnStreamResult,
+    ) -> AsyncGenerator[ChatEvent, None]:
+        """Consume one generate_chat turn, splitting thinking from visible text.
+
+        Feeds each chunk through a ThinkingTracker, yields streaming events
+        (token / thinking_* / repetition_detected) and stops early on
+        repetitive output. Fills ``result`` in place: ``full_text`` is the
+        raw accumulated output for the parse step (with any incomplete
+        <think> block stripped on repetition), ``thinking_expected`` mirrors
+        the engine's meta chunk, and ``repetition_stopped`` is True when
+        generation was cut short.
+        """
+        repetition_stopped = False
+        token_count = 0
+        tracker = ThinkingTracker(
+            implicit_mode=implicit_thinking,
+            thinking_disabled=not self.config.thinking,
+            template_has_thinking=template_has_thinking,
+        )
+
+        async for chunk in await generate_chat(
+            self.manager,
+            self.config.model_name,
+            self.messages,
+            options=options,
+            tools=mcp_tools,
+            stream=True,
+            keep_alive="-1",
+            max_tokens=self.config.max_tokens,
+            cache_id="chat",
+            enable_thinking=self.config.thinking,
+        ):
+            if chunk.get("cache_info"):
+                continue
+            if "thinking_expected" in chunk:
+                # Captured so `parse_model_output` only fires the orphan-
+                # `</think>` heuristic when thinking was actually
+                # requested (issue #307).
+                result["thinking_expected"] = bool(chunk["thinking_expected"])
+                continue
+            if chunk.get("done"):
+                break
+            text = chunk.get("text", "")
+            if text:
+                token_count += 1
+                think_delta, visible_delta, thinking_ended, thinking_started = (
+                    tracker.feed(text)
+                )
+
+                if thinking_started:
+                    yield {"type": "thinking_start"}
+                if think_delta:
+                    yield {"type": "thinking_token", "text": think_delta}
+                if thinking_ended:
+                    yield {"type": "thinking_end"}
+                if visible_delta:
+                    yield {"type": "token", "text": visible_delta}
+
+                if token_count % 10 == 0 and _detect_repetition(
+                    tracker.accumulated,
+                    min_phrase_len=self.config.repetition_min_phrase_len,
+                    min_repeats=self.config.repetition_min_repeats,
+                ):
+                    logger.warning("Repetitive output detected, stopping generation")
+                    repetition_stopped = True
+                    yield {"type": "repetition_detected"}
+                    break
+
+        # Flush disabled-thinking content
+        if flush_text := tracker.flush_disabled():
+            yield {"type": "token", "text": flush_text}
+
+        # Strip incomplete thinking on repetition BEFORE yielding final events
+        was_in_thinking = tracker.in_thinking
+        if repetition_stopped:
+            tracker.strip_on_repetition()
+
+        # Close any open thinking block (only if content was stripped mid-think)
+        if was_in_thinking:
+            yield {"type": "thinking_end"}
+
+        result["full_text"] = tracker.accumulated
+        result["repetition_stopped"] = repetition_stopped
+
     async def send_message(self, user_text: str) -> AsyncGenerator[ChatEvent, None]:
         """Send a user message and run the agent loop.
 
@@ -976,102 +1079,28 @@ class ChatSession:
 
         consecutive_failures = 0
         for turn in range(self.config.max_turns):
-            repetition_stopped = False
-            token_count = 0
-            tracker = ThinkingTracker(
-                implicit_mode=assume_implicit_thinking and turn == 0,
-                thinking_disabled=not self.config.thinking,
-                template_has_thinking=template_has_thinking,
-            )
-
-            # Captured from the engine's `thinking_expected` meta chunk so
-            # `parse_model_output` only fires the orphan-`</think>`
-            # heuristic when thinking was actually requested (issue #307).
-            thinking_expected = False
-
-            async for chunk in await generate_chat(
-                self.manager,
-                self.config.model_name,
-                self.messages,
+            turn_result: _TurnStreamResult = {
+                "full_text": "",
+                "thinking_expected": False,
+                "repetition_stopped": False,
+            }
+            async for event in self._stream_one_turn(
                 options=options,
-                tools=mcp_tools,
-                stream=True,
-                keep_alive="-1",
-                max_tokens=self.config.max_tokens,
-                cache_id="chat",
-                enable_thinking=self.config.thinking,
+                mcp_tools=mcp_tools,
+                implicit_thinking=assume_implicit_thinking and turn == 0,
+                template_has_thinking=template_has_thinking,
+                result=turn_result,
             ):
-                if chunk.get("cache_info"):
-                    continue
-                if "thinking_expected" in chunk:
-                    thinking_expected = bool(chunk["thinking_expected"])
-                    continue
-                if chunk.get("done"):
-                    break
-                text = chunk.get("text", "")
-                if text:
-                    token_count += 1
-                    think_delta, visible_delta, thinking_ended, thinking_started = (
-                        tracker.feed(text)
-                    )
+                yield event
+            repetition_stopped = turn_result["repetition_stopped"]
 
-                    if thinking_started:
-                        yield {"type": "thinking_start"}
-                    if think_delta:
-                        yield {"type": "thinking_token", "text": think_delta}
-                    if thinking_ended:
-                        yield {"type": "thinking_end"}
-                    if visible_delta:
-                        yield {"type": "token", "text": visible_delta}
-
-                    if token_count % 10 == 0 and _detect_repetition(
-                        tracker.accumulated,
-                        min_phrase_len=self.config.repetition_min_phrase_len,
-                        min_repeats=self.config.repetition_min_repeats,
-                    ):
-                        logger.warning(
-                            "Repetitive output detected, stopping generation"
-                        )
-                        repetition_stopped = True
-                        yield {"type": "repetition_detected"}
-                        break
-
-            # Flush disabled-thinking content
-            if flush_text := tracker.flush_disabled():
-                yield {"type": "token", "text": flush_text}
-
-            # Strip incomplete thinking on repetition BEFORE yielding final events
-            was_in_thinking = tracker.in_thinking
-            if repetition_stopped:
-                tracker.strip_on_repetition()
-
-            # Close any open thinking block (only if content was stripped mid-think)
-            if was_in_thinking:
-                yield {"type": "thinking_end"}
-
-            full_text = tracker.accumulated
-
-            try:
-                _, visible_text, tool_uses = parse_model_output(
-                    full_text,
-                    has_tools=(mcp_tools is not None),
-                    thinking_expected=thinking_expected,
-                )
-            except Exception as exc:
-                logger.error(
-                    "Failed to parse model output: %s\ntext: %.200s",
-                    exc,
-                    full_text,
-                )
-                visible_text = _strip_thinking(full_text)
-                tool_uses = []
-                yield {
-                    "type": "tool_error",
-                    "name": "(parse error)",
-                    "error": f"Failed to parse model output; tools were dropped: {exc}",
-                    "id": "",
-                    "is_user_error": False,
-                }
+            visible_text, tool_uses, parse_error = _parse_turn_output(
+                turn_result["full_text"],
+                has_tools=(mcp_tools is not None),
+                thinking_expected=turn_result["thinking_expected"],
+            )
+            if parse_error is not None:
+                yield parse_error
 
             # Build assistant message
             assistant_msg: dict[str, Any] = {
@@ -1142,6 +1171,39 @@ class ChatSession:
             yield {"type": "max_turns_exceeded"}
 
         yield {"type": "done"}
+
+
+def _parse_turn_output(
+    full_text: str, *, has_tools: bool, thinking_expected: bool
+) -> tuple[str, list[dict[str, Any]], _ToolErrorEvent | None]:
+    """Parse one turn's raw model output into visible text and tool calls.
+
+    Returns ``(visible_text, tool_uses, parse_error)``. On parse failure,
+    falls back to thinking-stripped text with no tool calls and returns a
+    ``tool_error`` event for the caller to yield. (Named to avoid colliding
+    with the ``parse_model_output`` import from ``engine.tool_parser``.)
+    """
+    try:
+        _, visible_text, tool_uses = parse_model_output(
+            full_text,
+            has_tools=has_tools,
+            thinking_expected=thinking_expected,
+        )
+        return visible_text, tool_uses, None
+    except Exception as exc:
+        logger.error(
+            "Failed to parse model output: %s\ntext: %.200s",
+            exc,
+            full_text,
+        )
+        error: _ToolErrorEvent = {
+            "type": "tool_error",
+            "name": "(parse error)",
+            "error": f"Failed to parse model output; tools were dropped: {exc}",
+            "id": "",
+            "is_user_error": False,
+        }
+        return _strip_thinking(full_text), [], error
 
 
 def _strip_thinking(text: str) -> str:

--- a/tests/test_chat_session_helpers.py
+++ b/tests/test_chat_session_helpers.py
@@ -1,0 +1,232 @@
+"""Unit tests for the helpers extracted from ChatSession.send_message (issue #480).
+
+- ``_parse_turn_output``: the parse step (parse_model_output + error fallback)
+- ``ChatSession._stream_one_turn``: per-turn generate_chat consume loop +
+  ThinkingTracker handling
+
+All tests are hermetic: generate_chat is mocked, no model, no GPU.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from olmlx.chat.config import ChatConfig
+from olmlx.chat.session import ChatSession, _parse_turn_output
+from olmlx.engine.template_caps import TemplateCaps
+
+
+def _make_session(
+    *,
+    thinking=True,
+    template_has_thinking=False,
+):
+    config = ChatConfig(model_name="test:latest", thinking=thinking)
+    manager = MagicMock()
+    loaded_model = MagicMock()
+    loaded_model.template_caps = TemplateCaps(
+        supports_enable_thinking=template_has_thinking,
+        has_thinking_tags=template_has_thinking,
+    )
+    manager.ensure_loaded = AsyncMock(return_value=loaded_model)
+    return ChatSession(config=config, manager=manager)
+
+
+def _stream(*chunks):
+    """Build an async generator factory yielding the given chunks."""
+
+    async def gen(*args, **kwargs):
+        for c in chunks:
+            yield c
+
+    return gen
+
+
+def _new_result():
+    return {
+        "full_text": "",
+        "thinking_expected": False,
+        "repetition_stopped": False,
+    }
+
+
+async def _drain_turn(session, result, **kwargs):
+    kwargs.setdefault("options", {})
+    kwargs.setdefault("mcp_tools", None)
+    kwargs.setdefault("implicit_thinking", False)
+    kwargs.setdefault("template_has_thinking", False)
+    events = []
+    async for ev in session._stream_one_turn(result=result, **kwargs):
+        events.append(ev)
+    return events
+
+
+class TestParseTurnOutput:
+    def test_plain_text(self):
+        visible, tool_uses, error = _parse_turn_output(
+            "Hello world", has_tools=False, thinking_expected=False
+        )
+        assert visible == "Hello world"
+        assert tool_uses == []
+        assert error is None
+
+    def test_thinking_stripped(self):
+        visible, tool_uses, error = _parse_turn_output(
+            "<think>hmm</think>Answer", has_tools=False, thinking_expected=True
+        )
+        assert visible == "Answer"
+        assert tool_uses == []
+        assert error is None
+
+    def test_tool_call_parsed(self):
+        text = (
+            'Let me check.<tool_call>{"name": "get_weather", '
+            '"arguments": {"city": "Paris"}}</tool_call>'
+        )
+        visible, tool_uses, error = _parse_turn_output(
+            text, has_tools=True, thinking_expected=False
+        )
+        assert error is None
+        assert len(tool_uses) == 1
+        assert tool_uses[0]["name"] == "get_weather"
+        assert tool_uses[0]["input"] == {"city": "Paris"}
+
+    def test_parse_failure_falls_back_to_stripped_text(self):
+        with patch(
+            "olmlx.chat.session.parse_model_output",
+            side_effect=ValueError("boom"),
+        ):
+            visible, tool_uses, error = _parse_turn_output(
+                "<think>secret</think>The text",
+                has_tools=True,
+                thinking_expected=True,
+            )
+        assert visible == "The text"
+        assert tool_uses == []
+        assert error is not None
+        assert error["type"] == "tool_error"
+        assert error["name"] == "(parse error)"
+        assert error["is_user_error"] is False
+        assert "boom" in error["error"]
+
+
+class TestStreamOneTurn:
+    async def test_plain_tokens(self):
+        session = _make_session()
+        gen = _stream(
+            {"text": "Hello ", "done": False},
+            {"text": "world", "done": False},
+            {"text": "", "done": True},
+        )
+        result = _new_result()
+        with patch("olmlx.chat.session.generate_chat", side_effect=gen):
+            events = await _drain_turn(session, result)
+
+        token_text = "".join(e["text"] for e in events if e["type"] == "token")
+        assert token_text == "Hello world"
+        assert result["full_text"] == "Hello world"
+        assert result["thinking_expected"] is False
+        assert result["repetition_stopped"] is False
+
+    async def test_thinking_expected_meta_captured(self):
+        session = _make_session()
+        gen = _stream(
+            {"thinking_expected": True},
+            {"text": "Hi", "done": False},
+            {"text": "", "done": True},
+        )
+        result = _new_result()
+        with patch("olmlx.chat.session.generate_chat", side_effect=gen):
+            events = await _drain_turn(session, result)
+
+        assert result["thinking_expected"] is True
+        # The meta chunk must not surface as an event
+        assert all("thinking_expected" not in e for e in events)
+
+    async def test_cache_info_chunk_skipped(self):
+        session = _make_session()
+        gen = _stream(
+            {"cache_info": {"hit": True}},
+            {"text": "Hi", "done": False},
+            {"text": "", "done": True},
+        )
+        result = _new_result()
+        with patch("olmlx.chat.session.generate_chat", side_effect=gen):
+            events = await _drain_turn(session, result)
+
+        assert [e["type"] for e in events] == ["token"]
+        assert result["full_text"] == "Hi"
+
+    async def test_explicit_thinking_events(self):
+        session = _make_session(thinking=True)
+        gen = _stream(
+            {"text": "<think>let me think", "done": False},
+            {"text": "</think>", "done": False},
+            {"text": "Answer", "done": False},
+            {"text": "", "done": True},
+        )
+        result = _new_result()
+        with patch("olmlx.chat.session.generate_chat", side_effect=gen):
+            events = await _drain_turn(session, result)
+
+        types = [e["type"] for e in events]
+        assert "thinking_start" in types
+        assert "thinking_token" in types
+        assert "thinking_end" in types
+        think_text = "".join(e["text"] for e in events if e["type"] == "thinking_token")
+        assert "let me think" in think_text
+        token_text = "".join(e["text"] for e in events if e["type"] == "token")
+        assert token_text == "Answer"
+        # full_text keeps the raw output including tags for the parse step
+        assert "<think>" in result["full_text"]
+
+    async def test_repetition_detected_stops_stream(self):
+        session = _make_session()
+        chunks = [{"text": "repeat phrase here. ", "done": False} for _ in range(60)]
+        chunks.append({"text": "", "done": True})
+        gen = _stream(*chunks)
+        result = _new_result()
+        with patch("olmlx.chat.session.generate_chat", side_effect=gen):
+            events = await _drain_turn(session, result)
+
+        types = [e["type"] for e in events]
+        assert "repetition_detected" in types
+        assert result["repetition_stopped"] is True
+        # Stream stopped early — far fewer token events than the 60 chunks
+        assert types.count("token") < 60
+
+    async def test_disabled_thinking_implicit_flush(self):
+        """Implicit thinking with thinking disabled and no </think> flushes as visible."""
+        session = _make_session(thinking=False, template_has_thinking=True)
+        gen = _stream(
+            {"text": "buffered content", "done": False},
+            {"text": "", "done": True},
+        )
+        result = _new_result()
+        with patch("olmlx.chat.session.generate_chat", side_effect=gen):
+            events = await _drain_turn(
+                session,
+                result,
+                implicit_thinking=True,
+                template_has_thinking=True,
+            )
+
+        token_text = "".join(e["text"] for e in events if e["type"] == "token")
+        assert token_text == "buffered content"
+        assert not any(e["type"] == "thinking_token" for e in events)
+
+    async def test_repetition_mid_thinking_strips_and_closes(self):
+        """Repetition inside an open <think> block strips it and emits thinking_end."""
+        session = _make_session(thinking=True)
+        chunks = [{"text": "<think>", "done": False}]
+        chunks += [{"text": "repeat phrase here. ", "done": False} for _ in range(60)]
+        chunks.append({"text": "", "done": True})
+        gen = _stream(*chunks)
+        result = _new_result()
+        with patch("olmlx.chat.session.generate_chat", side_effect=gen):
+            events = await _drain_turn(session, result)
+
+        types = [e["type"] for e in events]
+        assert "repetition_detected" in types
+        assert "thinking_end" in types
+        assert result["repetition_stopped"] is True
+        # Incomplete think block stripped from the accumulated text
+        assert "<think>" not in result["full_text"]


### PR DESCRIPTION
## Summary

PR 1 of issue #480 (scope item 1): extract the per-turn streaming loop and the parse step from `ChatSession.send_message`, reducing it to orchestration. Behavior-preserving — no API or event-shape changes.

- **`ChatSession._stream_one_turn`**: the `generate_chat` consume loop + `ThinkingTracker` handling — thinking event emission, repetition detection/stop, disabled-thinking flush, and strip-on-repetition. Per-turn outputs (`full_text`, `thinking_expected`, `repetition_stopped`) are returned via a `_TurnStreamResult` TypedDict filled in place, since async generators cannot return values; matches the file's existing TypedDict-event style.
- **`_parse_turn_output`** (module-level): the inline try/except parse step — `parse_model_output` plus the strip-thinking fallback and `tool_error` event on failure. Named to avoid colliding with the `parse_model_output` import from `engine.tool_parser`, per the issue. Returns a plain tuple (no wrapper dataclass, per triage).

Per the issue, `_load_model_for_turn()` and `_run_agent_loop()` were **not** extracted (pure indirection).

## Testing

- New `tests/test_chat_session_helpers.py`: 11 unit tests covering both helpers directly (plain tokens, `thinking_expected` meta capture, `cache_info` skip, explicit-thinking events, repetition stop, repetition mid-`<think>` strip+close, disabled-thinking implicit flush; parse: plain/thinking/tool-call/parse-failure fallback). Written first against the missing helpers (TDD red), then the extraction made them pass.
- All existing chat-module tests pass unchanged (344 across the chat/session/tui/mcp/voice/tool-safety modules).
- ruff check + format clean.

Part of #480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)