### PR TITLE
refactor(chat): extract tool-call classification + parameterized confirm phase (#480)

### DIFF
--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -5,7 +5,7 @@ import json
 import logging
 import re
 from collections.abc import AsyncGenerator
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, TypedDict, cast
 
 from olmlx.chat.builtin_tools import BuiltinToolManager
 from olmlx.chat.config import ChatConfig
@@ -666,7 +666,7 @@ class ChatSession:
         self,
         tools: list[dict],
         *,
-        request_event: str,
+        request_event: Literal["tool_confirmation_needed", "tool_auto_judging"],
         context: list[dict] | None,
         denial_reason: str,
         denial_content: str,
@@ -682,12 +682,17 @@ class ChatSession:
         name).
         """
         for tu in tools:
-            yield {
-                "type": request_event,
-                "name": tu["name"],
-                "arguments": tu["input"],
-                "id": tu["id"],
-            }
+            # Both request-event TypedDicts share this shape; only the
+            # Literal tag differs, which request_event's type pins down.
+            yield cast(
+                "_ToolConfirmationNeededEvent | _ToolAutoJudgingEvent",
+                {
+                    "type": request_event,
+                    "name": tu["name"],
+                    "arguments": tu["input"],
+                    "id": tu["id"],
+                },
+            )
             if await self.tool_safety.check_and_confirm(
                 tu["name"], tu["input"], context=context
             ):

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -631,21 +631,17 @@ class ChatSession:
 
         return tools
 
-    async def _execute_tool_calls(
+    def _classify_tool_calls(
         self, tool_uses: list[dict]
-    ) -> AsyncGenerator[ChatEvent, None]:
-        """Classify, confirm, and execute tool calls. Yields event dicts.
+    ) -> tuple[list[dict], list[dict], list[dict], list[dict]]:
+        """Split tool calls into (allow, confirm, auto, deny) per safety policy.
 
-        Appends tool result messages to self.messages in original call order.
-        Tool errors are fed back to the model for recovery via tool_error
-        events and error messages appended to the conversation history.
+        Local tools (skills, builtins) bypass the safety policy by default
+        (local_tool_safety=False) because they run in-process and were
+        already trusted by the user when configured. Set
+        local_tool_safety=True to apply the safety policy to local tools
+        as well.
         """
-        # Classify tools by safety policy.
-        # Local tools (skills, builtins) bypass the safety policy
-        # by default (local_tool_safety=False) because they run
-        # in-process and were already trusted by the user when
-        # configured. Set local_tool_safety=True to apply the
-        # safety policy to local tools as well.
         local_tools = []
         remote_tools = []
         for tu in tool_uses:
@@ -664,6 +660,70 @@ class ChatSession:
             allow = local_tools + allow
         else:
             allow, confirm, auto, deny = local_tools + remote_tools, [], [], []
+        return allow, confirm, auto, deny
+
+    async def _confirm_tools(
+        self,
+        tools: list[dict],
+        *,
+        request_event: str,
+        context: list[dict] | None,
+        denial_reason: str,
+        denial_content: str,
+        approved: list[dict],
+        results_by_id: dict[str, dict],
+    ) -> AsyncGenerator[ChatEvent, None]:
+        """Run one confirmation phase (user confirm or LLM auto-judge).
+
+        Yields a `request_event` per tool, then `tool_approved` or
+        `tool_denied` based on `check_and_confirm`. Approved tools are
+        appended to `approved`; denials record a tool-result message in
+        `results_by_id` with `denial_content` (formatted with the tool
+        name).
+        """
+        for tu in tools:
+            yield {
+                "type": request_event,
+                "name": tu["name"],
+                "arguments": tu["input"],
+                "id": tu["id"],
+            }
+            if await self.tool_safety.check_and_confirm(
+                tu["name"], tu["input"], context=context
+            ):
+                approved.append(tu)
+                yield {
+                    "type": "tool_approved",
+                    "name": tu["name"],
+                    "id": tu["id"],
+                }
+            else:
+                yield {
+                    "type": "tool_denied",
+                    "name": tu["name"],
+                    "arguments": tu["input"],
+                    "id": tu["id"],
+                    "reason": denial_reason,
+                }
+                results_by_id[tu["id"]] = {
+                    "message": {
+                        "role": "tool",
+                        "tool_call_id": tu["id"],
+                        "name": tu["name"],
+                        "content": denial_content.format(name=tu["name"]),
+                    },
+                }
+
+    async def _execute_tool_calls(
+        self, tool_uses: list[dict]
+    ) -> AsyncGenerator[ChatEvent, None]:
+        """Classify, confirm, and execute tool calls. Yields event dicts.
+
+        Appends tool result messages to self.messages in original call order.
+        Tool errors are fed back to the model for recovery via tool_error
+        events and error messages appended to the conversation history.
+        """
+        allow, confirm, auto, deny = self._classify_tool_calls(tool_uses)
 
         # Collect results by tool_call_id for call-order output.
         results_by_id: dict[str, dict] = {}
