### PR TITLE
feat(panel): multi-model panel + judge coordinator (#520)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ olmlx/
 │   └── voice/          # Push-to-talk STT (Whisper) + Kokoro TTS
 ├── engine/
 │   ├── inference.py    # generate_chat/completion/embeddings/transcription/rerank
+│   ├── panel.py        # Multi-model panel + judge coordinator (per-turn reconciler)
 │   ├── model_manager.py
 │   ├── speculative_loaders.py
 │   ├── spec_decoder_base.py  # SpecDecoderBase: shared mechanics for all speculative strategies
@@ -73,6 +74,8 @@ olmlx/
 **TTS priming** — The router primes the PCM source generator's first chunk before starting the response. Priming the ffmpeg-encoded stream instead wouldn't work: ffmpeg emits its container header before reading stdin, so an upstream `ValueError` from a non-TTS model would leak after the 200 has been sent.
 
 **Flash prefetcher teardown order** — Prefetcher must be closed before the weight store on model unload. Prefetch tasks submit work into the store's thread pool; reversing the order leaves in-flight tasks referencing a closed store.
+
+**Panel coordinator routes through generate_chat** — `engine/panel.py` is a per-turn reconciler that rides the client's tool loop: it returns a `generate_chat`-shaped result whose text is either the judge's prose or canonical Qwen `<tool_call>` blocks, so both routers' existing `parse_model_output` paths handle it unchanged. Every classifier/panelist/judge call MUST go through `generate_chat` — never call MLX directly — or the Metal-stream/inference-lock handling is bypassed. Panels need `max_loaded_models ≥ members + judge + classifier` to avoid reload thrash.
 
 ## Development
 

--- a/docs/superpowers/plans/2026-06-14-multi-model-panel-judge.md
+++ b/docs/superpowers/plans/2026-06-14-multi-model-panel-judge.md
@@ -1,0 +1,1567 @@
+# Multi-model Panel + Judge Coordinator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a synthetic `type: "panel"` model that answers a request with a per-task-routed panel of models plus a judge that synthesizes one reconciled answer, while behaving as a drop-in tool-calling model (the client still executes tools).
+
+**Architecture:** A new `engine/panel.py` `panel_generate_chat()` mirrors `engine/inference.py:generate_chat()`'s signature and return shapes. It is a *per-turn reconciler* riding the client's existing tool loop: on each stateless HTTP call it routes via a small classifier, runs each panelist through `generate_chat`, then either (a) emits the **deduped union** of the panelists' proposed tool calls as canonical Qwen `<tool_call>` text, or (b) when no panelist wants tools, runs the judge (no tools) to synthesize a fresh merged answer. Because the coordinator returns a `generate_chat`-shaped result whose text is either the judge's prose or `<tool_call>` blocks, both routers' existing `parse_model_output` paths handle it unchanged — they only swap which dispatch function they call. Panels live as `type: "panel"` entries in `models.json`, parsed into a `PanelConfig` and stored in a separate registry map.
+
+**Tech Stack:** Python 3.12, FastAPI, MLX (via existing `generate_chat`), xgrammar (`engine/grammar.py`), pytest with `unittest.mock`.
+
+---
+
+## File Structure
+
+- **Create** `olmlx/engine/panel.py` — pure helpers (`first_user_text`, `route_grammar`, `select_members`, `merge_tool_calls`, `serialize_tool_calls_qwen`, `build_judge_messages`) + async coordinator (`classify`, `_run_panel`, `panel_generate_chat`).
+- **Modify** `olmlx/engine/registry.py` — add `PanelConfig` dataclass; parse `type: "panel"` entries in `load()` into `self._panels`; add `is_panel()`, `resolve_panel()`, and a post-load `_validate_panels()`.
+- **Modify** `olmlx/routers/openai.py` — branch the dispatch function on `registry.is_panel(req.model)`.
+- **Modify** `olmlx/routers/chat.py` — same branch for the Ollama route.
+- **Create** `tests/test_panel.py` — coordinator + helper unit tests (mocked `generate_chat`).
+- **Create** `tests/test_registry_panel.py` — panel config parsing + validation tests.
+- **Modify** `CLAUDE.md` — add the panel invariant note.
+
+### Key data shapes (used across tasks)
+
+- `parse_model_output(text, has_tools, *, thinking_expected=False)` returns `(thinking: str, visible: str, tool_uses: list[dict])`. Each tool_use is `{"name": str, "input": dict, "_span": tuple}` (the `_span` key is internal; helpers must ignore/strip it).
+- `generate_chat(...)` non-stream returns `{"text": str, "done": True, "stats": TimingStats, ...}` and may include `"raw_text"`. Streaming returns an async generator yielding `{"text": str}` chunks then a final `{"done": True, "raw_text"?: str, "done_reason"?: str, "stats"?: TimingStats}` chunk.
+- `GrammarSpec(kind="json_schema", schema={...})` from `olmlx/engine/grammar.py`.
+- Routers re-parse the result text, so the coordinator never assigns tool-call IDs — `_to_openai_tool_calls` (openai) and `_build_tool_calls` (chat) do that downstream.
+
+---
+
+## Task 1: `PanelConfig` dataclass in the registry
+
+**Files:**
+- Modify: `olmlx/engine/registry.py` (add near `class ModelConfig`, ~line 306)
+- Test: `tests/test_registry_panel.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_registry_panel.py`:
+
+```python
+"""Tests for panel-type entries in olmlx.engine.registry."""
+
+import pytest
+
+from olmlx.engine.registry import PanelConfig
+
+
+class TestPanelConfig:
+    def test_from_entry_parses_fields(self):
+        entry = {
+            "type": "panel",
+            "classifier": "qwen3-0.6b",
+            "judge": "gpt-oss-20b",
+            "routes": {
+                "code": ["qwen3-coder", "devstral"],
+                "default": ["qwen3", "mistral"],
+            },
+        }
+        pc = PanelConfig.from_entry("my-panel:latest", entry)
+        assert pc.name == "my-panel:latest"
+        assert pc.classifier == "qwen3-0.6b"
+        assert pc.judge == "gpt-oss-20b"
+        assert pc.routes["code"] == ["qwen3-coder", "devstral"]
+
+    def test_from_entry_requires_default_route(self):
+        entry = {
+            "type": "panel",
+            "classifier": "c",
+            "judge": "j",
+            "routes": {"code": ["a"]},
+        }
+        with pytest.raises(ValueError, match="default"):
+            PanelConfig.from_entry("p:latest", entry)
+
+    def test_from_entry_requires_classifier_and_judge(self):
+        entry = {"type": "panel", "routes": {"default": ["a"]}}
+        with pytest.raises(ValueError, match="classifier"):
+            PanelConfig.from_entry("p:latest", entry)
+
+    def test_all_member_names_unions_routes(self):
+        pc = PanelConfig.from_entry(
+            "p:latest",
+            {
+                "type": "panel",
+                "classifier": "c",
+                "judge": "j",
+                "routes": {"code": ["a", "b"], "default": ["b", "c2"]},
+            },
+        )
+        assert pc.all_member_names() == {"a", "b", "c2"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_registry_panel.py -v`
+Expected: FAIL with `ImportError: cannot import name 'PanelConfig'`.
+
+- [ ] **Step 3: Implement `PanelConfig`**
+
+In `olmlx/engine/registry.py`, add after the `ModelConfig` class definition (the dataclass block ending near line 306; place the new class immediately before `class ModelRegistry`). Ensure `from dataclasses import dataclass, field` and `from typing import Any` are already imported (they are — `ModelConfig` uses them):
+
+```python
+@dataclass(frozen=True)
+class PanelConfig:
+    """A ``type: "panel"`` entry from models.json.
+
+    A panel is not a loadable model: it has no weights. ``classifier``,
+    ``judge`` and the per-route member lists all reference other
+    models.json entries by name. See engine/panel.py for the coordinator
+    that executes a panel.
+    """
+
+    name: str
+    classifier: str
+    judge: str
+    routes: dict[str, list[str]]
+
+    @classmethod
+    def from_entry(cls, name: str, entry: dict) -> "PanelConfig":
+        classifier = entry.get("classifier")
+        judge = entry.get("judge")
+        routes = entry.get("routes")
+        if not classifier or not isinstance(classifier, str):
+            raise ValueError(
+                f"panel {name!r}: 'classifier' must be a non-empty model name"
+            )
+        if not judge or not isinstance(judge, str):
+            raise ValueError(
+                f"panel {name!r}: 'judge' must be a non-empty model name"
+            )
+        if not isinstance(routes, dict) or not routes:
+            raise ValueError(f"panel {name!r}: 'routes' must be a non-empty object")
+        for key, members in routes.items():
+            if (
+                not isinstance(members, list)
+                or not members
+                or not all(isinstance(m, str) and m for m in members)
+            ):
+                raise ValueError(
+                    f"panel {name!r}: route {key!r} must be a non-empty list "
+                    "of model names"
+                )
+        if "default" not in routes:
+            raise ValueError(f"panel {name!r}: 'routes' must contain a 'default' key")
+        return cls(name=name, classifier=classifier, judge=judge, routes=dict(routes))
+
+    def all_member_names(self) -> set[str]:
+        names: set[str] = set()
+        for members in self.routes.values():
+            names.update(members)
+        return names
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_registry_panel.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/registry.py tests/test_registry_panel.py
+git commit -m "feat(panel): add PanelConfig registry dataclass"
+```
+
+---
+
+## Task 2: Registry parses & validates panel entries
+
+**Files:**
+- Modify: `olmlx/engine/registry.py` — `__init__` (add `self._panels`), `load()` loop (~line 1252), add `is_panel`/`resolve_panel`/`_validate_panels`
+- Test: `tests/test_registry_panel.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_registry_panel.py`:
+
+```python
+import json
+
+from olmlx.engine.registry import ModelRegistry
+
+
+def _load_registry(tmp_path, monkeypatch, config: dict) -> ModelRegistry:
+    path = tmp_path / "models.json"
+    path.write_text(json.dumps(config))
+    monkeypatch.setattr("olmlx.engine.registry.settings.models_config", path)
+    reg = ModelRegistry()
+    reg.load()
+    return reg
+
+
+class TestRegistryPanelLoading:
+    def test_panel_entry_loaded_and_resolvable(self, tmp_path, monkeypatch):
+        reg = _load_registry(
+            tmp_path,
+            monkeypatch,
+            {
+                "qwen3": "Qwen/Qwen3-8B-MLX",
+                "small": "org/small",
+                "judgem": "org/judge",
+                "my-panel": {
+                    "type": "panel",
+                    "classifier": "small",
+                    "judge": "judgem",
+                    "routes": {"default": ["qwen3"]},
+                },
+            },
+        )
+        assert reg.is_panel("my-panel") is True
+        assert reg.is_panel("my-panel:latest") is True
+        assert reg.is_panel("qwen3") is False
+        pc = reg.resolve_panel("my-panel")
+        assert pc.judge == "judgem"
+        # A panel name is NOT a normal model.
+        assert reg.resolve("my-panel") is None
+
+    def test_panel_with_missing_member_is_dropped(self, tmp_path, monkeypatch):
+        reg = _load_registry(
+            tmp_path,
+            monkeypatch,
+            {
+                "small": "org/small",
+                "judgem": "org/judge",
+                "bad-panel": {
+                    "type": "panel",
+                    "classifier": "small",
+                    "judge": "judgem",
+                    "routes": {"default": ["does-not-exist"]},
+                },
+            },
+        )
+        assert reg.is_panel("bad-panel") is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_registry_panel.py::TestRegistryPanelLoading -v`
+Expected: FAIL with `AttributeError: 'ModelRegistry' object has no attribute 'is_panel'`.
+
+- [ ] **Step 3: Implement registry parsing + validation**
+
+In `olmlx/engine/registry.py`:
+
+(a) In `ModelRegistry.__init__`, alongside `self._mappings = ...`, add an empty panels dict. Find the `__init__` (search `def __init__` in `class ModelRegistry`) and add:
+
+```python
+        self._panels: dict[str, PanelConfig] = {}
+```
+
+(b) In `load()`, replace the entry loop (currently at lines 1248-1257):
+
+```python
+            self._mappings = {}
+            self._raw_unrecognized = {}
+            self._dirty_keys = set()
+            self._removed_keys = set()
+            for k, v in raw.items():
+                try:
+                    self._mappings[k] = ModelConfig.from_entry(v)
+                except (ValueError, TypeError) as exc:
+                    logger.warning("Skipping invalid models.json entry %r: %s", k, exc)
+                    self._raw_unrecognized[k] = v
+```
+
+with:
+
+```python
+            self._mappings = {}
+            self._panels = {}
+            self._raw_unrecognized = {}
+            self._dirty_keys = set()
+            self._removed_keys = set()
+            for k, v in raw.items():
+                normalized = self.normalize_name(k)
+                if isinstance(v, dict) and v.get("type") == "panel":
+                    try:
+                        self._panels[normalized] = PanelConfig.from_entry(normalized, v)
+                    except (ValueError, TypeError) as exc:
+                        logger.warning(
+                            "Skipping invalid panel entry %r: %s", k, exc
+                        )
+                        self._raw_unrecognized[k] = v
+                    continue
+                try:
+                    self._mappings[k] = ModelConfig.from_entry(v)
+                except (ValueError, TypeError) as exc:
+                    logger.warning("Skipping invalid models.json entry %r: %s", k, exc)
+                    self._raw_unrecognized[k] = v
+            self._validate_panels()
+```
+
+(c) Add these methods to `ModelRegistry` (place them next to `resolve`, after the `resolve` method ~line 1307):
+
+```python
+    def is_panel(self, name: str) -> bool:
+        """True if *name* resolves to a ``type: "panel"`` entry."""
+        return self.normalize_name(name) in self._panels
+
+    def resolve_panel(self, name: str) -> "PanelConfig | None":
+        """Resolve *name* to a PanelConfig, or None if it is not a panel."""
+        return self._panels.get(self.normalize_name(name))
+
+    def _validate_panels(self) -> None:
+        """Drop panels referencing unknown models; warn on judge-in-panel.
+
+        Cross-reference validation runs after all entries are loaded so a
+        panel may reference members declared anywhere in the file.
+        """
+        for name, panel in list(self._panels.items()):
+            refs = {panel.classifier, panel.judge} | panel.all_member_names()
+            missing = sorted(r for r in refs if self.resolve(r) is None)
+            if missing:
+                logger.warning(
+                    "Dropping panel %r: references unknown models %s",
+                    name,
+                    missing,
+                )
+                del self._panels[name]
+                continue
+            if panel.judge in panel.all_member_names():
+                logger.warning(
+                    "Panel %r: judge %r is also a panelist; this invites "
+                    "self-preference bias.",
+                    name,
+                    panel.judge,
+                )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_registry_panel.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/registry.py tests/test_registry_panel.py
+git commit -m "feat(panel): load and validate panel entries in registry"
+```
+
+---
+
+## Task 3: Pure helpers — request routing inputs
+
+**Files:**
+- Create: `olmlx/engine/panel.py`
+- Test: `tests/test_panel.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_panel.py`:
+
+```python
+"""Tests for olmlx.engine.panel."""
+
+from olmlx.engine.grammar import GrammarSpec
+from olmlx.engine.panel import (
+    first_user_text,
+    route_grammar,
+    select_members,
+)
+from olmlx.engine.registry import PanelConfig
+
+
+def _panel() -> PanelConfig:
+    return PanelConfig.from_entry(
+        "p:latest",
+        {
+            "type": "panel",
+            "classifier": "c",
+            "judge": "j",
+            "routes": {
+                "code": ["qwen3-coder", "devstral"],
+                "default": ["qwen3", "mistral"],
+            },
+        },
+    )
+
+
+class TestRoutingHelpers:
+    def test_first_user_text_string_content(self):
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello world"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        assert first_user_text(msgs) == "hello world"
+
+    def test_first_user_text_list_content(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "part one"},
+                    {"type": "text", "text": "part two"},
+                ],
+            }
+        ]
+        assert first_user_text(msgs) == "part one\npart two"
+
+    def test_first_user_text_no_user(self):
+        assert first_user_text([{"role": "system", "content": "x"}]) == ""
+
+    def test_route_grammar_enumerates_keys(self):
+        spec = route_grammar(_panel())
+        assert isinstance(spec, GrammarSpec)
+        assert spec.kind == "json_schema"
+        enum = spec.schema["properties"]["route"]["enum"]
+        assert set(enum) == {"code", "default"}
+
+    def test_select_members_known_route(self):
+        assert select_members("code", _panel()) == ["qwen3-coder", "devstral"]
+
+    def test_select_members_unknown_route_falls_back_to_default(self):
+        assert select_members("nonsense", _panel()) == ["qwen3", "mistral"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_panel.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'olmlx.engine.panel'`.
+
+- [ ] **Step 3: Create the module with the helpers**
+
+Create `olmlx/engine/panel.py`:
+
+```python
+"""Multi-model panel + judge coordinator (sequential, single-box).
+
+A ``type: "panel"`` model answers a request with a per-task-routed panel
+of models plus a judge that synthesizes one reconciled answer, while
+behaving as a drop-in tool-calling model: the *client* still executes
+tools. The coordinator is a per-turn reconciler riding the client's
+existing tool loop — see docs/superpowers/specs/2026-06-14-...-design.md.
+
+INVARIANT: every model call goes through ``generate_chat`` so the
+Metal-stream / inference-lock handling is reused. Never touch MLX here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any
+
+from olmlx.engine.grammar import GrammarSpec
+from olmlx.engine.inference import generate_chat
+from olmlx.engine.tool_parser import parse_model_output
+from olmlx.utils.timing import TimingStats
+
+if TYPE_CHECKING:
+    from olmlx.engine.model_manager import ModelManager
+    from olmlx.engine.registry import PanelConfig
+
+logger = logging.getLogger(__name__)
+
+
+def first_user_text(messages: list[dict]) -> str:
+    """Return the first user message's text (stable routing key).
+
+    The conversation's task is fixed by the first user turn, so routing
+    on it is deterministically re-derived every stateless HTTP call with
+    no stored server state.
+    """
+    for msg in messages:
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = [
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            ]
+            return "\n".join(p for p in parts if p)
+        return ""
+    return ""
+
+
+def route_grammar(panel: "PanelConfig") -> GrammarSpec:
+    """A JSON-schema grammar constraining the classifier to one route key."""
+    return GrammarSpec(
+        kind="json_schema",
+        schema={
+            "type": "object",
+            "properties": {
+                "route": {"type": "string", "enum": sorted(panel.routes)}
+            },
+            "required": ["route"],
+            "additionalProperties": False,
+        },
+    )
+
+
+def select_members(route_key: str, panel: "PanelConfig") -> list[str]:
+    """Members for *route_key*, falling back to the 'default' route."""
+    return panel.routes.get(route_key, panel.routes["default"])
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_panel.py -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/panel.py tests/test_panel.py
+git commit -m "feat(panel): routing helpers (first_user_text, route_grammar, select_members)"
+```
+
+---
+
+## Task 4: Pure helpers — tool-call union & serialization
+
+**Files:**
+- Modify: `olmlx/engine/panel.py`
+- Test: `tests/test_panel.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_panel.py`:
+
+```python
+from olmlx.engine.panel import merge_tool_calls, serialize_tool_calls_qwen
+from olmlx.engine.tool_parser import parse_model_output
+
+
+class TestToolCallUnion:
+    def test_merge_dedupes_identical_calls(self):
+        # Two panelists; one shared identical call, one unique each.
+        per_panelist = [
+            [
+                {"name": "search", "input": {"q": "x"}, "_span": (0, 1)},
+                {"name": "read", "input": {"path": "a"}},
+            ],
+            [
+                {"name": "search", "input": {"q": "x"}},
+                {"name": "read", "input": {"path": "b"}},
+            ],
+        ]
+        merged = merge_tool_calls(per_panelist)
+        # search{q:x} collapses to one; read{a} and read{b} both kept.
+        assert merged == [
+            {"name": "search", "input": {"q": "x"}},
+            {"name": "read", "input": {"path": "a"}},
+            {"name": "read", "input": {"path": "b"}},
+        ]
+        # _span must be stripped.
+        assert all("_span" not in tc for tc in merged)
+
+    def test_merge_empty(self):
+        assert merge_tool_calls([[], []]) == []
+
+    def test_serialize_round_trips_through_parser(self):
+        merged = [
+            {"name": "search", "input": {"q": "x"}},
+            {"name": "read", "input": {"path": "a"}},
+        ]
+        text = serialize_tool_calls_qwen(merged)
+        _thinking, _visible, tool_uses = parse_model_output(text, has_tools=True)
+        reparsed = [{"name": tu["name"], "input": tu["input"]} for tu in tool_uses]
+        assert reparsed == merged
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_panel.py::TestToolCallUnion -v`
+Expected: FAIL with `ImportError: cannot import name 'merge_tool_calls'`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Append to `olmlx/engine/panel.py`:
+
+```python
+def _tool_key(tool_use: dict) -> str:
+    """Stable dedup key: name + canonicalized arguments."""
+    args = tool_use.get("input") or {}
+    return tool_use["name"] + "\0" + json.dumps(args, sort_keys=True)
+
+
+def merge_tool_calls(per_panelist: list[list[dict]]) -> list[dict]:
+    """Deduped union of every panelist's proposed tool calls.
+
+    Identical ``(name, arguments)`` collapse to one execution; different
+    arguments both run. Insertion order is preserved (first panelist
+    first). The internal ``_span`` key from ``parse_model_output`` is
+    stripped. Tool-call IDs are assigned downstream by the routers.
+    """
+    merged: list[dict] = []
+    seen: set[str] = set()
+    for panelist_calls in per_panelist:
+        for call in panelist_calls:
+            key = _tool_key(call)
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append({"name": call["name"], "input": call.get("input") or {}})
+    return merged
+
+
+def serialize_tool_calls_qwen(tool_uses: list[dict]) -> str:
+    """Render tool calls as canonical Qwen ``<tool_call>`` blocks.
+
+    The routers re-parse this text via ``parse_model_output`` (the Qwen
+    parser maps ``arguments`` -> ``input``), so the panel's tool turn is
+    transparent to both the OpenAI and Ollama routers.
+    """
+    blocks = []
+    for tu in tool_uses:
+        payload = json.dumps({"name": tu["name"], "arguments": tu.get("input") or {}})
+        blocks.append(f"<tool_call>\n{payload}\n</tool_call>")
+    return "\n".join(blocks)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_panel.py::TestToolCallUnion -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/panel.py tests/test_panel.py
+git commit -m "feat(panel): tool-call union dedup + Qwen serialization"
+```
+
+---
+
+## Task 5: Pure helper — judge prompt construction
+
+**Files:**
+- Modify: `olmlx/engine/panel.py`
+- Test: `tests/test_panel.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_panel.py`:
+
+```python
+from olmlx.engine.panel import build_judge_messages
+
+
+class TestJudgePrompt:
+    def test_appends_candidates_as_final_user_turn(self):
+        original = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "What is 2+2?"},
+        ]
+        out = build_judge_messages(original, ["qwen3", "mistral"], ["four", "4"])
+        # Original messages preserved as a prefix (not mutated).
+        assert out[:2] == original
+        assert original[-1]["content"] == "What is 2+2?"  # input untouched
+        judge_turn = out[-1]
+        assert judge_turn["role"] == "user"
+        assert "qwen3" in judge_turn["content"]
+        assert "mistral" in judge_turn["content"]
+        assert "four" in judge_turn["content"]
+        assert "4" in judge_turn["content"]
+
+    def test_handles_empty_candidate_answer(self):
+        out = build_judge_messages(
+            [{"role": "user", "content": "q"}], ["m1"], [""]
+        )
+        assert "m1" in out[-1]["content"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_panel.py::TestJudgePrompt -v`
+Expected: FAIL with `ImportError: cannot import name 'build_judge_messages'`.
+
+- [ ] **Step 3: Implement the helper**
+
+Append to `olmlx/engine/panel.py`:
+
+```python
+_JUDGE_INSTRUCTION = (
+    "You are the judge for a panel of models that all answered the "
+    "conversation above. Several candidate answers are listed below. "
+    "Synthesize ONE best final answer for the user. Ground every claim in "
+    "the tool results already present in this conversation; do not call "
+    "tools or invent new facts. Reconcile disagreements and prefer "
+    "grounded, specific answers. Output only the final answer."
+)
+
+
+def build_judge_messages(
+    original_messages: list[dict],
+    member_names: list[str],
+    answers: list[str],
+) -> list[dict]:
+    """Original conversation + a final user turn carrying the candidates.
+
+    ``original_messages`` is not mutated (a new list is returned). The
+    judge sees the full conversation — including any tool results the
+    client executed — so it can verify groundedness.
+    """
+    candidates = []
+    for name, answer in zip(member_names, answers):
+        candidates.append(f"--- Candidate from {name} ---\n{answer.strip()}")
+    content = _JUDGE_INSTRUCTION + "\n\n" + "\n\n".join(candidates)
+    return [*original_messages, {"role": "user", "content": content}]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_panel.py::TestJudgePrompt -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/panel.py tests/test_panel.py
+git commit -m "feat(panel): judge prompt construction"
+```
+
+---
+
+## Task 6: Classifier call (`classify`)
+
+**Files:**
+- Modify: `olmlx/engine/panel.py`
+- Test: `tests/test_panel.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_panel.py`:
+
+```python
+import pytest
+
+from olmlx.engine import panel as panel_mod
+
+
+def _make_panel():
+    from olmlx.engine.registry import PanelConfig
+
+    return PanelConfig.from_entry(
+        "p:latest",
+        {
+            "type": "panel",
+            "classifier": "c",
+            "judge": "j",
+            "routes": {"code": ["qa", "qb"], "default": ["da", "db"]},
+        },
+    )
+
+
+def _fake_generate_chat_factory(responses: dict):
+    """Return an async generate_chat stub keyed by model name -> text."""
+
+    async def _fake(manager, model_name, messages, options=None, tools=None,
+                    stream=False, keep_alive=None, max_tokens=512, cache_id="",
+                    enable_thinking=None, grammar_spec=None):
+        text = responses[model_name]
+        return {"text": text, "done": True, "stats": None}
+
+    return _fake
+
+
+class TestClassify:
+    @pytest.mark.asyncio
+    async def test_classify_returns_route_members(self, monkeypatch):
+        monkeypatch.setattr(
+            panel_mod,
+            "generate_chat",
+            _fake_generate_chat_factory({"c": '{"route": "code"}'}),
+        )
+        members = await panel_mod.classify(
+            manager=None, panel=_make_panel(), user_text="write a function"
+        )
+        assert members == ["qa", "qb"]
+
+    @pytest.mark.asyncio
+    async def test_classify_bad_json_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setattr(
+            panel_mod,
+            "generate_chat",
+            _fake_generate_chat_factory({"c": "not json at all"}),
+        )
+        members = await panel_mod.classify(
+            manager=None, panel=_make_panel(), user_text="hi"
+        )
+        assert members == ["da", "db"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_panel.py::TestClassify -v`
+Expected: FAIL with `AttributeError: module 'olmlx.engine.panel' has no attribute 'classify'`.
+
+- [ ] **Step 3: Implement `classify`**
+
+Append to `olmlx/engine/panel.py`:
+
+```python
+_CLASSIFIER_SYSTEM = (
+    "You are a request router. Classify the user's request into exactly "
+    "one category. Respond ONLY with JSON of the form {\"route\": \"<category>\"}."
+)
+
+
+async def classify(
+    manager: "ModelManager",
+    panel: "PanelConfig",
+    user_text: str,
+    keep_alive: int | str | None = None,
+) -> list[str]:
+    """Route the request to a member list via the classifier model.
+
+    The classifier output is grammar-constrained to the route keys; any
+    parse failure falls back to the 'default' route.
+    """
+    categories = ", ".join(sorted(panel.routes))
+    messages = [
+        {"role": "system", "content": f"{_CLASSIFIER_SYSTEM} Categories: {categories}."},
+        {"role": "user", "content": user_text},
+    ]
+    result = await generate_chat(
+        manager,
+        panel.classifier,
+        messages,
+        tools=None,
+        stream=False,
+        keep_alive=keep_alive,
+        max_tokens=32,
+        grammar_spec=route_grammar(panel),
+    )
+    text = (result.get("text") or "").strip()
+    try:
+        route = json.loads(text).get("route", "default")
+    except (json.JSONDecodeError, AttributeError):
+        logger.warning("Panel classifier returned non-JSON %r; using default", text)
+        route = "default"
+    return select_members(route, panel)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_panel.py::TestClassify -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/panel.py tests/test_panel.py
+git commit -m "feat(panel): grammar-constrained classifier routing"
+```
+
+---
+
+## Task 7: Panel runner (`_run_panel`) — runs panelists, reconciles
+
+**Files:**
+- Modify: `olmlx/engine/panel.py`
+- Test: `tests/test_panel.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_panel.py`:
+
+```python
+class TestRunPanel:
+    @pytest.mark.asyncio
+    async def test_returns_union_when_any_panelist_wants_tools(self, monkeypatch):
+        # da proposes a tool call (Qwen format), db answers in prose.
+        responses = {
+            "c": '{"route": "default"}',
+            "da": '<tool_call>\n{"name": "search", "arguments": {"q": "x"}}\n</tool_call>',
+            "db": "I think the answer is 42.",
+        }
+        monkeypatch.setattr(
+            panel_mod, "generate_chat", _fake_generate_chat_factory(responses)
+        )
+        answers, merged = await panel_mod._run_panel(
+            manager=None,
+            panel=_make_panel(),
+            messages=[{"role": "user", "content": "find x"}],
+            tools=[{"type": "function", "function": {"name": "search"}}],
+            options=None,
+            keep_alive=None,
+            max_tokens=128,
+            enable_thinking=None,
+        )
+        assert merged == [{"name": "search", "input": {"q": "x"}}]
+
+    @pytest.mark.asyncio
+    async def test_returns_answers_when_no_tools_requested(self, monkeypatch):
+        responses = {
+            "c": '{"route": "default"}',
+            "da": "Answer A",
+            "db": "Answer B",
+        }
+        monkeypatch.setattr(
+            panel_mod, "generate_chat", _fake_generate_chat_factory(responses)
+        )
+        answers, merged = await panel_mod._run_panel(
+            manager=None,
+            panel=_make_panel(),
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            options=None,
+            keep_alive=None,
+            max_tokens=128,
+            enable_thinking=None,
+        )
+        assert merged == []
+        assert answers == (["da", "db"], ["Answer A", "Answer B"])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_panel.py::TestRunPanel -v`
+Expected: FAIL with `AttributeError: module 'olmlx.engine.panel' has no attribute '_run_panel'`.
+
+- [ ] **Step 3: Implement `_run_panel`**
+
+Append to `olmlx/engine/panel.py`:
+
+```python
+async def _run_panel(
+    manager: "ModelManager",
+    panel: "PanelConfig",
+    messages: list[dict],
+    tools: list[dict] | None,
+    options: dict | None,
+    keep_alive: int | str | None,
+    max_tokens: int,
+    enable_thinking: bool | None,
+) -> tuple[tuple[list[str], list[str]], list[dict]]:
+    """Route, run each panelist once, and reconcile this turn.
+
+    Returns ``((member_names, answers), merged_tool_uses)``. When any
+    panelist proposes tool calls, ``merged_tool_uses`` is their deduped
+    union and ``answers`` is unused by the caller (the turn is a tool
+    turn). When none do, ``merged_tool_uses`` is empty and the caller
+    runs the judge over ``answers``.
+
+    Any panelist/classifier failure propagates (fail the request).
+    """
+    user_text = first_user_text(messages)
+    members = await classify(manager, panel, user_text, keep_alive)
+
+    has_tools = bool(tools)
+    answers: list[str] = []
+    per_panelist_tools: list[list[dict]] = []
+    for member in members:
+        result = await generate_chat(
+            manager,
+            member,
+            messages,
+            options=options,
+            tools=tools,
+            stream=False,
+            keep_alive=keep_alive,
+            max_tokens=max_tokens,
+            enable_thinking=enable_thinking,
+        )
+        parse_text = result.get("raw_text") or result.get("text") or ""
+        _thinking, visible, tool_uses = parse_model_output(
+            parse_text,
+            has_tools,
+            thinking_expected=bool(result.get("thinking_expected")),
+        )
+        answers.append(visible)
+        per_panelist_tools.append(tool_uses)
+
+    merged = merge_tool_calls(per_panelist_tools)
+    return (members, answers), merged
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_panel.py::TestRunPanel -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/panel.py tests/test_panel.py
+git commit -m "feat(panel): _run_panel routes, runs panelists, reconciles turn"
+```
+
+---
+
+## Task 8: Coordinator entry — non-streaming (`panel_generate_chat`)
+
+**Files:**
+- Modify: `olmlx/engine/panel.py`
+- Test: `tests/test_panel.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_panel.py`:
+
+```python
+class TestPanelGenerateChatNonStream:
+    @pytest.mark.asyncio
+    async def test_tool_turn_returns_qwen_blocks(self, monkeypatch):
+        responses = {
+            "c": '{"route": "default"}',
+            "da": '<tool_call>\n{"name": "search", "arguments": {"q": "x"}}\n</tool_call>',
+            "db": "prose",
+        }
+        monkeypatch.setattr(
+            panel_mod, "generate_chat", _fake_generate_chat_factory(responses)
+        )
+        monkeypatch.setattr(
+            panel_mod, "_resolve_panel", lambda manager, name: _make_panel()
+        )
+        result = await panel_mod.panel_generate_chat(
+            manager=None,
+            model_name="p:latest",
+            messages=[{"role": "user", "content": "find x"}],
+            tools=[{"type": "function", "function": {"name": "search"}}],
+            stream=False,
+        )
+        # Router parses raw_text -> tool calls.
+        _t, _v, tool_uses = parse_model_output(result["raw_text"], has_tools=True)
+        assert [tu["name"] for tu in tool_uses] == ["search"]
+        assert result["done"] is True
+
+    @pytest.mark.asyncio
+    async def test_final_turn_returns_judge_answer(self, monkeypatch):
+        responses = {
+            "c": '{"route": "default"}',
+            "da": "Answer A",
+            "db": "Answer B",
+            "j": "Reconciled final answer.",
+        }
+        monkeypatch.setattr(
+            panel_mod, "generate_chat", _fake_generate_chat_factory(responses)
+        )
+        monkeypatch.setattr(
+            panel_mod, "_resolve_panel", lambda manager, name: _make_panel()
+        )
+        result = await panel_mod.panel_generate_chat(
+            manager=None,
+            model_name="p:latest",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            stream=False,
+        )
+        assert result["text"] == "Reconciled final answer."
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_panel.py::TestPanelGenerateChatNonStream -v`
+Expected: FAIL with `AttributeError: module 'olmlx.engine.panel' has no attribute 'panel_generate_chat'`.
+
+- [ ] **Step 3: Implement `_resolve_panel`, the judge call, and the non-stream path**
+
+Append to `olmlx/engine/panel.py`:
+
+```python
+def _resolve_panel(manager: "ModelManager", model_name: str) -> "PanelConfig":
+    """Resolve *model_name* to its PanelConfig or raise (fail the request)."""
+    panel = manager.registry.resolve_panel(model_name)
+    if panel is None:
+        raise ValueError(f"{model_name!r} is not a configured panel model")
+    return panel
+
+
+async def _judge_answer(
+    manager: "ModelManager",
+    panel: "PanelConfig",
+    messages: list[dict],
+    member_names: list[str],
+    answers: list[str],
+    options: dict | None,
+    keep_alive: int | str | None,
+    max_tokens: int,
+    enable_thinking: bool | None,
+    stream: bool,
+):
+    """Run the judge (no tools) to synthesize the final answer.
+
+    Returns the judge's ``generate_chat`` result verbatim — an async
+    generator when ``stream`` else a dict — so the routers stream/format
+    it exactly as a single model's output.
+    """
+    judge_messages = build_judge_messages(messages, member_names, answers)
+    return await generate_chat(
+        manager,
+        panel.judge,
+        judge_messages,
+        options=options,
+        tools=None,  # judge must not redo work
+        stream=stream,
+        keep_alive=keep_alive,
+        max_tokens=max_tokens,
+        enable_thinking=enable_thinking,
+    )
+
+
+async def panel_generate_chat(
+    manager: "ModelManager",
+    model_name: str,
+    messages: list[dict],
+    options: dict | None = None,
+    tools: list[dict] | None = None,
+    stream: bool = True,
+    keep_alive: int | str | None = None,
+    max_tokens: int = 512,
+    cache_id: str = "",
+    enable_thinking: bool | None = None,
+    grammar_spec: GrammarSpec | None = None,
+) -> AsyncGenerator[dict, None] | dict:
+    """Drop-in, ``generate_chat``-compatible entry point for a panel model.
+
+    ``cache_id`` and ``grammar_spec`` are accepted for signature parity
+    but not applied to the panel as a whole (the judge/panelists manage
+    their own caching).
+    """
+    panel = _resolve_panel(manager, model_name)
+    if stream:
+        return _panel_stream(
+            manager, panel, messages, options, tools, keep_alive,
+            max_tokens, enable_thinking,
+        )
+
+    (member_names, answers), merged = await _run_panel(
+        manager, panel, messages, tools, options, keep_alive,
+        max_tokens, enable_thinking,
+    )
+    if merged:
+        raw = serialize_tool_calls_qwen(merged)
+        return {"text": "", "raw_text": raw, "done": True, "stats": TimingStats()}
+    return await _judge_answer(
+        manager, panel, messages, member_names, answers, options,
+        keep_alive, max_tokens, enable_thinking, stream=False,
+    )
+```
+
+(The `_panel_stream` async generator is implemented in Task 9; add a temporary stub so the module imports — it will be replaced in Task 9:)
+
+```python
+async def _panel_stream(*args, **kwargs):  # replaced in Task 9
+    raise NotImplementedError
+    yield {}  # pragma: no cover  (makes this an async generator)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_panel.py::TestPanelGenerateChatNonStream -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/panel.py tests/test_panel.py
+git commit -m "feat(panel): non-streaming coordinator entry point"
+```
+
+---
+
+## Task 9: Coordinator entry — streaming (`_panel_stream`)
+
+**Files:**
+- Modify: `olmlx/engine/panel.py`
+- Test: `tests/test_panel.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_panel.py`:
+
+```python
+def _fake_generate_chat_streaming_factory(responses: dict, stream_models: set):
+    """generate_chat stub: dict for non-stream models, async-gen for streamed ones."""
+
+    async def _fake(manager, model_name, messages, options=None, tools=None,
+                    stream=False, keep_alive=None, max_tokens=512, cache_id="",
+                    enable_thinking=None, grammar_spec=None):
+        text = responses[model_name]
+        if stream and model_name in stream_models:
+            async def _gen():
+                yield {"text": text}
+                yield {"done": True, "done_reason": "stop"}
+            return _gen()
+        return {"text": text, "done": True, "stats": None}
+
+    return _fake
+
+
+async def _drain(agen) -> list[dict]:
+    return [chunk async for chunk in agen]
+
+
+class TestPanelGenerateChatStream:
+    @pytest.mark.asyncio
+    async def test_stream_tool_turn_emits_qwen_text_then_done(self, monkeypatch):
+        responses = {
+            "c": '{"route": "default"}',
+            "da": '<tool_call>\n{"name": "search", "arguments": {"q": "x"}}\n</tool_call>',
+            "db": "prose",
+        }
+        monkeypatch.setattr(
+            panel_mod,
+            "generate_chat",
+            _fake_generate_chat_streaming_factory(responses, stream_models=set()),
+        )
+        monkeypatch.setattr(panel_mod, "_resolve_panel", lambda m, n: _make_panel())
+        agen = await panel_mod.panel_generate_chat(
+            manager=None, model_name="p:latest",
+            messages=[{"role": "user", "content": "find x"}],
+            tools=[{"type": "function", "function": {"name": "search"}}],
+            stream=True,
+        )
+        chunks = await _drain(agen)
+        full = "".join(c.get("text", "") for c in chunks)
+        _t, _v, tool_uses = parse_model_output(full, has_tools=True)
+        assert [tu["name"] for tu in tool_uses] == ["search"]
+        assert chunks[-1].get("done") is True
+
+    @pytest.mark.asyncio
+    async def test_stream_final_turn_proxies_judge_stream(self, monkeypatch):
+        responses = {
+            "c": '{"route": "default"}',
+            "da": "A", "db": "B",
+            "j": "Final synthesized answer.",
+        }
+        monkeypatch.setattr(
+            panel_mod,
+            "generate_chat",
+            _fake_generate_chat_streaming_factory(responses, stream_models={"j"}),
+        )
+        monkeypatch.setattr(panel_mod, "_resolve_panel", lambda m, n: _make_panel())
+        agen = await panel_mod.panel_generate_chat(
+            manager=None, model_name="p:latest",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None, stream=True,
+        )
+        chunks = await _drain(agen)
+        full = "".join(c.get("text", "") for c in chunks)
+        assert full == "Final synthesized answer."
+        assert chunks[-1].get("done") is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_panel.py::TestPanelGenerateChatStream -v`
+Expected: FAIL with `NotImplementedError`.
+
+- [ ] **Step 3: Replace the `_panel_stream` stub**
+
+In `olmlx/engine/panel.py`, replace the temporary `_panel_stream` stub from Task 8 with:
+
+```python
+async def _panel_stream(
+    manager: "ModelManager",
+    panel: "PanelConfig",
+    messages: list[dict],
+    options: dict | None,
+    tools: list[dict] | None,
+    keep_alive: int | str | None,
+    max_tokens: int,
+    enable_thinking: bool | None,
+) -> AsyncGenerator[dict, None]:
+    """Streaming coordinator.
+
+    The panel compute runs *inside* the generator (during iteration) so
+    the router's keepalive wrapper stays active. A tool turn yields the
+    Qwen blocks as one text chunk; a final turn proxies the judge's token
+    stream straight through.
+    """
+    (member_names, answers), merged = await _run_panel(
+        manager, panel, messages, tools, options, keep_alive,
+        max_tokens, enable_thinking,
+    )
+    if merged:
+        raw = serialize_tool_calls_qwen(merged)
+        yield {"text": raw}
+        yield {"text": "", "done": True, "raw_text": raw, "done_reason": "stop"}
+        return
+
+    judge_stream = await _judge_answer(
+        manager, panel, messages, member_names, answers, options,
+        keep_alive, max_tokens, enable_thinking, stream=True,
+    )
+    async for chunk in judge_stream:
+        yield chunk
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_panel.py -v`
+Expected: PASS (all panel tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/engine/panel.py tests/test_panel.py
+git commit -m "feat(panel): streaming coordinator entry point"
+```
+
+---
+
+## Task 10: Wire the OpenAI router
+
+**Files:**
+- Modify: `olmlx/routers/openai.py` (imports + `openai_chat`, lines 310-431)
+- Test: `tests/test_panel.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_panel.py`:
+
+```python
+class TestRouterDispatch:
+    def test_openai_router_imports_panel_dispatch(self):
+        from olmlx.routers import openai as openai_router
+
+        assert hasattr(openai_router, "panel_generate_chat")
+```
+
+This is a thin guard; the real behavioral coverage is the coordinator tests plus the manual smoke test in Task 12.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_panel.py::TestRouterDispatch -v`
+Expected: FAIL with `AttributeError: module 'olmlx.routers.openai' has no attribute 'panel_generate_chat'`.
+
+- [ ] **Step 3: Add the import and branch**
+
+In `olmlx/routers/openai.py`, add to the imports (next to `from olmlx.engine.inference import generate_chat`):
+
+```python
+from olmlx.engine.panel import panel_generate_chat
+```
+
+Then in `openai_chat`, immediately after `enable_thinking = resolve_openai_think(...)` (line 374) and before `if req.stream:` (line 376), add:
+
+```python
+    registry = request.app.state.registry
+    dispatch = panel_generate_chat if registry.is_panel(req.model) else generate_chat
+```
+
+Replace both `generate_chat(` calls inside `openai_chat` (the streaming branch at line 377 and the non-streaming branch at line 420) with `dispatch(`. Leave every argument unchanged.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_panel.py::TestRouterDispatch -v`
+Expected: PASS.
+
+Also run the existing OpenAI router tests to confirm no regression:
+
+Run: `uv run pytest tests/ -k "openai" -q`
+Expected: PASS (no new failures vs. baseline).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/routers/openai.py tests/test_panel.py
+git commit -m "feat(panel): dispatch panel models from the OpenAI router"
+```
+
+---
+
+## Task 11: Wire the Ollama router
+
+**Files:**
+- Modify: `olmlx/routers/chat.py` (imports + `chat`, lines 163-200 and the non-stream branch)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_panel.py`:
+
+```python
+    def test_ollama_router_imports_panel_dispatch(self):
+        from olmlx.routers import chat as chat_router
+
+        assert hasattr(chat_router, "panel_generate_chat")
+```
+
+(Add this method inside the existing `TestRouterDispatch` class.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_panel.py::TestRouterDispatch::test_ollama_router_imports_panel_dispatch -v`
+Expected: FAIL with `AttributeError`.
+
+- [ ] **Step 3: Add the import and branch**
+
+In `olmlx/routers/chat.py`, add to the imports (next to `from olmlx.engine.inference import generate_chat`):
+
+```python
+from olmlx.engine.panel import panel_generate_chat
+```
+
+In the `chat` handler, immediately after `enable_thinking = resolve_think_flag(req.think)` (line 171) add:
+
+```python
+    dispatch = (
+        panel_generate_chat
+        if request.app.state.registry.is_panel(req.model)
+        else generate_chat
+    )
+```
+
+Replace the `generate_chat(` call in the streaming branch (line 178) **and** the corresponding call in the non-streaming branch below it with `dispatch(`. Leave all arguments unchanged.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_panel.py::TestRouterDispatch -v`
+Expected: PASS.
+
+Run the Ollama chat router tests for regressions:
+
+Run: `uv run pytest tests/ -k "chat and not session and not cli and not tui" -q`
+Expected: PASS (no new failures vs. baseline).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/routers/chat.py tests/test_panel.py
+git commit -m "feat(panel): dispatch panel models from the Ollama router"
+```
+
+---
+
+## Task 12: Manual smoke test with stub models
+
+**Files:**
+- Read only; no code changes unless a bug surfaces.
+
+- [ ] **Step 1: Create a temporary panel config**
+
+Pick three small models you already have locally (run `uv run olmlx models` to list them) plus a small classifier and a distinct judge. Add a panel entry to your dev `models.json` (`OLMLX_MODELS_CONFIG=models.json`), e.g.:
+
+```jsonc
+"smoke-panel": {
+  "type": "panel",
+  "classifier": "<small-model>",
+  "judge": "<distinct-model>",
+  "routes": { "default": ["<model-a>", "<model-b>"] }
+}
+```
+
+Raise `OLMLX_MAX_LOADED_MODELS` to at least 4 (members + judge + classifier) to avoid reload thrash.
+
+- [ ] **Step 2: Start the server**
+
+Run: `OLMLX_MODELS_CONFIG=models.json OLMLX_MAX_LOADED_MODELS=6 uv run olmlx`
+Expected: server starts on `http://localhost:11434`, no panel-validation warnings in the log.
+
+- [ ] **Step 3: Non-tool request (judge synthesis path)**
+
+```bash
+curl -s localhost:11434/v1/chat/completions -d '{
+  "model": "smoke-panel",
+  "messages": [{"role": "user", "content": "In one sentence, what is MLX?"}],
+  "stream": false
+}' | python3 -m json.tool
+```
+
+Expected: a single assistant `content` answer; `finish_reason: "stop"`. Server log shows the classifier, both panelists, and the judge each running once.
+
+- [ ] **Step 4: Tool request (union path)**
+
+```bash
+curl -s localhost:11434/v1/chat/completions -d '{
+  "model": "smoke-panel",
+  "stream": false,
+  "messages": [{"role": "user", "content": "What files are in the cwd?"}],
+  "tools": [{"type": "function", "function": {
+     "name": "list_dir", "description": "List a directory",
+     "parameters": {"type": "object", "properties": {"path": {"type": "string"}}}}}]
+}' | python3 -m json.tool
+```
+
+Expected: response has `finish_reason: "tool_calls"` and a `tool_calls` array (the deduped union of what the panelists proposed). Feed a fake tool result back as a second request and confirm the loop continues and eventually returns `content`.
+
+- [ ] **Step 5: Commit (only if a fix was needed)**
+
+If steps 3-4 surfaced a bug, write a failing test reproducing it, fix it, then:
+
+```bash
+git add -A && git commit -m "fix(panel): <describe the bug found in smoke test>"
+```
+
+Otherwise no commit.
+
+---
+
+## Task 13: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md` (Non-Obvious Invariants section + Project Structure)
+
+- [ ] **Step 1: Add the project-structure line**
+
+In `CLAUDE.md`, under the `engine/` tree listing, add a line near the other engine modules:
+
+```
+│   ├── panel.py        # Multi-model panel + judge coordinator (per-turn reconciler)
+```
+
+- [ ] **Step 2: Add the invariant note**
+
+In the "Non-Obvious Invariants" section, add:
+
+```markdown
+**Panel coordinator routes through generate_chat** — `engine/panel.py` is a
+per-turn reconciler that rides the client's tool loop: it returns a
+`generate_chat`-shaped result whose text is either the judge's prose or canonical
+Qwen `<tool_call>` blocks, so both routers' existing `parse_model_output` paths
+handle it unchanged. Every classifier/panelist/judge call MUST go through
+`generate_chat` — never call MLX directly — or the Metal-stream/inference-lock
+handling is bypassed. Panels need `max_loaded_models ≥ members + judge + classifier`
+to avoid reload thrash.
+```
+
+- [ ] **Step 3: Verify markdown renders**
+
+Run: `git diff CLAUDE.md`
+Expected: the two additions appear with correct fencing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): document panel coordinator invariant"
+```
+
+---
+
+## Task 14: Full verification & ruff
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the new test modules**
+
+Run: `uv run pytest tests/test_panel.py tests/test_registry_panel.py -v`
+Expected: all PASS.
+
+- [ ] **Step 2: Run ruff (required before push)**
+
+Run: `uv run ruff check olmlx/engine/panel.py olmlx/engine/registry.py olmlx/routers/openai.py olmlx/routers/chat.py tests/test_panel.py tests/test_registry_panel.py && uv run ruff format olmlx/engine/panel.py olmlx/engine/registry.py tests/test_panel.py tests/test_registry_panel.py`
+Expected: no lint errors; formatting clean.
+
+- [ ] **Step 3: Run the registry + router suites for regressions**
+
+Run: `uv run pytest tests/test_registry.py tests/ -k "openai or (chat and not session and not cli and not tui)" -q`
+Expected: PASS (no new failures vs. baseline; note the known full-suite SIGABRT flake — trust targeted suites + CI).
+
+- [ ] **Step 4: Commit any ruff fixups**
+
+```bash
+git add -A && git commit -m "style(panel): ruff" || echo "nothing to format"
+```
+
+---
+
+## Self-Review Notes (for the implementer)
+
+- **Spec coverage:** entry surface (Tasks 10-11), per-turn reconciler (Tasks 7-9), client-executed tools via Qwen-block round-trip (Tasks 4, 8-9), per-task routing (Tasks 1-2, 6), judge synthesis without tools (Tasks 5, 8), `models.json` config + validation (Tasks 1-2), stop-when-no-tools (Task 7 `merge`), fail-the-request (Tasks 6-7 propagate; Task 8 `_resolve_panel` raises), CLAUDE.md invariant (Task 13).
+- **Out of scope (no task, by design):** distributed/parallel execution; adding panels to `/v1/models` listing (follow-up — `list_models` returns `ModelConfig`, panels are a different type).
+- **Type consistency:** tool_use dicts use `{"name", "input"}` throughout; `serialize_tool_calls_qwen` writes the `arguments` wire key that `parse_model_output` maps back to `input`. `panel_generate_chat` mirrors `generate_chat`'s exact signature so the router `dispatch = ... if ... else generate_chat` swap is safe.
+- **Known caveat to watch in Task 12:** every tool turn re-runs classifier + all N panelists (final turn adds the judge) — sequential under the lock. Expected and accepted; just confirm latency is sane for your panel size.

--- a/docs/superpowers/specs/2026-06-14-multi-model-panel-judge-design.md
+++ b/docs/superpowers/specs/2026-06-14-multi-model-panel-judge-design.md
@@ -1,0 +1,176 @@
+# Multi-model panel + judge coordinator (sequential, single-box)
+
+Issue: #520
+
+## Summary
+
+A new synthetic `type: "panel"` "model" that answers a request with a **panel** of
+several models and a separate **judge** that reconciles the panel's output into one
+response. It is a **drop-in replacement** for any tool-calling model: the standard
+OpenAI / Ollama contract is preserved, and **the caller (coding agent) executes the
+tools**, exactly as with a single model.
+
+Scope here is the **sequential, single-box** variant: classifier, panelists, and judge
+run one at a time under the existing global inference lock. Distributed/parallel
+execution is an explicit follow-up (out of scope).
+
+## Key design decision: panel as a per-turn reconciler
+
+The issue's literal premise — "each panelist runs its own agent loop with its own tool
+calls and its own results" — is **incompatible** with two hard constraints we adopt:
+drop-in tool-calling semantics, and **client-side** tool execution. If the client
+executes tools, the server cannot drive N divergent tool loops to completion, because
+each loop would need results only one client conversation can produce.
+
+The reconciliation: **do not build a server-side agent loop. Reuse the client's loop.**
+The panel "model" only has to satisfy the contract on each turn — return either
+`tool_calls` or `content`. All multi-model logic is internal to a single turn:
+
+```
+request ──> [stateless coordinator call]
+              route (classifier) → pick panel members
+              run each panelist on shared history (sequential, under the lock)
+              reconcile:
+                 any panelist wants tools?  → emit deduped UNION of tool_calls ──┐
+                 nobody wants tools?         → judge synthesizes fresh answer    │
+                                                                                 │
+client executes tools, appends results, calls again  <───────────────────────────┘
+```
+
+From the coding agent's perspective this is indistinguishable from one tool-calling
+model: same request shape, same `tool_calls`/`content` responses, same
+resubmit-with-results loop. No server-side MCP, no new tool executor.
+
+**What we give up:** panelists do not have independent tool traces — they share one
+tool-result history (one client, one conversation). Per turn each *proposes* tool calls,
+but only the reconciled union executes, and everyone sees those results next turn. The
+judge can still verify groundedness against the shared tool results; it just cannot
+compare divergent tool *paths*. This is the only shape consistent with "drop-in + client
+executes tools."
+
+## Decisions (locked)
+
+| Question | Decision |
+|---|---|
+| Entry surface | HTTP synthetic model (OpenAI + Ollama routers), selectable by name |
+| Tool execution | Client-side; panel is a per-turn reconciler riding the client's loop; server stateless across calls |
+| Tool-call merge | Deduped **union** of all panelists' proposed calls |
+| Panel composition | **Per-task routing** via a dedicated small classifier model |
+| Judge output | **Synthesize a fresh merged answer** |
+| Config surface | Synthetic `type: "panel"` entry in `models.json` |
+| Stop condition | Stop issuing tools only when **no panelist** requests any |
+| Failure handling | **Fail the request** (HTTP error) on any classifier/panelist/judge failure |
+
+## Architecture
+
+### Component & placement
+
+New module `engine/panel.py` exposing `PanelCoordinator` with a
+**`generate_chat`-compatible** entry point — same arguments and same return shapes
+(`AsyncGenerator[dict]` when `stream=True`, `dict` otherwise). It calls
+`engine/inference.py:generate_chat` for **every** model (classifier, panelists, judge),
+so all Metal-stream and inference-lock handling is reused unchanged. The coordinator
+never touches MLX directly.
+
+### Per-turn flow (stateless)
+
+The server stays stateless across HTTP calls — the client carries history and executes
+tools. Each coordinator call:
+
+1. **Route.** Run the classifier model on the **first user message** (stable across the
+   conversation → routing is deterministically re-derived every turn, no stored state).
+   Output is grammar-constrained (`engine/grammar.py` xgrammar) to one of the configured
+   route keys → yields the panel member list. Unknown/edge → `default` route.
+2. **Run panelists.** For each member: `generate_chat(stream=False)` on the current
+   history with the client's declared tools; `parse_model_output` →
+   `(thinking, answer, tool_uses)`. Sequential under the lock.
+3. **Reconcile.**
+   - If **any** panelist proposed tool calls → emit the **deduped union** as this turn's
+     `tool_calls` and return.
+   - If **none** did → run the **judge** (no tools passed to it, so it can only write
+     prose) to synthesize a fresh merged answer from the panelists' answers + thinking +
+     the shared tool results already present in history. Emit as `content`.
+
+### Tool-call union
+
+Dedup panelist `tool_uses` by normalized `(name, arguments)`: identical calls collapse
+to one execution; different args both run. Assign fresh unique `tool_call` IDs. The
+client executes all and returns results keyed by ID; next turn the history holds every
+tool_call+result pair, so all panelists see all gathered evidence. The emitted assistant
+turn carries the union (a panelist may "see" calls it did not make — the accepted
+shared-history fiction).
+
+### Config schema (`models.json`)
+
+```jsonc
+"my-panel:latest": {
+  "type": "panel",
+  "classifier": "qwen3-0.6b",        // dedicated small router model
+  "judge": "gpt-oss-20b",            // synthesizer; runs WITHOUT tools
+  "routes": {
+    "code":    ["qwen3-coder", "devstral", "deepseek-coder"],
+    "math":    ["qwen3", "deepseek-r1-distill", "magistral"],
+    "general": ["qwen3", "llama3.1", "gpt-oss-20b"],
+    "default": ["qwen3", "mistral", "llama3.1"]
+  }
+}
+```
+
+Members / judge / classifier reference existing `models.json` entries by name. Registry
+load **validates** they all exist and **warns** if the judge is also a panelist
+(self-preference bias). `routes` must contain `default`.
+
+### Router integration & streaming
+
+In `routers/openai.py` and `routers/chat.py`, before `ensure_loaded`, branch on
+`registry.is_panel(model_name)` → dispatch to the coordinator instead of `generate_chat`.
+The coordinator returns the same post-parse structure both routers already format, so
+tool-call conversion / SSE / NDJSON paths are reused.
+
+Streaming: the classifier and panelists run buffered — reuse the keepalive in
+`routers/streaming_common.py` so long internal compute does not time the client out —
+then proxy the judge's token stream straight through. Tool-call turns emit a single
+tool-calls chunk (existing tools-mode buffering handles it).
+
+### Failure handling
+
+Any classifier / panelist (load, generate, timeout) / judge failure raises and surfaces
+as an HTTP error. No silent degradation.
+
+## Performance & memory caveats
+
+- Every **tool turn** re-runs the classifier + all N panelists; the **final turn** adds
+  the judge. A coding agent doing 20 tool round-trips pays ~20×(1+N) sequential model
+  calls. This is inherent to stateless + drop-in and is the cost the issue accepts.
+- With `max_loaded_models=1`, every panelist call evicts the prior model → reload thrash.
+  Panel use effectively requires `max_loaded_models ≥ panel size + judge + classifier` so
+  diverse 4-bit models co-reside. The coordinator **warns** (does not auto-change) if the
+  limit looks too low for the configured panel.
+
+## Testing (TDD, mocked models)
+
+Unit tests mock `generate_chat` for determinism:
+
+- Route selection from (grammar-constrained) classifier output → correct member list;
+  unknown category → `default`.
+- Tool-call union: dedup by `(name, args)`, unique IDs assigned.
+- Reconcile decision: any-tools → emit union; none → judge synthesis.
+- Deterministic re-routing on a continuation history (tool results present) → same panel.
+- Judge invoked **without** tools.
+- Failure (classifier/panelist/judge) → raises, request fails.
+- Registry validation of `panel` entries (missing member errors; judge-in-panel warns;
+  missing `default` errors).
+- One router interception test (panel model name routes to coordinator).
+
+Heavy real-model runs stay out of the default suite, matching the existing canary
+pattern.
+
+## Scope
+
+**In scope:** sequential single-box panel + per-task routing + judge synthesis,
+HTTP-surfaced, client-executed tools.
+
+**Out of scope (issue follow-up):** distributed / parallel panelist execution.
+
+**Docs:** add a CLAUDE.md invariant once implemented — the panel coordinator must route
+every model call through `generate_chat`; never bypass the generation-stream handling.

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -1778,7 +1778,7 @@ def _format_size(size_bytes: int) -> str:
 
 
 def cmd_models_list(_args):
-    """List locally downloaded models."""
+    """List locally downloaded models and configured synthetic panels."""
     try:
         store = _create_store()
     except Exception as e:
@@ -1789,20 +1789,38 @@ def cmd_models_list(_args):
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
-    if not models:
+
+    # Synthetic panel "models" have no weights, so they aren't in the store —
+    # pull them from the registry so they show up here and are selectable.
+    registry = _load_registry_for_audit()
+    panels = registry.list_panels() if registry is not None else {}
+
+    if not models and not panels:
         print("No models downloaded.")
         return
-    # Header
-    print(f"{'NAME':<30} {'SIZE':<12} {'PARAMS':<10} {'QUANT':<10} {'HF PATH'}")
-    print("-" * 90)
-    for m in sorted(models, key=lambda x: x.name or ""):
-        name = (m.name or "")[:30]
-        params = (m.parameter_size or "")[:10]
-        quant = (m.quantization_level or "")[:10]
-        print(
-            f"{name:<30} {_format_size(m.size):<12} "
-            f"{params:<10} {quant:<10} {m.hf_path}"
-        )
+
+    if models:
+        print(f"{'NAME':<30} {'SIZE':<12} {'PARAMS':<10} {'QUANT':<10} {'HF PATH'}")
+        print("-" * 90)
+        for m in sorted(models, key=lambda x: x.name or ""):
+            name = (m.name or "")[:30]
+            params = (m.parameter_size or "")[:10]
+            quant = (m.quantization_level or "")[:10]
+            print(
+                f"{name:<30} {_format_size(m.size):<12} "
+                f"{params:<10} {quant:<10} {m.hf_path}"
+            )
+
+    if panels:
+        if models:
+            print()
+        print("Panels (synthetic — selectable by name):")
+        for name, panel in sorted(panels.items()):
+            routes = ",".join(panel.routes)
+            print(
+                f"  {name:<30} judge={panel.judge}  "
+                f"routes={routes}  stop={panel.stop_condition}"
+            )
 
 
 def cmd_models_search(args):

--- a/olmlx/engine/chat_templating.py
+++ b/olmlx/engine/chat_templating.py
@@ -176,6 +176,7 @@ def _apply_chat_template(
     *,
     tokenize: bool = False,
     enable_thinking: bool | None = None,
+    reasoning_effort: str | None = None,
 ) -> Any:
     """Core chat template application.
 
@@ -199,6 +200,12 @@ def _apply_chat_template(
         kwargs["enable_thinking"] = _resolve_thinking_active(
             caps, tools, enable_thinking
         )
+
+    # Channel-format reasoners (gpt-oss / Harmony) use ``reasoning_effort``
+    # instead of the boolean ``enable_thinking``. Only pass it when the template
+    # declares the variable and a level was requested.
+    if caps.supports_reasoning_effort and reasoning_effort is not None:
+        kwargs["reasoning_effort"] = reasoning_effort
 
     try:
         return tokenizer.apply_chat_template(messages, **kwargs)
@@ -228,6 +235,7 @@ def apply_chat_template_text(
     caps: TemplateCaps | None = None,
     *,
     enable_thinking: bool | None = None,
+    reasoning_effort: str | None = None,
 ) -> str:
     """Apply chat template for text-only models (mlx-lm), returning prompt text."""
     return _apply_chat_template(
@@ -237,6 +245,7 @@ def apply_chat_template_text(
         caps,
         tokenize=False,
         enable_thinking=enable_thinking,
+        reasoning_effort=reasoning_effort,
     )
 
 

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -4187,6 +4187,7 @@ async def generate_chat(
     max_tokens: int = ...,
     cache_id: str = ...,
     enable_thinking: bool | None = ...,
+    reasoning_effort: str | None = ...,
     grammar_spec: GrammarSpec | None = ...,
 ) -> AsyncGenerator[dict, None]: ...
 
@@ -4204,6 +4205,7 @@ async def generate_chat(
     max_tokens: int = ...,
     cache_id: str = ...,
     enable_thinking: bool | None = ...,
+    reasoning_effort: str | None = ...,
     grammar_spec: GrammarSpec | None = ...,
 ) -> dict: ...
 
@@ -4220,6 +4222,7 @@ async def generate_chat(
     max_tokens: int = ...,
     cache_id: str = ...,
     enable_thinking: bool | None = ...,
+    reasoning_effort: str | None = ...,
     grammar_spec: GrammarSpec | None = ...,
 ) -> AsyncGenerator[dict, None] | dict: ...
 
@@ -4235,6 +4238,7 @@ async def generate_chat(
     max_tokens: int = 512,
     cache_id: str = "",
     enable_thinking: bool | None = None,
+    reasoning_effort: str | None = None,
     grammar_spec: GrammarSpec | None = None,
 ) -> AsyncGenerator[dict, None] | dict:
     """Generate a chat completion."""
@@ -4257,6 +4261,11 @@ async def generate_chat(
         # See issue #400.
         if enable_thinking is None and lm.enable_thinking is not None:
             enable_thinking = lm.enable_thinking
+
+        # Per-model default reasoning level (gpt-oss / Harmony) applies when the
+        # caller didn't pass one. An explicit caller value still wins.
+        if reasoning_effort is None and lm.reasoning_effort is not None:
+            reasoning_effort = lm.reasoning_effort
 
         images = _extract_images(messages)
         audio = _extract_audio(messages)
@@ -4363,6 +4372,7 @@ async def generate_chat(
                 tools,
                 caps=lm.template_caps,
                 enable_thinking=enable_thinking,
+                reasoning_effort=reasoning_effort,
             )
             if tools:
                 logger.info("Chat prompt with %d tools", len(tools))

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -555,6 +555,10 @@ class LoadedModel:
     # ``generate_chat`` consults this when the request didn't set the
     # flag.  None means defer to the engine default.
     enable_thinking: bool | None = None
+    # Per-model default reasoning level for channel-format reasoners
+    # (gpt-oss / Harmony): "low"/"medium"/"high". ``generate_chat`` consults
+    # this when the caller didn't pass ``reasoning_effort``.
+    reasoning_effort: str | None = None
     # Per-model override for the cross-request prompt cache toggle.
     # ``generate_chat`` honours this in place of ``settings.prompt_cache``
     # when set. None means defer to the global setting. Surfaced for
@@ -1526,6 +1530,7 @@ class ModelManager(SpeculativeLoaderMixin):
                         inference_timeout=model_config.inference_timeout,
                         sync_mode=model_config.sync_mode,
                         enable_thinking=model_config.enable_thinking,
+                        reasoning_effort=model_config.reasoning_effort,
                         prompt_cache=model_config.prompt_cache,
                         batching=model_config.batching,
                         batch_completion_size=model_config.batch_completion_size,

--- a/olmlx/engine/panel.py
+++ b/olmlx/engine/panel.py
@@ -29,6 +29,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _message_text(content: object) -> str:
+    """Extract plain text from a message ``content`` (str or content-parts)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        ]
+        return "\n".join(p for p in parts if p)
+    return ""
+
+
 def first_user_text(messages: list[dict]) -> str:
     """Return the first user message's text (stable routing key).
 
@@ -37,19 +51,8 @@ def first_user_text(messages: list[dict]) -> str:
     no stored server state.
     """
     for msg in messages:
-        if msg.get("role") != "user":
-            continue
-        content = msg.get("content")
-        if isinstance(content, str):
-            return content
-        if isinstance(content, list):
-            parts = [
-                part.get("text", "")
-                for part in content
-                if isinstance(part, dict) and part.get("type") == "text"
-            ]
-            return "\n".join(p for p in parts if p)
-        return ""
+        if msg.get("role") == "user":
+            return _message_text(msg.get("content"))
     return ""
 
 
@@ -98,13 +101,36 @@ def merge_tool_calls(per_panelist: list[list[dict]]) -> list[dict]:
 
 
 _JUDGE_INSTRUCTION = (
-    "You are the judge for a panel of models that all answered the "
-    "conversation above. Several candidate answers are listed below. "
-    "Synthesize ONE best final answer for the user. Ground every claim in "
-    "the tool results already present in this conversation; do not call "
-    "tools or invent new facts. Reconcile disagreements and prefer "
-    "grounded, specific answers. Output only the final answer."
+    "You are the judge for a panel of models that answered a user request. "
+    "Below are the user's request, any tool results gathered while answering, "
+    "and each panelist's candidate answer. Synthesize ONE best final answer "
+    "for the user, grounded in the tool results. Do NOT call tools, do NOT "
+    "continue any tool sequence, and do NOT invent facts. Reconcile "
+    "disagreements and prefer grounded, specific answers. Output ONLY the "
+    "final answer prose for the user."
 )
+
+
+def _flatten_tool_results(messages: list[dict]) -> list[str]:
+    """Pair each tool-result message with the call that produced it.
+
+    Returns ``["name(args) -> result", ...]`` in conversation order, so the
+    judge sees the gathered evidence without the agentic turn structure.
+    """
+    labels: dict[str, str] = {}
+    for msg in messages:
+        if msg.get("role") == "assistant":
+            for call in msg.get("tool_calls") or []:
+                cid = call.get("id")
+                fn = call.get("function") or {}
+                if cid:
+                    labels[cid] = f"{fn.get('name', '?')}({fn.get('arguments', '')})"
+    results = []
+    for msg in messages:
+        if msg.get("role") == "tool":
+            label = labels.get(msg.get("tool_call_id") or "", "tool")
+            results.append(f"{label} -> {_message_text(msg.get('content'))}")
+    return results
 
 
 def build_judge_messages(
@@ -112,17 +138,38 @@ def build_judge_messages(
     member_names: list[str],
     answers: list[str],
 ) -> list[dict]:
-    """Original conversation + a final user turn carrying the candidates.
+    """Flatten the panel run into a clean summarize-and-answer prompt.
 
-    ``original_messages`` is not mutated (a new list is returned). The
-    judge sees the full conversation — including any tool results the
-    client executed — so it can verify groundedness.
+    Returns a short ``[system, user]`` message list carrying the user's
+    request, the tool results gathered during the loop, and the panelists'
+    candidate answers — NOT a replay of the agentic assistant/tool turns.
+    Replaying the raw conversation primes agentic models (notably gpt-oss) to
+    keep calling tools and emit reasoning instead of a final answer. The judge
+    still sees every tool result, so groundedness is preserved.
+    ``original_messages`` is not mutated.
     """
-    candidates = []
-    for name, answer in zip(member_names, answers):
-        candidates.append(f"--- Candidate from {name} ---\n{answer.strip()}")
-    content = _JUDGE_INSTRUCTION + "\n\n" + "\n\n".join(candidates)
-    return [*original_messages, {"role": "user", "content": content}]
+    request = "\n\n".join(
+        t
+        for t in (
+            _message_text(m.get("content"))
+            for m in original_messages
+            if m.get("role") == "user"
+        )
+        if t
+    )
+    tool_results = _flatten_tool_results(original_messages)
+    candidates = "\n\n".join(
+        f"--- Candidate from {name} ---\n{answer.strip()}"
+        for name, answer in zip(member_names, answers)
+    )
+    sections = [f"## User request\n{request}"]
+    if tool_results:
+        sections.append("## Tool results gathered\n" + "\n\n".join(tool_results))
+    sections.append("## Panel candidate answers\n" + candidates)
+    return [
+        {"role": "system", "content": _JUDGE_INSTRUCTION},
+        {"role": "user", "content": "\n\n".join(sections)},
+    ]
 
 
 def serialize_tool_calls_qwen(tool_uses: list[dict]) -> str:

--- a/olmlx/engine/panel.py
+++ b/olmlx/engine/panel.py
@@ -339,6 +339,50 @@ async def panel_generate_chat(
     )
 
 
-async def _panel_stream(*args, **kwargs):  # replaced in Task 9
-    raise NotImplementedError
-    yield {}  # pragma: no cover  (makes this an async generator)
+async def _panel_stream(
+    manager: "ModelManager",
+    panel: "PanelConfig",
+    messages: list[dict],
+    options: dict | None,
+    tools: list[dict] | None,
+    keep_alive: int | str | None,
+    max_tokens: int,
+    enable_thinking: bool | None,
+) -> AsyncGenerator[dict, None]:
+    """Streaming coordinator.
+
+    The panel compute runs *inside* the generator (during iteration) so
+    the router's keepalive wrapper stays active. A tool turn yields the
+    Qwen blocks as one text chunk; a final turn proxies the judge's token
+    stream straight through.
+    """
+    (member_names, answers), merged = await _run_panel(
+        manager,
+        panel,
+        messages,
+        tools,
+        options,
+        keep_alive,
+        max_tokens,
+        enable_thinking,
+    )
+    if merged:
+        raw = serialize_tool_calls_qwen(merged)
+        yield {"text": raw}
+        yield {"text": "", "done": True, "raw_text": raw, "done_reason": "stop"}
+        return
+
+    judge_stream = await _judge_answer(
+        manager,
+        panel,
+        messages,
+        member_names,
+        answers,
+        options,
+        keep_alive,
+        max_tokens,
+        enable_thinking,
+        stream=True,
+    )
+    async for chunk in judge_stream:
+        yield chunk

--- a/olmlx/engine/panel.py
+++ b/olmlx/engine/panel.py
@@ -355,6 +355,7 @@ async def _judge_wants_gather(
         keep_alive=keep_alive,
         max_tokens=16,
         enable_thinking=False,
+        reasoning_effort="low",
         grammar_spec=_decision_grammar(),
     )
     text = (result.get("text") or "").strip()
@@ -445,6 +446,10 @@ async def _judge_answer(
         keep_alive=keep_alive,
         max_tokens=max_tokens,
         enable_thinking=enable_thinking,
+        # The judge summarizes; keep channel-format reasoners (gpt-oss) terse so
+        # they emit a clean final answer instead of spending the token budget in
+        # the analysis channel. No-op for non-reasoning judges.
+        reasoning_effort="low",
     )
 
 

--- a/olmlx/engine/panel.py
+++ b/olmlx/engine/panel.py
@@ -92,6 +92,34 @@ def merge_tool_calls(per_panelist: list[list[dict]]) -> list[dict]:
     return merged
 
 
+_JUDGE_INSTRUCTION = (
+    "You are the judge for a panel of models that all answered the "
+    "conversation above. Several candidate answers are listed below. "
+    "Synthesize ONE best final answer for the user. Ground every claim in "
+    "the tool results already present in this conversation; do not call "
+    "tools or invent new facts. Reconcile disagreements and prefer "
+    "grounded, specific answers. Output only the final answer."
+)
+
+
+def build_judge_messages(
+    original_messages: list[dict],
+    member_names: list[str],
+    answers: list[str],
+) -> list[dict]:
+    """Original conversation + a final user turn carrying the candidates.
+
+    ``original_messages`` is not mutated (a new list is returned). The
+    judge sees the full conversation — including any tool results the
+    client executed — so it can verify groundedness.
+    """
+    candidates = []
+    for name, answer in zip(member_names, answers):
+        candidates.append(f"--- Candidate from {name} ---\n{answer.strip()}")
+    content = _JUDGE_INSTRUCTION + "\n\n" + "\n\n".join(candidates)
+    return [*original_messages, {"role": "user", "content": content}]
+
+
 def serialize_tool_calls_qwen(tool_uses: list[dict]) -> str:
     """Render tool calls as canonical Qwen ``<tool_call>`` blocks.
 

--- a/olmlx/engine/panel.py
+++ b/olmlx/engine/panel.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 from olmlx.engine.grammar import GrammarSpec
 from olmlx.engine.inference import generate_chat
+from olmlx.engine.tool_parser import parse_model_output
 
 if TYPE_CHECKING:
     from olmlx.engine.model_manager import ModelManager
@@ -184,3 +185,54 @@ async def classify(
         logger.warning("Panel classifier returned non-JSON %r; using default", text)
         route = "default"
     return select_members(route, panel)
+
+
+async def _run_panel(
+    manager: "ModelManager",
+    panel: "PanelConfig",
+    messages: list[dict],
+    tools: list[dict] | None,
+    options: dict | None,
+    keep_alive: int | str | None,
+    max_tokens: int,
+    enable_thinking: bool | None,
+) -> tuple[tuple[list[str], list[str]], list[dict]]:
+    """Route, run each panelist once, and reconcile this turn.
+
+    Returns ``((member_names, answers), merged_tool_uses)``. When any
+    panelist proposes tool calls, ``merged_tool_uses`` is their deduped
+    union and ``answers`` is unused by the caller (the turn is a tool
+    turn). When none do, ``merged_tool_uses`` is empty and the caller
+    runs the judge over ``answers``.
+
+    Any panelist/classifier failure propagates (fail the request).
+    """
+    user_text = first_user_text(messages)
+    members = await classify(manager, panel, user_text, keep_alive)
+
+    has_tools = bool(tools)
+    answers: list[str] = []
+    per_panelist_tools: list[list[dict]] = []
+    for member in members:
+        result = await generate_chat(
+            manager,
+            member,
+            messages,
+            options=options,
+            tools=tools,
+            stream=False,
+            keep_alive=keep_alive,
+            max_tokens=max_tokens,
+            enable_thinking=enable_thinking,
+        )
+        parse_text = result.get("raw_text") or result.get("text") or ""
+        _thinking, visible, tool_uses = parse_model_output(
+            parse_text,
+            has_tools,
+            thinking_expected=bool(result.get("thinking_expected")),
+        )
+        answers.append(visible)
+        per_panelist_tools.append(tool_uses)
+
+    merged = merge_tool_calls(per_panelist_tools)
+    return (members, answers), merged

--- a/olmlx/engine/panel.py
+++ b/olmlx/engine/panel.py
@@ -178,6 +178,9 @@ async def classify(
         stream=False,
         keep_alive=keep_alive,
         max_tokens=32,
+        # Routing is a constrained JSON task — never spend tokens on reasoning,
+        # regardless of the request's or classifier model's thinking default.
+        enable_thinking=False,
         grammar_spec=route_grammar(panel),
     )
     text = (result.get("text") or "").strip()
@@ -369,7 +372,13 @@ async def _panel_stream(
     if merged:
         raw = serialize_tool_calls_qwen(merged)
         yield {"text": raw}
-        yield {"text": "", "done": True, "raw_text": raw, "done_reason": "stop"}
+        yield {
+            "text": "",
+            "done": True,
+            "raw_text": raw,
+            "done_reason": "stop",
+            "stats": TimingStats(),
+        }
         return
 
     judge_stream = await _judge_answer(

--- a/olmlx/engine/panel.py
+++ b/olmlx/engine/panel.py
@@ -1,0 +1,65 @@
+"""Multi-model panel + judge coordinator (sequential, single-box).
+
+A ``type: "panel"`` model answers a request with a per-task-routed panel
+of models plus a judge that synthesizes one reconciled answer, while
+behaving as a drop-in tool-calling model: the *client* still executes
+tools. The coordinator is a per-turn reconciler riding the client's
+existing tool loop — see docs/superpowers/specs/2026-06-14-multi-model-panel-judge-design.md.
+
+INVARIANT: every model call goes through ``generate_chat`` so the
+Metal-stream / inference-lock handling is reused. Never touch MLX here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from olmlx.engine.grammar import GrammarSpec
+
+if TYPE_CHECKING:
+    from olmlx.engine.registry import PanelConfig
+
+logger = logging.getLogger(__name__)
+
+
+def first_user_text(messages: list[dict]) -> str:
+    """Return the first user message's text (stable routing key).
+
+    The conversation's task is fixed by the first user turn, so routing
+    on it is deterministically re-derived every stateless HTTP call with
+    no stored server state.
+    """
+    for msg in messages:
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = [
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            ]
+            return "\n".join(p for p in parts if p)
+        return ""
+    return ""
+
+
+def route_grammar(panel: "PanelConfig") -> GrammarSpec:
+    """A JSON-schema grammar constraining the classifier to one route key."""
+    return GrammarSpec(
+        kind="json_schema",
+        schema={
+            "type": "object",
+            "properties": {"route": {"type": "string", "enum": sorted(panel.routes)}},
+            "required": ["route"],
+            "additionalProperties": False,
+        },
+    )
+
+
+def select_members(route_key: str, panel: "PanelConfig") -> list[str]:
+    """Members for *route_key*, falling back to the 'default' route."""
+    return panel.routes.get(route_key, panel.routes["default"])

--- a/olmlx/engine/panel.py
+++ b/olmlx/engine/panel.py
@@ -14,11 +14,13 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
 
 from olmlx.engine.grammar import GrammarSpec
 from olmlx.engine.inference import generate_chat
 from olmlx.engine.tool_parser import parse_model_output
+from olmlx.utils.timing import TimingStats
 
 if TYPE_CHECKING:
     from olmlx.engine.model_manager import ModelManager
@@ -236,3 +238,107 @@ async def _run_panel(
 
     merged = merge_tool_calls(per_panelist_tools)
     return (members, answers), merged
+
+
+def _resolve_panel(manager: "ModelManager", model_name: str) -> "PanelConfig":
+    """Resolve *model_name* to its PanelConfig or raise (fail the request)."""
+    panel = manager.registry.resolve_panel(model_name)
+    if panel is None:
+        raise ValueError(f"{model_name!r} is not a configured panel model")
+    return panel
+
+
+async def _judge_answer(
+    manager: "ModelManager",
+    panel: "PanelConfig",
+    messages: list[dict],
+    member_names: list[str],
+    answers: list[str],
+    options: dict | None,
+    keep_alive: int | str | None,
+    max_tokens: int,
+    enable_thinking: bool | None,
+    stream: bool,
+):
+    """Run the judge (no tools) to synthesize the final answer.
+
+    Returns the judge's ``generate_chat`` result verbatim — an async
+    generator when ``stream`` else a dict — so the routers stream/format
+    it exactly as a single model's output.
+    """
+    judge_messages = build_judge_messages(messages, member_names, answers)
+    return await generate_chat(
+        manager,
+        panel.judge,
+        judge_messages,
+        options=options,
+        tools=None,  # judge must not redo work
+        stream=stream,
+        keep_alive=keep_alive,
+        max_tokens=max_tokens,
+        enable_thinking=enable_thinking,
+    )
+
+
+async def panel_generate_chat(
+    manager: "ModelManager",
+    model_name: str,
+    messages: list[dict],
+    options: dict | None = None,
+    tools: list[dict] | None = None,
+    stream: bool = True,
+    keep_alive: int | str | None = None,
+    max_tokens: int = 512,
+    cache_id: str = "",
+    enable_thinking: bool | None = None,
+    grammar_spec: GrammarSpec | None = None,
+) -> AsyncGenerator[dict, None] | dict:
+    """Drop-in, ``generate_chat``-compatible entry point for a panel model.
+
+    ``cache_id`` and ``grammar_spec`` are accepted for signature parity
+    but not applied to the panel as a whole (the judge/panelists manage
+    their own caching).
+    """
+    panel = _resolve_panel(manager, model_name)
+    if stream:
+        return _panel_stream(
+            manager,
+            panel,
+            messages,
+            options,
+            tools,
+            keep_alive,
+            max_tokens,
+            enable_thinking,
+        )
+
+    (member_names, answers), merged = await _run_panel(
+        manager,
+        panel,
+        messages,
+        tools,
+        options,
+        keep_alive,
+        max_tokens,
+        enable_thinking,
+    )
+    if merged:
+        raw = serialize_tool_calls_qwen(merged)
+        return {"text": "", "raw_text": raw, "done": True, "stats": TimingStats()}
+    return await _judge_answer(
+        manager,
+        panel,
+        messages,
+        member_names,
+        answers,
+        options,
+        keep_alive,
+        max_tokens,
+        enable_thinking,
+        stream=False,
+    )
+
+
+async def _panel_stream(*args, **kwargs):  # replaced in Task 9
+    raise NotImplementedError
+    yield {}  # pragma: no cover  (makes this an async generator)

--- a/olmlx/engine/panel.py
+++ b/olmlx/engine/panel.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from olmlx.engine.grammar import GrammarSpec
 from olmlx.engine.inference import generate_chat
@@ -384,5 +384,8 @@ async def _panel_stream(
         enable_thinking,
         stream=True,
     )
-    async for chunk in judge_stream:
+    # ``_judge_answer`` calls ``generate_chat`` with a runtime ``stream`` bool,
+    # so the overload can't narrow the return to the async-generator branch.
+    # We pass ``stream=True`` here, so the result is always an async generator.
+    async for chunk in cast("AsyncGenerator[dict, None]", judge_stream):
         yield chunk

--- a/olmlx/engine/panel.py
+++ b/olmlx/engine/panel.py
@@ -12,6 +12,7 @@ Metal-stream / inference-lock handling is reused. Never touch MLX here.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -63,3 +64,43 @@ def route_grammar(panel: "PanelConfig") -> GrammarSpec:
 def select_members(route_key: str, panel: "PanelConfig") -> list[str]:
     """Members for *route_key*, falling back to the 'default' route."""
     return panel.routes.get(route_key, panel.routes["default"])
+
+
+def _tool_key(tool_use: dict) -> str:
+    """Stable dedup key: name + canonicalized arguments."""
+    args = tool_use.get("input") or {}
+    return tool_use["name"] + "\0" + json.dumps(args, sort_keys=True)
+
+
+def merge_tool_calls(per_panelist: list[list[dict]]) -> list[dict]:
+    """Deduped union of every panelist's proposed tool calls.
+
+    Identical ``(name, arguments)`` collapse to one execution; different
+    arguments both run. Insertion order is preserved (first panelist
+    first). The internal ``_span`` key from ``parse_model_output`` is
+    stripped. Tool-call IDs are assigned downstream by the routers.
+    """
+    merged: list[dict] = []
+    seen: set[str] = set()
+    for panelist_calls in per_panelist:
+        for call in panelist_calls:
+            key = _tool_key(call)
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append({"name": call["name"], "input": call.get("input") or {}})
+    return merged
+
+
+def serialize_tool_calls_qwen(tool_uses: list[dict]) -> str:
+    """Render tool calls as canonical Qwen ``<tool_call>`` blocks.
+
+    The routers re-parse this text via ``parse_model_output`` (the Qwen
+    parser maps ``arguments`` -> ``input``), so the panel's tool turn is
+    transparent to both the OpenAI and Ollama routers.
+    """
+    blocks = []
+    for tu in tool_uses:
+        payload = json.dumps({"name": tu["name"], "arguments": tu.get("input") or {}})
+        blocks.append(f"<tool_call>\n{payload}\n</tool_call>")
+    return "\n".join(blocks)

--- a/olmlx/engine/panel.py
+++ b/olmlx/engine/panel.py
@@ -102,5 +102,11 @@ def serialize_tool_calls_qwen(tool_uses: list[dict]) -> str:
     blocks = []
     for tu in tool_uses:
         payload = json.dumps({"name": tu["name"], "arguments": tu.get("input") or {}})
+        # A literal "</tool_call>" inside an argument value would make the
+        # non-greedy Qwen parser regex close the block early and drop the
+        # call. Escaping the slash keeps the substring out of the text while
+        # remaining valid JSON: json.loads decodes "<\/tool_call>" back to
+        # "</tool_call>", so the round-trip is exact.
+        payload = payload.replace("</tool_call>", "<\\/tool_call>")
         blocks.append(f"<tool_call>\n{payload}\n</tool_call>")
     return "\n".join(blocks)

--- a/olmlx/engine/panel.py
+++ b/olmlx/engine/panel.py
@@ -17,8 +17,10 @@ import logging
 from typing import TYPE_CHECKING
 
 from olmlx.engine.grammar import GrammarSpec
+from olmlx.engine.inference import generate_chat
 
 if TYPE_CHECKING:
+    from olmlx.engine.model_manager import ModelManager
     from olmlx.engine.registry import PanelConfig
 
 logger = logging.getLogger(__name__)
@@ -138,3 +140,47 @@ def serialize_tool_calls_qwen(tool_uses: list[dict]) -> str:
         payload = payload.replace("</tool_call>", "<\\/tool_call>")
         blocks.append(f"<tool_call>\n{payload}\n</tool_call>")
     return "\n".join(blocks)
+
+
+_CLASSIFIER_SYSTEM = (
+    "You are a request router. Classify the user's request into exactly "
+    'one category. Respond ONLY with JSON of the form {"route": "<category>"}.'
+)
+
+
+async def classify(
+    manager: "ModelManager",
+    panel: "PanelConfig",
+    user_text: str,
+    keep_alive: int | str | None = None,
+) -> list[str]:
+    """Route the request to a member list via the classifier model.
+
+    The classifier output is grammar-constrained to the route keys; any
+    parse failure falls back to the 'default' route.
+    """
+    categories = ", ".join(sorted(panel.routes))
+    messages = [
+        {
+            "role": "system",
+            "content": f"{_CLASSIFIER_SYSTEM} Categories: {categories}.",
+        },
+        {"role": "user", "content": user_text},
+    ]
+    result = await generate_chat(
+        manager,
+        panel.classifier,
+        messages,
+        tools=None,
+        stream=False,
+        keep_alive=keep_alive,
+        max_tokens=32,
+        grammar_spec=route_grammar(panel),
+    )
+    text = (result.get("text") or "").strip()
+    try:
+        route = json.loads(text).get("route", "default")
+    except (json.JSONDecodeError, AttributeError):
+        logger.warning("Panel classifier returned non-JSON %r; using default", text)
+        route = "default"
+    return select_members(route, panel)

--- a/olmlx/engine/panel.py
+++ b/olmlx/engine/panel.py
@@ -239,8 +239,126 @@ async def _run_panel(
         answers.append(visible)
         per_panelist_tools.append(tool_uses)
 
-    merged = merge_tool_calls(per_panelist_tools)
+    merged = await _resolve_tool_turn(
+        manager,
+        panel,
+        messages,
+        members,
+        answers,
+        per_panelist_tools,
+        options,
+        keep_alive,
+    )
     return (members, answers), merged
+
+
+def _decision_grammar() -> GrammarSpec:
+    """Constrain the judge's stop decision to ``{"action": "answer"|"gather"}``."""
+    return GrammarSpec(
+        kind="json_schema",
+        schema={
+            "type": "object",
+            "properties": {"action": {"type": "string", "enum": ["answer", "gather"]}},
+            "required": ["action"],
+            "additionalProperties": False,
+        },
+    )
+
+
+_JUDGE_DECISION_SYSTEM = (
+    "You are the controller for a panel of models answering the conversation "
+    "above. Some panelists proposed tool calls to gather more information. "
+    "Decide whether there is already enough grounded information to write a "
+    "final answer, or whether the proposed tools should be run first. Respond "
+    'ONLY with JSON {"action": "answer"} or {"action": "gather"}.'
+)
+
+
+async def _judge_wants_gather(
+    manager: "ModelManager",
+    panel: "PanelConfig",
+    messages: list[dict],
+    members: list[str],
+    answers: list[str],
+    per_panelist_tools: list[list[dict]],
+    options: dict | None,
+    keep_alive: int | str | None,
+) -> bool:
+    """Ask the judge whether to gather more via tools (True) or finalize.
+
+    Any parse failure defaults to finalize (``False``) — the ``"judge"`` stop
+    condition exists to curb runaway tool loops, so an unreadable decision
+    should stop rather than keep gathering.
+    """
+    states = []
+    for name, answer, tools in zip(members, answers, per_panelist_tools):
+        if tools:
+            names = ", ".join(t["name"] for t in tools)
+            states.append(f"- {name}: proposes tool calls [{names}]")
+        else:
+            states.append(f"- {name}: ready to answer: {answer.strip()[:200]}")
+    content = _JUDGE_DECISION_SYSTEM + "\n\nPanelist states:\n" + "\n".join(states)
+    result = await generate_chat(
+        manager,
+        panel.judge,
+        [*messages, {"role": "user", "content": content}],
+        tools=None,
+        stream=False,
+        options=options,
+        keep_alive=keep_alive,
+        max_tokens=16,
+        enable_thinking=False,
+        grammar_spec=_decision_grammar(),
+    )
+    text = (result.get("text") or "").strip()
+    try:
+        action = json.loads(text).get("action", "answer")
+    except (json.JSONDecodeError, AttributeError):
+        logger.warning("Panel judge decision returned non-JSON %r; finalizing", text)
+        action = "answer"
+    return action == "gather"
+
+
+async def _resolve_tool_turn(
+    manager: "ModelManager",
+    panel: "PanelConfig",
+    messages: list[dict],
+    members: list[str],
+    answers: list[str],
+    per_panelist_tools: list[list[dict]],
+    options: dict | None,
+    keep_alive: int | str | None,
+) -> list[dict]:
+    """Apply the panel's ``stop_condition`` to decide this turn's output.
+
+    Returns the deduped union of proposed tool calls to emit a tool turn, or
+    ``[]`` to finalize (let the judge synthesize). When no panelist proposes
+    tools, every condition finalizes.
+    """
+    wanting = sum(1 for tools in per_panelist_tools if tools)
+    if wanting == 0:
+        return []
+    cond = panel.stop_condition
+    if cond == "majority":
+        ready = len(per_panelist_tools) - wanting
+        if ready > len(per_panelist_tools) / 2:
+            return []
+        return merge_tool_calls(per_panelist_tools)
+    if cond == "judge":
+        if await _judge_wants_gather(
+            manager,
+            panel,
+            messages,
+            members,
+            answers,
+            per_panelist_tools,
+            options,
+            keep_alive,
+        ):
+            return merge_tool_calls(per_panelist_tools)
+        return []
+    # "all" (default): emit the union whenever any panelist wants tools.
+    return merge_tool_calls(per_panelist_tools)
 
 
 def _resolve_panel(manager: "ModelManager", model_name: str) -> "PanelConfig":

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -1230,9 +1230,7 @@ class PanelConfig:
                 f"panel {name!r}: 'classifier' must be a non-empty model name"
             )
         if not judge or not isinstance(judge, str):
-            raise ValueError(
-                f"panel {name!r}: 'judge' must be a non-empty model name"
-            )
+            raise ValueError(f"panel {name!r}: 'judge' must be a non-empty model name")
         if not isinstance(routes, dict) or not routes:
             raise ValueError(f"panel {name!r}: 'routes' must be a non-empty object")
         for key, members in routes.items():

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -361,6 +361,11 @@ class ModelConfig:
     #: Applied by ``generate_chat`` when the request didn't set the flag.
     #: ``None`` means fall back to the engine default (think unless tools).
     enable_thinking: bool | None = None
+    #: Per-model default reasoning level for channel-format reasoners
+    #: (gpt-oss / Harmony): ``"low"``, ``"medium"``, or ``"high"``. Applied by
+    #: ``generate_chat`` when the caller didn't pass one; ignored by templates
+    #: that don't support ``reasoning_effort``. ``None`` uses the template default.
+    reasoning_effort: str | None = None
     #: Per-model override for the cross-request prompt cache toggle. When set,
     #: fully overrides ``OLMLX_PROMPT_CACHE`` for this model — useful when a
     #: specific architecture surfaces a checkpoint-path bug while the rest of
@@ -561,6 +566,15 @@ class ModelConfig:
         ):
             raise ValueError(
                 f"'enable_thinking' must be a bool or None, got {self.enable_thinking!r}"
+            )
+        if self.reasoning_effort is not None and self.reasoning_effort not in (
+            "low",
+            "medium",
+            "high",
+        ):
+            raise ValueError(
+                "'reasoning_effort' must be 'low', 'medium', 'high', or None, "
+                f"got {self.reasoning_effort!r}"
             )
         if self.prompt_cache is not None and not isinstance(self.prompt_cache, bool):
             raise ValueError(
@@ -930,6 +944,7 @@ class ModelConfig:
             flash_speculative_draft_model = entry.get("flash_speculative_draft_model")
             flash_speculative_tokens = entry.get("flash_speculative_tokens")
             enable_thinking_raw = entry.get("enable_thinking")
+            reasoning_effort_raw = entry.get("reasoning_effort")
             prompt_cache_raw = entry.get("prompt_cache")
             batching_raw = entry.get("batching")
             batch_completion_size_raw = entry.get("batch_completion_size")
@@ -1001,6 +1016,7 @@ class ModelConfig:
                 flash_speculative_draft_model=flash_speculative_draft_model,
                 flash_speculative_tokens=flash_speculative_tokens,
                 enable_thinking=enable_thinking_raw,
+                reasoning_effort=reasoning_effort_raw,
                 prompt_cache=prompt_cache_raw,
                 batching=batching_raw,
                 batch_completion_size=batch_completion_size_raw,
@@ -1045,6 +1061,7 @@ class ModelConfig:
             and self.flash_speculative_draft_model is None
             and self.flash_speculative_tokens is None
             and self.enable_thinking is None
+            and self.reasoning_effort is None
             and self.prompt_cache is None
             and self.batching is None
             and self.batch_completion_size is None
@@ -1116,6 +1133,8 @@ class ModelConfig:
             result["flash_speculative_tokens"] = self.flash_speculative_tokens
         if self.enable_thinking is not None:
             result["enable_thinking"] = self.enable_thinking
+        if self.reasoning_effort is not None:
+            result["reasoning_effort"] = self.reasoning_effort
         if self.prompt_cache is not None:
             result["prompt_cache"] = self.prompt_cache
         if self.batching is not None:

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -1219,12 +1219,23 @@ class PanelConfig:
     classifier: str
     judge: str
     routes: dict[str, list[str]]
+    #: When to stop issuing tool calls and let the judge synthesize. ``"all"``
+    #: (default) finalizes only when no panelist proposes tools; ``"majority"``
+    #: finalizes once a majority of panelists are ready; ``"judge"`` asks the
+    #: judge each turn. See engine/panel.py.
+    stop_condition: str = "all"
 
     @classmethod
     def from_entry(cls, name: str, entry: dict) -> "PanelConfig":
         classifier = entry.get("classifier")
         judge = entry.get("judge")
         routes = entry.get("routes")
+        stop_condition = entry.get("stop_condition", "all")
+        if stop_condition not in ("all", "majority", "judge"):
+            raise ValueError(
+                f"panel {name!r}: 'stop_condition' must be one of "
+                f"'all', 'majority', 'judge'; got {stop_condition!r}"
+            )
         if not classifier or not isinstance(classifier, str):
             raise ValueError(
                 f"panel {name!r}: 'classifier' must be a non-empty model name"
@@ -1245,7 +1256,13 @@ class PanelConfig:
                 )
         if "default" not in routes:
             raise ValueError(f"panel {name!r}: 'routes' must contain a 'default' key")
-        return cls(name=name, classifier=classifier, judge=judge, routes=dict(routes))
+        return cls(
+            name=name,
+            classifier=classifier,
+            judge=judge,
+            routes=dict(routes),
+            stop_condition=stop_condition,
+        )
 
     def all_member_names(self) -> set[str]:
         names: set[str] = set()

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -1259,6 +1259,7 @@ class ModelRegistry:
 
     def __init__(self):
         self._mappings: dict[str, ModelConfig] = {}
+        self._panels: dict[str, PanelConfig] = {}
         self._raw_unrecognized: dict[str, Any] = {}
         self._dirty_keys: set[str] = set()
         self._removed_keys: set[str] = set()
@@ -1295,15 +1296,25 @@ class ModelRegistry:
                     f"file is not overwritten."
                 )
             self._mappings = {}
+            self._panels = {}
             self._raw_unrecognized = {}
             self._dirty_keys = set()
             self._removed_keys = set()
             for k, v in raw.items():
+                normalized = self.normalize_name(k)
+                if isinstance(v, dict) and v.get("type") == "panel":
+                    try:
+                        self._panels[normalized] = PanelConfig.from_entry(normalized, v)
+                    except (ValueError, TypeError) as exc:
+                        logger.warning("Skipping invalid panel entry %r: %s", k, exc)
+                        self._raw_unrecognized[k] = v
+                    continue
                 try:
                     self._mappings[k] = ModelConfig.from_entry(v)
                 except (ValueError, TypeError) as exc:
                     logger.warning("Skipping invalid models.json entry %r: %s", k, exc)
                     self._raw_unrecognized[k] = v
+            self._validate_panels()
         if self._aliases_path.exists():
             try:
                 with open(self._aliases_path) as f:
@@ -1354,6 +1365,39 @@ class ModelRegistry:
         if name in self._mappings:
             return self._mappings[name]
         return None
+
+    def is_panel(self, name: str) -> bool:
+        """True if *name* resolves to a ``type: "panel"`` entry."""
+        return self.normalize_name(name) in self._panels
+
+    def resolve_panel(self, name: str) -> "PanelConfig | None":
+        """Resolve *name* to a PanelConfig, or None if it is not a panel."""
+        return self._panels.get(self.normalize_name(name))
+
+    def _validate_panels(self) -> None:
+        """Drop panels referencing unknown models; warn on judge-in-panel.
+
+        Cross-reference validation runs after all entries are loaded so a
+        panel may reference members declared anywhere in the file.
+        """
+        for name, panel in list(self._panels.items()):
+            refs = {panel.classifier, panel.judge} | panel.all_member_names()
+            missing = sorted(r for r in refs if self.resolve(r) is None)
+            if missing:
+                logger.warning(
+                    "Dropping panel %r: references unknown models %s",
+                    name,
+                    missing,
+                )
+                del self._panels[name]
+                continue
+            if panel.judge in panel.all_member_names():
+                logger.warning(
+                    "Panel %r: judge %r is also a panelist; this invites "
+                    "self-preference bias.",
+                    name,
+                    panel.judge,
+                )
 
     def list_models(self) -> dict[str, ModelConfig]:
         """Return all known model name → ModelConfig mappings.

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -1205,6 +1205,57 @@ def validate_hf_path(hf_path: str) -> None:
         raise ValueError(f"HuggingFace path {hf_path!r} must be in 'owner/repo' format")
 
 
+@dataclass(frozen=True)
+class PanelConfig:
+    """A ``type: "panel"`` entry from models.json.
+
+    A panel is not a loadable model: it has no weights. ``classifier``,
+    ``judge`` and the per-route member lists all reference other
+    models.json entries by name. See engine/panel.py for the coordinator
+    that executes a panel.
+    """
+
+    name: str
+    classifier: str
+    judge: str
+    routes: dict[str, list[str]]
+
+    @classmethod
+    def from_entry(cls, name: str, entry: dict) -> "PanelConfig":
+        classifier = entry.get("classifier")
+        judge = entry.get("judge")
+        routes = entry.get("routes")
+        if not classifier or not isinstance(classifier, str):
+            raise ValueError(
+                f"panel {name!r}: 'classifier' must be a non-empty model name"
+            )
+        if not judge or not isinstance(judge, str):
+            raise ValueError(
+                f"panel {name!r}: 'judge' must be a non-empty model name"
+            )
+        if not isinstance(routes, dict) or not routes:
+            raise ValueError(f"panel {name!r}: 'routes' must be a non-empty object")
+        for key, members in routes.items():
+            if (
+                not isinstance(members, list)
+                or not members
+                or not all(isinstance(m, str) and m for m in members)
+            ):
+                raise ValueError(
+                    f"panel {name!r}: route {key!r} must be a non-empty list "
+                    "of model names"
+                )
+        if "default" not in routes:
+            raise ValueError(f"panel {name!r}: 'routes' must contain a 'default' key")
+        return cls(name=name, classifier=classifier, judge=judge, routes=dict(routes))
+
+    def all_member_names(self) -> set[str]:
+        names: set[str] = set()
+        for members in self.routes.values():
+            names.update(members)
+        return names
+
+
 class ModelRegistry:
     """Resolves Ollama model names to HuggingFace paths via config file."""
 

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -1410,6 +1410,15 @@ class ModelRegistry:
         """Resolve *name* to a PanelConfig, or None if it is not a panel."""
         return self._panels.get(self.normalize_name(name))
 
+    def list_panels(self) -> dict[str, "PanelConfig"]:
+        """Return all configured panel name → PanelConfig mappings.
+
+        Panels are synthetic (no weights), so they're kept separate from
+        ``list_models`` — model-listing surfaces (``/v1/models``, ``/api/tags``,
+        the CLI) append these so panels are selectable by clients like opencode.
+        """
+        return dict(self._panels)
+
     def _validate_panels(self) -> None:
         """Drop panels referencing unknown models; warn on judge-in-panel.
 

--- a/olmlx/engine/template_caps.py
+++ b/olmlx/engine/template_caps.py
@@ -11,6 +11,9 @@ logger = logging.getLogger(__name__)
 class TemplateCaps:
     supports_tools: bool = False
     supports_enable_thinking: bool = False
+    #: Channel-format reasoners (gpt-oss / Harmony) take a ``reasoning_effort``
+    #: kwarg ("low"/"medium"/"high") instead of a boolean ``enable_thinking``.
+    supports_reasoning_effort: bool = False
     has_thinking_tags: bool = False
     has_channel_format: bool = False
     uses_tool_responses: bool = False
@@ -53,11 +56,13 @@ def detect_caps(tokenizer: Any) -> TemplateCaps:
         # AST-based detection: only match actual template variables
         supports_tools = "tools" in variables
         supports_enable_thinking = "enable_thinking" in variables
+        supports_reasoning_effort = "reasoning_effort" in variables
     else:
         # Fallback: substring matching (for malformed templates)
         logger.debug("Jinja2 parsing failed, falling back to substring matching")
         supports_tools = "tools" in tpl
         supports_enable_thinking = "enable_thinking" in tpl
+        supports_reasoning_effort = "reasoning_effort" in tpl
 
     # has_thinking_tags checks for literal output, not a variable — keep string check
     has_thinking_tags = "<think>" in tpl or "thinking" in tpl.lower()
@@ -90,6 +95,7 @@ def detect_caps(tokenizer: Any) -> TemplateCaps:
     return TemplateCaps(
         supports_tools=supports_tools,
         supports_enable_thinking=supports_enable_thinking,
+        supports_reasoning_effort=supports_reasoning_effort,
         has_thinking_tags=has_thinking_tags,
         has_channel_format=has_channel_format,
         uses_tool_responses=uses_tool_responses,

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -9,6 +9,7 @@ from fastapi.responses import StreamingResponse
 from olmlx.config import settings
 from olmlx.engine.grammar import parse_response_format
 from olmlx.engine.inference import generate_chat
+from olmlx.engine.panel import panel_generate_chat
 from olmlx.engine.tool_parser import (
     fill_missing_required_args,
     parse_model_output,
@@ -174,8 +175,14 @@ async def chat(req: ChatRequest, request: Request):
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
 
+    dispatch = (
+        panel_generate_chat
+        if request.app.state.registry.is_panel(req.model)
+        else generate_chat
+    )
+
     if req.stream:
-        result = await generate_chat(
+        result = await dispatch(
             manager,
             req.model,
             messages,
@@ -290,7 +297,7 @@ async def chat(req: ChatRequest, request: Request):
             media_type="application/x-ndjson",
         )
     else:
-        result = await generate_chat(
+        result = await dispatch(
             manager,
             req.model,
             messages,

--- a/olmlx/routers/models.py
+++ b/olmlx/routers/models.py
@@ -50,6 +50,17 @@ async def list_models(request: Request):
                 )
             )
 
+    # Synthetic panel models: no weights, but selectable by name. Mark the
+    # family as "panel" so clients can tell them apart.
+    for name in registry.list_panels():
+        models.append(
+            ModelInfo(
+                name=name,
+                model=name,
+                details=ModelDetails(family="panel"),
+            )
+        )
+
     return TagsResponse(models=models)
 
 

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -17,6 +17,7 @@ from olmlx.engine.inference import (
     generate_completion,
     generate_embeddings,
 )
+from olmlx.engine.panel import panel_generate_chat
 from olmlx.engine.tool_parser import (
     fill_missing_required_args,
     parse_model_output,
@@ -372,9 +373,11 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
     enable_thinking = resolve_openai_think(
         req.reasoning_effort, req.chat_template_kwargs
     )
+    registry = request.app.state.registry
+    dispatch = panel_generate_chat if registry.is_panel(req.model) else generate_chat
 
     if req.stream:
-        result = await generate_chat(
+        result = await dispatch(
             manager,
             req.model,
             messages,
@@ -417,7 +420,7 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
             media_type="text/event-stream",
         )
     else:
-        result = await generate_chat(
+        result = await dispatch(
             manager,
             req.model,
             messages,

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -556,8 +556,12 @@ async def openai_completions(req: OpenAICompletionRequest, request: Request):
 )
 async def openai_list_models(request: Request):
     registry = request.app.state.registry
+    created = int(time.time())
     models = registry.list_models()
-    data = [OpenAIModel(id=name, created=int(time.time())) for name in models]
+    data = [OpenAIModel(id=name, created=created) for name in models]
+    # Synthetic panel models have no weights but are selectable by name, so
+    # clients (opencode, etc.) need to see them in the model list.
+    data += [OpenAIModel(id=name, created=created) for name in registry.list_panels()]
     return OpenAIModelList(data=data)
 
 

--- a/tests/test_chat_templating_reasoning.py
+++ b/tests/test_chat_templating_reasoning.py
@@ -1,0 +1,41 @@
+"""reasoning_effort plumbing in olmlx.engine.chat_templating."""
+
+from unittest.mock import MagicMock
+
+from olmlx.engine.chat_templating import apply_chat_template_text
+from olmlx.engine.template_caps import TemplateCaps
+
+
+def _capturing_tokenizer():
+    tok = MagicMock()
+    captured: dict = {}
+
+    def _apply(messages, **kwargs):
+        captured.update(kwargs)
+        return "PROMPT"
+
+    tok.apply_chat_template = _apply
+    return tok, captured
+
+
+_MSGS = [{"role": "user", "content": "hi"}]
+
+
+class TestReasoningEffortPlumbing:
+    def test_passes_reasoning_effort_when_supported(self):
+        tok, captured = _capturing_tokenizer()
+        caps = TemplateCaps(supports_reasoning_effort=True)
+        apply_chat_template_text(tok, _MSGS, None, caps, reasoning_effort="low")
+        assert captured.get("reasoning_effort") == "low"
+
+    def test_omits_when_template_unsupported(self):
+        tok, captured = _capturing_tokenizer()
+        caps = TemplateCaps(supports_reasoning_effort=False)
+        apply_chat_template_text(tok, _MSGS, None, caps, reasoning_effort="low")
+        assert "reasoning_effort" not in captured
+
+    def test_omits_when_none(self):
+        tok, captured = _capturing_tokenizer()
+        caps = TemplateCaps(supports_reasoning_effort=True)
+        apply_chat_template_text(tok, _MSGS, None, caps, reasoning_effort=None)
+        assert "reasoning_effort" not in captured

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -277,6 +277,100 @@ class TestRunPanel:
         assert answers == (["da", "db"], ["Answer A", "Answer B"])
 
 
+_TOOL = '<tool_call>\n{"name": "search", "arguments": {"q": "x"}}\n</tool_call>'
+
+
+def _panel_with_stop(cond):
+    from olmlx.engine.registry import PanelConfig
+
+    return PanelConfig.from_entry(
+        "p:latest",
+        {
+            "type": "panel",
+            "classifier": "c",
+            "judge": "j",
+            "routes": {"default": ["da", "db", "dc"]},
+            "stop_condition": cond,
+        },
+    )
+
+
+class TestStopConditions:
+    async def _run(self, monkeypatch, cond, responses):
+        monkeypatch.setattr(
+            panel_mod, "generate_chat", _fake_generate_chat_factory(responses)
+        )
+        (_members, _answers), merged = await panel_mod._run_panel(
+            manager=None,
+            panel=_panel_with_stop(cond),
+            messages=[{"role": "user", "content": "q"}],
+            tools=[{"type": "function", "function": {"name": "search"}}],
+            options=None,
+            keep_alive=None,
+            max_tokens=128,
+            enable_thinking=None,
+        )
+        return merged
+
+    @pytest.mark.asyncio
+    async def test_all_emits_on_any_tool(self, monkeypatch):
+        # 1 of 3 wants tools -> "all" still emits the union.
+        responses = {"c": '{"route": "default"}', "da": _TOOL, "db": "x", "dc": "y"}
+        merged = await self._run(monkeypatch, "all", responses)
+        assert [t["name"] for t in merged] == ["search"]
+
+    @pytest.mark.asyncio
+    async def test_majority_finalizes_when_majority_ready(self, monkeypatch):
+        # 1 of 3 wants tools, 2 ready -> majority finalizes (no tools emitted).
+        responses = {"c": '{"route": "default"}', "da": _TOOL, "db": "x", "dc": "y"}
+        merged = await self._run(monkeypatch, "majority", responses)
+        assert merged == []
+
+    @pytest.mark.asyncio
+    async def test_majority_gathers_when_majority_want_tools(self, monkeypatch):
+        # 2 of 3 want tools, 1 ready -> majority gathers (emit union).
+        responses = {"c": '{"route": "default"}', "da": _TOOL, "db": _TOOL, "dc": "y"}
+        merged = await self._run(monkeypatch, "majority", responses)
+        assert [t["name"] for t in merged] == ["search"]
+
+    @pytest.mark.asyncio
+    async def test_judge_gather_emits_tools(self, monkeypatch):
+        responses = {
+            "c": '{"route": "default"}',
+            "da": _TOOL,
+            "db": "x",
+            "dc": "y",
+            "j": '{"action": "gather"}',
+        }
+        merged = await self._run(monkeypatch, "judge", responses)
+        assert [t["name"] for t in merged] == ["search"]
+
+    @pytest.mark.asyncio
+    async def test_judge_answer_finalizes(self, monkeypatch):
+        responses = {
+            "c": '{"route": "default"}',
+            "da": _TOOL,
+            "db": "x",
+            "dc": "y",
+            "j": '{"action": "answer"}',
+        }
+        merged = await self._run(monkeypatch, "judge", responses)
+        assert merged == []
+
+    @pytest.mark.asyncio
+    async def test_judge_bad_json_finalizes(self, monkeypatch):
+        # Unparseable judge decision defaults to finalize (curb runaway loops).
+        responses = {
+            "c": '{"route": "default"}',
+            "da": _TOOL,
+            "db": "x",
+            "dc": "y",
+            "j": "not json",
+        }
+        merged = await self._run(monkeypatch, "judge", responses)
+        assert merged == []
+
+
 class TestPanelGenerateChatNonStream:
     @pytest.mark.asyncio
     async def test_tool_turn_returns_qwen_blocks(self, monkeypatch):

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -801,3 +801,73 @@ class TestRouterDispatchBehavioral:
         assert generate_called == [], (
             f"generate_chat was called unexpectedly: {generate_called}"
         )
+
+
+def _registry_with_panel(monkeypatch):
+    import json as _json
+    import pathlib
+    import tempfile
+
+    from olmlx.engine.registry import ModelRegistry
+
+    config = {
+        "small": "org/small",
+        "judge-m": "org/judge",
+        "panelist-m": "org/panelist",
+        "list-panel": {
+            "type": "panel",
+            "classifier": "small",
+            "judge": "judge-m",
+            "routes": {"default": ["panelist-m"]},
+        },
+    }
+    with tempfile.TemporaryDirectory() as td:
+        cfg = pathlib.Path(td) / "models.json"
+        cfg.write_text(_json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", cfg)
+        reg = ModelRegistry()
+        reg.load()
+    return reg
+
+
+class TestPanelModelListing:
+    @pytest.mark.asyncio
+    async def test_openai_v1_models_includes_panel(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from httpx import ASGITransport, AsyncClient
+        from olmlx.app import create_app
+
+        app = create_app()
+        app.state.registry = _registry_with_panel(monkeypatch)
+        app.state.model_manager = MagicMock()
+        app.state.model_store = MagicMock()
+
+        transport = ASGITransport(app=app, raise_app_exceptions=True)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/v1/models")
+        assert resp.status_code == 200
+        ids = {m["id"] for m in resp.json()["data"]}
+        assert "list-panel:latest" in ids
+
+    @pytest.mark.asyncio
+    async def test_ollama_api_tags_includes_panel(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from httpx import ASGITransport, AsyncClient
+        from olmlx.app import create_app
+
+        app = create_app()
+        app.state.registry = _registry_with_panel(monkeypatch)
+        app.state.model_manager = MagicMock()
+        store = MagicMock()
+        store.list_local.return_value = []
+        app.state.model_store = store
+
+        transport = ASGITransport(app=app, raise_app_exceptions=True)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/tags")
+        assert resp.status_code == 200
+        entries = {m["name"]: m for m in resp.json()["models"]}
+        assert "list-panel:latest" in entries
+        assert entries["list-panel:latest"]["details"]["family"] == "panel"

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -403,3 +403,8 @@ class TestRouterDispatch:
         from olmlx.routers import openai as openai_router
 
         assert hasattr(openai_router, "panel_generate_chat")
+
+    def test_ollama_router_imports_panel_dispatch(self):
+        from olmlx.routers import chat as chat_router
+
+        assert hasattr(chat_router, "panel_generate_chat")

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -3,10 +3,13 @@
 from olmlx.engine.grammar import GrammarSpec
 from olmlx.engine.panel import (
     first_user_text,
+    merge_tool_calls,
     route_grammar,
     select_members,
+    serialize_tool_calls_qwen,
 )
 from olmlx.engine.registry import PanelConfig
+from olmlx.engine.tool_parser import parse_model_output
 
 
 def _panel() -> PanelConfig:
@@ -60,3 +63,40 @@ class TestRoutingHelpers:
 
     def test_select_members_unknown_route_falls_back_to_default(self):
         assert select_members("nonsense", _panel()) == ["qwen3", "mistral"]
+
+
+class TestToolCallUnion:
+    def test_merge_dedupes_identical_calls(self):
+        # Two panelists; one shared identical call, one unique each.
+        per_panelist = [
+            [
+                {"name": "search", "input": {"q": "x"}, "_span": (0, 1)},
+                {"name": "read", "input": {"path": "a"}},
+            ],
+            [
+                {"name": "search", "input": {"q": "x"}},
+                {"name": "read", "input": {"path": "b"}},
+            ],
+        ]
+        merged = merge_tool_calls(per_panelist)
+        # search{q:x} collapses to one; read{a} and read{b} both kept.
+        assert merged == [
+            {"name": "search", "input": {"q": "x"}},
+            {"name": "read", "input": {"path": "a"}},
+            {"name": "read", "input": {"path": "b"}},
+        ]
+        # _span must be stripped.
+        assert all("_span" not in tc for tc in merged)
+
+    def test_merge_empty(self):
+        assert merge_tool_calls([[], []]) == []
+
+    def test_serialize_round_trips_through_parser(self):
+        merged = [
+            {"name": "search", "input": {"q": "x"}},
+            {"name": "read", "input": {"path": "a"}},
+        ]
+        text = serialize_tool_calls_qwen(merged)
+        _thinking, _visible, tool_uses = parse_model_output(text, has_tools=True)
+        reparsed = [{"name": tu["name"], "input": tu["input"]} for tu in tool_uses]
+        assert reparsed == merged

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -396,3 +396,10 @@ class TestPanelGenerateChatStream:
         full = "".join(c.get("text", "") for c in chunks)
         assert full == "Final synthesized answer."
         assert chunks[-1].get("done") is True
+
+
+class TestRouterDispatch:
+    def test_openai_router_imports_panel_dispatch(self):
+        from olmlx.routers import openai as openai_router
+
+        assert hasattr(openai_router, "panel_generate_chat")

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -309,3 +309,90 @@ class TestPanelGenerateChatNonStream:
             stream=False,
         )
         assert result["text"] == "Reconciled final answer."
+
+
+def _fake_generate_chat_streaming_factory(responses: dict, stream_models: set):
+    """generate_chat stub: dict for non-stream models, async-gen for streamed ones."""
+
+    async def _fake(
+        manager,
+        model_name,
+        messages,
+        options=None,
+        tools=None,
+        stream=False,
+        keep_alive=None,
+        max_tokens=512,
+        cache_id="",
+        enable_thinking=None,
+        grammar_spec=None,
+    ):
+        text = responses[model_name]
+        if stream and model_name in stream_models:
+
+            async def _gen():
+                yield {"text": text}
+                yield {"done": True, "done_reason": "stop"}
+
+            return _gen()
+        return {"text": text, "done": True, "stats": None}
+
+    return _fake
+
+
+async def _drain(agen) -> list[dict]:
+    return [chunk async for chunk in agen]
+
+
+class TestPanelGenerateChatStream:
+    @pytest.mark.asyncio
+    async def test_stream_tool_turn_emits_qwen_text_then_done(self, monkeypatch):
+        responses = {
+            "c": '{"route": "default"}',
+            "da": '<tool_call>\n{"name": "search", "arguments": {"q": "x"}}\n</tool_call>',
+            "db": "prose",
+        }
+        monkeypatch.setattr(
+            panel_mod,
+            "generate_chat",
+            _fake_generate_chat_streaming_factory(responses, stream_models=set()),
+        )
+        monkeypatch.setattr(panel_mod, "_resolve_panel", lambda m, n: _make_panel())
+        agen = await panel_mod.panel_generate_chat(
+            manager=None,
+            model_name="p:latest",
+            messages=[{"role": "user", "content": "find x"}],
+            tools=[{"type": "function", "function": {"name": "search"}}],
+            stream=True,
+        )
+        chunks = await _drain(agen)
+        full = "".join(c.get("text", "") for c in chunks)
+        _t, _v, tool_uses = parse_model_output(full, has_tools=True)
+        assert [tu["name"] for tu in tool_uses] == ["search"]
+        assert chunks[-1].get("done") is True
+
+    @pytest.mark.asyncio
+    async def test_stream_final_turn_proxies_judge_stream(self, monkeypatch):
+        responses = {
+            "c": '{"route": "default"}',
+            "da": "A",
+            "db": "B",
+            "j": "Final synthesized answer.",
+        }
+        monkeypatch.setattr(
+            panel_mod,
+            "generate_chat",
+            _fake_generate_chat_streaming_factory(responses, stream_models={"j"}),
+        )
+        monkeypatch.setattr(panel_mod, "_resolve_panel", lambda m, n: _make_panel())
+        agen = await panel_mod.panel_generate_chat(
+            manager=None,
+            model_name="p:latest",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            stream=True,
+        )
+        chunks = await _drain(agen)
+        full = "".join(c.get("text", "") for c in chunks)
+        assert full == "Final synthesized answer."
+        assert chunks[-1].get("done") is True

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -1,5 +1,8 @@
 """Tests for olmlx.engine.panel."""
 
+import pytest
+
+from olmlx.engine import panel as panel_mod
 from olmlx.engine.grammar import GrammarSpec
 from olmlx.engine.panel import (
     build_judge_messages,
@@ -146,3 +149,65 @@ class TestJudgePrompt:
     def test_handles_empty_candidate_answer(self):
         out = build_judge_messages([{"role": "user", "content": "q"}], ["m1"], [""])
         assert "m1" in out[-1]["content"]
+
+
+def _make_panel():
+    from olmlx.engine.registry import PanelConfig
+
+    return PanelConfig.from_entry(
+        "p:latest",
+        {
+            "type": "panel",
+            "classifier": "c",
+            "judge": "j",
+            "routes": {"code": ["qa", "qb"], "default": ["da", "db"]},
+        },
+    )
+
+
+def _fake_generate_chat_factory(responses: dict):
+    """Return an async generate_chat stub keyed by model name -> text."""
+
+    async def _fake(
+        manager,
+        model_name,
+        messages,
+        options=None,
+        tools=None,
+        stream=False,
+        keep_alive=None,
+        max_tokens=512,
+        cache_id="",
+        enable_thinking=None,
+        grammar_spec=None,
+    ):
+        text = responses[model_name]
+        return {"text": text, "done": True, "stats": None}
+
+    return _fake
+
+
+class TestClassify:
+    @pytest.mark.asyncio
+    async def test_classify_returns_route_members(self, monkeypatch):
+        monkeypatch.setattr(
+            panel_mod,
+            "generate_chat",
+            _fake_generate_chat_factory({"c": '{"route": "code"}'}),
+        )
+        members = await panel_mod.classify(
+            manager=None, panel=_make_panel(), user_text="write a function"
+        )
+        assert members == ["qa", "qb"]
+
+    @pytest.mark.asyncio
+    async def test_classify_bad_json_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setattr(
+            panel_mod,
+            "generate_chat",
+            _fake_generate_chat_factory({"c": "not json at all"}),
+        )
+        members = await panel_mod.classify(
+            manager=None, panel=_make_panel(), user_text="hi"
+        )
+        assert members == ["da", "db"]

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -211,3 +211,51 @@ class TestClassify:
             manager=None, panel=_make_panel(), user_text="hi"
         )
         assert members == ["da", "db"]
+
+
+class TestRunPanel:
+    @pytest.mark.asyncio
+    async def test_returns_union_when_any_panelist_wants_tools(self, monkeypatch):
+        # da proposes a tool call (Qwen format), db answers in prose.
+        responses = {
+            "c": '{"route": "default"}',
+            "da": '<tool_call>\n{"name": "search", "arguments": {"q": "x"}}\n</tool_call>',
+            "db": "I think the answer is 42.",
+        }
+        monkeypatch.setattr(
+            panel_mod, "generate_chat", _fake_generate_chat_factory(responses)
+        )
+        answers, merged = await panel_mod._run_panel(
+            manager=None,
+            panel=_make_panel(),
+            messages=[{"role": "user", "content": "find x"}],
+            tools=[{"type": "function", "function": {"name": "search"}}],
+            options=None,
+            keep_alive=None,
+            max_tokens=128,
+            enable_thinking=None,
+        )
+        assert merged == [{"name": "search", "input": {"q": "x"}}]
+
+    @pytest.mark.asyncio
+    async def test_returns_answers_when_no_tools_requested(self, monkeypatch):
+        responses = {
+            "c": '{"route": "default"}',
+            "da": "Answer A",
+            "db": "Answer B",
+        }
+        monkeypatch.setattr(
+            panel_mod, "generate_chat", _fake_generate_chat_factory(responses)
+        )
+        answers, merged = await panel_mod._run_panel(
+            manager=None,
+            panel=_make_panel(),
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            options=None,
+            keep_alive=None,
+            max_tokens=128,
+            enable_thinking=None,
+        )
+        assert merged == []
+        assert answers == (["da", "db"], ["Answer A", "Answer B"])

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -212,6 +212,7 @@ def _fake_generate_chat_factory(responses: dict):
         max_tokens=512,
         cache_id="",
         enable_thinking=None,
+        reasoning_effort=None,
         grammar_spec=None,
     ):
         text = responses[model_name]
@@ -431,6 +432,28 @@ class TestPanelGenerateChatNonStream:
         assert result["done"] is True
 
     @pytest.mark.asyncio
+    async def test_judge_synthesis_uses_low_reasoning_effort(self, monkeypatch):
+        # The judge call must request reasoning_effort="low" so channel-format
+        # reasoners (gpt-oss) stay terse instead of leaking analysis.
+        captured = {}
+
+        async def _capture(manager, model_name, messages, **kwargs):
+            if model_name == "j":  # judge synthesis
+                captured.update(kwargs)
+            return {"text": "final", "done": True, "stats": None}
+
+        monkeypatch.setattr(panel_mod, "generate_chat", _capture)
+        monkeypatch.setattr(panel_mod, "_resolve_panel", lambda m, n: _make_panel())
+        await panel_mod.panel_generate_chat(
+            manager=None,
+            model_name="p:latest",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            stream=False,
+        )
+        assert captured.get("reasoning_effort") == "low"
+
+    @pytest.mark.asyncio
     async def test_final_turn_returns_judge_answer(self, monkeypatch):
         responses = {
             "c": '{"route": "default"}',
@@ -468,6 +491,7 @@ def _fake_generate_chat_streaming_factory(responses: dict, stream_models: set):
         max_tokens=512,
         cache_id="",
         enable_thinking=None,
+        reasoning_effort=None,
         grammar_spec=None,
     ):
         text = responses[model_name]
@@ -614,6 +638,7 @@ class TestFailurePropagation:
             max_tokens=512,
             cache_id="",
             enable_thinking=None,
+            reasoning_effort=None,
             grammar_spec=None,
         ):
             if model_name == raise_on:

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -130,25 +130,58 @@ class TestToolCallUnion:
 
 
 class TestJudgePrompt:
-    def test_appends_candidates_as_final_user_turn(self):
+    def test_flattens_request_and_candidates(self):
         original = [
             {"role": "system", "content": "sys"},
             {"role": "user", "content": "What is 2+2?"},
         ]
         out = build_judge_messages(original, ["qwen3", "mistral"], ["four", "4"])
-        # Original messages preserved as a prefix (not mutated).
-        assert out[:2] == original
-        assert original[-1]["content"] == "What is 2+2?"  # input untouched
-        judge_turn = out[-1]
-        assert judge_turn["role"] == "user"
-        assert "qwen3" in judge_turn["content"]
-        assert "mistral" in judge_turn["content"]
-        assert "four" in judge_turn["content"]
-        assert "4" in judge_turn["content"]
+        # Flattened to a short fixed prompt (system + user), not a conversation
+        # replay; original is not mutated.
+        assert all(m["role"] in ("system", "user") for m in out)
+        assert original[-1]["content"] == "What is 2+2?"
+        blob = " ".join(m["content"] for m in out)
+        assert "What is 2+2?" in blob  # request
+        assert "qwen3" in blob and "mistral" in blob  # candidate labels
+        assert "four" in blob and "4" in blob  # candidate answers
+
+    def test_does_not_replay_agentic_turns(self):
+        # The whole point of the fix: a tool-heavy conversation must NOT be
+        # replayed as assistant(tool_calls)/tool turns, which primes the judge
+        # to keep calling tools. It must be flattened into a clean prompt that
+        # still carries the tool results.
+        original = [
+            {"role": "user", "content": "read the config"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path": "config.py"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "PREFIX=OLMLX_"},
+        ]
+        out = build_judge_messages(original, ["m1"], ["the prefix is OLMLX_"])
+        # No assistant tool_calls and no tool-role messages leak through.
+        assert not any("tool_calls" in m for m in out)
+        assert not any(m["role"] == "tool" for m in out)
+        blob = " ".join(m["content"] for m in out)
+        assert "read the config" in blob  # request preserved
+        assert "PREFIX=OLMLX_" in blob  # tool RESULT preserved
+        assert "read_file" in blob  # which call produced it
+        assert "the prefix is OLMLX_" in blob  # candidate
 
     def test_handles_empty_candidate_answer(self):
         out = build_judge_messages([{"role": "user", "content": "q"}], ["m1"], [""])
-        assert "m1" in out[-1]["content"]
+        blob = " ".join(m["content"] for m in out)
+        assert "q" in blob and "m1" in blob
 
 
 def _make_panel():

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -1,0 +1,62 @@
+"""Tests for olmlx.engine.panel."""
+
+from olmlx.engine.grammar import GrammarSpec
+from olmlx.engine.panel import (
+    first_user_text,
+    route_grammar,
+    select_members,
+)
+from olmlx.engine.registry import PanelConfig
+
+
+def _panel() -> PanelConfig:
+    return PanelConfig.from_entry(
+        "p:latest",
+        {
+            "type": "panel",
+            "classifier": "c",
+            "judge": "j",
+            "routes": {
+                "code": ["qwen3-coder", "devstral"],
+                "default": ["qwen3", "mistral"],
+            },
+        },
+    )
+
+
+class TestRoutingHelpers:
+    def test_first_user_text_string_content(self):
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello world"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        assert first_user_text(msgs) == "hello world"
+
+    def test_first_user_text_list_content(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "part one"},
+                    {"type": "text", "text": "part two"},
+                ],
+            }
+        ]
+        assert first_user_text(msgs) == "part one\npart two"
+
+    def test_first_user_text_no_user(self):
+        assert first_user_text([{"role": "system", "content": "x"}]) == ""
+
+    def test_route_grammar_enumerates_keys(self):
+        spec = route_grammar(_panel())
+        assert isinstance(spec, GrammarSpec)
+        assert spec.kind == "json_schema"
+        enum = spec.schema["properties"]["route"]["enum"]
+        assert set(enum) == {"code", "default"}
+
+    def test_select_members_known_route(self):
+        assert select_members("code", _panel()) == ["qwen3-coder", "devstral"]
+
+    def test_select_members_unknown_route_falls_back_to_default(self):
+        assert select_members("nonsense", _panel()) == ["qwen3", "mistral"]

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -408,3 +408,225 @@ class TestRouterDispatch:
         from olmlx.routers import chat as chat_router
 
         assert hasattr(chat_router, "panel_generate_chat")
+
+
+# ---------------------------------------------------------------------------
+# Gap 1 — Continuation-history re-routing stays stable
+# ---------------------------------------------------------------------------
+
+
+class TestContinuationRouting:
+    def test_first_user_text_stable_with_tool_history(self):
+        # A continuation history: system first, then the original user turn,
+        # then an assistant tool-call turn and a tool result.  first_user_text
+        # must still return the ORIGINAL user message (routing key is stable).
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "original task"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
+            {"role": "tool", "content": "tool result", "tool_call_id": "1"},
+        ]
+        assert first_user_text(messages) == "original task"
+
+    @pytest.mark.asyncio
+    async def test_run_panel_routes_same_on_continuation(self, monkeypatch):
+        # Same classifier output -> same members, regardless of added history.
+        responses = {"c": '{"route": "code"}', "qa": "A", "qb": "B"}
+        monkeypatch.setattr(
+            panel_mod, "generate_chat", _fake_generate_chat_factory(responses)
+        )
+        base = [{"role": "user", "content": "write code"}]
+        continuation = base + [
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
+            {"role": "tool", "content": "result", "tool_call_id": "1"},
+        ]
+        (members_a, _), _ = await panel_mod._run_panel(
+            None, _make_panel(), base, None, None, None, 128, None
+        )
+        (members_b, _), _ = await panel_mod._run_panel(
+            None, _make_panel(), continuation, None, None, None, 128, None
+        )
+        assert members_a == members_b == ["qa", "qb"]
+
+
+# ---------------------------------------------------------------------------
+# Gap 2 — Failure propagation
+# ---------------------------------------------------------------------------
+
+
+class TestFailurePropagation:
+    @staticmethod
+    def _raising_factory(responses: dict, raise_on: str):
+        async def _fake(
+            manager,
+            model_name,
+            messages,
+            options=None,
+            tools=None,
+            stream=False,
+            keep_alive=None,
+            max_tokens=512,
+            cache_id="",
+            enable_thinking=None,
+            grammar_spec=None,
+        ):
+            if model_name == raise_on:
+                raise RuntimeError(f"boom in {model_name}")
+            return {"text": responses[model_name], "done": True, "stats": None}
+
+        return _fake
+
+    @pytest.mark.asyncio
+    async def test_panelist_failure_propagates_nonstream(self, monkeypatch):
+        responses = {"c": '{"route": "default"}', "da": "A", "db": "B"}
+        monkeypatch.setattr(
+            panel_mod,
+            "generate_chat",
+            self._raising_factory(responses, raise_on="da"),
+        )
+        monkeypatch.setattr(panel_mod, "_resolve_panel", lambda m, n: _make_panel())
+        with pytest.raises(RuntimeError, match="boom in da"):
+            await panel_mod.panel_generate_chat(
+                manager=None,
+                model_name="p:latest",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=None,
+                stream=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_classifier_failure_propagates_nonstream(self, monkeypatch):
+        responses = {"c": "unused"}
+        monkeypatch.setattr(
+            panel_mod,
+            "generate_chat",
+            self._raising_factory(responses, raise_on="c"),
+        )
+        monkeypatch.setattr(panel_mod, "_resolve_panel", lambda m, n: _make_panel())
+        with pytest.raises(RuntimeError, match="boom in c"):
+            await panel_mod.panel_generate_chat(
+                manager=None,
+                model_name="p:latest",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=None,
+                stream=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_panelist_failure_propagates_stream(self, monkeypatch):
+        responses = {"c": '{"route": "default"}', "da": "A", "db": "B"}
+        monkeypatch.setattr(
+            panel_mod,
+            "generate_chat",
+            self._raising_factory(responses, raise_on="da"),
+        )
+        monkeypatch.setattr(panel_mod, "_resolve_panel", lambda m, n: _make_panel())
+        agen = await panel_mod.panel_generate_chat(
+            manager=None,
+            model_name="p:latest",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            stream=True,
+        )
+        with pytest.raises(RuntimeError, match="boom in da"):
+            await _drain(agen)
+
+
+# ---------------------------------------------------------------------------
+# Gap 4 — Router actually dispatches to the coordinator (behavioral)
+# ---------------------------------------------------------------------------
+
+
+class TestRouterDispatchBehavioral:
+    @pytest.mark.asyncio
+    async def test_panel_model_dispatches_to_panel_generate_chat(self, monkeypatch):
+        """Non-streaming request for a panel model calls panel_generate_chat,
+        NOT generate_chat."""
+        import json as _json
+
+        from httpx import ASGITransport, AsyncClient
+        from olmlx.app import create_app
+        from olmlx.engine.registry import ModelRegistry
+        from olmlx.utils.timing import TimingStats
+
+        # Build a registry that exposes a panel model.
+        import tempfile
+        import pathlib
+
+        config = {
+            "classifier-m": "org/small",
+            "judge-m": "org/judge",
+            "panelist-m": "org/panelist",
+            "my-panel": {
+                "type": "panel",
+                "classifier": "classifier-m",
+                "judge": "judge-m",
+                "routes": {"default": ["panelist-m"]},
+            },
+        }
+        with tempfile.TemporaryDirectory() as td:
+            cfg_path = pathlib.Path(td) / "models.json"
+            cfg_path.write_text(_json.dumps(config))
+            monkeypatch.setattr(
+                "olmlx.engine.registry.settings.models_config", cfg_path
+            )
+            reg = ModelRegistry()
+            reg.load()
+
+        assert reg.is_panel("my-panel") is True
+
+        panel_called: list[str] = []
+        generate_called: list[str] = []
+
+        async def fake_panel_generate_chat(
+            manager, model_name, messages, options=None, **kwargs
+        ):
+            panel_called.append(model_name)
+            return {
+                "text": "panel answer",
+                "done": True,
+                "stats": TimingStats(),
+            }
+
+        async def fake_generate_chat(
+            manager, model_name, messages, options=None, **kwargs
+        ):
+            generate_called.append(model_name)
+            return {
+                "text": "plain answer",
+                "done": True,
+                "stats": TimingStats(),
+            }
+
+        monkeypatch.setattr(
+            "olmlx.routers.openai.panel_generate_chat", fake_panel_generate_chat
+        )
+        monkeypatch.setattr("olmlx.routers.openai.generate_chat", fake_generate_chat)
+
+        app = create_app()
+        app.state.registry = reg
+        # model_manager can be a minimal stub — dispatch happens before any
+        # actual inference.
+        from unittest.mock import MagicMock
+
+        app.state.model_manager = MagicMock()
+        app.state.model_store = MagicMock()
+
+        transport = ASGITransport(app=app, raise_app_exceptions=True)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "my-panel",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "stream": False,
+                },
+            )
+
+        assert resp.status_code == 200
+        assert panel_called == ["my-panel"], (
+            f"panel_generate_chat was not called; panel_called={panel_called}"
+        )
+        assert generate_called == [], (
+            f"generate_chat was called unexpectedly: {generate_called}"
+        )

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -259,3 +259,53 @@ class TestRunPanel:
         )
         assert merged == []
         assert answers == (["da", "db"], ["Answer A", "Answer B"])
+
+
+class TestPanelGenerateChatNonStream:
+    @pytest.mark.asyncio
+    async def test_tool_turn_returns_qwen_blocks(self, monkeypatch):
+        responses = {
+            "c": '{"route": "default"}',
+            "da": '<tool_call>\n{"name": "search", "arguments": {"q": "x"}}\n</tool_call>',
+            "db": "prose",
+        }
+        monkeypatch.setattr(
+            panel_mod, "generate_chat", _fake_generate_chat_factory(responses)
+        )
+        monkeypatch.setattr(
+            panel_mod, "_resolve_panel", lambda manager, name: _make_panel()
+        )
+        result = await panel_mod.panel_generate_chat(
+            manager=None,
+            model_name="p:latest",
+            messages=[{"role": "user", "content": "find x"}],
+            tools=[{"type": "function", "function": {"name": "search"}}],
+            stream=False,
+        )
+        # Router parses raw_text -> tool calls.
+        _t, _v, tool_uses = parse_model_output(result["raw_text"], has_tools=True)
+        assert [tu["name"] for tu in tool_uses] == ["search"]
+        assert result["done"] is True
+
+    @pytest.mark.asyncio
+    async def test_final_turn_returns_judge_answer(self, monkeypatch):
+        responses = {
+            "c": '{"route": "default"}',
+            "da": "Answer A",
+            "db": "Answer B",
+            "j": "Reconciled final answer.",
+        }
+        monkeypatch.setattr(
+            panel_mod, "generate_chat", _fake_generate_chat_factory(responses)
+        )
+        monkeypatch.setattr(
+            panel_mod, "_resolve_panel", lambda manager, name: _make_panel()
+        )
+        result = await panel_mod.panel_generate_chat(
+            manager=None,
+            model_name="p:latest",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            stream=False,
+        )
+        assert result["text"] == "Reconciled final answer."

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -100,3 +100,26 @@ class TestToolCallUnion:
         _thinking, _visible, tool_uses = parse_model_output(text, has_tools=True)
         reparsed = [{"name": tu["name"], "input": tu["input"]} for tu in tool_uses]
         assert reparsed == merged
+
+    def test_serialize_round_trips_tool_call_tag_in_args(self):
+        # An argument value containing the literal closing tag must survive
+        # the serialize -> parse_model_output round-trip (the panel emits
+        # this text and the routers re-parse it).
+        # With two calls, the non-greedy Qwen regex closes early inside the
+        # first arg, the first call is silently dropped, and only the second
+        # is returned — a real production failure.
+        merged = [
+            {"name": "search", "input": {"q": "see </tool_call> here"}},
+            {"name": "read", "input": {"path": "/tmp/foo"}},
+        ]
+        text = serialize_tool_calls_qwen(merged)
+        _t, _v, tool_uses = parse_model_output(text, has_tools=True)
+        reparsed = [{"name": tu["name"], "input": tu["input"]} for tu in tool_uses]
+        assert reparsed == merged
+
+    def test_merge_handles_none_input(self):
+        merged = merge_tool_calls([[{"name": "f", "input": None}]])
+        assert merged == [{"name": "f", "input": {}}]
+
+    def test_merge_no_panelists(self):
+        assert merge_tool_calls([]) == []

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -2,6 +2,7 @@
 
 from olmlx.engine.grammar import GrammarSpec
 from olmlx.engine.panel import (
+    build_judge_messages,
     first_user_text,
     merge_tool_calls,
     route_grammar,
@@ -123,3 +124,25 @@ class TestToolCallUnion:
 
     def test_merge_no_panelists(self):
         assert merge_tool_calls([]) == []
+
+
+class TestJudgePrompt:
+    def test_appends_candidates_as_final_user_turn(self):
+        original = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "What is 2+2?"},
+        ]
+        out = build_judge_messages(original, ["qwen3", "mistral"], ["four", "4"])
+        # Original messages preserved as a prefix (not mutated).
+        assert out[:2] == original
+        assert original[-1]["content"] == "What is 2+2?"  # input untouched
+        judge_turn = out[-1]
+        assert judge_turn["role"] == "user"
+        assert "qwen3" in judge_turn["content"]
+        assert "mistral" in judge_turn["content"]
+        assert "four" in judge_turn["content"]
+        assert "4" in judge_turn["content"]
+
+    def test_handles_empty_candidate_answer(self):
+        out = build_judge_messages([{"role": "user", "content": "q"}], ["m1"], [""])
+        assert "m1" in out[-1]["content"]

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -212,6 +212,22 @@ class TestClassify:
         )
         assert members == ["da", "db"]
 
+    @pytest.mark.asyncio
+    async def test_classify_disables_thinking(self, monkeypatch):
+        # Routing is a constrained JSON task: the classifier must never be
+        # asked to think, regardless of model/request defaults.
+        captured = {}
+
+        async def _capture(manager, model_name, messages, **kwargs):
+            captured.update(kwargs)
+            return {"text": '{"route": "code"}', "done": True, "stats": None}
+
+        monkeypatch.setattr(panel_mod, "generate_chat", _capture)
+        await panel_mod.classify(
+            manager=None, panel=_make_panel(), user_text="write a function"
+        )
+        assert captured["enable_thinking"] is False
+
 
 class TestRunPanel:
     @pytest.mark.asyncio
@@ -370,6 +386,9 @@ class TestPanelGenerateChatStream:
         _t, _v, tool_uses = parse_model_output(full, has_tools=True)
         assert [tu["name"] for tu in tool_uses] == ["search"]
         assert chunks[-1].get("done") is True
+        # Done chunk carries stats, matching the non-streaming tool turn so the
+        # Ollama timing-metadata path stays symmetric.
+        assert chunks[-1].get("stats") is not None
 
     @pytest.mark.asyncio
     async def test_stream_final_turn_proxies_judge_stream(self, monkeypatch):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -697,6 +697,27 @@ class TestModelConfig:
         with pytest.raises(ValueError, match="enable_thinking"):
             ModelConfig.from_entry({"hf_path": "org/model", "enable_thinking": "yes"})
 
+    def test_reasoning_effort_default_none(self):
+        mc = ModelConfig.from_entry({"hf_path": "org/model"})
+        assert mc.reasoning_effort is None
+
+    @pytest.mark.parametrize("value", ["low", "medium", "high"])
+    def test_reasoning_effort_parsed(self, value):
+        mc = ModelConfig.from_entry({"hf_path": "org/model", "reasoning_effort": value})
+        assert mc.reasoning_effort == value
+
+    def test_reasoning_effort_invalid_rejected(self):
+        with pytest.raises(ValueError, match="reasoning_effort"):
+            ModelConfig.from_entry(
+                {"hf_path": "org/model", "reasoning_effort": "turbo"}
+            )
+
+    def test_reasoning_effort_round_trip(self):
+        mc = ModelConfig(hf_path="org/model", reasoning_effort="low")
+        entry = mc.to_entry()
+        assert entry["reasoning_effort"] == "low"
+        assert ModelConfig.from_entry(entry).reasoning_effort == "low"
+
     def test_enable_thinking_round_trip(self):
         """``enable_thinking`` survives to_entry → from_entry."""
         mc = ModelConfig(hf_path="org/model", enable_thinking=False)

--- a/tests/test_registry_panel.py
+++ b/tests/test_registry_panel.py
@@ -7,6 +7,30 @@ import pytest
 from olmlx.engine.registry import ModelRegistry, PanelConfig
 
 
+class TestPanelStopCondition:
+    def _entry(self, **extra):
+        return {
+            "type": "panel",
+            "classifier": "c",
+            "judge": "j",
+            "routes": {"default": ["a"]},
+            **extra,
+        }
+
+    def test_defaults_to_all(self):
+        pc = PanelConfig.from_entry("p:latest", self._entry())
+        assert pc.stop_condition == "all"
+
+    def test_accepts_majority_and_judge(self):
+        for cond in ("all", "majority", "judge"):
+            pc = PanelConfig.from_entry("p:latest", self._entry(stop_condition=cond))
+            assert pc.stop_condition == cond
+
+    def test_rejects_unknown_stop_condition(self):
+        with pytest.raises(ValueError, match="stop_condition"):
+            PanelConfig.from_entry("p:latest", self._entry(stop_condition="bogus"))
+
+
 class TestPanelConfig:
     def test_from_entry_parses_fields(self):
         entry = {

--- a/tests/test_registry_panel.py
+++ b/tests/test_registry_panel.py
@@ -122,3 +122,44 @@ class TestRegistryPanelLoading:
             },
         )
         assert reg.is_panel("bad-panel") is False
+
+    # ---------------------------------------------------------------------------
+    # Gap 3 — Registry panel validation: judge-in-panel warns; missing judge drops
+    # ---------------------------------------------------------------------------
+
+    def test_judge_in_panel_warns_but_keeps(self, tmp_path, monkeypatch, caplog):
+        import logging
+
+        config = {
+            "qwen3": "Qwen/Qwen3-8B-MLX",
+            "small": "org/small",
+            "panel-x": {
+                "type": "panel",
+                "classifier": "small",
+                "judge": "qwen3",
+                "routes": {"default": ["qwen3"]},  # judge is also a member
+            },
+        }
+        with caplog.at_level(logging.WARNING):
+            reg = _load_registry(tmp_path, monkeypatch, config)
+        assert reg.is_panel("panel-x") is True  # kept, not dropped
+        # The warning from _validate_panels mentions self-preference bias.
+        assert any(
+            "self-preference" in r.message or "self-preference bias" in r.message
+            for r in caplog.records
+        ), (
+            f"Expected self-preference warning, got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_missing_judge_drops_panel(self, tmp_path, monkeypatch):
+        config = {
+            "small": "org/small",
+            "panel-y": {
+                "type": "panel",
+                "classifier": "small",
+                "judge": "no-such-model",
+                "routes": {"default": ["small"]},
+            },
+        }
+        reg = _load_registry(tmp_path, monkeypatch, config)
+        assert reg.is_panel("panel-y") is False

--- a/tests/test_registry_panel.py
+++ b/tests/test_registry_panel.py
@@ -129,6 +129,11 @@ class TestRegistryPanelLoading:
         assert pc.judge == "judgem"
         # A panel name is NOT a normal model.
         assert reg.resolve("my-panel") is None
+        # ...but it IS listed for model-listing surfaces, separate from models.
+        panels = reg.list_panels()
+        assert "my-panel:latest" in panels
+        assert panels["my-panel:latest"].judge == "judgem"
+        assert "my-panel:latest" not in reg.list_models()
 
     def test_panel_with_missing_member_is_dropped(self, tmp_path, monkeypatch):
         reg = _load_registry(

--- a/tests/test_registry_panel.py
+++ b/tests/test_registry_panel.py
@@ -1,0 +1,50 @@
+"""Tests for panel-type entries in olmlx.engine.registry."""
+
+import pytest
+
+from olmlx.engine.registry import PanelConfig
+
+
+class TestPanelConfig:
+    def test_from_entry_parses_fields(self):
+        entry = {
+            "type": "panel",
+            "classifier": "qwen3-0.6b",
+            "judge": "gpt-oss-20b",
+            "routes": {
+                "code": ["qwen3-coder", "devstral"],
+                "default": ["qwen3", "mistral"],
+            },
+        }
+        pc = PanelConfig.from_entry("my-panel:latest", entry)
+        assert pc.name == "my-panel:latest"
+        assert pc.classifier == "qwen3-0.6b"
+        assert pc.judge == "gpt-oss-20b"
+        assert pc.routes["code"] == ["qwen3-coder", "devstral"]
+
+    def test_from_entry_requires_default_route(self):
+        entry = {
+            "type": "panel",
+            "classifier": "c",
+            "judge": "j",
+            "routes": {"code": ["a"]},
+        }
+        with pytest.raises(ValueError, match="default"):
+            PanelConfig.from_entry("p:latest", entry)
+
+    def test_from_entry_requires_classifier_and_judge(self):
+        entry = {"type": "panel", "routes": {"default": ["a"]}}
+        with pytest.raises(ValueError, match="classifier"):
+            PanelConfig.from_entry("p:latest", entry)
+
+    def test_all_member_names_unions_routes(self):
+        pc = PanelConfig.from_entry(
+            "p:latest",
+            {
+                "type": "panel",
+                "classifier": "c",
+                "judge": "j",
+                "routes": {"code": ["a", "b"], "default": ["b", "c2"]},
+            },
+        )
+        assert pc.all_member_names() == {"a", "b", "c2"}

--- a/tests/test_registry_panel.py
+++ b/tests/test_registry_panel.py
@@ -37,6 +37,26 @@ class TestPanelConfig:
         with pytest.raises(ValueError, match="classifier"):
             PanelConfig.from_entry("p:latest", entry)
 
+    def test_from_entry_rejects_non_string_member(self):
+        entry = {
+            "type": "panel",
+            "classifier": "c",
+            "judge": "j",
+            "routes": {"default": ["ok", 42]},
+        }
+        with pytest.raises(ValueError, match="default"):
+            PanelConfig.from_entry("p:latest", entry)
+
+    def test_from_entry_rejects_empty_member_list(self):
+        entry = {
+            "type": "panel",
+            "classifier": "c",
+            "judge": "j",
+            "routes": {"default": []},
+        }
+        with pytest.raises(ValueError, match="default"):
+            PanelConfig.from_entry("p:latest", entry)
+
     def test_all_member_names_unions_routes(self):
         pc = PanelConfig.from_entry(
             "p:latest",

--- a/tests/test_registry_panel.py
+++ b/tests/test_registry_panel.py
@@ -1,8 +1,10 @@
 """Tests for panel-type entries in olmlx.engine.registry."""
 
+import json
+
 import pytest
 
-from olmlx.engine.registry import PanelConfig
+from olmlx.engine.registry import ModelRegistry, PanelConfig
 
 
 class TestPanelConfig:
@@ -68,3 +70,55 @@ class TestPanelConfig:
             },
         )
         assert pc.all_member_names() == {"a", "b", "c2"}
+
+
+def _load_registry(tmp_path, monkeypatch, config: dict) -> ModelRegistry:
+    path = tmp_path / "models.json"
+    path.write_text(json.dumps(config))
+    monkeypatch.setattr("olmlx.engine.registry.settings.models_config", path)
+    reg = ModelRegistry()
+    reg.load()
+    return reg
+
+
+class TestRegistryPanelLoading:
+    def test_panel_entry_loaded_and_resolvable(self, tmp_path, monkeypatch):
+        reg = _load_registry(
+            tmp_path,
+            monkeypatch,
+            {
+                "qwen3": "Qwen/Qwen3-8B-MLX",
+                "small": "org/small",
+                "judgem": "org/judge",
+                "my-panel": {
+                    "type": "panel",
+                    "classifier": "small",
+                    "judge": "judgem",
+                    "routes": {"default": ["qwen3"]},
+                },
+            },
+        )
+        assert reg.is_panel("my-panel") is True
+        assert reg.is_panel("my-panel:latest") is True
+        assert reg.is_panel("qwen3") is False
+        pc = reg.resolve_panel("my-panel")
+        assert pc.judge == "judgem"
+        # A panel name is NOT a normal model.
+        assert reg.resolve("my-panel") is None
+
+    def test_panel_with_missing_member_is_dropped(self, tmp_path, monkeypatch):
+        reg = _load_registry(
+            tmp_path,
+            monkeypatch,
+            {
+                "small": "org/small",
+                "judgem": "org/judge",
+                "bad-panel": {
+                    "type": "panel",
+                    "classifier": "small",
+                    "judge": "judgem",
+                    "routes": {"default": ["does-not-exist"]},
+                },
+            },
+        )
+        assert reg.is_panel("bad-panel") is False

--- a/tests/test_template_caps.py
+++ b/tests/test_template_caps.py
@@ -59,6 +59,20 @@ class TestDetectCaps:
         assert caps.supports_enable_thinking is True
         assert caps.has_thinking_tags is True
 
+    def test_reasoning_effort_template(self):
+        # gpt-oss / Harmony style: a reasoning_effort variable, no enable_thinking.
+        tok = MagicMock()
+        tok.chat_template = "Reasoning: {{ reasoning_effort }}{{ messages }}"
+        caps = detect_caps(tok)
+        assert caps.supports_reasoning_effort is True
+        assert caps.supports_enable_thinking is False
+
+    def test_no_reasoning_effort_by_default(self):
+        tok = MagicMock()
+        tok.chat_template = "{% if enable_thinking %}<think>{% endif %}{{ messages }}"
+        caps = detect_caps(tok)
+        assert caps.supports_reasoning_effort is False
+
     def test_qwen_style_template(self):
         tok = MagicMock()
         tok.chat_template = (


### PR DESCRIPTION
## Summary

Adds a synthetic `type: "panel"` model that answers a request with a **per-task-routed panel** of models plus a **judge** that synthesizes one reconciled answer — while behaving as a **drop-in tool-calling model** where the *client* still executes tools. Closes the sequential, single-box scope of #520.

The keystone design decision: rather than building a server-side agent loop, the panel is a **per-turn reconciler that rides the client's existing tool loop**. `engine/panel.py:panel_generate_chat` has the same signature and return shapes as `generate_chat`, so both routers dispatch to it transparently when `registry.is_panel(model)`. Each stateless turn:

1. **Route** — a small classifier (grammar-constrained to the route keys) picks the panel members from the first user message (stable across turns, so routing is re-derived deterministically with no server state).
2. **Run panelists** — each via `generate_chat`, parsed with the existing `parse_model_output`.
3. **Reconcile** — if any panelist proposed tool calls, emit the **deduped union** serialized as canonical Qwen `<tool_call>` blocks (the routers re-parse them, so it's fully transparent); otherwise run the **judge** (no tools) to synthesize a fresh merged answer.

Because every model call goes through `generate_chat`, the Metal-stream / inference-lock handling is reused unchanged.

### What's included
- `engine/panel.py` — coordinator (`panel_generate_chat`) + pure helpers (routing, tool-call union/serialization, judge prompt) + classifier.
- `engine/registry.py` — parses/validates `type: "panel"` entries into a `PanelConfig` (separate `_panels` map; never returned by `resolve()`); `is_panel`/`resolve_panel`.
- `routers/openai.py`, `routers/chat.py` — dispatch to the coordinator for panel models (one-line swap each).
- 40 tests (`tests/test_panel.py`, `tests/test_registry_panel.py`); CLAUDE.md invariant; design spec + implementation plan under `docs/superpowers/`.

### Config shape (`models.json`)
```jsonc
"my-panel:latest": {
  "type": "panel",
  "classifier": "qwen3-0.6b",
  "judge": "gpt-oss-20b",            // not a panelist (self-preference bias warned)
  "routes": {
    "code":    ["qwen3-coder", "devstral", "deepseek-coder"],
    "general": ["qwen3", "llama3.1", "gpt-oss-20b"],
    "default": ["qwen3", "mistral", "llama3.1"]
  }
}
```

### Notable decisions / caveats
- **Drop-in + client-side tools** is incompatible with independent per-panelist tool traces; panelists share one tool-result history (accepted tradeoff, documented in the spec).
- `</tool_call>` in a tool argument is escaped so the non-greedy Qwen parser can't close a block early and silently drop a call (covered by a two-call round-trip test).
- Failure of classifier/panelist/judge **fails the request** (no silent degradation).
- Panel use needs `max_loaded_models ≥ members + judge + classifier` to avoid reload thrash (coordinator warns if too low).
- **Out of scope (follow-up):** distributed/parallel execution; listing panels in `/v1/models`.
- The dispatch swap introduces some non-gating pyright advisory warnings (panel func lacks `stream: Literal[...]` overloads) — consistent with existing codebase posture; CI gates on errors only.

## Test Plan
- [x] 40 unit tests pass (`tests/test_panel.py`, `tests/test_registry_panel.py`) — incl. continuation re-routing, failure propagation, registry validation, and a behavioral router-dispatch test
- [x] 376 registry + router regression tests pass, 0 failures
- [x] ruff check + format clean
- [ ] **Manual smoke test (not yet run — requires real local models):** full multi-turn tool loop against a real client; Qwen-block re-parse fidelity on both routers; real grammar-constrained classifier; Metal-stream correctness across heterogeneous panelists (Qwen3.x hybrid + dense + gpt-oss); `max_loaded_models` thrash warning; failure surfaces as HTTP error; streaming keepalive on slow panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)