### PR TITLE
fix(engine): harden the loop-affinity contract at two interior sites (#463)

### DIFF
--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -1018,6 +1018,11 @@ class ModelManager(SpeculativeLoaderMixin):
         about to use. The caller MUST release the pin exactly once (the
         inference paths adopt it via ``_inference_ref(..., adopt=True)``).
         """
+        # Same loop-affinity contract as unload/_expire_stale (#463):
+        # ensure_loaded inserts into _loaded and drives LRU eviction, and
+        # self._lock is an asyncio.Lock, which only serializes coroutines
+        # on the loop — it offers no protection against an off-loop caller.
+        assert_loop_thread("ModelManager.ensure_loaded")
         normalized = self.registry.normalize_name(name)
         if normalized != name:
             logger.info("Normalized model name '%s' -> '%s'", name, normalized)

--- a/olmlx/engine/prompt_cache/store.py
+++ b/olmlx/engine/prompt_cache/store.py
@@ -403,6 +403,11 @@ class PromptCacheStore:
         - On LRU eviction: (evicted_id, evicted_state)
         - No eviction needed: (None, None)
         """
+        # Redundant for current callers (every public entry point asserts),
+        # but this is the insertion chokepoint for _entries/_radix — a
+        # future caller that bypasses the public surface still trips the
+        # contract here (#463).
+        assert_loop_thread("PromptCacheStore._set_in_memory")
         if cache_id in self._entries:
             self._entries.move_to_end(cache_id)
             old = self._entries[cache_id]

--- a/tests/test_loop_affinity.py
+++ b/tests/test_loop_affinity.py
@@ -122,6 +122,18 @@ class TestModelManagerAffinity:
         assert isinstance(exc, RuntimeError)
         assert "event-loop thread" in str(exc)
 
+    def test_ensure_loaded_off_loop_raises(self, mock_manager):
+        # ensure_loaded mutates _loaded (insert + LRU eviction) under the
+        # same loop-affinity contract as unload's check-then-pop; an
+        # off-loop caller must trip before touching anything.
+        loop_affinity.bind_loop_thread()
+        exc = _run_in_thread(
+            lambda: asyncio.run(mock_manager.ensure_loaded("qwen3:latest"))
+        )
+        assert isinstance(exc, RuntimeError)
+        assert "ModelManager.ensure_loaded" in str(exc)
+        assert "qwen3:latest" in mock_manager._loaded
+
 
 class TestPromptCacheStoreAffinity:
     def test_mutators_off_loop_raise(self):
@@ -162,6 +174,18 @@ class TestPromptCacheStoreAffinity:
         assert store.get("a") is not None
         store.remove("a")
         assert store.get("a") is None
+
+    def test_set_in_memory_off_loop_raises(self):
+        # _set_in_memory is the insertion chokepoint for _entries/_radix;
+        # every public entry point asserts, but the helper carries its own
+        # (idempotent on-loop) check so a future caller that bypasses the
+        # public surface still trips the contract.
+        store = PromptCacheStore(max_slots=4)
+        loop_affinity.bind_loop_thread()
+        exc = _run_in_thread(lambda: store._set_in_memory("a", _make_state(1)))
+        assert isinstance(exc, RuntimeError)
+        assert "PromptCacheStore._set_in_memory" in str(exc)
+        assert store.peek("a") is None
 
     def test_clear_allowed_off_loop(self):
         # clear()'s only production caller is _close_loaded_model, which runs


### PR DESCRIPTION
## Summary

Follow-up to #488 — the two hardening deltas carried over from the review of the superseded #489, implemented with the merged `loop_affinity` helper:

- **`ModelManager.ensure_loaded`** now asserts the loop thread like `unload`/`_expire_stale`. It inserts into `_loaded` and drives LRU eviction, and `self._lock` is an `asyncio.Lock` — it only serializes coroutines on the loop, so it offers no protection against an off-loop caller.
- **`PromptCacheStore._set_in_memory`** asserts internally. Every public entry point already asserts at its top, but this helper is the insertion chokepoint for `_entries`/`_radix` — a future method that calls it directly and forgets the entry-point assert would otherwise bypass the tripwire entirely and corrupt the LRU/trie silently. The check is redundant (and a same-thread no-op) on all current paths.

## Testing

- TDD: both tests written first and watched fail (`test_ensure_loaded_off_loop_raises`, `test_set_in_memory_off_loop_raises` in `tests/test_loop_affinity.py`, following the file's existing conventions).
- Full suite: 4599 passed, 4 skipped.
- `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)