### PR TITLE
feat(engine): continuous batching Phase 3 — consumer backpressure + docs

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -1327,6 +1327,11 @@ All settings are configured via `OLMLX_`-prefixed environment variables. You can
 | `OLMLX_LOG_LEVEL` | string | `INFO` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
 | `OLMLX_TRACING` | bool | `false` | Enable OpenTelemetry tracing (requires `uv sync --extra otel`). Endpoint/sampler/etc. configured via native `OTEL_*` env vars. See "Distributed Tracing" above |
 | `OLMLX_INFERENCE_QUEUE_TIMEOUT` | float/None | `300.0` | Max seconds to wait for inference lock (5 min). `None` = no timeout |
+| `OLMLX_BATCHING` | bool | `false` | Enable continuous batching of concurrent chat requests (see "Continuous Batching"). Eligible requests share one decode loop instead of serializing on the lock |
+| `OLMLX_BATCH_COMPLETION_SIZE` | int | `8` | Max sequences decoding concurrently in a batch |
+| `OLMLX_BATCH_PREFILL_SIZE` | int | `4` | Max sequences in chunked prefill at once |
+| `OLMLX_BATCH_PREFILL_STEP` | int | `2048` | Prefill chunk size (tokens) for batched requests |
+| `OLMLX_BATCH_CONSUMER_LAG_LIMIT` | int | `2048` | Drop a batched sequence whose unconsumed event backlog exceeds this (stalled client backpressure). `0` disables |
 | `OLMLX_MAX_TOKENS_LIMIT` | int | `131072` | Maximum tokens allowed per request |
 | `OLMLX_CORS_ORIGINS` | list | `["http://localhost:*", "http://127.0.0.1:*"]` | Allowed CORS origins |
 | `OLMLX_ANTHROPIC_MODELS` | dict | `{}` | Claude model name->local model mapping for the Anthropic endpoint |
@@ -1551,6 +1556,31 @@ Parsers are tried in order; the first successful match is used. Tool calls are c
 ### Inference Concurrency
 
 A single global inference lock prevents concurrent Metal command buffer submission across all models. This sacrifices parallelism for stability on Apple Silicon — concurrent Metal operations can cause GPU crashes. The lock uses a configurable queue timeout (`OLMLX_INFERENCE_QUEUE_TIMEOUT`, default 300s) and returns HTTP 503 with `Retry-After` when the queue is full.
