### PR TITLE
fix(speculative): revive bit-rotted tree-forward + add real-model canary (#501)

### DIFF
--- a/olmlx/engine/tree_speculative.py
+++ b/olmlx/engine/tree_speculative.py
@@ -391,12 +391,22 @@ def _patch_target_for_tree_forward(
 
     orig_call = type(inner).__call__
 
-    def _tree_call(self_: Any, inputs: mx.array, cache: Any = None) -> Any:
-        h = embed_fn(inputs)
+    def _tree_call(
+        self_: Any,
+        inputs: mx.array,
+        cache: Any = None,
+        input_embeddings: Any = None,
+    ) -> Any:
+        h = input_embeddings if input_embeddings is not None else embed_fn(inputs)
+        # Cast the additive mask to the hidden-state dtype: current mlx's
+        # scaled_dot_product_attention requires the mask to promote to the
+        # output dtype, and a float32 mask cannot downcast to a bf16 model.
+        # Mirrors mlx-lm's create_attention_mask, which builds in h.dtype.
+        mask = tree_mask.astype(h.dtype)
         if cache is None:
             cache = [None] * len(layers)
         for layer, c in zip(layers, cache):
-            h = layer(h, tree_mask, c)
+            h = layer(h, mask, c)
         return norm_fn(h)
 
     type(inner).__call__ = _tree_call  # type: ignore[method-assign]

--- a/tests/live/test_tree_speculative_real.py
+++ b/tests/live/test_tree_speculative_real.py
@@ -1,17 +1,18 @@
 """Live greedy-parity canary for tree speculative verification (#501).
 
-Greedy speculative decoding is exactness-preserving: its output must equal
-the target model's own greedy decode, *modulo argmax tie-breaks*. When two
-tokens share the exact same top logit, the L=1 single-token forward (pure
-greedy / draft) and the L=N verify forward may resolve the tie to different
-token ids; that is benign nondeterminism, not corruption, and it affects the
-linear path too (verified 2026-06: on this prompt the linear path diverges
-from pure greedy at an exact 0.0-margin tie while the tree path matches it).
+Greedy speculative decoding is exactness-preserving: every token it emits
+must be the target model's own greedy argmax given the true preceding
+context — *modulo argmax tie-breaks*. When two tokens share (within bf16
+noise) the top logit, a batched verify forward and a single-token forward
+may resolve the tie to different ids; that is benign nondeterminism, not
+corruption, and it affects the linear path too.
 
-So this canary asserts both the tree and the linear path match the target's
-pure-greedy decode, tolerating divergences that occur only at a tie position
-(top1-top2 logit margin below TIE_EPS). A divergence at a clear-margin
-position is a real correctness bug and fails loudly.
+This canary teacher-forces each path's full output back through the target
+in one clean forward and asserts every position is the target's argmax,
+tolerating only positions whose top1-top2 logit margin is below TIE_EPS.
+Teacher-forcing checks the WHOLE sequence (not just up to a first
+divergence), so a real corruption that lands after a benign tie-break is
+still caught; any clear-margin mismatch fails loudly.
 
 This is also the regression guard for the bit-rot that left the tree path
 crashing on current mlx (no real-model test exercised it before #501 — the
@@ -31,8 +32,10 @@ from olmlx.config import settings
 TARGET = "mlx-community/Qwen3-0.6B-4bit"
 DRAFT = "mlx-community/Qwen3-0.6B-4bit"
 N_TOKENS = 48
-# Tokens whose target top1-top2 logit gap is below this are exact/near ties;
-# a path may legitimately break them differently from pure greedy.
+# A position whose target top1-top2 logit gap is below this is an exact/near
+# tie that a path may legitimately break differently from a single clean
+# forward. Kept small: a real corruption surfaces as a clearly-higher-logit
+# alternative (margin well above this), so it is still caught.
 TIE_EPS = 1e-2
 
 
@@ -92,50 +95,46 @@ def _spec_sequence(draft, target, prompt_ids, *, tree_width):
     return out[:N_TOKENS]
 
 
-def _pure_greedy(target, prompt_ids):
-    """Reference: token-by-token greedy target decode plus, per step, the
-    top1-top2 logit margin used to recognise tie positions."""
+def _assert_target_greedy(label, seq, target, prompt_ids):
+    """Teacher-force ``seq`` through the target in one forward and assert every
+    token is the target's greedy argmax given its true preceding context,
+    excusing only positions where the target logits are a tie (< TIE_EPS).
+
+    Unlike a reference-walk that bails at the first divergence, this checks
+    every position, so corruption after a benign tie-break is still caught.
+    """
     import mlx.core as mx
     from mlx_lm.models.cache import make_prompt_cache
 
+    # full = prompt + seq[:-1]; logit at index (len(prompt)-1 + i) predicts
+    # seq[i] from the real context prompt + seq[:i].
+    full = list(prompt_ids) + list(seq[:-1])
     cache = make_prompt_cache(target)
-    logits = target(mx.array([prompt_ids]), cache=cache)[:, -1, :]
-    tokens = [int(mx.argmax(logits, axis=-1).item())]
-    margins = [float("inf")]  # the prefill step's own token (margin unused)
-    for _ in range(N_TOKENS - 1):
-        logits = target(mx.array([[tokens[-1]]]), cache=cache)[:, -1, :]
-        row = logits[0]
-        top2 = mx.sort(row)[-2:]
-        margins.append(float((top2[1] - top2[0]).item()))
-        tokens.append(int(mx.argmax(row).item()))
-    return tokens, margins
+    logits = target(mx.array([full]), cache=cache)[0]
+    base = len(prompt_ids) - 1
 
-
-def _assert_greedy_modulo_ties(label, seq, greedy, margins):
-    """seq must equal the pure-greedy decode up to the first divergence, and
-    any first divergence must land on a tie position (margin < TIE_EPS)."""
-    for i, (a, b) in enumerate(zip(seq, greedy)):
-        if a == b:
+    for i, tok in enumerate(seq):
+        row = logits[base + i]
+        pred = int(mx.argmax(row).item())
+        if pred == tok:
             continue
-        # First divergence: acceptable only if greedy[i] was a tie.
-        assert margins[i] < TIE_EPS, (
-            f"{label} diverges from pure greedy at index {i} "
-            f"(got {a}, greedy {b}) where the target logit margin is "
-            f"{margins[i]:.4f} >= {TIE_EPS} — not a tie, real corruption"
+        top2 = mx.sort(row)[-2:]
+        margin = float((top2[1] - top2[0]).item())
+        assert margin < TIE_EPS, (
+            f"{label} token {i} = {tok} but target greedy = {pred} "
+            f"(top1-top2 margin {margin:.4f} >= {TIE_EPS}) — not a tie, "
+            f"real corruption"
         )
-        return  # contexts diverge after a legit tie-break; stop comparing
-    # No divergence at all.
 
 
-def test_tree_and_linear_match_pure_greedy(models):
+def test_tree_and_linear_are_target_greedy(models):
     target, draft, tokenizer = models
     ids = _prompt_ids(
         tokenizer,
         "List the first five prime numbers, comma-separated.",
     )
-    greedy, margins = _pure_greedy(target, ids)
     linear = _spec_sequence(draft, target, ids, tree_width=1)
     tree = _spec_sequence(draft, target, ids, tree_width=3)
 
-    _assert_greedy_modulo_ties("linear", linear, greedy, margins)
-    _assert_greedy_modulo_ties("tree", tree, greedy, margins)
+    _assert_target_greedy("linear", linear, target, ids)
+    _assert_target_greedy("tree", tree, target, ids)

--- a/tests/live/test_tree_speculative_real.py
+++ b/tests/live/test_tree_speculative_real.py
@@ -1,0 +1,141 @@
+"""Live greedy-parity canary for tree speculative verification (#501).
+
+Greedy speculative decoding is exactness-preserving: its output must equal
+the target model's own greedy decode, *modulo argmax tie-breaks*. When two
+tokens share the exact same top logit, the L=1 single-token forward (pure
+greedy / draft) and the L=N verify forward may resolve the tie to different
+token ids; that is benign nondeterminism, not corruption, and it affects the
+linear path too (verified 2026-06: on this prompt the linear path diverges
+from pure greedy at an exact 0.0-margin tie while the tree path matches it).
+
+So this canary asserts both the tree and the linear path match the target's
+pure-greedy decode, tolerating divergences that occur only at a tie position
+(top1-top2 logit margin below TIE_EPS). A divergence at a clear-margin
+position is a real correctness bug and fails loudly.
+
+This is also the regression guard for the bit-rot that left the tree path
+crashing on current mlx (no real-model test exercised it before #501 — the
+_tree_call signature + mask-dtype fixes).
+
+Lives outside tests/integration/ to dodge its autouse MLX mock.
+real_model; skipped in CI (`-m "not real_model"`) and when the model
+isn't downloaded.
+
+Run: uv run pytest tests/live/test_tree_speculative_real.py -m real_model -v
+"""
+
+import pytest
+
+from olmlx.config import settings
+
+TARGET = "mlx-community/Qwen3-0.6B-4bit"
+DRAFT = "mlx-community/Qwen3-0.6B-4bit"
+N_TOKENS = 48
+# Tokens whose target top1-top2 logit gap is below this are exact/near ties;
+# a path may legitimately break them differently from pure greedy.
+TIE_EPS = 1e-2
+
+
+def _model_dir(model: str):
+    from olmlx.models.store import _safe_dir_name
+
+    return settings.models_dir / _safe_dir_name(model)
+
+
+def _present(model: str) -> bool:
+    return (_model_dir(model) / "config.json").exists()
+
+
+pytestmark = [
+    pytest.mark.real_model,
+    pytest.mark.skipif(
+        not (_present(TARGET) and _present(DRAFT)),
+        reason=f"{TARGET}/{DRAFT} not downloaded in {settings.models_dir}",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def models():
+    from mlx_lm import load
+
+    target, tokenizer = load(str(_model_dir(TARGET)))
+    draft, _ = load(str(_model_dir(DRAFT)))
+    return target, draft, tokenizer
+
+
+def _prompt_ids(tokenizer, content: str):
+    return tokenizer.apply_chat_template(
+        [{"role": "user", "content": content}],
+        add_generation_prompt=True,
+        enable_thinking=False,
+    )
+
+
+def _spec_sequence(draft, target, prompt_ids, *, tree_width):
+    import mlx.core as mx
+
+    from olmlx.engine.speculative import SpeculativeDecoder
+
+    dec = SpeculativeDecoder(
+        draft,
+        target,
+        num_speculative_tokens=4,
+        tree_width=tree_width,
+        tree_max_nodes=12,
+    )
+    out = [dec.prefill(mx.array([prompt_ids]))]
+    while len(out) < N_TOKENS:
+        accepted, _ = dec.step()
+        out.extend(accepted)
+    dec.close()
+    return out[:N_TOKENS]
+
+
+def _pure_greedy(target, prompt_ids):
+    """Reference: token-by-token greedy target decode plus, per step, the
+    top1-top2 logit margin used to recognise tie positions."""
+    import mlx.core as mx
+    from mlx_lm.models.cache import make_prompt_cache
+
+    cache = make_prompt_cache(target)
+    logits = target(mx.array([prompt_ids]), cache=cache)[:, -1, :]
+    tokens = [int(mx.argmax(logits, axis=-1).item())]
+    margins = [float("inf")]  # the prefill step's own token (margin unused)
+    for _ in range(N_TOKENS - 1):
+        logits = target(mx.array([[tokens[-1]]]), cache=cache)[:, -1, :]
+        row = logits[0]
+        top2 = mx.sort(row)[-2:]
+        margins.append(float((top2[1] - top2[0]).item()))
+        tokens.append(int(mx.argmax(row).item()))
+    return tokens, margins
+
+
+def _assert_greedy_modulo_ties(label, seq, greedy, margins):
+    """seq must equal the pure-greedy decode up to the first divergence, and
+    any first divergence must land on a tie position (margin < TIE_EPS)."""
+    for i, (a, b) in enumerate(zip(seq, greedy)):
+        if a == b:
+            continue
+        # First divergence: acceptable only if greedy[i] was a tie.
+        assert margins[i] < TIE_EPS, (
+            f"{label} diverges from pure greedy at index {i} "
+            f"(got {a}, greedy {b}) where the target logit margin is "
+            f"{margins[i]:.4f} >= {TIE_EPS} — not a tie, real corruption"
+        )
+        return  # contexts diverge after a legit tie-break; stop comparing
+    # No divergence at all.
+
+
+def test_tree_and_linear_match_pure_greedy(models):
+    target, draft, tokenizer = models
+    ids = _prompt_ids(
+        tokenizer,
+        "List the first five prime numbers, comma-separated.",
+    )
+    greedy, margins = _pure_greedy(target, ids)
+    linear = _spec_sequence(draft, target, ids, tree_width=1)
+    tree = _spec_sequence(draft, target, ids, tree_width=3)
+
+    _assert_greedy_modulo_ties("linear", linear, greedy, margins)
+    _assert_greedy_modulo_ties("tree", tree, greedy, margins)


### PR DESCRIPTION
## What

Repairs the `OLMLX_TREE_SPECULATIVE` tree-verification path (#358), which had silently bit-rotted and was crashing on the **first tree step** against the current mlx/mlx-lm stack, and adds the real-model test coverage whose absence let it rot unnoticed.

This is the salvage from a Phase-1 investigation of #501 (tree-based draft verification). The tree *feature* itself did not pan out — benchmarked ~2× slower than the linear chain on a 4-bit target, and the GDN path needs from-scratch design work — so only the regression fix + test are kept here. (Full negative-result write-up lives on the `spec/tree-draft-verification-501` branch.)

## The two regressions fixed

Both uncaught because **no real-model test exercised the tree path**:

1. **Forward signature** — `_tree_call` accepted `(inputs, cache)`, but mlx-lm's Qwen3 wrapper now calls the inner model with a third positional `input_embeddings`, raising `TypeError` on the first tree step. Now threaded through to `embed_fn`.
2. **Mask dtype** — the additive tree mask was `float32`; current mlx `scaled_dot_product_attention` requires the mask to promote to the model's `bf16` output dtype. Now cast to the hidden-state dtype, mirroring mlx-lm's own `create_attention_mask`.

`tree_width >= 2` runs end-to-end again.

## Test

New live canary `tests/live/test_tree_speculative_real.py` (real_model; skipped in CI and when the model isn't downloaded). It asserts both the tree (`tree_width>=2`) and linear paths match the target's **pure-greedy decode**, tolerating divergences that land only on exact-tie positions (top1−top2 logit margin < `TIE_EPS`) and failing loudly on any clear-margin divergence — the real exactness contract under argmax tie-breaking. Verified: the tree path matches pure greedy exactly while the linear path tie-breaks one 0.0-margin position differently (so a naive `tree == linear` assertion was the wrong invariant).

## Scope

- Only `olmlx/engine/tree_speculative.py` (+13/−3) and the new test file.
- No behavior change to any non-tree path; `OLMLX_TREE_SPECULATIVE` remains off by default.
- GDN/hybrid targets still not supported by the tree path (separate, documented design gap — `_step_tree` assumes a trimmable `KVCache` at layer 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)