### PR TITLE
fix(bench): treat pld as draftless in speculative audit

### DIFF
--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -1042,7 +1042,8 @@ def _audit_speculative_config(
                 exc_info=True,
             )
             continue
-        if enabled and not draft and strategy != "self_speculative":
+        _draftless = {"self_speculative", "pld"}
+        if enabled and not draft and strategy not in _draftless:
             bad.append(name)
         elif not enabled and mc.speculative_draft_model:
             # Use the raw per-model field rather than the resolved

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1067,6 +1067,31 @@ class TestBuildParser:
         assert dflash_moe == ["moe-eagle/m:latest"]
         assert global_used is False
 
+    def test_audit_pld_not_flagged_as_bad_without_draft(self, monkeypatch, tmp_path):
+        """PLD strategy needs no draft model — must not appear in ``bad``."""
+        from olmlx.cli import _audit_speculative_config
+        from olmlx.config import settings as _settings
+
+        models_json = tmp_path / "models.json"
+        models_json.write_text(
+            json.dumps(
+                {
+                    "pld/m:latest": {
+                        "hf_path": "pld/m",
+                        "speculative": True,
+                        "speculative_strategy": "pld",
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr(_settings, "models_config", models_json)
+        monkeypatch.setattr(_settings, "speculative", False)
+        monkeypatch.setattr(_settings, "speculative_draft_model", None)
+
+        bad, dormant, flash, dflash_moe, global_used = _audit_speculative_config()
+        assert bad == [], "pld model should not be flagged as bad (no draft needed)"
+        assert dormant == []
+
     def test_per_model_flash_mismatch_in_distributed_exits(
         self, monkeypatch, tmp_path, capsys
     ):


### PR DESCRIPTION
## Summary

- `_audit_speculative_config` only excluded `self_speculative` from the "missing draft model" check. PLD (`speculative_strategy: "pld"`) uses n-gram matching from context and also needs no external draft model.
- This caused every bench run including the `pld` scenario to fail at server startup when any model in `models.json` had `speculative: true` (e.g. Qwen3.6-35B-A3B-6bit with dflash), because the audit flagged it as misconfigured and aborted.
- Fix: add `pld` to the `_draftless` set alongside `self_speculative`.

## Context

Discovered during a full bench sweep of all downloaded models (2026-06-14). The bug blocked PLD testing for all models whenever any speculative model existed in `models.json`.

## Test plan

- [ ] `pytest tests/test_cli.py::TestBuildParser::test_audit_pld_not_flagged_as_bad_without_draft` — new test covering the exact failure path
- [ ] `pytest tests/test_cli.py` — full audit test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)