+
+### Continuous Batching (Experimental)
+
+By default, concurrent chat requests serialize on the inference lock: request N waits for request N-1 to finish. **Continuous batching** (`OLMLX_BATCHING=true`, off by default) instead lets eligible requests *share a single decode loop* on one model. Because decode on Apple Silicon is memory-bandwidth-bound, B sequences decode for roughly the cost of one — aggregate throughput scales with concurrency, and a newly arriving request's prefill interleaves with the running decodes instead of queueing behind them. Greedy output is bit-for-bit identical to the serial path. Measured on an M-series machine (Qwen3-4B-4bit, ~100-token generations): ~80 tok/s single stream → ~120 at 2 concurrent, ~135 at 4, ~142 at 8. **Per-request** decode speed drops as the batch fills (the bandwidth is shared); **aggregate** throughput is what rises.
+
+This is the right tool when you drive a model with many parallel requests — e.g. Claude-Code-style subagents or a fan-out script hitting one local model. A single sequential client sees no benefit (and pays nothing).
+
+**Eligibility.** A request is batched only when *all* hold; otherwise it transparently falls back to the exclusive-lock path:
+
+- `OLMLX_BATCHING=true`
+- A text LLM on a plain-`KVCache` layout (dense full-attention models — Qwen3 dense, Llama-family, etc.)
+- No images/audio, no VLM/Whisper/TTS/reranker/embeddings
+- KV quantization off, not distributed, not flash / flash-MoE, not speculative
+- No per-request `seed` (a batched global PRNG can't keep the reproducibility promise)
+- Not a gpt-oss channel-format model
+
+Grammar / JSON-schema (`response_format`, `format`) and prompt-cache reuse **do** work under batching. Hybrid linear-attention (GDN / `ArraysCache`) models stay on the exclusive path for now.
+
+**Fairness.** Non-batchable work (embeddings, a KV-quant model, a different model) still acquires the lock normally. When such a request starts waiting, the batch stops admitting new sequences, lets its in-flight sequences finish, and hands the lock over — so exclusive traffic is never starved. A steady stream of batched requests therefore yields to a waiting exclusive request at the next drain.
+
+**Backpressure.** A stalled-but-connected client (slow SSE reader) can't pin a batch slot forever: if its unconsumed event backlog exceeds `OLMLX_BATCH_CONSUMER_LAG_LIMIT` (default 2048; `0` disables), the worker drops that sequence from the batch and ends its stream, freeing the slot for live requests. A client reading at any reasonable pace never approaches the limit.
+
+Tuning knobs: `OLMLX_BATCH_COMPLETION_SIZE` (max concurrently *decoding* sequences, default 8), `OLMLX_BATCH_PREFILL_SIZE` (max sequences in chunked prefill, default 4), `OLMLX_BATCH_PREFILL_STEP` (prefill chunk size, default 2048). All are per-model overridable at the top level of `models.json`.
+
+> **Timing note:** on the batched path, `prompt_eval_duration` includes batch-queue wait and co-tenant prefill interleave, and `eval_duration` is wall time shared across co-batched sequences. These reflect user-perceived latency, not isolated single-model speed — use the exclusive path (or `bench run`) for per-model benchmarking.
 
 ### Error Handling
 

--- a/docs/batching-plan.md
+++ b/docs/batching-plan.md
@@ -1,6 +1,8 @@
 # Implementation Plan: Continuous Batching via mlx-lm `BatchGenerator`
 
-Status: **Phases 0–2 implemented** (engine/ropefix.py, engine/batching.py,
+Status: **Phases 0–2 implemented; Phase 3 in progress** (consumer
+backpressure + USER_MANUAL docs landed — see §10/§11). (engine/ropefix.py,
+engine/batching.py,
 inference.py `_batch_eligible` / `_get_batch_scheduler` /
 `_stream_completion_batched` / `_full_completion_batched` /
 `_setup_batched_prompt_cache`, settings, LoadedModel fields + teardown;
@@ -328,8 +330,13 @@ Live (`tests/live/test_batching_real.py`, `real_model`):
   helpers (used by `_inference_locked`, `_stream_completion`, and the batch
   scheduler's `acquire_gpu`/`release_gpu`), and one `StopScanner`
   (`engine/stop_sequences.py`) replacing the three inline copies.
-- **Phase 3 — hardening**: admission control vs `OLMLX_MEMORY_LIMIT_FRACTION`;
-  fairness guard tuning; docs (USER_MANUAL); consider default-on per-model.
+- **Phase 3 — hardening** (in progress): consumer backpressure (done —
+  `OLMLX_BATCH_CONSUMER_LAG_LIMIT`, drop-the-laggard, see §11) and user
+  docs (done — USER_MANUAL "Continuous Batching"). Per-request KV admission
+  vs `OLMLX_MEMORY_LIMIT_FRACTION` already landed in Phase 2
+  (`_batched_kv_preflight`); remaining: aggregate (cross-sequence) admission
+  accounting for `gen.prompt_cache_nbytes`, fairness-guard tuning, and
+  default-on per-model.
 - **Phase 4 — extensions** (separate decisions): hybrid `ArraysCache` (GDN)
   models behind a flag; batch-capable KV-quant caches (upstream-shaped work);
   drain-and-switch policy for multi-model juggling; `insert_segments` +
@@ -359,12 +366,21 @@ Live (`tests/live/test_batching_real.py`, `real_model`):
 - **Starvation in reverse**: the fairness guard means heavy exclusive traffic
   (e.g. KV-quant model in rotation) can keep collapsing the batch; acceptable
   for v1, revisit with drain-and-switch in Phase 4.
-- **No consumer backpressure** (PR #507 review): the per-sequence event
-  bridge is an unbounded queue — a stalled-but-connected SSE client lets the
-  worker decode its sequence to max_tokens while event dicts accumulate
-  (vs CancellableStream's bounded Queue(32)). Phase 3: consumer-lag
-  threshold → cancel, mirroring the exclusive path's bounded-buffer
-  semantics.
+- **Consumer backpressure** (PR #507 review; **resolved, Phase 3**): the
+  per-sequence event bridge is still an unbounded `asyncio.Queue`, but the
+  worker now drops a sequence whose unconsumed backlog exceeds
+  `OLMLX_BATCH_CONSUMER_LAG_LIMIT` (default 2048; `0` disables). Lag is
+  `BatchSequence._emitted` (worker writer) minus `_consumed` (consumer
+  writer, bumped via `note_consumed()` after every `out.get()`) — each is
+  single-writer so plain-int reads are torn-free under the GIL, the same
+  discipline as the scheduler counters. `_sweep_lagging` flags over-limit
+  sequences (sets `lagged`, clears `want_cache`) and `_sweep_cancelled`
+  removes them with a `{"truncated": "lag"}` done event; the consumer
+  treats that as a benign truncation (ends cleanly, stores nothing —
+  parity with the timeout invalidate path) rather than the model-unload
+  cancel (which still raises). Unlike CancellableStream's bounded
+  `Queue(32)` *blocking* backpressure, a batch can't block one slow reader
+  without stalling its co-tenants, so the v1 policy is drop-the-laggard.
 - **Batched timing semantics differ**: `prompt_eval_duration` (TTFT) on the
   batched path includes batch-queue wait and co-tenant prefill interleave,
   and `eval_duration` is wall time shared with co-batched sequences — they

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -317,6 +317,12 @@ class Settings(BaseSettings):
     batch_completion_size: Annotated[int, Field(ge=1)] = 8
     batch_prefill_size: Annotated[int, Field(ge=1)] = 4
     batch_prefill_step: Annotated[int, Field(ge=1)] = 2048
+    # Backpressure (plan §11): a batched sequence whose SSE consumer falls
+    # more than this many events behind the worker is dropped from the
+    # batch — a stalled-but-connected client otherwise pins a slot and
+    # decodes to max_tokens unread (the unbounded per-sequence event queue
+    # has no flow control of its own). 0 disables the cut-off.
+    batch_consumer_lag_limit: Annotated[int, Field(ge=0)] = 2048
 
     # Flash inference (LLM in a Flash). Primary, user-facing knobs.
     # Advanced tuning (window size, IO threads, cache budget, predictor

--- a/olmlx/engine/batching.py
+++ b/olmlx/engine/batching.py
@@ -156,14 +156,31 @@ class BatchSequence:
         self.out: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self.cancelled = threading.Event()
         self.want_cache = request.return_cache
+        # Backpressure (plan §11): the worker can outrun a slow/stalled
+        # consumer because ``out`` is unbounded. ``_emitted`` (worker
+        # writer) minus ``_consumed`` (consumer writer) is the outstanding
+        # event lag; each is single-writer so plain-int reads are torn-free
+        # under the GIL (the same discipline as the scheduler counters).
+        self._emitted = 0
+        self._consumed = 0
+        self.lagged = False
 
     def emit(self, event: dict[str, Any]) -> None:
         """Deliver an event to the consumer; safe from any thread."""
+        self._emitted += 1
         try:
             self.loop.call_soon_threadsafe(self.out.put_nowait, event)
         except RuntimeError:
             # Event loop closed (shutdown) — the consumer is gone.
             pass
+
+    def note_consumed(self) -> None:
+        """Consumer ack — call once per event pulled from ``out``."""
+        self._consumed += 1
+
+    def lag(self) -> int:
+        """Outstanding (emitted-but-unconsumed) events, worker's view."""
+        return self._emitted - self._consumed
 
 
 class BatchScheduler:
@@ -181,12 +198,18 @@ class BatchScheduler:
         acquire_gpu: Callable[[], Awaitable[None]],
         release_gpu: Callable[[], None],
         exclusive_pending: Callable[[], bool] | None = None,
+        consumer_lag_limit: int = 0,
         name: str = "",
     ):
         self._generator_factory = generator_factory
         self._acquire_gpu = acquire_gpu
         self._release_gpu = release_gpu
         self._exclusive_pending = exclusive_pending or (lambda: False)
+        # 0 disables backpressure cancellation; otherwise a sequence whose
+        # consumer falls more than this many events behind is dropped from
+        # the batch so a stalled-but-connected client can't pin a slot and
+        # decode to max_tokens unread (plan §11).
+        self._consumer_lag_limit = consumer_lag_limit
         self._name = name
         self._inbox: queue.Queue[BatchSequence] = queue.Queue()
         self._loop: asyncio.AbstractEventLoop | None = None
@@ -355,6 +378,7 @@ class BatchScheduler:
                     if self._closing:
                         for seq in active.values():
                             seq.cancelled.set()
+                    self._sweep_lagging(active)
                     self._sweep_cancelled(gen, active)
                     self._active_count = len(active)
                     if not active:
@@ -455,6 +479,29 @@ class BatchScheduler:
             active[uid] = seq
             self._inserts_total += 1
 
+    def _sweep_lagging(self, active: dict[int, BatchSequence]) -> None:
+        """Flag sequences whose consumer has fallen too far behind.
+
+        Marks them cancelled (the next ``_sweep_cancelled`` removes them
+        from the batch) and clears ``want_cache`` — a partly-consumed
+        stream is incomplete, so its KV must not re-enter the prompt cache
+        (parity with the timeout invalidate path)."""
+        limit = self._consumer_lag_limit
+        if limit <= 0:
+            return
+        for seq in active.values():
+            if not seq.cancelled.is_set() and seq.lag() > limit:
+                logger.warning(
+                    "batch[%s]: dropping sequence — consumer lag %d > %d "
+                    "(stalled client); freeing the slot",
+                    self._name,
+                    seq.lag(),
+                    limit,
+                )
+                seq.lagged = True
+                seq.want_cache = False
+                seq.cancelled.set()
+
     def _sweep_cancelled(self, gen: Any, active: dict[int, BatchSequence]) -> None:
         gone = [uid for uid, seq in active.items() if seq.cancelled.is_set()]
         if not gone:
@@ -464,6 +511,8 @@ class BatchScheduler:
         for uid in gone:
             seq = active.pop(uid)
             done: dict[str, Any] = {"type": "done", "reason": "cancelled"}
+            if seq.lagged:
+                done["truncated"] = "lag"
             extracted = caches.get(uid) if caches else None
             if seq.want_cache and extracted is not None:
                 cache, tokens = extracted

--- a/olmlx/engine/batching.py
+++ b/olmlx/engine/batching.py
@@ -167,12 +167,16 @@ class BatchSequence:
 
     def emit(self, event: dict[str, Any]) -> None:
         """Deliver an event to the consumer; safe from any thread."""
-        self._emitted += 1
         try:
             self.loop.call_soon_threadsafe(self.out.put_nowait, event)
         except RuntimeError:
-            # Event loop closed (shutdown) — the consumer is gone.
-            pass
+            # Event loop closed (shutdown) — the consumer is gone. Don't
+            # count an event the consumer can never pull, or the lag would
+            # stay permanently inflated.
+            return
+        # Only after the put is scheduled: ``_emitted`` must mean "events
+        # the consumer will see", or backpressure lag drifts.
+        self._emitted += 1
 
     def note_consumed(self) -> None:
         """Consumer ack — call once per event pulled from ``out``."""

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -2693,6 +2693,7 @@ def _get_batch_scheduler(lm: LoadedModel) -> Any:
         acquire_gpu=acquire_gpu,
         release_gpu=release_gpu,
         exclusive_pending=lambda: _queue_depth > 0,
+        consumer_lag_limit=settings.batch_consumer_lag_limit,
         name=lm.name,
     )
     return lm.batch_scheduler
@@ -2941,6 +2942,7 @@ async def _stream_completion_batched(
     stop_scanner = StopScanner(stop_sequences)
     stop_hit = False
     timed_out = False
+    lagged = False
     terminal_seen = False
     start_ns = time.monotonic_ns()
     first_token_ns: int | None = None
@@ -2986,6 +2988,7 @@ async def _stream_completion_batched(
                     else:
                         event = await seq.out.get()
                     awaiting_first = False
+                    seq.note_consumed()  # keep the backpressure lag honest
                     etype = event["type"]
                     if etype == "progress":
                         continue
@@ -2998,14 +3001,24 @@ async def _stream_completion_batched(
                         raise event["exc"]
                     if etype == "done":
                         terminal_seen = True
-                        if event["reason"] == "cancelled" and not (
-                            stop_hit or timed_out
+                        # A lag cancellation (worker dropped a slow consumer
+                        # — plan §11) is a benign truncation, not the
+                        # model-unload cancel; end the stream cleanly.
+                        lagged = event.get("truncated") == "lag"
+                        if lagged:
+                            logger.warning(
+                                "Batched generation truncated: consumer lag "
+                                "exceeded the backpressure limit"
+                            )
+                        if (
+                            event["reason"] == "cancelled"
+                            and not (stop_hit or timed_out or lagged)
                         ):
                             # Scheduler closed under us (model unload).
                             raise RuntimeError(
                                 "Batched generation cancelled (model unloading)"
                             )
-                        if not (stop_hit or timed_out):
+                        if not (stop_hit or timed_out or lagged):
                             detokenizer.finalize()
                             tail = detokenizer.last_segment
                             if tail:
@@ -3024,6 +3037,7 @@ async def _stream_completion_batched(
                         if (
                             ev_cache is not None
                             and not timed_out
+                            and not lagged
                             and len(event.get("tokens") or []) >= len(tokens)
                         ):
                             all_toks = event["tokens"]

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -3010,9 +3010,8 @@ async def _stream_completion_batched(
                                 "Batched generation truncated: consumer lag "
                                 "exceeded the backpressure limit"
                             )
-                        if (
-                            event["reason"] == "cancelled"
-                            and not (stop_hit or timed_out or lagged)
+                        if event["reason"] == "cancelled" and not (
+                            stop_hit or timed_out or lagged
                         ):
                             # Scheduler closed under us (model unload).
                             raise RuntimeError(

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -346,7 +346,9 @@ class _GpuLog:
         self.events.append("release")
 
 
-def _make_scheduler(scripts, *, exclusive_pending=None, gens=None, on_next=None):
+def _make_scheduler(
+    scripts, *, exclusive_pending=None, gens=None, on_next=None, consumer_lag_limit=0
+):
     from olmlx.engine.batching import BatchScheduler
 
     gpu = _GpuLog()
@@ -363,6 +365,7 @@ def _make_scheduler(scripts, *, exclusive_pending=None, gens=None, on_next=None)
         acquire_gpu=gpu.acquire,
         release_gpu=gpu.release,
         exclusive_pending=exclusive_pending,
+        consumer_lag_limit=consumer_lag_limit,
         name="test",
     )
     return sched, gpu, made
@@ -804,6 +807,96 @@ class TestSchedulerStats:
         assert sched.stats()["batch_active_sequences"] == 0
 
 
+class TestBackpressure:
+    async def test_lagging_consumer_dropped(self):
+        """A consumer that never acks events lets lag grow past the limit;
+        the worker drops the sequence instead of decoding to max_tokens."""
+        from olmlx.engine.batching import BatchRequest
+
+        long_script = [(i, None) for i in range(500)] + [(0, "stop")]
+        # _collect drains seq.out but never calls note_consumed(), so the
+        # worker's lag == its own emitted count and crosses the limit fast.
+        sched, _, gens = _make_scheduler([long_script], consumer_lag_limit=3)
+        seq = await sched.submit(BatchRequest(tokens=[1], max_tokens=500))
+        events = await _collect(seq)
+        done = events[-1]
+        assert done["type"] == "done"
+        assert done["reason"] == "cancelled"
+        assert done["truncated"] == "lag"
+        assert gens[0].removed == [0]
+        # Cut off near the limit — nowhere near the 500-token script.
+        assert len(_tokens(events)) <= 4
+
+    async def test_lag_cancel_omits_cache(self):
+        """A lag-dropped sequence is incomplete, so its KV is not returned
+        even when the request asked for it (want_cache cleared)."""
+        from olmlx.engine.batching import BatchRequest
+
+        long_script = [(i, None) for i in range(500)] + [(0, "stop")]
+        sched, _, _ = _make_scheduler([long_script], consumer_lag_limit=3)
+        seq = await sched.submit(
+            BatchRequest(tokens=[1], max_tokens=500, return_cache=True)
+        )
+        events = await _collect(seq)
+        assert events[-1]["truncated"] == "lag"
+        assert "cache" not in events[-1]
+
+    async def test_lag_counter_tracks_emitted_minus_consumed(self):
+        from olmlx.engine.batching import BatchRequest, BatchSequence
+
+        loop = asyncio.get_running_loop()
+        seq = BatchSequence(BatchRequest(tokens=[1], max_tokens=1), loop)
+        assert seq.lag() == 0
+        seq.emit({"type": "token", "token": 1})
+        seq.emit({"type": "token", "token": 2})
+        assert seq.lag() == 2
+        seq.note_consumed()
+        assert seq.lag() == 1
+
+    async def test_acking_consumer_runs_to_completion(self):
+        """A consumer that acks each event keeps lag at zero, so even a
+        tiny limit never trips. The worker is throttled one event per tick
+        (modelling real decode latency) so the unthrottled fake can't burst
+        past the acks."""
+        from olmlx.engine.batching import BatchRequest
+
+        tick = threading.Event()
+
+        def throttle(_gen):
+            tick.wait(timeout=5.0)
+            tick.clear()
+
+        sched, _, gens = _make_scheduler(
+            [[(10, None), (11, None), (0, "stop")]],
+            consumer_lag_limit=1,
+            on_next=throttle,
+        )
+        seq = await sched.submit(BatchRequest(tokens=[1], max_tokens=8))
+        events = []
+        while True:
+            tick.set()  # release one worker tick
+            ev = await asyncio.wait_for(seq.out.get(), timeout=5.0)
+            seq.note_consumed()
+            events.append(ev)
+            if ev["type"] in ("done", "error"):
+                break
+        assert _tokens(events) == [10, 11]
+        assert events[-1] == {"type": "done", "reason": "stop"}
+        assert gens[0].removed == []
+
+    async def test_disabled_limit_never_cancels(self):
+        from olmlx.engine.batching import BatchRequest
+
+        sched, _, gens = _make_scheduler(
+            [[(10, None), (11, None), (0, "stop")]], consumer_lag_limit=0
+        )
+        seq = await sched.submit(BatchRequest(tokens=[1], max_tokens=8))
+        events = await _collect(seq)  # never acks, but limit is off
+        assert _tokens(events) == [10, 11]
+        assert events[-1]["reason"] == "stop"
+        assert gens[0].removed == []
+
+
 # ---------------------------------------------------------------------------
 # Consumer round trip (Phase 2): _stream_completion_batched + prompt cache
 # ---------------------------------------------------------------------------
@@ -855,6 +948,28 @@ def _consumer_lm():
         prompt_cache_store=PromptCacheStore(max_slots=4),
         supports_cache_persistence=True,
     )
+
+
+class _ScriptedScheduler:
+    """Minimal scheduler whose submit() returns a sequence pre-loaded with
+    a fixed event list — for driving consumer-side terminal handling
+    without a worker thread."""
+
+    def __init__(self, events):
+        self._events = events
+        self.cancelled: list = []
+
+    async def submit(self, request):
+        from olmlx.engine.batching import BatchSequence
+
+        loop = asyncio.get_running_loop()
+        seq = BatchSequence(request, loop)
+        for ev in self._events:
+            seq.out.put_nowait(ev)
+        return seq
+
+    def cancel(self, seq):
+        self.cancelled.append(seq)
 
 
 async def _run_batched(lm, sched, monkeypatch, prompt, gen_kwargs=None, **kw):
@@ -1114,6 +1229,42 @@ class TestConsumerCacheRoundTrip:
         assert len(lm.prompt_cache_store) == 0
         assert gens[0].insert_calls[0]["caches"] == [None]
 
+    async def test_lag_truncation_ends_cleanly_and_skips_store(self, monkeypatch):
+        """A lag-cancelled terminal (``truncated == 'lag'``) ends the stream
+        gracefully — no model-unload RuntimeError — and stores nothing
+        (incomplete generation, parity with the timeout path)."""
+        lm = _consumer_lm()
+        events = [
+            {"type": "token", "token": 10},
+            {"type": "token", "token": 11},
+            {"type": "done", "reason": "cancelled", "truncated": "lag"},
+        ]
+        sched = _ScriptedScheduler(events)
+        chunks = await _run_batched(
+            lm, sched, monkeypatch, [1, 2], use_prompt_cache=True, cache_id="cid"
+        )
+        assert chunks[-1]["done"] is True
+        text = "".join(c.get("text", "") for c in chunks if c.get("text"))
+        assert text == "<10><11>"
+        assert lm.prompt_cache_store.peek("cid") is None
+
+    async def test_unload_cancel_still_raises(self, monkeypatch):
+        """A plain cancelled terminal (no ``truncated`` marker) is the
+        model-unload path and must still raise — lag handling didn't
+        soften it."""
+        from olmlx.engine import inference
+        from olmlx.utils.timing import TimingStats
+
+        lm = _consumer_lm()
+        sched = _ScriptedScheduler([{"type": "done", "reason": "cancelled"}])
+        monkeypatch.setattr(inference, "_get_batch_scheduler", lambda _lm: sched)
+        monkeypatch.setattr(inference, "_batched_kv_preflight", lambda *a, **k: None)
+        with pytest.raises(RuntimeError, match="model unloading"):
+            async for _ in inference._stream_completion_batched(
+                lm, [1, 2], 32, {}, TimingStats()
+            ):
+                pass
+
 
 class TestFullCompletionBatched:
     async def test_aggregates_stream_into_result_dict(self, monkeypatch):
@@ -1367,6 +1518,7 @@ class TestBatchingSettings:
             "OLMLX_BATCH_COMPLETION_SIZE",
             "OLMLX_BATCH_PREFILL_SIZE",
             "OLMLX_BATCH_PREFILL_STEP",
+            "OLMLX_BATCH_CONSUMER_LAG_LIMIT",
         ):
             monkeypatch.delenv(var, raising=False)
         s = Settings()
@@ -1374,17 +1526,25 @@ class TestBatchingSettings:
         assert s.batch_completion_size == 8
         assert s.batch_prefill_size == 4
         assert s.batch_prefill_step == 2048
+        assert s.batch_consumer_lag_limit == 2048
 
     def test_env_override(self, monkeypatch):
         monkeypatch.setenv("OLMLX_BATCHING", "true")
         monkeypatch.setenv("OLMLX_BATCH_COMPLETION_SIZE", "16")
         monkeypatch.setenv("OLMLX_BATCH_PREFILL_SIZE", "2")
         monkeypatch.setenv("OLMLX_BATCH_PREFILL_STEP", "1024")
+        monkeypatch.setenv("OLMLX_BATCH_CONSUMER_LAG_LIMIT", "256")
         s = Settings()
         assert s.batching is True
         assert s.batch_completion_size == 16
         assert s.batch_prefill_size == 2
         assert s.batch_prefill_step == 1024
+        assert s.batch_consumer_lag_limit == 256
+
+    def test_lag_limit_zero_allowed(self, monkeypatch):
+        # 0 disables backpressure cancellation (unlike the size knobs).
+        monkeypatch.setenv("OLMLX_BATCH_CONSUMER_LAG_LIMIT", "0")
+        assert Settings().batch_consumer_lag_limit == 0
 
     @pytest.mark.parametrize(
         "var",


### PR DESCRIPTION
## Summary

Phase 3 (hardening) of the continuous-batching plan (`docs/batching-plan.md`). Picks up the two concretely-specified items: the **consumer backpressure** risk from the PR #507 review (§11) and **user-facing docs**.

### Consumer backpressure (drop-the-laggard)

Previously the per-sequence event bridge was an unbounded `asyncio.Queue`: a stalled-but-connected SSE client let the worker decode its sequence to `max_tokens` unread, pinning a batch slot and piling up event dicts (vs CancellableStream's bounded `Queue(32)`).

- `BatchSequence` now tracks `lag()` = `_emitted` (worker writer) − `_consumed` (consumer writer via `note_consumed()`). Each counter is single-writer, so plain-int reads are torn-free under the GIL — the same discipline the scheduler counters use.
- A new `_sweep_lagging` step flags any active sequence past `consumer_lag_limit`, clears its `want_cache`, and cancels it; `_sweep_cancelled` tags the done event `{"truncated": "lag"}`.
- The consumer acks via `note_consumed()` after every `out.get()` and treats a lag terminal as a **benign truncation** (clean end, stores nothing — parity with the timeout invalidate path) rather than the model-unload cancel, which still raises.
- New knob `OLMLX_BATCH_CONSUMER_LAG_LIMIT` (default 2048; `0` disables), wired through `_get_batch_scheduler`.

A batch can't block one slow reader without stalling its co-tenants, so the v1 policy is drop-the-laggard.

### Docs

- `USER_MANUAL.md`: new "Continuous Batching" section (eligibility, fairness, backpressure, tuning, timing caveat) + the four `OLMLX_BATCH_*` env vars in the settings table.
- `batching-plan.md`: Phase 3 marked in progress; §11 backpressure note resolved.

## Tests (TDD)

8 new tests in `tests/test_batching.py`: scheduler-level lag-drop, cache-omission on lag, disabled-limit, lag-counter unit, throttled keep-up completion, consumer graceful-truncation + store-skip, and a guard that a plain (non-lag) cancel still raises — plus settings coverage.

All 86 batching + 151 batching/config tests pass; `ruff` clean.

> Note: the 3 failures visible in a full `inference/batch/stream` run are pre-existing test-ordering pollution — they reproduce identically on `main` and pass in isolation.

## Not in this PR (deferred Phase 3 bullets)

Aggregate (cross-sequence) KV admission and fairness-guard tuning. Per-request KV admission (`_batched_kv_preflight` vs `OLMLX_MEMORY_LIMIT_FRACTION`) already landed in Phase 2; a true aggregate heuristic risks wrongly 503-ing valid requests, so it's left for a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)