### PR TITLE
ci(smoke): pre-pull live-test models so the nightly run isn't all-skipped

### DIFF
--- a/scripts/real_model_smoke.sh
+++ b/scripts/real_model_smoke.sh
@@ -13,7 +13,9 @@
 set -u
 
 FILES=("$@")
+DEFAULT_RUN=0
 if [ ${#FILES[@]} -eq 0 ]; then
+  DEFAULT_RUN=1
   FILES=(
     # Text model end-to-end (tiny: Qwen2.5-0.5B-4bit).
     tests/integration/test_real_model.py
@@ -24,6 +26,25 @@ if [ ${#FILES[@]} -eq 0 ]; then
     # Speculative: real MTP draft-head download + strict weight load.
     tests/test_mtp_loader.py
   )
+fi
+
+# Models the curated default subset's live tests skipif when absent from the
+# olmlx store (~/.olmlx/models). Without them present those files skip every
+# test, which the summary below (correctly) treats as a failed smoke run, not a
+# green one. Pre-pull them so the run exercises real coverage. Pull reuses the
+# HF blob cache, so this is cheap once the runner has downloaded them once
+# (test_real_model.py and test_mtp_loader.py self-provision and are omitted).
+# Only for the default subset — explicit file args manage their own models.
+DEFAULT_MODELS=(
+  "mlx-community/Qwen3-4B-4bit"
+  "mlx-community/gemma-4-26B-A4B-it-4bit"
+)
+if [ "$DEFAULT_RUN" -eq 1 ]; then
+  for m in "${DEFAULT_MODELS[@]}"; do
+    echo "::group::pull ${m}"
+    uv run olmlx models pull "$m" || echo "warning: pull failed for ${m} (its test will skip)"
+    echo "::endgroup::"
+  done
 fi
 
 overall=0


### PR DESCRIPTION
## What failed

The first nightly run of `real-model-smoke.yml` (#470) failed — not from a real-model bug, but from silent zero-coverage. The summary:

```
PASS tests/integration/test_real_model.py
FAIL (exit 0 but no tests ran — all skipped?) tests/live/test_responses_sdk.py
FAIL (exit 0 but no tests ran — all skipped?) tests/live/test_vlm_cache_grammar.py
PASS tests/test_mtp_loader.py
```

Both live files `skipif` their model is absent from the **olmlx store** (`~/.olmlx/models`):
- `test_responses_sdk.py` → `mlx-community/Qwen3-4B-4bit` (3 skipped)
- `test_vlm_cache_grammar.py` → `mlx-community/gemma-4-26B-A4B-it-4bit` (4 skipped)

Those models were never provisioned into `~/.olmlx/models` on the runner. `models_dir` defaults to `~/.olmlx/models`, which is a separate store from the runner's HF blob cache (`~/.cache/huggingface`). So every test in both files skipped, and `scripts/real_model_smoke.sh` correctly treats "exit 0 but nothing ran" as a failure.

The other two files passed because they self-provision: `test_real_model.py` downloads tiny Qwen2.5-0.5B into a tmp dir, and `test_mtp_loader.py` downloads its MTP head.

## The fix

Added a pre-pull step to the smoke script (default subset only): before the pytest loop it runs `olmlx models pull` for the two models the live tests need.

- **Cheap on repeat runs** — `store.pull` → `snapshot_download` reuses the existing HF blob cache, so real download work only happens the first time.
- **Scoped to the default run** — explicit file args still manage their own models.
- **Non-fatal pulls** — a failed pull just warns; the existing skip-detection still surfaces it as a FAIL, so a genuinely unprovisionable model can't masquerade as green.

## Verification

Syntax-checked with `bash -n`. Can't run the real smoke here (no Apple Silicon/MLX); the workflow has `workflow_dispatch` so it can be kicked manually against the live runner to confirm the live tests now execute instead of skip.

https://claude.ai/code/session_018G3CdnkvEUYxG6Xu1Xcd9q

---
_Generated by [Claude Code](https://claude.ai/code/session_018G3CdnkvEUYxG6Xu1Xcd9q)_