@@ -687,71 +747,29 @@ class ChatSession:
             }
 
         # Prompt for confirmation on confirm tools
-        approved = []
-        for tu in confirm:
-            yield {
-                "type": "tool_confirmation_needed",
-                "name": tu["name"],
-                "arguments": tu["input"],
-                "id": tu["id"],
-            }
-            if await self.tool_safety.check_and_confirm(tu["name"], tu["input"]):
-                approved.append(tu)
-                yield {
-                    "type": "tool_approved",
-                    "name": tu["name"],
-                    "id": tu["id"],
-                }
-            else:
-                yield {
-                    "type": "tool_denied",
-                    "name": tu["name"],
-                    "arguments": tu["input"],
-                    "id": tu["id"],
-                    "reason": "user",
-                }
-                results_by_id[tu["id"]] = {
-                    "message": {
-                        "role": "tool",
-                        "tool_call_id": tu["id"],
-                        "name": tu["name"],
-                        "content": f"Tool '{tu['name']}' was not approved",
-                    },
-                }
+        approved: list[dict] = []
+        async for event in self._confirm_tools(
+            confirm,
+            request_event="tool_confirmation_needed",
+            context=None,
+            denial_reason="user",
+            denial_content="Tool '{name}' was not approved",
+            approved=approved,
+            results_by_id=results_by_id,
+        ):
+            yield event
 
         # Auto-judge tools via LLM
-        for tu in auto:
-            yield {
-                "type": "tool_auto_judging",
-                "name": tu["name"],
-                "arguments": tu["input"],
-                "id": tu["id"],
-            }
-            if await self.tool_safety.check_and_confirm(
-                tu["name"], tu["input"], context=self.messages
-            ):
-                approved.append(tu)
-                yield {
-                    "type": "tool_approved",
-                    "name": tu["name"],
-                    "id": tu["id"],
-                }
-            else:
-                yield {
-                    "type": "tool_denied",
-                    "name": tu["name"],
-                    "arguments": tu["input"],
-                    "id": tu["id"],
-                    "reason": "auto",
-                }
-                results_by_id[tu["id"]] = {
-                    "message": {
-                        "role": "tool",
-                        "tool_call_id": tu["id"],
-                        "name": tu["name"],
-                        "content": f"Tool '{tu['name']}' was not approved by safety check",
-                    },
-                }
+        async for event in self._confirm_tools(
+            auto,
+            request_event="tool_auto_judging",
+            context=self.messages,
+            denial_reason="auto",
+            denial_content="Tool '{name}' was not approved by safety check",
+            approved=approved,
+            results_by_id=results_by_id,
+        ):
+            yield event
 
         # Execute allowed + approved tools
         to_execute = allow + approved

--- a/tests/test_chat_session.py
+++ b/tests/test_chat_session.py
@@ -1636,6 +1636,170 @@ class TestExecuteToolCalls:
         assert session.messages[1]["tool_call_id"] == "tc_b"
 
 
+class TestClassifyToolCalls:
+    """Tests for ChatSession._classify_tool_calls."""
+
+    def _make_tool_use(self, name="read_file", id_="tc_1"):
+        return {"name": name, "input": {}, "id": id_}
+
+    def test_no_safety_policy_all_allowed(self):
+        session = _make_session()
+        tu = self._make_tool_use()
+        allow, confirm, auto, deny = session._classify_tool_calls([tu])
+        assert allow == [tu]
+        assert confirm == [] and auto == [] and deny == []
+
+    def test_policy_buckets(self):
+        config = ToolSafetyConfig(
+            tool_policies={
+                "reader": ToolPolicy.ALLOW,
+                "writer": ToolPolicy.CONFIRM,
+                "judged": ToolPolicy.AUTO,
+                "blocked": ToolPolicy.DENY,
+            }
+        )
+        policy = ToolSafetyPolicy(config)
+        session = _make_session(tool_safety=policy)
+        tus = [
+            self._make_tool_use(name=n, id_=f"tc_{n}")
+            for n in ("reader", "writer", "judged", "blocked")
+        ]
+        allow, confirm, auto, deny = session._classify_tool_calls(tus)
+        assert [t["name"] for t in allow] == ["reader"]
+        assert [t["name"] for t in confirm] == ["writer"]
+        assert [t["name"] for t in auto] == ["judged"]
+        assert [t["name"] for t in deny] == ["blocked"]
+
+    def test_local_builtin_bypasses_policy(self):
+        config = ToolSafetyConfig(tool_policies={"bash": ToolPolicy.DENY})
+        policy = ToolSafetyPolicy(config)
+        session = _make_session(tool_safety=policy)
+        session.builtin = MagicMock(tool_names={"bash"})
+        tu = self._make_tool_use(name="bash")
+        allow, confirm, auto, deny = session._classify_tool_calls([tu])
+        assert allow == [tu]
+        assert deny == []
+
+    def test_local_tool_safety_applies_policy_to_builtin(self):
+        config = ToolSafetyConfig(tool_policies={"bash": ToolPolicy.DENY})
+        policy = ToolSafetyPolicy(config)
+        session = _make_session(tool_safety=policy)
+        session.builtin = MagicMock(tool_names={"bash"})
+        session.config.local_tool_safety = True
+        tu = self._make_tool_use(name="bash")
+        allow, confirm, auto, deny = session._classify_tool_calls([tu])
+        assert allow == []
+        assert deny == [tu]
+
+    def test_use_skill_is_local_when_skills_configured(self):
+        config = ToolSafetyConfig(tool_policies={"use_skill": ToolPolicy.DENY})
+        policy = ToolSafetyPolicy(config)
+        session = _make_session(tool_safety=policy)
+        session.skills = MagicMock()
+        tu = self._make_tool_use(name="use_skill")
+        allow, confirm, auto, deny = session._classify_tool_calls([tu])
+        assert allow == [tu]
+        assert deny == []
+
+    def test_local_tools_precede_remote_allowed(self):
+        """Local tools are prepended to the policy-allowed bucket."""
+        config = ToolSafetyConfig(tool_policies={"read_file": ToolPolicy.ALLOW})
+        policy = ToolSafetyPolicy(config)
+        session = _make_session(tool_safety=policy)
+        session.builtin = MagicMock(tool_names={"bash"})
+        tu_remote = self._make_tool_use(name="read_file", id_="tc_r")
+        tu_local = self._make_tool_use(name="bash", id_="tc_l")
+        allow, _, _, _ = session._classify_tool_calls([tu_remote, tu_local])
+        assert [t["id"] for t in allow] == ["tc_l", "tc_r"]
+
+
+class TestConfirmTools:
+    """Tests for ChatSession._confirm_tools (parameterized confirm/auto-judge phase)."""
+
+    def _make_tool_use(self, name="write_file", id_="tc_1"):
+        return {"name": name, "input": {"path": "/tmp/x"}, "id": id_}
+
+    def _make_session_with_policy(self, *, confirm_result: bool):
+        policy = MagicMock()
+        policy.check_and_confirm = AsyncMock(return_value=confirm_result)
+        return _make_session(tool_safety=policy)
+
+    @pytest.mark.asyncio
+    async def test_approved_yields_events_and_collects(self):
+        session = self._make_session_with_policy(confirm_result=True)
+        tu = self._make_tool_use()
+        approved: list[dict] = []
+        results_by_id: dict[str, dict] = {}
+        events = [
+            e
+            async for e in session._confirm_tools(
+                [tu],
+                request_event="tool_confirmation_needed",
+                context=None,
+                denial_reason="user",
+                denial_content="Tool '{name}' was not approved",
+                approved=approved,
+                results_by_id=results_by_id,
+            )
+        ]
+        assert [e["type"] for e in events] == [
+            "tool_confirmation_needed",
+            "tool_approved",
+        ]
+        assert events[0]["name"] == "write_file"
+        assert events[0]["arguments"] == {"path": "/tmp/x"}
+        assert approved == [tu]
+        assert results_by_id == {}
+        session.tool_safety.check_and_confirm.assert_awaited_once_with(
+            "write_file", {"path": "/tmp/x"}, context=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_denied_records_result_message(self):
+        session = self._make_session_with_policy(confirm_result=False)
+        tu = self._make_tool_use()
+        approved: list[dict] = []
+        results_by_id: dict[str, dict] = {}
+        events = [
+            e
+            async for e in session._confirm_tools(
+                [tu],
+                request_event="tool_auto_judging",
+                context=session.messages,
+                denial_reason="auto",
+                denial_content="Tool '{name}' was not approved by safety check",
+                approved=approved,
+                results_by_id=results_by_id,
+            )
+        ]
+        assert [e["type"] for e in events] == ["tool_auto_judging", "tool_denied"]
+        assert events[1]["reason"] == "auto"
+        assert approved == []
+        msg = results_by_id["tc_1"]["message"]
+        assert msg["role"] == "tool"
+        assert msg["tool_call_id"] == "tc_1"
+        assert msg["content"] == "Tool 'write_file' was not approved by safety check"
+
+    @pytest.mark.asyncio
+    async def test_context_threaded_to_check(self):
+        session = self._make_session_with_policy(confirm_result=True)
+        tu = self._make_tool_use()
+        context = [{"role": "user", "content": "hi"}]
+        async for _ in session._confirm_tools(
+            [tu],
+            request_event="tool_auto_judging",
+            context=context,
+            denial_reason="auto",
+            denial_content="Tool '{name}' was not approved by safety check",
+            approved=[],
+            results_by_id={},
+        ):
+            pass
+        session.tool_safety.check_and_confirm.assert_awaited_once_with(
+            "write_file", {"path": "/tmp/x"}, context=context
+        )
+
+
 class TestConsecutiveToolFailures:
     """Tests for max_consecutive_tool_failures config option."""
 


### PR DESCRIPTION
Part 2 of #480 (scope item 2): extract the tool-execution safety phases from `_execute_tool_calls`.

## Changes

- **`_classify_tool_calls`** — extracts the classification block: the local/remote split (skills + builtins bypass policy unless `local_tool_safety=True`) and the `classify_batch` bucketing into `(allow, confirm, auto, deny)`. Semantics unchanged, including local tools being prepended to the allowed bucket.
- **`_confirm_tools`** — one parameterized sub-generator replacing the near-duplicate confirm and auto-judge loops. The varying pieces are parameters: request event type (`tool_confirmation_needed` / `tool_auto_judging`), the `context=` passed to `check_and_confirm` (`None` / `self.messages`), the denial reason (`user` / `auto`), and the denial message. Approved tools accumulate into the caller's `approved` list; denials record their tool-result message in `results_by_id`.

Per the issue triage, the **execution phase is deliberately untouched** — the `pending_cancelled` / `deferred_exc` / `results_by_id` ordering invariants are load-bearing (history must be appended before re-raising `CancelledError`). The diff does not touch any of those lines.

Note: the old confirm loop called `check_and_confirm(name, input)` with no `context` argument; the helper passes `context=None` explicitly, which is identical to the parameter's default.

## Testing

- New unit tests: `TestClassifyToolCalls` (6 tests: no-policy passthrough, policy bucketing, builtin/skill bypass, `local_tool_safety` opt-in, local-before-remote ordering) and `TestConfirmTools` (3 tests: approved path, denied path with recorded denial message, context threading). Written first and watched fail (`AttributeError`) before extraction.
- All 209 existing chat-module tests pass unchanged (behavior-preserving), plus the session-adjacent suites (`test_chat_session_helpers`, `test_tracing_integration`, `test_builtin_tools`).
- ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)