### PR TITLE
feat(proxy-tuning): Stage 1 — olmlx-domain SFT data pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ htmlcov/
 .claude/scheduled_tasks.lock
 .worktrees/
 .bench-runs/
+
+# Proxy-tuning generated datasets (large, regenerable)
+data/proxy_tuning/

--- a/docs/superpowers/plans/2026-06-15-proxy-tuning-data-pipeline.md
+++ b/docs/superpowers/plans/2026-06-15-proxy-tuning-data-pipeline.md
@@ -1,0 +1,1625 @@
+# Proxy-Tuning Data Pipeline (Stage 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the offline data pipeline that turns the olmlx repo into a curated ~10k-example chat-format SFT dataset (`train.jsonl` / `valid.jsonl`) for training the proxy-tuning expert M⁺.
+
+**Architecture:** A three-phase offline pipeline in a new importable package `olmlx/proxy_tuning_pipeline/`: (1) **mechanical extraction** mines grounded `(source, seed)` units from functions, CLAUDE.md invariants, docs, tests, and git commits — pure stdlib, deterministic; (2) **expansion** sends each unit to a `Generator` (OpenAI GPT-5.4-mini by default, dependency-injected so tests use a fake) to produce diverse instruction→response pairs; (3) **curation** dedupes, filters, and splits into mlx-lm chat JSONL. A thin CLI wires the phases with intermediate artifacts under `data/proxy_tuning/` (gitignored).
+
+**Tech Stack:** Python 3.11 (stdlib `ast`, `subprocess`, `json`, `re`, `hashlib`, `random`), `openai>=1.66` (already a dependency; lazy/injected), pytest.
+
+**Scope:** This plan is **Stage 1 only** of `docs/superpowers/specs/2026-06-15-olmlx-proxy-tuning-pair-design.md`. Stages 2 (training) and 3 (eval/serve) are separate plans, each blocked on this stage's artifacts.
+
+**Key design choices (locked in this plan):**
+- Package `olmlx/proxy_tuning_pipeline/` (importable; never imported by the running server, so it adds no runtime coupling).
+- `Generator` is a `Protocol`; `expand_units` takes one via dependency injection. Tests use `FakeGenerator`; the concrete `OpenAIGenerator` accepts an injectable client so its test needs no network and no real `openai` object.
+- Generator returns JSON `{"pairs": [{"instruction": ..., "response": ...}]}`; the driver parses + validates.
+- Dedup is **normalized-exact** (lowercase + whitespace-collapsed hash) — no embedding/ML deps (YAGNI). Near-dup-by-embedding is a documented future option, not built here.
+- Output is mlx-lm chat format: `{"messages": [{"role": "user", ...}, {"role": "assistant", ...}]}`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `olmlx/proxy_tuning_pipeline/__init__.py` | Package marker | Create |
+| `olmlx/proxy_tuning_pipeline/schema.py` | `ExtractionUnit`, `ChatExample` dataclasses + JSONL read/write | Create |
+| `olmlx/proxy_tuning_pipeline/extract.py` | `strip_secrets` + 5 extractors + `extract_repo` aggregator + `dedupe_units` | Create |
+| `olmlx/proxy_tuning_pipeline/expand.py` | `Generator` protocol, `build_messages`, `parse_pairs`, `expand_units`, `OpenAIGenerator` | Create |
+| `olmlx/proxy_tuning_pipeline/curate.py` | `quality_filter`, `dedupe_examples`, `split_train_valid` | Create |
+| `olmlx/proxy_tuning_pipeline/cli.py` | `main()` — wire extract → expand → curate → write artifacts | Create |
+| `tests/test_proxy_tuning_pipeline.py` | All unit + end-to-end tests for the pipeline | Create |
+| `.gitignore` | Ignore `data/proxy_tuning/` outputs | Modify |
+
+---
+
+## Task 1: Package + schema + JSONL IO
+
+**Files:**
+- Create: `olmlx/proxy_tuning_pipeline/__init__.py`
+- Create: `olmlx/proxy_tuning_pipeline/schema.py`
+- Modify: `.gitignore`
+- Test: `tests/test_proxy_tuning_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_proxy_tuning_pipeline.py`:
+
+```python
+"""Tests for the proxy-tuning data pipeline (olmlx/proxy_tuning_pipeline)."""
+
+from __future__ import annotations
+
+from olmlx.proxy_tuning_pipeline.schema import (
+    ChatExample,
+    ExtractionUnit,
+    read_jsonl,
+    write_jsonl,
+)
+
+
+def test_jsonl_round_trip(tmp_path):
+    rows = [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+    path = tmp_path / "out.jsonl"
+    write_jsonl(path, rows)
+    assert read_jsonl(path) == rows
+
+
+def test_extraction_unit_to_dict():
+    u = ExtractionUnit(
+        kind="function",
+        provenance="olmlx/foo.py:10",
+        instruction_hint="explain this",
+        source_context="def f(): ...",
+    )
+    assert u.to_dict() == {
+        "kind": "function",
+        "provenance": "olmlx/foo.py:10",
+        "instruction_hint": "explain this",
+        "source_context": "def f(): ...",
+    }
+
+
+def test_chat_example_to_jsonl_row_is_mlx_chat_format():
+    ex = ChatExample(
+        kind="function",
+        provenance="olmlx/foo.py:10",
+        user="How does f work?",
+        assistant="It returns nothing.",
+    )
+    # mlx-lm chat format: only the `messages` key reaches train.jsonl.
+    assert ex.to_chat_row() == {
+        "messages": [
+            {"role": "user", "content": "How does f work?"},
+            {"role": "assistant", "content": "It returns nothing."},
+        ]
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'olmlx.proxy_tuning_pipeline'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `olmlx/proxy_tuning_pipeline/__init__.py`:
+
+```python
+"""Offline data/training tooling for proxy-tuning (Stage 1: data pipeline).
+
+NOT imported by the running olmlx server — this package builds the SFT dataset
+used to train the proxy-tuning expert M+. See
+docs/superpowers/specs/2026-06-15-olmlx-proxy-tuning-pair-design.md.
+"""
+```
+
+Create `olmlx/proxy_tuning_pipeline/schema.py`:
+
+```python
+"""Data types + JSONL IO for the proxy-tuning data pipeline."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class ExtractionUnit:
+    """A grounded source chunk + a seed describing what to generate from it."""
+
+    kind: str  # "function" | "invariant" | "doc" | "test" | "commit"
+    provenance: str  # "olmlx/foo.py:10" or "git:<sha>"
+    instruction_hint: str  # short seed for the generator
+    source_context: str  # grounding text the generator must answer from
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "provenance": self.provenance,
+            "instruction_hint": self.instruction_hint,
+            "source_context": self.source_context,
+        }
+
+
+@dataclass(frozen=True)
+class ChatExample:
+    """One instruction->response training pair plus provenance metadata."""
+
+    kind: str
+    provenance: str
+    user: str
+    assistant: str
+
+    def to_chat_row(self) -> dict[str, Any]:
+        """mlx-lm chat format — only this shape goes into train.jsonl."""
+        return {
+            "messages": [
+                {"role": "user", "content": self.user},
+                {"role": "assistant", "content": self.assistant},
+            ]
+        }
+
+
+def write_jsonl(path: str | Path, rows: Iterable[dict[str, Any]]) -> int:
+    """Write rows as JSON Lines; return the number of rows written."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    n = 0
+    with path.open("w") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+            n += 1
+    return n
+
+
+def read_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    """Read a JSON Lines file into a list of dicts (blank lines skipped)."""
+    out: list[dict[str, Any]] = []
+    with Path(path).open() as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+```
+
+Append to `.gitignore` (add a new line at the end):
+
+```
+# Proxy-tuning generated datasets (large, regenerable)
+data/proxy_tuning/
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -v`
+Expected: 3 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/proxy_tuning_pipeline/__init__.py olmlx/proxy_tuning_pipeline/schema.py tests/test_proxy_tuning_pipeline.py .gitignore
+git commit -m "feat(proxy-tuning-data): schema + JSONL IO for the data pipeline"
+```
+
+---
+
+## Task 2: `strip_secrets`
+
+**Files:**
+- Create: `olmlx/proxy_tuning_pipeline/extract.py`
+- Test: `tests/test_proxy_tuning_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_proxy_tuning_pipeline.py`:
+
+```python
+from olmlx.proxy_tuning_pipeline.extract import strip_secrets
+
+
+def test_strip_secrets_redacts_known_token_shapes():
+    text = (
+        "key sk-abc123def456ghi789jkl012mno345pqr and "
+        "hf_AbCdEfGhIjKlMnOpQrStUvWxYz012345 plus "
+        "OLMLX_SECRET=topsecretvalue123 done"
+    )
+    out = strip_secrets(text)
+    assert "sk-abc123" not in out
+    assert "hf_AbCdEf" not in out
+    assert "topsecretvalue123" not in out
+    assert "[REDACTED]" in out
+    # Non-secret text is preserved.
+    assert out.startswith("key ") and out.endswith(" done")
+
+
+def test_strip_secrets_leaves_ordinary_text_untouched():
+    text = "def generate_chat(model, messages): return run(model, messages)"
+    assert strip_secrets(text) == text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k strip_secrets -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'olmlx.proxy_tuning_pipeline.extract'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `olmlx/proxy_tuning_pipeline/extract.py`:
+
+```python
+"""Mechanical extraction of grounded units from the olmlx repo (no LLM)."""
+
+from __future__ import annotations
+
+import re
+
+from olmlx.proxy_tuning_pipeline.schema import ExtractionUnit
+
+# Token shapes to redact before any text leaves the repo for generation.
+_SECRET_PATTERNS = [
+    re.compile(r"\bsk-[A-Za-z0-9_-]{16,}"),  # OpenAI-style keys
+    re.compile(r"\bhf_[A-Za-z0-9]{16,}"),  # HuggingFace tokens
+    re.compile(r"\b[A-Z][A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD)\s*=\s*\S+"),
+]
+
+
+def strip_secrets(text: str) -> str:
+    """Redact secret-shaped substrings; preserve everything else verbatim."""
+    for pat in _SECRET_PATTERNS:
+        text = pat.sub("[REDACTED]", text)
+    return text
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k strip_secrets -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/proxy_tuning_pipeline/extract.py tests/test_proxy_tuning_pipeline.py
+git commit -m "feat(proxy-tuning-data): strip_secrets redaction"
+```
+
+---
+
+## Task 3: Function/docstring extractor
+
+**Files:**
+- Modify: `olmlx/proxy_tuning_pipeline/extract.py`
+- Test: `tests/test_proxy_tuning_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_proxy_tuning_pipeline.py`:
+
+```python
+from olmlx.proxy_tuning_pipeline.extract import extract_functions
+
+
+def test_extract_functions_yields_unit_per_function(tmp_path):
+    src = tmp_path / "mod.py"
+    src.write_text(
+        'def add(a, b):\n'
+        '    """Return the sum of a and b."""\n'
+        '    return a + b\n'
+        '\n'
+        'def _private():\n'
+        '    return 1\n'
+    )
+    units = list(extract_functions(tmp_path))
+    by_name = {u.provenance: u for u in units}
+    # Both functions captured; provenance is file:lineno.
+    assert any(p.endswith("mod.py:1") for p in by_name)
+    add_unit = next(u for u in units if "def add" in u.source_context)
+    assert add_unit.kind == "function"
+    assert "Return the sum" in add_unit.source_context
+    assert "add" in add_unit.instruction_hint
+
+
+def test_extract_functions_skips_non_python_and_pycache(tmp_path):
+    (tmp_path / "note.txt").write_text("def not_python(): pass")
+    cache = tmp_path / "__pycache__"
+    cache.mkdir()
+    (cache / "x.py").write_text("def cached(): pass")
+    assert list(extract_functions(tmp_path)) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k extract_functions -v`
+Expected: FAIL with `ImportError: cannot import name 'extract_functions'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `olmlx/proxy_tuning_pipeline/extract.py` (append imports + function):
+
+```python
+import ast
+from pathlib import Path
+from typing import Iterator
+
+# Cap grounding size so a huge function/file doesn't blow the generator context.
+_MAX_SOURCE_CHARS = 6000
+
+
+def _iter_py_files(root: Path) -> Iterator[Path]:
+    for p in sorted(root.rglob("*.py")):
+        if "__pycache__" in p.parts:
+            continue
+        yield p
+
+
+def extract_functions(root: str | Path) -> Iterator[ExtractionUnit]:
+    """Yield one unit per top-level/class function with its source + docstring."""
+    root = Path(root)
+    for path in _iter_py_files(root):
+        try:
+            text = path.read_text()
+            tree = ast.parse(text)
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            try:
+                segment = ast.get_source_segment(text, node) or ""
+            except Exception:  # noqa: BLE001
+                segment = ""
+            if not segment.strip():
+                continue
+            rel = path.relative_to(root) if path.is_relative_to(root) else path
+            yield ExtractionUnit(
+                kind="function",
+                provenance=f"{rel}:{node.lineno}",
+                instruction_hint=f"the `{node.name}` function and its olmlx conventions",
+                source_context=strip_secrets(segment[:_MAX_SOURCE_CHARS]),
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k extract_functions -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/proxy_tuning_pipeline/extract.py tests/test_proxy_tuning_pipeline.py
+git commit -m "feat(proxy-tuning-data): function/docstring extractor"
+```
+
+---
+
+## Task 4: CLAUDE.md invariants extractor
+
+**Files:**
+- Modify: `olmlx/proxy_tuning_pipeline/extract.py`
+- Test: `tests/test_proxy_tuning_pipeline.py`
+
+**Context:** In `CLAUDE.md`, the `## Non-Obvious Invariants` section contains one invariant per paragraph, each starting with a bold title then an em-dash: `**Metal stream hazard** — All non-speculative inference ...`. Paragraphs are blank-line separated. The section ends at the next `## ` heading.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_proxy_tuning_pipeline.py`:
+
+```python
+from olmlx.proxy_tuning_pipeline.extract import extract_invariants
+
+
+def test_extract_invariants_parses_bold_lead_paragraphs(tmp_path):
+    md = tmp_path / "CLAUDE.md"
+    md.write_text(
+        "# Title\n\n"
+        "## Non-Obvious Invariants\n\n"
+        "**Metal stream hazard** — All inference must run on one stream.\n\n"
+        "**MTP concat order** — embed first, opposite of EAGLE.\n\n"
+        "## Development\n\n"
+        "not an invariant\n"
+    )
+    units = list(extract_invariants(md))
+    titles = [u.instruction_hint for u in units]
+    assert any("Metal stream hazard" in t for t in titles)
+    assert any("MTP concat order" in t for t in titles)
+    assert all(u.kind == "invariant" for u in units)
+    # The trailing "## Development" content is not captured.
+    assert not any("not an invariant" in u.source_context for u in units)
+    assert len(units) == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k extract_invariants -v`
+Expected: FAIL with `ImportError: cannot import name 'extract_invariants'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `olmlx/proxy_tuning_pipeline/extract.py`:
+
+```python
+def extract_invariants(claude_md_path: str | Path) -> Iterator[ExtractionUnit]:
+    """Yield one unit per `**Title** — ...` paragraph under the invariants section."""
+    path = Path(claude_md_path)
+    text = path.read_text()
+    # Isolate the "## Non-Obvious Invariants" section up to the next "## " heading.
+    m = re.search(r"^##\s+Non-Obvious Invariants\s*$", text, flags=re.MULTILINE)
+    if not m:
+        return
+    rest = text[m.end():]
+    nxt = re.search(r"^##\s+", rest, flags=re.MULTILINE)
+    section = rest[: nxt.start()] if nxt else rest
+    for para in re.split(r"\n\s*\n", section):
+        para = para.strip()
+        title_m = re.match(r"\*\*(.+?)\*\*", para)
+        if not title_m:
+            continue
+        yield ExtractionUnit(
+            kind="invariant",
+            provenance=f"{path.name}#non-obvious-invariants",
+            instruction_hint=f"the olmlx invariant: {title_m.group(1)}",
+            source_context=strip_secrets(para[:_MAX_SOURCE_CHARS]),
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k extract_invariants -v`
+Expected: 1 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/proxy_tuning_pipeline/extract.py tests/test_proxy_tuning_pipeline.py
+git commit -m "feat(proxy-tuning-data): CLAUDE.md invariants extractor"
+```
+
+---
+
+## Task 5: Docs/specs extractor
+
+**Files:**
+- Modify: `olmlx/proxy_tuning_pipeline/extract.py`
+- Test: `tests/test_proxy_tuning_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_proxy_tuning_pipeline.py`:
+
+```python
+from olmlx.proxy_tuning_pipeline.extract import extract_docs
+
+
+def test_extract_docs_chunks_by_section(tmp_path):
+    d = tmp_path / "docs"
+    d.mkdir()
+    (d / "a.md").write_text(
+        "# Intro\n\nWelcome to olmlx.\n\n"
+        "## Speculative\n\nDraft then verify.\n\n"
+        "## Flash\n\nSSD-backed MoE.\n"
+    )
+    (d / "nested" / "b.md").parent.mkdir()
+    (d / "nested" / "b.md").write_text("# Nested\n\nbody here\n")
+    units = list(extract_docs(d))
+    headings = [u.instruction_hint for u in units]
+    assert any("Speculative" in h for h in headings)
+    assert any("Flash" in h for h in headings)
+    assert any("Nested" in h for h in headings)
+    assert all(u.kind == "doc" for u in units)
+    spec = next(u for u in units if "Speculative" in u.instruction_hint)
+    assert "Draft then verify" in spec.source_context
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k extract_docs -v`
+Expected: FAIL with `ImportError: cannot import name 'extract_docs'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `olmlx/proxy_tuning_pipeline/extract.py`:
+
+```python
+def extract_docs(docs_dir: str | Path) -> Iterator[ExtractionUnit]:
+    """Yield one unit per markdown section (## or # heading + its body)."""
+    docs_dir = Path(docs_dir)
+    for path in sorted(docs_dir.rglob("*.md")):
+        text = path.read_text()
+        # Split on headings, keeping the heading with its following body.
+        parts = re.split(r"(?m)^(#{1,3}\s+.*)$", text)
+        # parts = [pre, heading1, body1, heading2, body2, ...]
+        for i in range(1, len(parts), 2):
+            heading = parts[i].lstrip("#").strip()
+            body = parts[i + 1].strip() if i + 1 < len(parts) else ""
+            if not body:
+                continue
+            rel = path.relative_to(docs_dir) if path.is_relative_to(docs_dir) else path
+            yield ExtractionUnit(
+                kind="doc",
+                provenance=f"docs/{rel}#{heading[:40]}",
+                instruction_hint=f"the olmlx documentation section: {heading}",
+                source_context=strip_secrets((parts[i] + "\n" + body)[:_MAX_SOURCE_CHARS]),
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k extract_docs -v`
+Expected: 1 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/proxy_tuning_pipeline/extract.py tests/test_proxy_tuning_pipeline.py
+git commit -m "feat(proxy-tuning-data): docs/specs section extractor"
+```
+
+---
+
+## Task 6: Tests extractor
+
+**Files:**
+- Modify: `olmlx/proxy_tuning_pipeline/extract.py`
+- Test: `tests/test_proxy_tuning_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_proxy_tuning_pipeline.py`:
+
+```python
+from olmlx.proxy_tuning_pipeline.extract import extract_tests
+
+
+def test_extract_tests_yields_unit_per_test_function(tmp_path):
+    t = tmp_path / "tests"
+    t.mkdir()
+    (t / "test_thing.py").write_text(
+        'def test_adds():\n'
+        '    """Addition works."""\n'
+        '    assert 1 + 1 == 2\n'
+        '\n'
+        'def helper():\n'
+        '    return 0\n'
+    )
+    units = list(extract_tests(t))
+    assert len(units) == 1
+    u = units[0]
+    assert u.kind == "test"
+    assert "test_adds" in u.instruction_hint
+    assert "assert 1 + 1 == 2" in u.source_context
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k extract_tests -v`
+Expected: FAIL with `ImportError: cannot import name 'extract_tests'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `olmlx/proxy_tuning_pipeline/extract.py`:
+
+```python
+def extract_tests(tests_dir: str | Path) -> Iterator[ExtractionUnit]:
+    """Yield one unit per `def test_*` function (the behavior it enforces)."""
+    tests_dir = Path(tests_dir)
+    for path in sorted(tests_dir.rglob("test_*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        try:
+            text = path.read_text()
+            tree = ast.parse(text)
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not node.name.startswith("test_"):
+                continue
+            segment = ast.get_source_segment(text, node) or ""
+            if not segment.strip():
+                continue
+            rel = path.relative_to(tests_dir) if path.is_relative_to(tests_dir) else path
+            yield ExtractionUnit(
+                kind="test",
+                provenance=f"tests/{rel}:{node.lineno}",
+                instruction_hint=f"the behavior enforced by `{node.name}`",
+                source_context=strip_secrets(segment[:_MAX_SOURCE_CHARS]),
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k extract_tests -v`
+Expected: 1 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/proxy_tuning_pipeline/extract.py tests/test_proxy_tuning_pipeline.py
+git commit -m "feat(proxy-tuning-data): test-function extractor"
+```
+
+---
+
+## Task 7: Git-commit extractor
+
+**Files:**
+- Modify: `olmlx/proxy_tuning_pipeline/extract.py`
+- Test: `tests/test_proxy_tuning_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_proxy_tuning_pipeline.py`:
+
+```python
+import subprocess
+
+from olmlx.proxy_tuning_pipeline.extract import extract_commits
+
+
+def _git(repo, *args):
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        env={
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+            "PATH": __import__("os").environ.get("PATH", ""),
+        },
+    )
+
+
+def test_extract_commits_yields_message_and_diff(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    (repo / "f.py").write_text("x = 1\n")
+    _git(repo, "add", "f.py")
+    _git(repo, "commit", "-m", "feat: add x constant")
+    units = list(extract_commits(repo, limit=10))
+    assert len(units) == 1
+    u = units[0]
+    assert u.kind == "commit"
+    assert "feat: add x constant" in u.source_context
+    assert "x = 1" in u.source_context  # diff body included
+    assert u.provenance.startswith("git:")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k extract_commits -v`
+Expected: FAIL with `ImportError: cannot import name 'extract_commits'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `olmlx/proxy_tuning_pipeline/extract.py` (append `import subprocess` near the top imports):
+
+```python
+import subprocess
+
+
+def extract_commits(root: str | Path, limit: int = 400) -> Iterator[ExtractionUnit]:
+    """Yield one unit per commit: subject + body + diff (capped). Newest first."""
+    root = Path(root)
+    try:
+        shas = subprocess.run(
+            ["git", "-C", str(root), "log", f"-n{limit}", "--format=%H"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.split()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return
+    for sha in shas:
+        show = subprocess.run(
+            ["git", "-C", str(root), "show", "--format=%s%n%n%b", "--stat", "-p", sha],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        if not show.strip():
+            continue
+        yield ExtractionUnit(
+            kind="commit",
+            provenance=f"git:{sha[:12]}",
+            instruction_hint="implementing this change the olmlx way (message -> diff)",
+            source_context=strip_secrets(show[:_MAX_SOURCE_CHARS]),
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k extract_commits -v`
+Expected: 1 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/proxy_tuning_pipeline/extract.py tests/test_proxy_tuning_pipeline.py
+git commit -m "feat(proxy-tuning-data): git-commit extractor"
+```
+
+---
+
+## Task 8: `extract_repo` aggregator + `dedupe_units`
+
+**Files:**
+- Modify: `olmlx/proxy_tuning_pipeline/extract.py`
+- Test: `tests/test_proxy_tuning_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_proxy_tuning_pipeline.py`:
+
+```python
+from olmlx.proxy_tuning_pipeline.extract import dedupe_units, extract_repo
+
+
+def test_dedupe_units_drops_identical_source_context():
+    u1 = ExtractionUnit("function", "a.py:1", "h", "def f(): pass")
+    u2 = ExtractionUnit("function", "b.py:9", "h2", "def f(): pass")  # same source
+    u3 = ExtractionUnit("function", "c.py:1", "h", "def g(): pass")
+    out = dedupe_units([u1, u2, u3])
+    assert len(out) == 2
+    assert out[0] is u1 and out[1] is u3  # first occurrence kept, order preserved
+
+
+def test_extract_repo_composes_all_extractors(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "olmlx").mkdir(parents=True)
+    (repo / "olmlx" / "m.py").write_text('def f():\n    """doc."""\n    return 1\n')
+    (repo / "CLAUDE.md").write_text(
+        "## Non-Obvious Invariants\n\n**Inv one** — a rule.\n"
+    )
+    (repo / "docs").mkdir()
+    (repo / "docs" / "x.md").write_text("## Sec\n\nbody.\n")
+    (repo / "tests").mkdir()
+    (repo / "tests" / "test_m.py").write_text("def test_f():\n    assert True\n")
+    units = extract_repo(repo)
+    kinds = {u.kind for u in units}
+    # Commit extractor finds nothing here (no git repo) — that's fine.
+    assert {"function", "invariant", "doc", "test"} <= kinds
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k "dedupe_units or extract_repo" -v`
+Expected: FAIL with `ImportError: cannot import name 'dedupe_units'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `olmlx/proxy_tuning_pipeline/extract.py`:
+
+```python
+def dedupe_units(units: list[ExtractionUnit]) -> list[ExtractionUnit]:
+    """Drop units whose `source_context` was already seen (order-preserving)."""
+    seen: set[str] = set()
+    out: list[ExtractionUnit] = []
+    for u in units:
+        key = " ".join(u.source_context.split()).lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(u)
+    return out
+
+
+def extract_repo(root: str | Path) -> list[ExtractionUnit]:
+    """Run every extractor over the repo and return deduped units.
+
+    Each extractor is best-effort: a missing CLAUDE.md / docs / tests / git
+    history simply contributes nothing rather than failing the whole run.
+    """
+    root = Path(root)
+    units: list[ExtractionUnit] = []
+    units += list(extract_functions(root / "olmlx" if (root / "olmlx").is_dir() else root))
+    claude = root / "CLAUDE.md"
+    if claude.is_file():
+        units += list(extract_invariants(claude))
+    docs = root / "docs"
+    if docs.is_dir():
+        units += list(extract_docs(docs))
+    tests = root / "tests"
+    if tests.is_dir():
+        units += list(extract_tests(tests))
+    units += list(extract_commits(root))
+    return dedupe_units(units)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k "dedupe_units or extract_repo" -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Run ruff, then commit**
+
+Run: `uv run ruff check olmlx/proxy_tuning_pipeline/ && uv run ruff format olmlx/proxy_tuning_pipeline/`
+Expected: no errors
+
+```bash
+git add olmlx/proxy_tuning_pipeline/extract.py tests/test_proxy_tuning_pipeline.py
+git commit -m "feat(proxy-tuning-data): extract_repo aggregator + unit dedup"
+```
+
+---
+
+## Task 9: `Generator` protocol + `build_messages` + `parse_pairs`
+
+**Files:**
+- Create: `olmlx/proxy_tuning_pipeline/expand.py`
+- Test: `tests/test_proxy_tuning_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_proxy_tuning_pipeline.py`:
+
+```python
+import pytest
+
+from olmlx.proxy_tuning_pipeline.expand import build_messages, parse_pairs
+
+
+def test_build_messages_grounds_in_source_and_requests_json():
+    u = ExtractionUnit("function", "a.py:1", "the `f` function", "def f(): return 1")
+    system, user = build_messages(u, n_pairs=3)
+    assert "ground" in system.lower()  # grounding discipline present
+    assert "JSON" in system or "json" in system
+    assert "def f(): return 1" in user  # source context embedded
+    assert "3" in user  # requested count
+    assert "the `f` function" in user  # instruction hint embedded
+
+
+def test_build_messages_truncates_oversized_source():
+    u = ExtractionUnit("doc", "d.md#s", "a doc", "x" * 99999)
+    _system, user = build_messages(u, n_pairs=2)
+    assert len(user) < 20000  # clamped well below the raw 99999
+
+
+def test_parse_pairs_extracts_valid_pairs():
+    text = '{"pairs": [{"instruction": "Q1", "response": "A1"}, {"instruction": "Q2", "response": "A2"}]}'
+    assert parse_pairs(text) == [("Q1", "A1"), ("Q2", "A2")]
+
+
+def test_parse_pairs_tolerates_code_fences_and_drops_incomplete():
+    text = (
+        "```json\n"
+        '{"pairs": [{"instruction": "Q", "response": "A"}, '
+        '{"instruction": "", "response": "x"}, '
+        '{"instruction": "only-q"}]}\n'
+        "```"
+    )
+    assert parse_pairs(text) == [("Q", "A")]
+
+
+def test_parse_pairs_returns_empty_on_garbage():
+    assert parse_pairs("not json at all") == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k "build_messages or parse_pairs" -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'olmlx.proxy_tuning_pipeline.expand'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `olmlx/proxy_tuning_pipeline/expand.py`:
+
+```python
+"""Expansion of extracted units into instruction->response pairs via a Generator."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Protocol
+
+from olmlx.proxy_tuning_pipeline.schema import ChatExample, ExtractionUnit
+
+# Clamp the grounding so a long unit can't blow the generator's context budget.
+_MAX_USER_CHARS = 12000
+
+_SYSTEM_PROMPT = (
+    "You are generating supervised fine-tuning data about the olmlx codebase "
+    "(an Ollama-compatible MLX inference server) and adjacent MLX / inference "
+    "optimization topics. You MUST ground every answer strictly in the SOURCE "
+    "provided by the user — do not invent APIs, file names, or behavior that "
+    "is not in the SOURCE; if the SOURCE does not support a detail, omit it. "
+    "Produce diverse, natural instruction/response pairs that teach olmlx's "
+    "conventions and idioms. Reply with ONLY a JSON object of the form "
+    '{"pairs": [{"instruction": "...", "response": "..."}]} and nothing else.'
+)
+
+
+class Generator(Protocol):
+    """Anything that maps (system, user) prompts to a single text completion."""
+
+    def generate(self, system: str, user: str) -> str: ...
+
+
+def build_messages(unit: ExtractionUnit, n_pairs: int) -> tuple[str, str]:
+    """Build (system, user) prompts asking for `n_pairs` grounded pairs."""
+    source = unit.source_context[:_MAX_USER_CHARS]
+    user = (
+        f"Generate {n_pairs} diverse instruction/response pairs that teach "
+        f"{unit.instruction_hint}. Vary the task type (explain / implement / "
+        f"review / convert) and phrasing. Ground every answer in this SOURCE "
+        f"(provenance: {unit.provenance}):\n\n--- SOURCE ---\n{source}\n--- END SOURCE ---"
+    )
+    return _SYSTEM_PROMPT, user
+
+
+def parse_pairs(text: str) -> list[tuple[str, str]]:
+    """Parse a generator reply into (instruction, response) pairs; tolerant.
+
+    Strips ```json fences, ignores anything around the JSON object, and drops
+    pairs missing a non-empty instruction or response.
+    """
+    text = text.strip()
+    text = re.sub(r"^```(?:json)?\s*|\s*```$", "", text, flags=re.MULTILINE).strip()
+    m = re.search(r"\{.*\}", text, flags=re.DOTALL)
+    if not m:
+        return []
+    try:
+        data = json.loads(m.group(0))
+    except json.JSONDecodeError:
+        return []
+    out: list[tuple[str, str]] = []
+    for item in data.get("pairs", []):
+        if not isinstance(item, dict):
+            continue
+        instr = str(item.get("instruction", "")).strip()
+        resp = str(item.get("response", "")).strip()
+        if instr and resp:
+            out.append((instr, resp))
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k "build_messages or parse_pairs" -v`
+Expected: 5 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/proxy_tuning_pipeline/expand.py tests/test_proxy_tuning_pipeline.py
+git commit -m "feat(proxy-tuning-data): Generator protocol + prompt build + pair parse"
+```
+
+---
+
+## Task 10: `expand_units` driver (with injected generator)
+
+**Files:**
+- Modify: `olmlx/proxy_tuning_pipeline/expand.py`
+- Test: `tests/test_proxy_tuning_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_proxy_tuning_pipeline.py`:
+
+```python
+from olmlx.proxy_tuning_pipeline.expand import expand_units
+
+
+class _FakeGenerator:
+    def __init__(self, reply: str):
+        self.reply = reply
+        self.calls = 0
+
+    def generate(self, system: str, user: str) -> str:
+        self.calls += 1
+        return self.reply
+
+
+def test_expand_units_produces_chat_examples_with_provenance():
+    units = [
+        ExtractionUnit("function", "a.py:1", "fn a", "def a(): pass"),
+        ExtractionUnit("doc", "d.md#s", "doc s", "body"),
+    ]
+    gen = _FakeGenerator(
+        '{"pairs": [{"instruction": "Q1", "response": "A1"}, '
+        '{"instruction": "Q2", "response": "A2"}]}'
+    )
+    examples = expand_units(units, gen, n_per_unit=2)
+    assert gen.calls == 2  # one generation call per unit
+    assert len(examples) == 4  # 2 pairs * 2 units
+    assert all(isinstance(e, ChatExample) for e in examples)
+    first = examples[0]
+    assert first.user == "Q1" and first.assistant == "A1"
+    assert first.provenance == "a.py:1" and first.kind == "function"
+
+
+def test_expand_units_skips_units_that_yield_no_pairs():
+    units = [ExtractionUnit("doc", "d.md#s", "doc", "body")]
+    gen = _FakeGenerator("garbage, not json")
+    assert expand_units(units, gen, n_per_unit=3) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k expand_units -v`
+Expected: FAIL with `ImportError: cannot import name 'expand_units'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `olmlx/proxy_tuning_pipeline/expand.py`:
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def expand_units(
+    units: list[ExtractionUnit],
+    generator: Generator,
+    n_per_unit: int,
+) -> list[ChatExample]:
+    """Expand each unit into ChatExamples via the generator (one call per unit)."""
+    examples: list[ChatExample] = []
+    for i, unit in enumerate(units):
+        system, user = build_messages(unit, n_per_unit)
+        try:
+            reply = generator.generate(system, user)
+        except Exception:  # noqa: BLE001 — one bad unit must not abort the run
+            logger.warning("generation failed for %s", unit.provenance, exc_info=True)
+            continue
+        for instr, resp in parse_pairs(reply):
+            examples.append(
+                ChatExample(
+                    kind=unit.kind,
+                    provenance=unit.provenance,
+                    user=instr,
+                    assistant=resp,
+                )
+            )
+        if (i + 1) % 100 == 0:
+            logger.info("expanded %d/%d units, %d pairs so far", i + 1, len(units), len(examples))
+    return examples
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k expand_units -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/proxy_tuning_pipeline/expand.py tests/test_proxy_tuning_pipeline.py
+git commit -m "feat(proxy-tuning-data): expand_units driver"
+```
+
+---
+
+## Task 11: `OpenAIGenerator` (injectable client)
+
+**Files:**
+- Modify: `olmlx/proxy_tuning_pipeline/expand.py`
+- Test: `tests/test_proxy_tuning_pipeline.py`
+
+**Context:** `openai>=1.66` is already a project dependency. The real call is `client.chat.completions.create(model=..., messages=[...]).choices[0].message.content`. The class accepts an injectable `client` so the test needs no network and no real `openai` object; the real client is lazily constructed only when `client is None`. `DEFAULT_MODEL = "gpt-5.4-mini"` is the user-chosen generator and is overridable.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_proxy_tuning_pipeline.py`:
+
+```python
+from olmlx.proxy_tuning_pipeline.expand import DEFAULT_MODEL, OpenAIGenerator
+
+
+class _FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content):
+        self.message = _FakeMessage(content)
+
+
+class _FakeCompletion:
+    def __init__(self, content):
+        self.choices = [_FakeChoice(content)]
+
+
+class _FakeOpenAIClient:
+    def __init__(self, content):
+        self._content = content
+        self.last_kwargs = None
+
+        class _Completions:
+            def create(inner, **kwargs):
+                self.last_kwargs = kwargs
+                return _FakeCompletion(self._content)
+
+        class _Chat:
+            completions = _Completions()
+
+        self.chat = _Chat()
+
+
+def test_openai_generator_calls_chat_completions():
+    client = _FakeOpenAIClient('{"pairs": []}')
+    gen = OpenAIGenerator(client=client)
+    out = gen.generate("sys", "usr")
+    assert out == '{"pairs": []}'
+    assert client.last_kwargs["model"] == DEFAULT_MODEL
+    assert client.last_kwargs["messages"] == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "usr"},
+    ]
+
+
+def test_openai_generator_honors_model_override():
+    client = _FakeOpenAIClient("x")
+    OpenAIGenerator(client=client, model="custom-model").generate("s", "u")
+    assert client.last_kwargs["model"] == "custom-model"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k openai_generator -v`
+Expected: FAIL with `ImportError: cannot import name 'OpenAIGenerator'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `olmlx/proxy_tuning_pipeline/expand.py`:
+
+```python
+from typing import Any
+
+DEFAULT_MODEL = "gpt-5.4-mini"
+
+
+class OpenAIGenerator:
+    """`Generator` backed by OpenAI chat completions (GPT-5.4-mini by default).
+
+    `client` is injectable for testing; when None it is lazily constructed via
+    ``openai.OpenAI()`` (reads ``OPENAI_API_KEY`` from the environment).
+    """
+
+    def __init__(self, client: Any = None, model: str = DEFAULT_MODEL):
+        self._client = client
+        self._model = model
+
+    def _ensure_client(self) -> Any:
+        if self._client is None:
+            from openai import OpenAI
+
+            self._client = OpenAI()
+        return self._client
+
+    def generate(self, system: str, user: str) -> str:
+        resp = self._ensure_client().chat.completions.create(
+            model=self._model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+        )
+        return resp.choices[0].message.content or ""
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k openai_generator -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Run ruff, then commit**
+
+Run: `uv run ruff check olmlx/proxy_tuning_pipeline/ && uv run ruff format olmlx/proxy_tuning_pipeline/`
+Expected: no errors
+
+```bash
+git add olmlx/proxy_tuning_pipeline/expand.py tests/test_proxy_tuning_pipeline.py
+git commit -m "feat(proxy-tuning-data): OpenAIGenerator (GPT-5.4-mini)"
+```
+
+---
+
+## Task 12: Curation — `quality_filter` + `dedupe_examples`
+
+**Files:**
+- Create: `olmlx/proxy_tuning_pipeline/curate.py`
+- Test: `tests/test_proxy_tuning_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_proxy_tuning_pipeline.py`:
+
+```python
+from olmlx.proxy_tuning_pipeline.curate import dedupe_examples, quality_filter
+
+
+def _ex(user, assistant, kind="function", prov="a.py:1"):
+    return ChatExample(kind=kind, provenance=prov, user=user, assistant=assistant)
+
+
+def test_quality_filter_drops_too_short_and_too_long():
+    good = _ex("How does generate_chat route output?", "It calls parse_model_output ...")
+    too_short_q = _ex("hi", "a real-enough answer here please")
+    too_short_a = _ex("A perfectly reasonable question?", "no")
+    too_long = _ex("Q?", "x" * 100_000)
+    out = quality_filter([good, too_short_q, too_short_a, too_long])
+    assert out == [good]
+
+
+def test_dedupe_examples_drops_normalized_duplicates():
+    a = _ex("How  does   F work?", "Answer A")
+    b = _ex("how does f work?", "answer a")  # same after normalization
+    c = _ex("Different question?", "Different answer")
+    out = dedupe_examples([a, b, c])
+    assert out == [a, c]  # first kept, order preserved
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k "quality_filter or dedupe_examples" -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'olmlx.proxy_tuning_pipeline.curate'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `olmlx/proxy_tuning_pipeline/curate.py`:
+
+```python
+"""Curation: quality filtering, dedup, and train/valid split."""
+
+from __future__ import annotations
+
+import random
+
+from olmlx.proxy_tuning_pipeline.schema import ChatExample
+
+_MIN_USER_CHARS = 8
+_MIN_ASSISTANT_CHARS = 12
+_MAX_ASSISTANT_CHARS = 20_000
+
+
+def quality_filter(examples: list[ChatExample]) -> list[ChatExample]:
+    """Drop pairs that are too short to teach or implausibly long (likely junk)."""
+    out: list[ChatExample] = []
+    for e in examples:
+        if len(e.user.strip()) < _MIN_USER_CHARS:
+            continue
+        if not (_MIN_ASSISTANT_CHARS <= len(e.assistant.strip()) <= _MAX_ASSISTANT_CHARS):
+            continue
+        out.append(e)
+    return out
+
+
+def _norm(text: str) -> str:
+    return " ".join(text.split()).lower()
+
+
+def dedupe_examples(examples: list[ChatExample]) -> list[ChatExample]:
+    """Drop normalized-duplicate (user, assistant) pairs; order-preserving."""
+    seen: set[tuple[str, str]] = set()
+    out: list[ChatExample] = []
+    for e in examples:
+        key = (_norm(e.user), _norm(e.assistant))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(e)
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k "quality_filter or dedupe_examples" -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/proxy_tuning_pipeline/curate.py tests/test_proxy_tuning_pipeline.py
+git commit -m "feat(proxy-tuning-data): quality filter + example dedup"
+```
+
+---
+
+## Task 13: Curation — `split_train_valid`
+
+**Files:**
+- Modify: `olmlx/proxy_tuning_pipeline/curate.py`
+- Test: `tests/test_proxy_tuning_pipeline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_proxy_tuning_pipeline.py`:
+
+```python
+from olmlx.proxy_tuning_pipeline.curate import split_train_valid
+
+
+def test_split_train_valid_ratio_and_determinism():
+    examples = [_ex(f"Q{i}?", f"answer number {i}") for i in range(100)]
+    train1, valid1 = split_train_valid(examples, valid_frac=0.1, seed=42)
+    assert len(valid1) == 10 and len(train1) == 90
+    # No overlap; union is the whole set.
+    assert {id(e) for e in train1}.isdisjoint({id(e) for e in valid1})
+    assert len(train1) + len(valid1) == 100
+    # Deterministic for a fixed seed.
+    train2, valid2 = split_train_valid(examples, valid_frac=0.1, seed=42)
+    assert [e.user for e in valid1] == [e.user for e in valid2]
+
+
+def test_split_train_valid_guarantees_at_least_one_valid():
+    examples = [_ex("Q?", "a real answer here")]
+    train, valid = split_train_valid(examples, valid_frac=0.1, seed=0)
+    assert len(valid) == 1 and len(train) == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k split_train_valid -v`
+Expected: FAIL with `ImportError: cannot import name 'split_train_valid'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `olmlx/proxy_tuning_pipeline/curate.py`:
+
+```python
+def split_train_valid(
+    examples: list[ChatExample],
+    valid_frac: float,
+    seed: int,
+) -> tuple[list[ChatExample], list[ChatExample]]:
+    """Shuffle deterministically and split off a validation fraction.
+
+    Guarantees at least one validation example when the input is non-empty so
+    ``mlx_lm.lora`` always has a ``valid.jsonl`` to evaluate against.
+    """
+    shuffled = list(examples)
+    random.Random(seed).shuffle(shuffled)
+    n_valid = max(1, round(len(shuffled) * valid_frac)) if shuffled else 0
+    valid = shuffled[:n_valid]
+    train = shuffled[n_valid:]
+    return train, valid
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k split_train_valid -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Run ruff, then commit**
+
+Run: `uv run ruff check olmlx/proxy_tuning_pipeline/ && uv run ruff format olmlx/proxy_tuning_pipeline/`
+Expected: no errors
+
+```bash
+git add olmlx/proxy_tuning_pipeline/curate.py tests/test_proxy_tuning_pipeline.py
+git commit -m "feat(proxy-tuning-data): deterministic train/valid split"
+```
+
+---
+
+## Task 14: CLI wiring (`cli.py`) + end-to-end test
+
+**Files:**
+- Create: `olmlx/proxy_tuning_pipeline/cli.py`
+- Test: `tests/test_proxy_tuning_pipeline.py`
+
+**Context:** `run_pipeline` is the testable core (takes an injected `Generator`, writes artifacts, returns a stats dict). `main()` is the thin argv wrapper that constructs the real `OpenAIGenerator`. The end-to-end test drives `run_pipeline` with a `_FakeGenerator` over a fixture repo — no network. Stats include `generated` vs `kept` so truncation is never silent (per spec §5c).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_proxy_tuning_pipeline.py`:
+
+```python
+from olmlx.proxy_tuning_pipeline.cli import run_pipeline
+
+
+def test_run_pipeline_end_to_end(tmp_path):
+    # Minimal fixture repo.
+    repo = tmp_path / "repo"
+    (repo / "olmlx").mkdir(parents=True)
+    (repo / "olmlx" / "m.py").write_text('def f():\n    """doc."""\n    return 1\n')
+    (repo / "CLAUDE.md").write_text(
+        "## Non-Obvious Invariants\n\n**Inv one** — a real rule about streams.\n"
+    )
+    out_dir = tmp_path / "out"
+
+    gen = _FakeGenerator(
+        '{"pairs": [{"instruction": "Explain this clearly?", '
+        '"response": "A grounded, sufficiently long answer about olmlx."}]}'
+    )
+    stats = run_pipeline(
+        repo_root=repo,
+        out_dir=out_dir,
+        generator=gen,
+        n_per_unit=1,
+        valid_frac=0.5,
+        seed=7,
+    )
+
+    # Artifacts written in mlx-lm chat format.
+    train = read_jsonl(out_dir / "train.jsonl")
+    valid = read_jsonl(out_dir / "valid.jsonl")
+    assert train and valid
+    assert set(train[0].keys()) == {"messages"}
+    roles = [m["role"] for m in train[0]["messages"]]
+    assert roles == ["user", "assistant"]
+
+    # Stats report generated-vs-kept (no silent truncation).
+    assert stats["units"] >= 2  # function + invariant
+    assert stats["generated"] >= 2
+    assert stats["kept"] == stats["train"] + stats["valid"]
+    assert stats["train"] == len(train) and stats["valid"] == len(valid)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k run_pipeline -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'olmlx.proxy_tuning_pipeline.cli'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `olmlx/proxy_tuning_pipeline/cli.py`:
+
+```python
+"""CLI + orchestration for the proxy-tuning data pipeline.
+
+Usage:
+    OPENAI_API_KEY=... uv run python -m olmlx.proxy_tuning_pipeline.cli \
+        --repo . --out data/proxy_tuning --n-per-unit 4
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Any
+
+from olmlx.proxy_tuning_pipeline.curate import (
+    dedupe_examples,
+    quality_filter,
+    split_train_valid,
+)
+from olmlx.proxy_tuning_pipeline.expand import (
+    DEFAULT_MODEL,
+    Generator,
+    OpenAIGenerator,
+    expand_units,
+)
+from olmlx.proxy_tuning_pipeline.extract import extract_repo
+from olmlx.proxy_tuning_pipeline.schema import write_jsonl
+
+logger = logging.getLogger(__name__)
+
+
+def run_pipeline(
+    repo_root: str | Path,
+    out_dir: str | Path,
+    generator: Generator,
+    n_per_unit: int,
+    valid_frac: float,
+    seed: int,
+) -> dict[str, Any]:
+    """Extract -> expand -> curate -> write. Returns a stats dict."""
+    out_dir = Path(out_dir)
+    units = extract_repo(repo_root)
+    logger.info("extracted %d units", len(units))
+
+    examples = expand_units(units, generator, n_per_unit=n_per_unit)
+    generated = len(examples)
+
+    examples = dedupe_examples(quality_filter(examples))
+    kept = len(examples)
+
+    train, valid = split_train_valid(examples, valid_frac=valid_frac, seed=seed)
+    write_jsonl(out_dir / "train.jsonl", (e.to_chat_row() for e in train))
+    write_jsonl(out_dir / "valid.jsonl", (e.to_chat_row() for e in valid))
+
+    stats = {
+        "units": len(units),
+        "generated": generated,
+        "kept": kept,
+        "dropped": generated - kept,
+        "train": len(train),
+        "valid": len(valid),
+    }
+    logger.info("pipeline stats: %s", stats)
+    return stats
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    ap = argparse.ArgumentParser(description="Build proxy-tuning SFT data from the olmlx repo.")
+    ap.add_argument("--repo", default=".", help="repo root to mine")
+    ap.add_argument("--out", default="data/proxy_tuning", help="output dir for train/valid jsonl")
+    ap.add_argument("--n-per-unit", type=int, default=4, help="pairs requested per source unit")
+    ap.add_argument("--valid-frac", type=float, default=0.08, help="validation fraction")
+    ap.add_argument("--seed", type=int, default=0, help="split shuffle seed")
+    ap.add_argument("--model", default=DEFAULT_MODEL, help="OpenAI generator model id")
+    args = ap.parse_args(argv)
+
+    stats = run_pipeline(
+        repo_root=args.repo,
+        out_dir=args.out,
+        generator=OpenAIGenerator(model=args.model),
+        n_per_unit=args.n_per_unit,
+        valid_frac=args.valid_frac,
+        seed=args.seed,
+    )
+    print(f"Done. {stats}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -k run_pipeline -v`
+Expected: 1 passed
+
+- [ ] **Step 5: Run the full pipeline test suite + ruff, then commit**
+
+Run: `uv run pytest tests/test_proxy_tuning_pipeline.py -v && uv run ruff check olmlx/proxy_tuning_pipeline/ tests/test_proxy_tuning_pipeline.py && uv run ruff format olmlx/proxy_tuning_pipeline/ tests/test_proxy_tuning_pipeline.py`
+Expected: all pass; ruff clean
+
+```bash
+git add olmlx/proxy_tuning_pipeline/cli.py tests/test_proxy_tuning_pipeline.py
+git commit -m "feat(proxy-tuning-data): CLI wiring + end-to-end pipeline"
+```
+
+---
+
+## Task 15: Real dry run on the olmlx repo (manual validation)
+
+**Files:** none (operational validation — needs an `OPENAI_API_KEY`)
+
+> This is the only step that calls the real GPT-5.4-mini. It validates the whole pipeline end-to-end on the actual repo at a tiny scale before the full ~10k run. **Cost is a few cents at this scale.**
+
+- [ ] **Step 1: Tiny real run (a handful of units)**
+
+Add a temporary `--limit-units` guard if you want, or just run with `--n-per-unit 1` and Ctrl-C after ~20 units. Simplest: run the extractor-only count first to confirm volume:
+
+Run: `uv run python -c "from olmlx.proxy_tuning_pipeline.extract import extract_repo; print(len(extract_repo('.')))"`
+Expected: a few thousand units (functions + tests dominate).
+
+- [ ] **Step 2: Small real generation pass**
+
+Run:
+```bash
+OPENAI_API_KEY=$OPENAI_API_KEY uv run python -m olmlx.proxy_tuning_pipeline.cli \
+  --repo . --out /tmp/ptdata_smoke --n-per-unit 1 --valid-frac 0.1
+```
+(Interrupt after a minute if you only want a smoke sample, or let it complete for a real partial set.)
+Expected: logs show `extracted N units` and a final `pipeline stats: {...}`; `/tmp/ptdata_smoke/train.jsonl` and `valid.jsonl` exist.
+
+- [ ] **Step 3: Eyeball the output quality**
+
+Run: `head -3 /tmp/ptdata_smoke/train.jsonl`
+Expected: valid mlx-lm chat rows; responses are **grounded in real olmlx code/conventions**, not hallucinated APIs. If responses invent non-existent olmlx APIs, tighten the grounding language in `_SYSTEM_PROMPT` (expand.py) and re-run before the full pass.
+
+- [ ] **Step 4: No commit** — validation only. If Step 3 surfaces a grounding/quality issue, fix `_SYSTEM_PROMPT` or filters with a failing test first, then re-run.
+
+---
+
+## Self-Review
+
+**Spec coverage (against `2026-06-15-...-design.md` §5):**
+- ✅ §5a mechanical extraction — all five sources: functions (Task 3), invariants (Task 4), docs (Task 5), tests (Task 6), commits (Task 7); aggregated + deduped (Task 8). Secret-stripping (Task 2). Provenance on every unit. Context clamped (`_MAX_SOURCE_CHARS` / `_MAX_USER_CHARS`).
+- ✅ §5b GPT-5.4-mini expansion — `Generator` protocol + `OpenAIGenerator` (Tasks 9, 11); grounding discipline in `_SYSTEM_PROMPT`; JSON pairs parsed (Task 9); one call per unit (Task 10). OpenAI SDK confirmed already a dep.
+- ✅ §5c curate — dedup (Task 12), quality/length filters (Task 12), train/valid split (Task 13), JSONL output in mlx-lm chat format (Task 1/14), generated-vs-kept stats logged (Task 14, no silent truncation).
+- ✅ §5 testing — extractors unit-tested on fixtures; OpenAI mocked via injected client; curation unit-tested; end-to-end with `_FakeGenerator` (Task 14); real dry run (Task 15).
+- ✅ Artifacts: `data/proxy_tuning/train.jsonl` + `valid.jsonl`, gitignored (Task 1). Target ~10k is reached by setting `--n-per-unit` against the unit count from Task 15 Step 1 (e.g. ~3–4k units × `--n-per-unit 3` → ~10k before curation).
+
+**Placeholder scan:** No TBD/TODO. `DEFAULT_MODEL = "gpt-5.4-mini"` is a concrete configurable default (overridable via `--model`), not a placeholder. Every code step shows complete code.
+
+**Type consistency:** `ExtractionUnit(kind, provenance, instruction_hint, source_context)` and `ChatExample(kind, provenance, user, assistant)` are used identically across Tasks 1–14. `Generator.generate(system, user) -> str`, `build_messages(unit, n_pairs) -> (system, user)`, `parse_pairs(text) -> list[tuple[str,str]]`, `expand_units(units, generator, n_per_unit)`, `run_pipeline(repo_root, out_dir, generator, n_per_unit, valid_frac, seed)` are consistent between definition and call sites (Task 14 `main` → `run_pipeline`; tests).

--- a/docs/superpowers/specs/2026-06-15-olmlx-proxy-tuning-pair-design.md
+++ b/docs/superpowers/specs/2026-06-15-olmlx-proxy-tuning-pair-design.md
@@ -1,0 +1,220 @@
+# olmlx-Domain Proxy-Tuning Pair — Design Spec
+
+**Status:** Draft for review
+**Date:** 2026-06-15
+**Author:** Daniel Palmqvist (with Claude)
+**Depends on:** Proxy-tuning decode mode (PR #525, merged `8204a5e`) — `engine/proxy_tuning.py`, `speculative_strategy="proxy_tuning"`.
+
+---
+
+## 1. Background & Goal
+
+olmlx now ships a **proxy-tuning** decode mode (Liu et al. 2024): a large base model `M` is steered at decode time, without touching its weights, by a small tuned **expert M⁺** and small untuned **anti-expert M⁻**, combining per token as `logits = M + α·(M⁺ − M⁻)`. The mechanism is built and merged; what it lacks is a *real* M⁺/M⁻ pair (the smoke test used a contrived, meaningless pair).
+
+**Goal:** produce a **production** M⁺/M⁻ pair whose tuning delta encodes **olmlx's own domain** — its code, conventions, the rich "why" documentation (CLAUDE.md invariants, code comments, `docs/` specs), and adjacent **MLX / inference-optimization** knowledge — so that steering a dense Qwen3 base nudges its output toward olmlx idioms and conventions.
+
+**What "production" means here:** the pair is trained on a real, curated dataset, validated against a held-out eval that *measures the steering lift* (not just "it runs"), and registered for serving on the user's live olmlx instance.
+
+### Realistic expectations (load-bearing)
+Proxy-tuning transfers **behavior, style, and conventions** well; it is **weak at injecting precise new facts** (logit arithmetic from a 1.7B cannot reliably make a 32B recall exact API names). The design therefore optimizes for **convention/idiom transfer** and treats fact transfer as a bonus, and it makes the eval an explicit **ship gate** rather than an assumption.
+
+---
+
+## 2. Goals / Non-Goals
+
+**Goals**
+- A curated ~10k-example domain SFT dataset derived from the olmlx repo.
+- A trained, fused, quantized **M⁺** plus its untouched **M⁻**, sharing the exact Qwen3 tokenizer required by the loader's `check_vocab_identity` guard.
+- An eval harness that sweeps α and A/B-tests base-vs-steered on held-out olmlx-style prompts, gating "ship."
+- Registration of the pair via the existing proxy-tuning config (env + `models.json`).
+
+**Non-Goals**
+- No new training infrastructure in olmlx — fine-tuning uses **`mlx-lm`'s** mature LoRA tooling (`mlx_lm.lora` / `mlx_lm.fuse` / `mlx_lm.convert`).
+- No changes to the proxy-tuning decode mode itself (already merged).
+- No hybrid/GDN base support — proxy-tuning is **dense-only** in v1, so the steered base must be a dense Qwen3 (8B/14B/32B), **not** Qwen3-Next / Qwen3-Coder-Next.
+- Not a general-purpose instruction-tuned model — M⁺ exists only to produce a useful **delta**, not to be served directly.
+
+---
+
+## 3. Key Decisions (with rationale)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| **Domain** | olmlx repo + conventions + adjacent MLX/inference | User's target; strong fit for proxy-tuning's convention-transfer strength. |
+| **M± size** | **Qwen3-1.7B-Base** | Best capacity/cost balance across the 8B→32B target range. Decode runs *both* M± every token (cost ≈ `M + 2·M±`); a 4B pair ≈ doubles per-token cost on an 8B base and collapses the worth-it ratio. 1.7B is cheap on 8B (+~43%), near-free on 32B (+~11%). |
+| **Steered base M** | Dense Qwen3 8B→32B | Dense-only constraint; worth-it ratio `M ≫ M±` favorable. |
+| **Data strategy** | Mechanical-extraction **backbone** + LLM **expansion** (Option C) | Extraction guarantees grounding/coverage; LLM expansion gives the instruction diversity that actually teaches conventions as behavior. |
+| **Expansion generator** | **OpenAI GPT-5.4-mini** | User's choice; cheap/fast for grounded synthetic instruction data. Uses the OpenAI SDK + `OPENAI_API_KEY`; independent of the (provider-agnostic) training/serving path. |
+| **Dataset size** | **~10k** examples, ~5–10% held out | Sweet spot for a LoRA *style/convention delta* on a 1.7B; diversity matters more than raw count past this. |
+| **Training** | LoRA (bf16) → fuse → 4-bit quantize | LoRA is light on a 1.7B; fuse produces full M⁺ weights; quantize for serving parity with the 4-bit base. |
+| **Base sourcing** | Prebuilt MLX Qwen3-1.7B base if available, else `mlx_lm.convert` from `Qwen/Qwen3-1.7B-Base` | Must be a true **base** (non-instruct) checkpoint, bf16 for training. |
+| **Ship gate** | α-sweep + A/B vs base on held-out olmlx prompts, LLM-judged + manual spot-check | Proxy-tuning's transfer is uncertain for fact-heavy content; measure the lift, don't assume it. |
+
+---
+
+## 4. Architecture Overview
+
+Three stages, built and validated in order. Each stage's output is a concrete artifact consumed by the next.
+
+```
+┌─ Stage 1: Data pipeline ──────────────────────────────────────────────┐
+│  olmlx repo                                                            │
+│   ├─ source (1.4k funcs, comments)   ┐                                 │
+│   ├─ CLAUDE.md invariants            │  1a. mechanical extraction      │
+│   ├─ docs/ specs (54 files)          ├─────────────► (source, seed)    │
+│   ├─ tests (3.8k test fns)           │      units (grounded, $0)       │
+│   └─ git log (419 commits)           ┘            │                    │
+│                                                   ▼                    │
+│                              1b. GPT-5.4-mini expansion (OpenAI SDK)   │
+│                                  grounded chunk → diverse instructions │
+│                                                   │                    │
+│                                                   ▼                    │
+│                              1c. curate (dedup, filter, split)         │
+│                                                   │                    │
+└───────────────────────────────────────────────────┼───────────────────┘
+                                                     ▼
+                                    train.jsonl  +  valid.jsonl
+                                                     │
+┌─ Stage 2: Train M⁺ ────────────────────────────────┼───────────────────┐
+│  Qwen3-1.7B-Base (bf16)  ── M⁻ (used as-is) ───────┐│                    │
+│        │                                           ││                    │
+│        └─ mlx_lm.lora (LoRA, bf16) ◄───────────────┘▼                    │
+│                 │                                                        │
+│                 └─ mlx_lm.fuse ─► M⁺ (full bf16) ─► quantize ─► M⁺ 4-bit │
+└────────────────────────────────────────────────────┬───────────────────┘
+                                                      ▼
+                              M⁺ (4-bit MLX)   +   M⁻ (Qwen3-1.7B-Base, 4-bit MLX)
+                                                      │
+┌─ Stage 3: Evaluate & serve ─────────────────────────┼──────────────────┐
+│  held-out olmlx prompts × α∈{0,0.5,1.0,1.5}                             │
+│        │                                                                │
+│        ├─ generate via proxy-tuning (olmlx, dense Qwen3 base)           │
+│        ├─ LLM-judge convention-adherence + coherence                    │
+│        └─ ship-gate decision ──► register M⁺/M⁻ in env + models.json    │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Tokenizer invariant (spans all stages):** M⁻, M⁺, and the steered base M must share one exact tokenizer (Qwen3 vocab 151936). M⁺ inherits M⁻'s tokenizer by construction (it *is* M⁻ fine-tuned). The base↔pair identity is enforced at load by `check_vocab_identity`; we additionally assert it at the end of Stage 2.
+
+---
+
+## 5. Stage 1 — Data Pipeline
+
+**Output artifacts:** `data/train.jsonl`, `data/valid.jsonl` in mlx-lm chat format:
+```json
+{"messages": [{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]}
+```
+
+### 5a. Mechanical extraction backbone (`$0`, pure Python, no LLM)
+Walk the repo into grounded `(source_context, seed)` units. Sources and the seed shape each yields:
+
+| Source | Extractor | Seed kind |
+|---|---|---|
+| Functions + docstrings (`ast`) | signature + docstring + body | "explain / implement this" + completion |
+| CLAUDE.md "Non-Obvious Invariants" | each invariant block | "explain this invariant / why it holds" |
+| `docs/` specs & plans (54 files) | section chunks | Q&A grounded in the doc |
+| Tests (3.8k `test_*`) | test fn + target under test | "what behavior does this enforce" / spec→test |
+| `git log` (419 commits) | message + diff | "implement this change" (message → diff) |
+
+Requirements: chunk to fit the generator context; **strip secrets / tokens**; record provenance (file:line) per unit for grounding and debugging; dedup near-identical units before expansion.
+
+### 5b. GPT-5.4-mini expansion (OpenAI SDK)
+For each unit, prompt GPT-5.4-mini with the **source context as grounding** to produce several diverse instruction→response pairs (vary instruction phrasing, task type — explain / implement / review / convert). Generate ~N pairs per unit to reach ~10k after curation.
+
+- **Provider:** OpenAI SDK, `OPENAI_API_KEY`. (Not the Claude SDK — this step is deliberately a different provider per the user's choice.)
+- **Cost control:** batch requests; reuse the grounding chunk across the several generations per unit; cap output length.
+- **Grounding discipline:** the generator must answer *from the provided source*, not invent olmlx APIs — system prompt instructs grounding + "say what's not in the source." This bounds hallucination (the main synthetic-data risk).
+
+### 5c. Curate
+- **Dedup:** near-duplicate filter (e.g. embedding/MinHash) — diversity matters more than count for a style delta; synthetic data repeats.
+- **Quality/length filters:** drop truncated, empty, or degenerate pairs; basic schema validation.
+- **Split:** hold out ~5–10% as `valid.jsonl` (enough to measure training loss meaningfully; the *real* eval is Stage 3).
+- **Target:** ~10k `train` examples after curation. Log how many raw pairs were generated vs kept (no silent truncation).
+
+### Testing (Stage 1)
+- Unit-test each extractor on a small fixture repo subset (deterministic, no LLM): correct seed shape, provenance, secret-stripping.
+- Mock the OpenAI client to test the expansion driver's batching, grounding-prompt assembly, and JSONL formatting without network.
+- Curation: unit-test dedup, filters, and the split ratio on synthetic inputs.
+
+---
+
+## 6. Stage 2 — Train M⁺
+
+**Output artifacts:** `models/qwen3-1.7b-olmlx-expert` (M⁺, 4-bit MLX) and the resolved path to **M⁻** (`Qwen3-1.7B-Base`, 4-bit MLX).
+
+### Steps
+1. **Source M⁻:** locate a prebuilt MLX `Qwen3-1.7B-Base`; if absent, `mlx_lm.convert` from `Qwen/Qwen3-1.7B-Base` to bf16 MLX. Must be the **base** (non-instruct) checkpoint. Keep a bf16 copy for training and a 4-bit copy for serving as M⁻.
+2. **LoRA fine-tune:** `mlx_lm.lora --train --model <Qwen3-1.7B-Base-bf16> --data data/ --fine-tune-type lora` with tuned rank / epochs (default ~2–4 epochs; tune against `valid.jsonl` loss; watch for overfitting on the small set).
+3. **Fuse:** `mlx_lm.fuse` → full bf16 M⁺ weights.
+4. **Quantize:** 4-bit MLX M⁺ for serving parity with the 4-bit base.
+5. **Assert tokenizer identity:** confirm M⁺ and M⁻ produce identical `get_vocab()` (they must — M⁺ is M⁻ fine-tuned) and that vocab size matches the intended steered base (151936). This pre-flights the loader's `check_vocab_identity`.
+
+### Testing (Stage 2)
+- This stage is mostly orchestration of `mlx-lm` CLIs; validate by **artifact checks**, not unit tests: M⁺ loads, generates coherently standalone, `get_vocab()` == M⁻'s, quantized sizes sane.
+- A tiny "smoke train" (few steps on a handful of examples) to validate the pipeline wiring before the full 10k run.
+
+---
+
+## 7. Stage 3 — Evaluate & Serve
+
+**Output:** a ship/no-ship decision + (on ship) registered config.
+
+### Eval harness
+- **Held-out prompt set:** ~50–100 olmlx-style prompts — explain-this-invariant, "implement X following olmlx conventions", convention Q&A. Authored fresh (not drawn from training data) to test generalization.
+- **α sweep:** generate base (α=0) vs steered at α∈{0.5, 1.0, 1.5} for each prompt, via the real olmlx proxy-tuning path on a dense Qwen3 base (8B for cost; spot-check 32B).
+- **Scoring:** LLM judge (GPT-5.4-mini or Claude) on a rubric — **convention-adherence** (uses olmlx idioms, respects documented invariants, matches code style) + **coherence** (no degradation). Plus a manual spot-check by the user.
+- **Ship gate:** ship if steered at best α **beats base by a clear margin on convention-adherence without losing coherence**. If no lift: the delta isn't transferring — revisit (more diversity, higher α, larger M±, or accept proxy-tuning's limits for this content) rather than shipping a null result.
+
+### Serve (on ship)
+- Register via the existing proxy-tuning config (built in PR #525): global env `OLMLX_SPECULATIVE_PROXY_EXPERT_MODEL` / `_ANTIEXPERT_MODEL` / `_ALPHA` (best α from the sweep) in the server's `.env`, and per-model `speculative: true, speculative_strategy: "proxy_tuning"` on the chosen dense Qwen3 base in `models.json`.
+- Mind the live-server constraints already learned: the running server is the `olmlx-1` checkout on :11436; deploy by updating that checkout + config (see project memory).
+
+### Testing (Stage 3)
+- Unit-test the eval harness scaffolding (prompt loading, α iteration, result aggregation, judge-call assembly) with a mocked judge + a mocked olmlx endpoint.
+- The eval *run* itself is a real-model activity (Metal + the trained pair) — its output is the gate, executed manually.
+
+---
+
+## 8. Inter-Stage Interfaces (artifacts)
+
+| Producer | Artifact | Consumer |
+|---|---|---|
+| Stage 1 | `data/train.jsonl`, `data/valid.jsonl` (mlx-lm chat format) | Stage 2 `mlx_lm.lora --data` |
+| Stage 2 | M⁺ (4-bit MLX dir), M⁻ path (Qwen3-1.7B-Base 4-bit) | Stage 3 + serving config |
+| Stage 3 | best α + ship decision | `.env` / `models.json` registration |
+
+Clean artifact boundaries mean each stage is independently runnable and testable, and a re-run of a later stage doesn't force re-running an earlier one.
+
+---
+
+## 9. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Delta doesn't transfer** (fact-heavy content) | Eval is an explicit ship gate; α sweep; design optimizes for convention transfer, treats facts as bonus. |
+| **Synthetic-data homogeneity / hallucinated olmlx APIs** | Grounding discipline in 5b; dedup/diversity curation in 5c; provenance tracking. |
+| **Delta contamination** (M⁺ drifts to generic GPT-style instruct) | 10k (not 50k) examples; few epochs; validate via the *delta's* effect (Stage 3), not M⁺'s standalone quality. |
+| **Tokenizer mismatch** base↔pair | Stage 2 asserts `get_vocab()` identity; loader `check_vocab_identity` is the runtime floor. |
+| **No prebuilt MLX 1.7B base** | `mlx_lm.convert` fallback from the HF base checkpoint. |
+| **Decode cost on 8B** | 1.7B pair chosen specifically to keep overhead ~+43% on 8B; α tunable. |
+| **Cost overrun on generation** | Batch + cache grounding chunks; cap output; 10k cap; log kept-vs-generated. |
+
+---
+
+## 10. Decomposition into Implementation Plans
+
+This spec covers three subsystems with clean artifact boundaries. Each becomes its own implementation plan (spec → plan → build), in order:
+
+1. **Plan 1 — Data pipeline** (Stage 1): extractors + GPT-5.4-mini expansion + curation → `train/valid.jsonl`. TDD-able (mock OpenAI; fixture repo).
+2. **Plan 2 — Training** (Stage 2): M⁻ sourcing + LoRA + fuse + quantize + tokenizer assert. Orchestration + artifact checks; smoke-train first.
+3. **Plan 3 — Eval & serve** (Stage 3): eval harness + α sweep + judge + ship gate + registration.
+
+Build order is strict — each is blocked on the prior stage's artifact. We start with Plan 1.
+
+---
+
+## 11. Open Questions / Future
+
+- Whether to later train a **second pair at 4B** for a 32B-exclusive deployment (better delta, ~25% overhead on 32B) — deferred; revisit if 32B becomes the dominant target.
+- Whether to add per-model `models.json` overrides for the proxy fields (currently global-only in olmlx v1) — independent olmlx feature, out of scope here.
+- Whether "grammar-after-combination" (vs the current grammar-disables-proxy-tuning) is worth building for constrained olmlx-convention output — out of scope here.

--- a/olmlx/proxy_tuning_pipeline/__init__.py
+++ b/olmlx/proxy_tuning_pipeline/__init__.py
@@ -1,0 +1,6 @@
+"""Offline data/training tooling for proxy-tuning (Stage 1: data pipeline).
+
+NOT imported by the running olmlx server — this package builds the SFT dataset
+used to train the proxy-tuning expert M+. See
+docs/superpowers/specs/2026-06-15-olmlx-proxy-tuning-pair-design.md.
+"""

--- a/olmlx/proxy_tuning_pipeline/cli.py
+++ b/olmlx/proxy_tuning_pipeline/cli.py
@@ -45,7 +45,11 @@ def run_pipeline(
     examples = expand_units(units, generator, n_per_unit=n_per_unit)
     generated = len(examples)
 
-    examples = dedupe_examples(quality_filter(examples))
+    # Track the two drop sources separately: a large quality-drop points at the
+    # generator producing short/long junk; a large dedup-drop points at the
+    # generator being repetitive. They need different fixes (filters vs prompt).
+    filtered = quality_filter(examples)
+    examples = dedupe_examples(filtered)
     kept = len(examples)
 
     train, valid = split_train_valid(examples, valid_frac=valid_frac, seed=seed)
@@ -55,12 +59,20 @@ def run_pipeline(
     stats = {
         "units": len(units),
         "generated": generated,
+        "quality_dropped": generated - len(filtered),
+        "dedup_dropped": len(filtered) - kept,
         "kept": kept,
         "dropped": generated - kept,
         "train": len(train),
         "valid": len(valid),
     }
     logger.info("pipeline stats: %s", stats)
+    if units and not kept:
+        # Generator produced output but every pair was filtered/deduped away —
+        # an empty dataset only otherwise noticed at training time.
+        logger.error(
+            "run_pipeline: 0 examples survived curation (generated=%d)", generated
+        )
     return stats
 
 

--- a/olmlx/proxy_tuning_pipeline/cli.py
+++ b/olmlx/proxy_tuning_pipeline/cli.py
@@ -8,6 +8,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -31,6 +32,39 @@ from olmlx.proxy_tuning_pipeline.schema import write_jsonl
 logger = logging.getLogger(__name__)
 
 
+def _guard_checkpoint_config(
+    out_dir: Path, raw_path: Path, repo_root: str | Path, n_per_unit: int
+) -> None:
+    """Refuse to mix a checkpoint built for a different repo/config into a run.
+
+    Resuming ``raw.jsonl`` only makes sense for the same repo + ``n_per_unit``;
+    reusing an ``--out`` across a different repo or config would silently pollute
+    the dataset (aider review). Records the config in a ``raw.meta.json`` sidecar
+    and refuses on mismatch. Backward-compatible: a pre-existing ``raw.jsonl``
+    with no sidecar (e.g. from an in-flight run started by older code) is adopted
+    with a warning so it can still be resumed.
+    """
+    meta_path = out_dir / "raw.meta.json"
+    current = {"repo_root": str(Path(repo_root).resolve()), "n_per_unit": n_per_unit}
+    if raw_path.exists() and meta_path.exists():
+        prev = json.loads(meta_path.read_text())
+        if prev != current:
+            raise ValueError(
+                f"{raw_path} was built for a different config ({prev}) than this "
+                f"run ({current}). Use a fresh --out, or delete {raw_path} and "
+                f"{meta_path} to start over."
+            )
+    elif raw_path.exists():
+        logger.warning(
+            "%s has no recorded config; assuming it matches this run (%s). "
+            "Delete it if this is a different repo/config.",
+            raw_path,
+            current,
+        )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    meta_path.write_text(json.dumps(current))
+
+
 def run_pipeline(
     repo_root: str | Path,
     out_dir: str | Path,
@@ -52,6 +86,8 @@ def run_pipeline(
     """
     out_dir = Path(out_dir)
     raw_path = out_dir / "raw.jsonl"
+    _guard_checkpoint_config(out_dir, raw_path, repo_root, n_per_unit)
+
     units = extract_repo(repo_root)
     logger.info("extracted %d units", len(units))
     if limit_units is not None:

--- a/olmlx/proxy_tuning_pipeline/cli.py
+++ b/olmlx/proxy_tuning_pipeline/cli.py
@@ -36,11 +36,22 @@ def run_pipeline(
     n_per_unit: int,
     valid_frac: float,
     seed: int,
+    limit_units: int | None = None,
 ) -> dict[str, Any]:
-    """Extract -> expand -> curate -> write. Returns a stats dict."""
+    """Extract -> expand -> curate -> write. Returns a stats dict.
+
+    ``limit_units`` caps how many extracted units are expanded (the expensive
+    per-unit generator calls). Use it for a cheap, *complete* smoke run that
+    actually writes output — the full repo extracts thousands of units, and
+    output is only written after expansion finishes, so an unbounded run that is
+    interrupted produces nothing.
+    """
     out_dir = Path(out_dir)
     units = extract_repo(repo_root)
     logger.info("extracted %d units", len(units))
+    if limit_units is not None:
+        units = units[:limit_units]
+        logger.info("limiting to %d units for this run", len(units))
 
     examples = expand_units(units, generator, n_per_unit=n_per_unit)
     generated = len(examples)
@@ -95,6 +106,12 @@ def main(argv: list[str] | None = None) -> None:
     )
     ap.add_argument("--seed", type=int, default=0, help="split shuffle seed")
     ap.add_argument("--model", default=DEFAULT_MODEL, help="OpenAI generator model id")
+    ap.add_argument(
+        "--limit-units",
+        type=int,
+        default=None,
+        help="cap units expanded (cheap smoke run; omit to process the whole repo)",
+    )
     args = ap.parse_args(argv)
 
     stats = run_pipeline(
@@ -104,6 +121,7 @@ def main(argv: list[str] | None = None) -> None:
         n_per_unit=args.n_per_unit,
         valid_frac=args.valid_frac,
         seed=args.seed,
+        limit_units=args.limit_units,
     )
     print(f"Done. {stats}")
 

--- a/olmlx/proxy_tuning_pipeline/cli.py
+++ b/olmlx/proxy_tuning_pipeline/cli.py
@@ -1,0 +1,100 @@
+"""CLI + orchestration for the proxy-tuning data pipeline.
+
+Usage:
+    OPENAI_API_KEY=... uv run python -m olmlx.proxy_tuning_pipeline.cli \
+        --repo . --out data/proxy_tuning --n-per-unit 4
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Any
+
+from olmlx.proxy_tuning_pipeline.curate import (
+    dedupe_examples,
+    quality_filter,
+    split_train_valid,
+)
+from olmlx.proxy_tuning_pipeline.expand import (
+    DEFAULT_MODEL,
+    Generator,
+    OpenAIGenerator,
+    expand_units,
+)
+from olmlx.proxy_tuning_pipeline.extract import extract_repo
+from olmlx.proxy_tuning_pipeline.schema import write_jsonl
+
+logger = logging.getLogger(__name__)
+
+
+def run_pipeline(
+    repo_root: str | Path,
+    out_dir: str | Path,
+    generator: Generator,
+    n_per_unit: int,
+    valid_frac: float,
+    seed: int,
+) -> dict[str, Any]:
+    """Extract -> expand -> curate -> write. Returns a stats dict."""
+    out_dir = Path(out_dir)
+    units = extract_repo(repo_root)
+    logger.info("extracted %d units", len(units))
+
+    examples = expand_units(units, generator, n_per_unit=n_per_unit)
+    generated = len(examples)
+
+    examples = dedupe_examples(quality_filter(examples))
+    kept = len(examples)
+
+    train, valid = split_train_valid(examples, valid_frac=valid_frac, seed=seed)
+    write_jsonl(out_dir / "train.jsonl", (e.to_chat_row() for e in train))
+    write_jsonl(out_dir / "valid.jsonl", (e.to_chat_row() for e in valid))
+
+    stats = {
+        "units": len(units),
+        "generated": generated,
+        "kept": kept,
+        "dropped": generated - kept,
+        "train": len(train),
+        "valid": len(valid),
+    }
+    logger.info("pipeline stats: %s", stats)
+    return stats
+
+
+def main(argv: list[str] | None = None) -> None:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    ap = argparse.ArgumentParser(
+        description="Build proxy-tuning SFT data from the olmlx repo."
+    )
+    ap.add_argument("--repo", default=".", help="repo root to mine")
+    ap.add_argument(
+        "--out", default="data/proxy_tuning", help="output dir for train/valid jsonl"
+    )
+    ap.add_argument(
+        "--n-per-unit", type=int, default=4, help="pairs requested per source unit"
+    )
+    ap.add_argument(
+        "--valid-frac", type=float, default=0.08, help="validation fraction"
+    )
+    ap.add_argument("--seed", type=int, default=0, help="split shuffle seed")
+    ap.add_argument("--model", default=DEFAULT_MODEL, help="OpenAI generator model id")
+    args = ap.parse_args(argv)
+
+    stats = run_pipeline(
+        repo_root=args.repo,
+        out_dir=args.out,
+        generator=OpenAIGenerator(model=args.model),
+        n_per_unit=args.n_per_unit,
+        valid_frac=args.valid_frac,
+        seed=args.seed,
+    )
+    print(f"Done. {stats}")
+
+
+if __name__ == "__main__":
+    main()

--- a/olmlx/proxy_tuning_pipeline/cli.py
+++ b/olmlx/proxy_tuning_pipeline/cli.py
@@ -21,7 +21,9 @@ from olmlx.proxy_tuning_pipeline.expand import (
     DEFAULT_MODEL,
     Generator,
     OpenAIGenerator,
-    expand_units,
+    expand_units_checkpointed,
+    load_done_provenances,
+    load_examples,
 )
 from olmlx.proxy_tuning_pipeline.extract import extract_repo
 from olmlx.proxy_tuning_pipeline.schema import write_jsonl
@@ -37,23 +39,38 @@ def run_pipeline(
     valid_frac: float,
     seed: int,
     limit_units: int | None = None,
+    concurrency: int = 8,
 ) -> dict[str, Any]:
-    """Extract -> expand -> curate -> write. Returns a stats dict.
+    """Extract -> expand (checkpointed) -> curate -> write. Returns a stats dict.
 
-    ``limit_units`` caps how many extracted units are expanded (the expensive
-    per-unit generator calls). Use it for a cheap, *complete* smoke run that
-    actually writes output — the full repo extracts thousands of units, and
-    output is only written after expansion finishes, so an unbounded run that is
-    interrupted produces nothing.
+    Generation is crash-safe and resumable: each unit's pairs are appended to
+    ``<out_dir>/raw.jsonl`` as they complete, so an interrupted run loses nothing
+    durable and re-running skips units already present. ``limit_units`` caps how
+    many units are expanded (cheap smoke run); ``concurrency`` is the generator
+    thread-pool size. Curation reads ``raw.jsonl`` back, so it works even on a
+    partially-generated checkpoint.
     """
     out_dir = Path(out_dir)
+    raw_path = out_dir / "raw.jsonl"
     units = extract_repo(repo_root)
     logger.info("extracted %d units", len(units))
     if limit_units is not None:
         units = units[:limit_units]
         logger.info("limiting to %d units for this run", len(units))
 
-    examples = expand_units(units, generator, n_per_unit=n_per_unit)
+    done = load_done_provenances(raw_path)
+    if done:
+        logger.info("resume: %d units already in %s — skipping", len(done), raw_path)
+    expand_units_checkpointed(
+        units,
+        generator,
+        n_per_unit=n_per_unit,
+        raw_path=raw_path,
+        concurrency=concurrency,
+        done=done,
+    )
+
+    examples = load_examples(raw_path)
     generated = len(examples)
 
     # Track the two drop sources separately: a large quality-drop points at the
@@ -61,6 +78,9 @@ def run_pipeline(
     # generator being repetitive. They need different fixes (filters vs prompt).
     filtered = quality_filter(examples)
     examples = dedupe_examples(filtered)
+    # Deterministic order regardless of concurrent generation order, so the
+    # seeded train/valid split is reproducible across runs.
+    examples.sort(key=lambda e: (e.provenance, e.user))
     kept = len(examples)
 
     train, valid = split_train_valid(examples, valid_frac=valid_frac, seed=seed)
@@ -112,6 +132,12 @@ def main(argv: list[str] | None = None) -> None:
         default=None,
         help="cap units expanded (cheap smoke run; omit to process the whole repo)",
     )
+    ap.add_argument(
+        "--concurrency",
+        type=int,
+        default=8,
+        help="generator thread-pool size (parallel API calls)",
+    )
     args = ap.parse_args(argv)
 
     stats = run_pipeline(
@@ -122,6 +148,7 @@ def main(argv: list[str] | None = None) -> None:
         valid_frac=args.valid_frac,
         seed=args.seed,
         limit_units=args.limit_units,
+        concurrency=args.concurrency,
     )
     print(f"Done. {stats}")
 

--- a/olmlx/proxy_tuning_pipeline/cli.py
+++ b/olmlx/proxy_tuning_pipeline/cli.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from olmlx.proxy_tuning_pipeline.curate import (
+    cap_kind_fraction,
     dedupe_examples,
     quality_filter,
     split_train_valid,
@@ -30,6 +31,22 @@ from olmlx.proxy_tuning_pipeline.extract import extract_repo
 from olmlx.proxy_tuning_pipeline.schema import write_jsonl
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_cap_kind(value: str) -> tuple[str, float]:
+    """Parse a ``KIND=FRACTION`` CLI value into ``(kind, fraction)``."""
+    try:
+        kind, frac = value.split("=", 1)
+        f = float(frac)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"--cap-kind expects KIND=FRACTION (e.g. test=0.35), got {value!r}"
+        ) from None
+    if not (0.0 < f < 1.0):
+        raise argparse.ArgumentTypeError(
+            f"--cap-kind fraction must be in (0, 1), got {f}"
+        )
+    return kind, f
 
 
 def _guard_checkpoint_config(
@@ -74,6 +91,8 @@ def run_pipeline(
     seed: int,
     limit_units: int | None = None,
     concurrency: int = 8,
+    cap_kind: tuple[str, float] | None = None,
+    curate_only: bool = False,
 ) -> dict[str, Any]:
     """Extract -> expand (checkpointed) -> curate -> write. Returns a stats dict.
 
@@ -81,30 +100,43 @@ def run_pipeline(
     ``<out_dir>/raw.jsonl`` as they complete, so an interrupted run loses nothing
     durable and re-running skips units already present. ``limit_units`` caps how
     many units are expanded (cheap smoke run); ``concurrency`` is the generator
-    thread-pool size. Curation reads ``raw.jsonl`` back, so it works even on a
-    partially-generated checkpoint.
+    thread-pool size. ``cap_kind=(kind, fraction)`` downsamples an
+    over-represented kind to at most ``fraction`` of the curated set.
+
+    ``curate_only=True`` skips extraction and generation entirely and just
+    re-curates the existing ``raw.jsonl`` into train/valid — for cheaply trying a
+    different ``cap_kind``/``seed`` without touching (or re-extracting) the repo.
     """
     out_dir = Path(out_dir)
     raw_path = out_dir / "raw.jsonl"
-    _guard_checkpoint_config(out_dir, raw_path, repo_root, n_per_unit)
 
-    units = extract_repo(repo_root)
-    logger.info("extracted %d units", len(units))
-    if limit_units is not None:
-        units = units[:limit_units]
-        logger.info("limiting to %d units for this run", len(units))
-
-    done = load_done_provenances(raw_path)
-    if done:
-        logger.info("resume: %d units already in %s — skipping", len(done), raw_path)
-    expand_units_checkpointed(
-        units,
-        generator,
-        n_per_unit=n_per_unit,
-        raw_path=raw_path,
-        concurrency=concurrency,
-        done=done,
-    )
+    if curate_only:
+        if not raw_path.exists():
+            raise FileNotFoundError(
+                f"--curate-only needs an existing checkpoint at {raw_path}"
+            )
+        n_units = len(load_done_provenances(raw_path))
+    else:
+        _guard_checkpoint_config(out_dir, raw_path, repo_root, n_per_unit)
+        units = extract_repo(repo_root)
+        logger.info("extracted %d units", len(units))
+        if limit_units is not None:
+            units = units[:limit_units]
+            logger.info("limiting to %d units for this run", len(units))
+        done = load_done_provenances(raw_path)
+        if done:
+            logger.info(
+                "resume: %d units already in %s — skipping", len(done), raw_path
+            )
+        expand_units_checkpointed(
+            units,
+            generator,
+            n_per_unit=n_per_unit,
+            raw_path=raw_path,
+            concurrency=concurrency,
+            done=done,
+        )
+        n_units = len(units)
 
     examples = load_examples(raw_path)
     generated = len(examples)
@@ -113,7 +145,18 @@ def run_pipeline(
     # generator producing short/long junk; a large dedup-drop points at the
     # generator being repetitive. They need different fixes (filters vs prompt).
     filtered = quality_filter(examples)
-    examples = dedupe_examples(filtered)
+    deduped = dedupe_examples(filtered)
+    if cap_kind is not None:
+        examples = cap_kind_fraction(deduped, cap_kind[0], cap_kind[1], seed=seed)
+        logger.info(
+            "capped kind %r to <=%.0f%%: %d -> %d",
+            cap_kind[0],
+            cap_kind[1] * 100,
+            len(deduped),
+            len(examples),
+        )
+    else:
+        examples = deduped
     # Deterministic order regardless of concurrent generation order, so the
     # seeded train/valid split is reproducible across runs.
     examples.sort(key=lambda e: (e.provenance, e.user))
@@ -124,17 +167,18 @@ def run_pipeline(
     write_jsonl(out_dir / "valid.jsonl", (e.to_chat_row() for e in valid))
 
     stats = {
-        "units": len(units),
+        "units": n_units,
         "generated": generated,
         "quality_dropped": generated - len(filtered),
-        "dedup_dropped": len(filtered) - kept,
+        "dedup_dropped": len(filtered) - len(deduped),
+        "cap_dropped": len(deduped) - kept,
         "kept": kept,
         "dropped": generated - kept,
         "train": len(train),
         "valid": len(valid),
     }
     logger.info("pipeline stats: %s", stats)
-    if units and not kept:
+    if n_units and not kept:
         # Generator produced output but every pair was filtered/deduped away —
         # an empty dataset only otherwise noticed at training time.
         logger.error(
@@ -174,6 +218,19 @@ def main(argv: list[str] | None = None) -> None:
         default=8,
         help="generator thread-pool size (parallel API calls)",
     )
+    ap.add_argument(
+        "--cap-kind",
+        type=_parse_cap_kind,
+        default=None,
+        metavar="KIND=FRACTION",
+        help="downsample an over-represented kind, e.g. test=0.35",
+    )
+    ap.add_argument(
+        "--curate-only",
+        action="store_true",
+        help="skip extraction/generation; re-curate the existing raw.jsonl "
+        "(use to retry a different --cap-kind/--seed cheaply)",
+    )
     args = ap.parse_args(argv)
 
     stats = run_pipeline(
@@ -185,6 +242,8 @@ def main(argv: list[str] | None = None) -> None:
         seed=args.seed,
         limit_units=args.limit_units,
         concurrency=args.concurrency,
+        cap_kind=args.cap_kind,
+        curate_only=args.curate_only,
     )
     print(f"Done. {stats}")
 

--- a/olmlx/proxy_tuning_pipeline/curate.py
+++ b/olmlx/proxy_tuning_pipeline/curate.py
@@ -49,8 +49,9 @@ def split_train_valid(
 ) -> tuple[list[ChatExample], list[ChatExample]]:
     """Shuffle deterministically and split off a validation fraction.
 
-    Guarantees at least one validation example when the input is non-empty so
-    ``mlx_lm.lora`` always has a ``valid.jsonl`` to evaluate against.
+    Guarantees at least one validation example whenever the input is non-empty
+    (regardless of ``valid_frac``, including ``0.0``) so ``mlx_lm.lora`` always
+    has a ``valid.jsonl`` to evaluate against.
     """
     shuffled = list(examples)
     random.Random(seed).shuffle(shuffled)

--- a/olmlx/proxy_tuning_pipeline/curate.py
+++ b/olmlx/proxy_tuning_pipeline/curate.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import math
 import random
 
 from olmlx.proxy_tuning_pipeline.schema import ChatExample
+
+logger = logging.getLogger(__name__)
 
 _MIN_USER_CHARS = 8
 _MIN_ASSISTANT_CHARS = 12
@@ -28,6 +31,17 @@ def cap_kind_fraction(
         return list(examples)
     others = [e for e in examples if e.kind != kind]
     targeted = [e for e in examples if e.kind == kind]
+    if not others:
+        # Nothing of another kind to dilute with — the cap is unsatisfiable
+        # without dropping everything. Preserve the data rather than return [].
+        logger.warning(
+            "cap_kind_fraction: dataset is entirely kind %r; cannot cap to %.0f%% "
+            "without emptying it — keeping all %d examples.",
+            kind,
+            max_fraction * 100,
+            len(targeted),
+        )
+        return list(examples)
     # targeted / (targeted + others) <= max_fraction  ->  targeted <= f/(1-f)*others
     cap = math.floor(max_fraction / (1.0 - max_fraction) * len(others))
     if len(targeted) <= cap:

--- a/olmlx/proxy_tuning_pipeline/curate.py
+++ b/olmlx/proxy_tuning_pipeline/curate.py
@@ -78,6 +78,8 @@ def split_train_valid(
     (regardless of ``valid_frac``, including ``0.0``) so ``mlx_lm.lora`` always
     has a ``valid.jsonl`` to evaluate against.
     """
+    if not (0.0 <= valid_frac < 1.0):
+        raise ValueError(f"valid_frac must be in [0, 1), got {valid_frac}")
     shuffled = list(examples)
     random.Random(seed).shuffle(shuffled)
     n_valid = max(1, round(len(shuffled) * valid_frac)) if shuffled else 0

--- a/olmlx/proxy_tuning_pipeline/curate.py
+++ b/olmlx/proxy_tuning_pipeline/curate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import random
 
 from olmlx.proxy_tuning_pipeline.schema import ChatExample
@@ -9,6 +10,30 @@ from olmlx.proxy_tuning_pipeline.schema import ChatExample
 _MIN_USER_CHARS = 8
 _MIN_ASSISTANT_CHARS = 12
 _MAX_ASSISTANT_CHARS = 20_000
+
+
+def cap_kind_fraction(
+    examples: list[ChatExample],
+    kind: str,
+    max_fraction: float,
+    seed: int,
+) -> list[ChatExample]:
+    """Deterministically downsample one over-represented ``kind``.
+
+    Keeps every example of the other kinds; randomly samples ``kind`` down so it
+    is at most ``max_fraction`` of the returned set. No-op when ``kind`` is
+    already under the cap or ``max_fraction`` is not in (0, 1).
+    """
+    if not (0.0 < max_fraction < 1.0):
+        return list(examples)
+    others = [e for e in examples if e.kind != kind]
+    targeted = [e for e in examples if e.kind == kind]
+    # targeted / (targeted + others) <= max_fraction  ->  targeted <= f/(1-f)*others
+    cap = math.floor(max_fraction / (1.0 - max_fraction) * len(others))
+    if len(targeted) <= cap:
+        return list(examples)
+    kept = random.Random(seed).sample(targeted, cap)
+    return others + kept
 
 
 def quality_filter(examples: list[ChatExample]) -> list[ChatExample]:

--- a/olmlx/proxy_tuning_pipeline/curate.py
+++ b/olmlx/proxy_tuning_pipeline/curate.py
@@ -1,0 +1,60 @@
+"""Curation: quality filtering, dedup, and train/valid split."""
+
+from __future__ import annotations
+
+import random
+
+from olmlx.proxy_tuning_pipeline.schema import ChatExample
+
+_MIN_USER_CHARS = 8
+_MIN_ASSISTANT_CHARS = 12
+_MAX_ASSISTANT_CHARS = 20_000
+
+
+def quality_filter(examples: list[ChatExample]) -> list[ChatExample]:
+    """Drop pairs that are too short to teach or implausibly long (likely junk)."""
+    out: list[ChatExample] = []
+    for e in examples:
+        if len(e.user.strip()) < _MIN_USER_CHARS:
+            continue
+        if not (
+            _MIN_ASSISTANT_CHARS <= len(e.assistant.strip()) <= _MAX_ASSISTANT_CHARS
+        ):
+            continue
+        out.append(e)
+    return out
+
+
+def _norm(text: str) -> str:
+    return " ".join(text.split()).lower()
+
+
+def dedupe_examples(examples: list[ChatExample]) -> list[ChatExample]:
+    """Drop normalized-duplicate (user, assistant) pairs; order-preserving."""
+    seen: set[tuple[str, str]] = set()
+    out: list[ChatExample] = []
+    for e in examples:
+        key = (_norm(e.user), _norm(e.assistant))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(e)
+    return out
+
+
+def split_train_valid(
+    examples: list[ChatExample],
+    valid_frac: float,
+    seed: int,
+) -> tuple[list[ChatExample], list[ChatExample]]:
+    """Shuffle deterministically and split off a validation fraction.
+
+    Guarantees at least one validation example when the input is non-empty so
+    ``mlx_lm.lora`` always has a ``valid.jsonl`` to evaluate against.
+    """
+    shuffled = list(examples)
+    random.Random(seed).shuffle(shuffled)
+    n_valid = max(1, round(len(shuffled) * valid_frac)) if shuffled else 0
+    valid = shuffled[:n_valid]
+    train = shuffled[n_valid:]
+    return train, valid

--- a/olmlx/proxy_tuning_pipeline/expand.py
+++ b/olmlx/proxy_tuning_pipeline/expand.py
@@ -42,19 +42,43 @@ def build_messages(unit: ExtractionUnit, n_pairs: int) -> tuple[str, str]:
     return _SYSTEM_PROMPT, user
 
 
+def _extract_json_object(text: str) -> str | None:
+    """Return the first balanced ``{...}`` span, or None.
+
+    A greedy ``\\{.*\\}`` regex over-grabs when the model wraps the JSON in
+    prose or emits a second object — it would span to the *last* ``}`` and
+    fail to parse, silently dropping good data. Walk braces instead so prose
+    and nested braces in values are handled correctly.
+    """
+    start = text.find("{")
+    if start == -1:
+        return None
+    depth = 0
+    for i in range(start, len(text)):
+        ch = text[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
+
+
 def parse_pairs(text: str) -> list[tuple[str, str]]:
     """Parse a generator reply into (instruction, response) pairs; tolerant.
 
-    Strips ```json fences, ignores anything around the JSON object, and drops
-    pairs missing a non-empty instruction or response.
+    Strips ```json fences, extracts the first balanced JSON object (ignoring
+    surrounding prose), and drops pairs missing a non-empty instruction or
+    response.
     """
     text = text.strip()
     text = re.sub(r"^```(?:json)?\s*|\s*```$", "", text, flags=re.MULTILINE).strip()
-    m = re.search(r"\{.*\}", text, flags=re.DOTALL)
-    if not m:
+    obj = _extract_json_object(text)
+    if obj is None:
         return []
     try:
-        data = json.loads(m.group(0))
+        data = json.loads(obj)
     except json.JSONDecodeError:
         return []
     out: list[tuple[str, str]] = []
@@ -78,11 +102,13 @@ def expand_units(
 ) -> list[ChatExample]:
     """Expand each unit into ChatExamples via the generator (one call per unit)."""
     examples: list[ChatExample] = []
+    failures = 0
     for i, unit in enumerate(units):
         system, user = build_messages(unit, n_per_unit)
         try:
             reply = generator.generate(system, user)
         except Exception:  # noqa: BLE001 — one bad unit must not abort the run
+            failures += 1
             logger.warning("generation failed for %s", unit.provenance, exc_info=True)
             continue
         for instr, resp in parse_pairs(reply):
@@ -101,6 +127,15 @@ def expand_units(
                 len(units),
                 len(examples),
             )
+    # Surface systemic failure: a run where every call failed (bad key, bad
+    # model, exhausted quota) would otherwise silently produce an empty dataset
+    # only noticed at training time.
+    if failures:
+        logger.warning(
+            "expand_units: %d/%d units failed generation", failures, len(units)
+        )
+    if units and not examples:
+        logger.error("expand_units: produced 0 examples from %d units", len(units))
     return examples
 
 
@@ -126,6 +161,8 @@ class OpenAIGenerator:
         return self._client
 
     def generate(self, system: str, user: str) -> str:
+        # TODO: add retry/backoff on 429 / transient 5xx before the full run —
+        # a single rate-limit error currently drops one unit's pairs.
         resp = self._ensure_client().chat.completions.create(
             model=self._model,
             messages=[

--- a/olmlx/proxy_tuning_pipeline/expand.py
+++ b/olmlx/proxy_tuning_pipeline/expand.py
@@ -53,17 +53,30 @@ def _extract_json_object(text: str) -> str | None:
     """Return the first balanced ``{...}`` span, or None.
 
     A greedy ``\\{.*\\}`` regex over-grabs when the model wraps the JSON in
-    prose or emits a second object — it would span to the *last* ``}`` and
-    fail to parse, silently dropping good data. Walk braces instead so prose
-    and nested braces in values are handled correctly.
+    prose or emits a second object. Walk braces instead — and track JSON
+    string/escape state so a literal ``{`` or ``}`` *inside a quoted value*
+    (very common here: the responses contain olmlx code snippets) doesn't
+    miscount the depth and drop otherwise-valid data.
     """
     start = text.find("{")
     if start == -1:
         return None
     depth = 0
+    in_str = False
+    escaped = False
     for i in range(start, len(text)):
         ch = text[i]
-        if ch == "{":
+        if in_str:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == "{":
             depth += 1
         elif ch == "}":
             depth -= 1

--- a/olmlx/proxy_tuning_pipeline/expand.py
+++ b/olmlx/proxy_tuning_pipeline/expand.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import threading
 from typing import Any, Protocol
 
 import concurrent.futures
@@ -253,14 +254,19 @@ class OpenAIGenerator:
         self._client = client
         self._model = model
         self._max_retries = max_retries
+        self._client_lock = threading.Lock()
 
     def _ensure_client(self) -> Any:
+        # Double-checked lock: under concurrency the first batch of worker
+        # threads would otherwise each construct a client.
         if self._client is None:
-            from openai import OpenAI
+            with self._client_lock:
+                if self._client is None:
+                    from openai import OpenAI
 
-            # The SDK auto-retries 429 / transient 5xx with exponential backoff;
-            # raise the cap above the default 2 for a multi-hour batch run.
-            self._client = OpenAI(max_retries=self._max_retries)
+                    # The SDK auto-retries 429 / transient 5xx with exponential
+                    # backoff; raise the cap above the default 2 for a long run.
+                    self._client = OpenAI(max_retries=self._max_retries)
         return self._client
 
     def generate(self, system: str, user: str) -> str:

--- a/olmlx/proxy_tuning_pipeline/expand.py
+++ b/olmlx/proxy_tuning_pipeline/expand.py
@@ -1,0 +1,133 @@
+"""Expansion of extracted units into instruction->response pairs via a Generator."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Protocol
+
+from olmlx.proxy_tuning_pipeline.schema import ChatExample, ExtractionUnit
+
+# Clamp the grounding so a long unit can't blow the generator's context budget.
+_MAX_USER_CHARS = 12000
+
+_SYSTEM_PROMPT = (
+    "You are generating supervised fine-tuning data about the olmlx codebase "
+    "(an Ollama-compatible MLX inference server) and adjacent MLX / inference "
+    "optimization topics. You MUST ground every answer strictly in the SOURCE "
+    "provided by the user — do not invent APIs, file names, or behavior that "
+    "is not in the SOURCE; if the SOURCE does not support a detail, omit it. "
+    "Produce diverse, natural instruction/response pairs that teach olmlx's "
+    "conventions and idioms. Reply with ONLY a JSON object of the form "
+    '{"pairs": [{"instruction": "...", "response": "..."}]} and nothing else.'
+)
+
+
+class Generator(Protocol):
+    """Anything that maps (system, user) prompts to a single text completion."""
+
+    def generate(self, system: str, user: str) -> str: ...
+
+
+def build_messages(unit: ExtractionUnit, n_pairs: int) -> tuple[str, str]:
+    """Build (system, user) prompts asking for `n_pairs` grounded pairs."""
+    source = unit.source_context[:_MAX_USER_CHARS]
+    user = (
+        f"Generate {n_pairs} diverse instruction/response pairs that teach "
+        f"{unit.instruction_hint}. Vary the task type (explain / implement / "
+        f"review / convert) and phrasing. Ground every answer in this SOURCE "
+        f"(provenance: {unit.provenance}):\n\n--- SOURCE ---\n{source}\n--- END SOURCE ---"
+    )
+    return _SYSTEM_PROMPT, user
+
+
+def parse_pairs(text: str) -> list[tuple[str, str]]:
+    """Parse a generator reply into (instruction, response) pairs; tolerant.
+
+    Strips ```json fences, ignores anything around the JSON object, and drops
+    pairs missing a non-empty instruction or response.
+    """
+    text = text.strip()
+    text = re.sub(r"^```(?:json)?\s*|\s*```$", "", text, flags=re.MULTILINE).strip()
+    m = re.search(r"\{.*\}", text, flags=re.DOTALL)
+    if not m:
+        return []
+    try:
+        data = json.loads(m.group(0))
+    except json.JSONDecodeError:
+        return []
+    out: list[tuple[str, str]] = []
+    for item in data.get("pairs", []):
+        if not isinstance(item, dict):
+            continue
+        instr = str(item.get("instruction", "")).strip()
+        resp = str(item.get("response", "")).strip()
+        if instr and resp:
+            out.append((instr, resp))
+    return out
+
+
+logger = logging.getLogger(__name__)
+
+
+def expand_units(
+    units: list[ExtractionUnit],
+    generator: Generator,
+    n_per_unit: int,
+) -> list[ChatExample]:
+    """Expand each unit into ChatExamples via the generator (one call per unit)."""
+    examples: list[ChatExample] = []
+    for i, unit in enumerate(units):
+        system, user = build_messages(unit, n_per_unit)
+        try:
+            reply = generator.generate(system, user)
+        except Exception:  # noqa: BLE001 — one bad unit must not abort the run
+            logger.warning("generation failed for %s", unit.provenance, exc_info=True)
+            continue
+        for instr, resp in parse_pairs(reply):
+            examples.append(
+                ChatExample(
+                    kind=unit.kind,
+                    provenance=unit.provenance,
+                    user=instr,
+                    assistant=resp,
+                )
+            )
+        if (i + 1) % 100 == 0:
+            logger.info(
+                "expanded %d/%d units, %d pairs so far", i + 1, len(units), len(examples)
+            )
+    return examples
+
+
+DEFAULT_MODEL = "gpt-5.4-mini"
+
+
+class OpenAIGenerator:
+    """`Generator` backed by OpenAI chat completions (GPT-5.4-mini by default).
+
+    `client` is injectable for testing; when None it is lazily constructed via
+    ``openai.OpenAI()`` (reads ``OPENAI_API_KEY`` from the environment).
+    """
+
+    def __init__(self, client: Any = None, model: str = DEFAULT_MODEL):
+        self._client = client
+        self._model = model
+
+    def _ensure_client(self) -> Any:
+        if self._client is None:
+            from openai import OpenAI
+
+            self._client = OpenAI()
+        return self._client
+
+    def generate(self, system: str, user: str) -> str:
+        resp = self._ensure_client().chat.completions.create(
+            model=self._model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+        )
+        return resp.choices[0].message.content or ""

--- a/olmlx/proxy_tuning_pipeline/expand.py
+++ b/olmlx/proxy_tuning_pipeline/expand.py
@@ -7,7 +7,14 @@ import logging
 import re
 from typing import Any, Protocol
 
-from olmlx.proxy_tuning_pipeline.schema import ChatExample, ExtractionUnit
+import concurrent.futures
+from pathlib import Path
+
+from olmlx.proxy_tuning_pipeline.schema import (
+    ChatExample,
+    ExtractionUnit,
+    read_jsonl,
+)
 
 # Clamp the grounding so a long unit can't blow the generator's context budget.
 _MAX_USER_CHARS = 12000
@@ -95,31 +102,39 @@ def parse_pairs(text: str) -> list[tuple[str, str]]:
 logger = logging.getLogger(__name__)
 
 
+def _examples_for_unit(
+    unit: ExtractionUnit, generator: Generator, n_per_unit: int
+) -> list[ChatExample]:
+    """One generate call -> parsed ChatExamples for a single unit. May raise."""
+    system, user = build_messages(unit, n_per_unit)
+    reply = generator.generate(system, user)
+    return [
+        ChatExample(
+            kind=unit.kind, provenance=unit.provenance, user=instr, assistant=resp
+        )
+        for instr, resp in parse_pairs(reply)
+    ]
+
+
 def expand_units(
     units: list[ExtractionUnit],
     generator: Generator,
     n_per_unit: int,
 ) -> list[ChatExample]:
-    """Expand each unit into ChatExamples via the generator (one call per unit)."""
+    """Expand each unit into ChatExamples via the generator (one call per unit).
+
+    In-memory, sequential. ``expand_units_checkpointed`` is the crash-safe,
+    concurrent variant used for the full run.
+    """
     examples: list[ChatExample] = []
     failures = 0
     for i, unit in enumerate(units):
-        system, user = build_messages(unit, n_per_unit)
         try:
-            reply = generator.generate(system, user)
+            examples.extend(_examples_for_unit(unit, generator, n_per_unit))
         except Exception:  # noqa: BLE001 — one bad unit must not abort the run
             failures += 1
             logger.warning("generation failed for %s", unit.provenance, exc_info=True)
             continue
-        for instr, resp in parse_pairs(reply):
-            examples.append(
-                ChatExample(
-                    kind=unit.kind,
-                    provenance=unit.provenance,
-                    user=instr,
-                    assistant=resp,
-                )
-            )
         if (i + 1) % 100 == 0:
             logger.info(
                 "expanded %d/%d units, %d pairs so far",
@@ -127,9 +142,6 @@ def expand_units(
                 len(units),
                 len(examples),
             )
-    # Surface systemic failure: a run where every call failed (bad key, bad
-    # model, exhausted quota) would otherwise silently produce an empty dataset
-    # only noticed at training time.
     if failures:
         logger.warning(
             "expand_units: %d/%d units failed generation", failures, len(units)
@@ -137,6 +149,79 @@ def expand_units(
     if units and not examples:
         logger.error("expand_units: produced 0 examples from %d units", len(units))
     return examples
+
+
+def load_done_provenances(raw_path: str | Path) -> set[str]:
+    """Provenances already present in the checkpoint file (for resume)."""
+    p = Path(raw_path)
+    if not p.exists():
+        return set()
+    return {row["provenance"] for row in read_jsonl(p)}
+
+
+def load_examples(raw_path: str | Path) -> list[ChatExample]:
+    """Read the checkpoint file back into ChatExamples (empty if absent)."""
+    p = Path(raw_path)
+    if not p.exists():
+        return []
+    return [ChatExample.from_dict(row) for row in read_jsonl(p)]
+
+
+def expand_units_checkpointed(
+    units: list[ExtractionUnit],
+    generator: Generator,
+    n_per_unit: int,
+    raw_path: str | Path,
+    concurrency: int = 8,
+    *,
+    done: set[str] | None = None,
+) -> int:
+    """Expand units concurrently, appending each unit's pairs to ``raw_path``.
+
+    Crash-safe and resumable: every unit's pairs are flushed to ``raw_path`` the
+    moment that unit finishes, so an interrupt loses at most the in-flight units.
+    Units whose provenance is in ``done`` are skipped (resume). Returns the
+    number of pairs written this run.
+
+    Generator calls run in a bounded thread pool (the OpenAI client releases the
+    GIL during network I/O); the single main thread is the only writer, so
+    ``raw_path`` needs no locking.
+    """
+    done = done or set()
+    todo = [u for u in units if u.provenance not in done]
+    raw_path = Path(raw_path)
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    failures = 0
+    with (
+        raw_path.open("a") as f,
+        concurrent.futures.ThreadPoolExecutor(max_workers=max(concurrency, 1)) as pool,
+    ):
+        fut_to_unit = {
+            pool.submit(_examples_for_unit, u, generator, n_per_unit): u for u in todo
+        }
+        for i, fut in enumerate(concurrent.futures.as_completed(fut_to_unit), 1):
+            unit = fut_to_unit[fut]
+            try:
+                examples = fut.result()
+            except Exception:  # noqa: BLE001 — one bad unit must not abort the run
+                failures += 1
+                logger.warning(
+                    "generation failed for %s", unit.provenance, exc_info=True
+                )
+                continue
+            for e in examples:
+                f.write(json.dumps(e.to_dict(), ensure_ascii=False) + "\n")
+                written += 1
+            f.flush()  # checkpoint durability: survive a crash on the next unit
+            if i % 100 == 0:
+                logger.info(
+                    "expanded %d/%d units, %d pairs written", i, len(todo), written
+                )
+    if failures:
+        logger.warning("expand: %d/%d units failed generation", failures, len(todo))
+    return written
 
 
 DEFAULT_MODEL = "gpt-5.4-mini"
@@ -149,20 +234,23 @@ class OpenAIGenerator:
     ``openai.OpenAI()`` (reads ``OPENAI_API_KEY`` from the environment).
     """
 
-    def __init__(self, client: Any = None, model: str = DEFAULT_MODEL):
+    def __init__(
+        self, client: Any = None, model: str = DEFAULT_MODEL, max_retries: int = 6
+    ):
         self._client = client
         self._model = model
+        self._max_retries = max_retries
 
     def _ensure_client(self) -> Any:
         if self._client is None:
             from openai import OpenAI
 
-            self._client = OpenAI()
+            # The SDK auto-retries 429 / transient 5xx with exponential backoff;
+            # raise the cap above the default 2 for a multi-hour batch run.
+            self._client = OpenAI(max_retries=self._max_retries)
         return self._client
 
     def generate(self, system: str, user: str) -> str:
-        # TODO: add retry/backoff on 429 / transient 5xx before the full run —
-        # a single rate-limit error currently drops one unit's pairs.
         resp = self._ensure_client().chat.completions.create(
             model=self._model,
             messages=[

--- a/olmlx/proxy_tuning_pipeline/expand.py
+++ b/olmlx/proxy_tuning_pipeline/expand.py
@@ -96,7 +96,10 @@ def expand_units(
             )
         if (i + 1) % 100 == 0:
             logger.info(
-                "expanded %d/%d units, %d pairs so far", i + 1, len(units), len(examples)
+                "expanded %d/%d units, %d pairs so far",
+                i + 1,
+                len(units),
+                len(examples),
             )
     return examples
 

--- a/olmlx/proxy_tuning_pipeline/extract.py
+++ b/olmlx/proxy_tuning_pipeline/extract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import re
+import subprocess
 from pathlib import Path
 from typing import Iterator
 
@@ -134,3 +135,32 @@ def extract_tests(tests_dir: str | Path) -> Iterator[ExtractionUnit]:
                 instruction_hint=f"the behavior enforced by `{node.name}`",
                 source_context=strip_secrets(segment[:_MAX_SOURCE_CHARS]),
             )
+
+
+def extract_commits(root: str | Path, limit: int = 400) -> Iterator[ExtractionUnit]:
+    """Yield one unit per commit: subject + body + diff (capped). Newest first."""
+    root = Path(root)
+    try:
+        shas = subprocess.run(
+            ["git", "-C", str(root), "log", f"-n{limit}", "--format=%H"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.split()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return
+    for sha in shas:
+        show = subprocess.run(
+            ["git", "-C", str(root), "show", "--format=%s%n%n%b", "--stat", "-p", sha],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        if not show.strip():
+            continue
+        yield ExtractionUnit(
+            kind="commit",
+            provenance=f"git:{sha[:12]}",
+            instruction_hint="implementing this change the olmlx way (message -> diff)",
+            source_context=strip_secrets(show[:_MAX_SOURCE_CHARS]),
+        )

--- a/olmlx/proxy_tuning_pipeline/extract.py
+++ b/olmlx/proxy_tuning_pipeline/extract.py
@@ -71,7 +71,7 @@ def extract_invariants(claude_md_path: str | Path) -> Iterator[ExtractionUnit]:
     m = re.search(r"^##\s+Non-Obvious Invariants\s*$", text, flags=re.MULTILINE)
     if not m:
         return
-    rest = text[m.end():]
+    rest = text[m.end() :]
     nxt = re.search(r"^##\s+", rest, flags=re.MULTILINE)
     section = rest[: nxt.start()] if nxt else rest
     for para in re.split(r"\n\s*\n", section):
@@ -105,7 +105,9 @@ def extract_docs(docs_dir: str | Path) -> Iterator[ExtractionUnit]:
                 kind="doc",
                 provenance=f"docs/{rel}#{heading[:40]}",
                 instruction_hint=f"the olmlx documentation section: {heading}",
-                source_context=strip_secrets((parts[i] + "\n" + body)[:_MAX_SOURCE_CHARS]),
+                source_context=strip_secrets(
+                    (parts[i] + "\n" + body)[:_MAX_SOURCE_CHARS]
+                ),
             )
 
 
@@ -128,7 +130,9 @@ def extract_tests(tests_dir: str | Path) -> Iterator[ExtractionUnit]:
             segment = ast.get_source_segment(text, node) or ""
             if not segment.strip():
                 continue
-            rel = path.relative_to(tests_dir) if path.is_relative_to(tests_dir) else path
+            rel = (
+                path.relative_to(tests_dir) if path.is_relative_to(tests_dir) else path
+            )
             yield ExtractionUnit(
                 kind="test",
                 provenance=f"tests/{rel}:{node.lineno}",
@@ -164,3 +168,40 @@ def extract_commits(root: str | Path, limit: int = 400) -> Iterator[ExtractionUn
             instruction_hint="implementing this change the olmlx way (message -> diff)",
             source_context=strip_secrets(show[:_MAX_SOURCE_CHARS]),
         )
+
+
+def dedupe_units(units: list[ExtractionUnit]) -> list[ExtractionUnit]:
+    """Drop units whose `source_context` was already seen (order-preserving)."""
+    seen: set[str] = set()
+    out: list[ExtractionUnit] = []
+    for u in units:
+        key = " ".join(u.source_context.split()).lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(u)
+    return out
+
+
+def extract_repo(root: str | Path) -> list[ExtractionUnit]:
+    """Run every extractor over the repo and return deduped units.
+
+    Each extractor is best-effort: a missing CLAUDE.md / docs / tests / git
+    history simply contributes nothing rather than failing the whole run.
+    """
+    root = Path(root)
+    units: list[ExtractionUnit] = []
+    units += list(
+        extract_functions(root / "olmlx" if (root / "olmlx").is_dir() else root)
+    )
+    claude = root / "CLAUDE.md"
+    if claude.is_file():
+        units += list(extract_invariants(claude))
+    docs = root / "docs"
+    if docs.is_dir():
+        units += list(extract_docs(docs))
+    tests = root / "tests"
+    if tests.is_dir():
+        units += list(extract_tests(tests))
+    units += list(extract_commits(root))
+    return dedupe_units(units)

--- a/olmlx/proxy_tuning_pipeline/extract.py
+++ b/olmlx/proxy_tuning_pipeline/extract.py
@@ -66,7 +66,7 @@ def extract_functions(root: str | Path) -> Iterator[ExtractionUnit]:
 def extract_invariants(claude_md_path: str | Path) -> Iterator[ExtractionUnit]:
     """Yield one unit per `**Title** — ...` paragraph under the invariants section."""
     path = Path(claude_md_path)
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8", errors="replace")
     # Isolate the "## Non-Obvious Invariants" section up to the next "## " heading.
     m = re.search(r"^##\s+Non-Obvious Invariants\s*$", text, flags=re.MULTILINE)
     if not m:
@@ -91,7 +91,7 @@ def extract_docs(docs_dir: str | Path) -> Iterator[ExtractionUnit]:
     """Yield one unit per markdown section (## or # heading + its body)."""
     docs_dir = Path(docs_dir)
     for path in sorted(docs_dir.rglob("*.md")):
-        text = path.read_text()
+        text = path.read_text(encoding="utf-8", errors="replace")
         # Split on headings, keeping the heading with its following body.
         parts = re.split(r"(?m)^(#{1,3}\s+.*)$", text)
         # parts = [pre, heading1, body1, heading2, body2, ...]
@@ -154,12 +154,26 @@ def extract_commits(root: str | Path, limit: int = 400) -> Iterator[ExtractionUn
     except (subprocess.CalledProcessError, FileNotFoundError):
         return
     for sha in shas:
-        show = subprocess.run(
-            ["git", "-C", str(root), "show", "--format=%s%n%n%b", "--stat", "-p", sha],
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout
+        try:
+            show = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(root),
+                    "show",
+                    "--format=%s%n%n%b",
+                    "--stat",
+                    "-p",
+                    sha,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+        except subprocess.CalledProcessError:
+            # Best-effort: skip a commit whose object can't be shown (shallow
+            # clone, pack race) rather than aborting the whole extraction.
+            continue
         if not show.strip():
             continue
         yield ExtractionUnit(

--- a/olmlx/proxy_tuning_pipeline/extract.py
+++ b/olmlx/proxy_tuning_pipeline/extract.py
@@ -106,3 +106,31 @@ def extract_docs(docs_dir: str | Path) -> Iterator[ExtractionUnit]:
                 instruction_hint=f"the olmlx documentation section: {heading}",
                 source_context=strip_secrets((parts[i] + "\n" + body)[:_MAX_SOURCE_CHARS]),
             )
+
+
+def extract_tests(tests_dir: str | Path) -> Iterator[ExtractionUnit]:
+    """Yield one unit per `def test_*` function (the behavior it enforces)."""
+    tests_dir = Path(tests_dir)
+    for path in sorted(tests_dir.rglob("test_*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        try:
+            text = path.read_text()
+            tree = ast.parse(text)
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not node.name.startswith("test_"):
+                continue
+            segment = ast.get_source_segment(text, node) or ""
+            if not segment.strip():
+                continue
+            rel = path.relative_to(tests_dir) if path.is_relative_to(tests_dir) else path
+            yield ExtractionUnit(
+                kind="test",
+                provenance=f"tests/{rel}:{node.lineno}",
+                instruction_hint=f"the behavior enforced by `{node.name}`",
+                source_context=strip_secrets(segment[:_MAX_SOURCE_CHARS]),
+            )

--- a/olmlx/proxy_tuning_pipeline/extract.py
+++ b/olmlx/proxy_tuning_pipeline/extract.py
@@ -169,6 +169,9 @@ def extract_commits(root: str | Path, limit: int = 400) -> Iterator[ExtractionUn
                 check=True,
                 capture_output=True,
                 text=True,
+                # A diff can contain non-UTF8 bytes (binary files, latin-1 in
+                # old commits); decode leniently so it doesn't crash extraction.
+                errors="replace",
             ).stdout
         except subprocess.CalledProcessError:
             # Best-effort: skip a commit whose object can't be shown (shallow

--- a/olmlx/proxy_tuning_pipeline/extract.py
+++ b/olmlx/proxy_tuning_pipeline/extract.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import ast
 import re
+from pathlib import Path
+from typing import Iterator
 
 from olmlx.proxy_tuning_pipeline.schema import ExtractionUnit
 
@@ -19,3 +22,41 @@ def strip_secrets(text: str) -> str:
     for pat in _SECRET_PATTERNS:
         text = pat.sub("[REDACTED]", text)
     return text
+
+
+# Cap grounding size so a huge function/file doesn't blow the generator context.
+_MAX_SOURCE_CHARS = 6000
+
+
+def _iter_py_files(root: Path) -> Iterator[Path]:
+    for p in sorted(root.rglob("*.py")):
+        if "__pycache__" in p.parts:
+            continue
+        yield p
+
+
+def extract_functions(root: str | Path) -> Iterator[ExtractionUnit]:
+    """Yield one unit per top-level/class function with its source + docstring."""
+    root = Path(root)
+    for path in _iter_py_files(root):
+        try:
+            text = path.read_text()
+            tree = ast.parse(text)
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            try:
+                segment = ast.get_source_segment(text, node) or ""
+            except Exception:  # noqa: BLE001
+                segment = ""
+            if not segment.strip():
+                continue
+            rel = path.relative_to(root) if path.is_relative_to(root) else path
+            yield ExtractionUnit(
+                kind="function",
+                provenance=f"{rel}:{node.lineno}",
+                instruction_hint=f"the `{node.name}` function and its olmlx conventions",
+                source_context=strip_secrets(segment[:_MAX_SOURCE_CHARS]),
+            )

--- a/olmlx/proxy_tuning_pipeline/extract.py
+++ b/olmlx/proxy_tuning_pipeline/extract.py
@@ -84,3 +84,25 @@ def extract_invariants(claude_md_path: str | Path) -> Iterator[ExtractionUnit]:
             instruction_hint=f"the olmlx invariant: {title_m.group(1)}",
             source_context=strip_secrets(para[:_MAX_SOURCE_CHARS]),
         )
+
+
+def extract_docs(docs_dir: str | Path) -> Iterator[ExtractionUnit]:
+    """Yield one unit per markdown section (## or # heading + its body)."""
+    docs_dir = Path(docs_dir)
+    for path in sorted(docs_dir.rglob("*.md")):
+        text = path.read_text()
+        # Split on headings, keeping the heading with its following body.
+        parts = re.split(r"(?m)^(#{1,3}\s+.*)$", text)
+        # parts = [pre, heading1, body1, heading2, body2, ...]
+        for i in range(1, len(parts), 2):
+            heading = parts[i].lstrip("#").strip()
+            body = parts[i + 1].strip() if i + 1 < len(parts) else ""
+            if not body:
+                continue
+            rel = path.relative_to(docs_dir) if path.is_relative_to(docs_dir) else path
+            yield ExtractionUnit(
+                kind="doc",
+                provenance=f"docs/{rel}#{heading[:40]}",
+                instruction_hint=f"the olmlx documentation section: {heading}",
+                source_context=strip_secrets((parts[i] + "\n" + body)[:_MAX_SOURCE_CHARS]),
+            )

--- a/olmlx/proxy_tuning_pipeline/extract.py
+++ b/olmlx/proxy_tuning_pipeline/extract.py
@@ -60,3 +60,27 @@ def extract_functions(root: str | Path) -> Iterator[ExtractionUnit]:
                 instruction_hint=f"the `{node.name}` function and its olmlx conventions",
                 source_context=strip_secrets(segment[:_MAX_SOURCE_CHARS]),
             )
+
+
+def extract_invariants(claude_md_path: str | Path) -> Iterator[ExtractionUnit]:
+    """Yield one unit per `**Title** — ...` paragraph under the invariants section."""
+    path = Path(claude_md_path)
+    text = path.read_text()
+    # Isolate the "## Non-Obvious Invariants" section up to the next "## " heading.
+    m = re.search(r"^##\s+Non-Obvious Invariants\s*$", text, flags=re.MULTILINE)
+    if not m:
+        return
+    rest = text[m.end():]
+    nxt = re.search(r"^##\s+", rest, flags=re.MULTILINE)
+    section = rest[: nxt.start()] if nxt else rest
+    for para in re.split(r"\n\s*\n", section):
+        para = para.strip()
+        title_m = re.match(r"\*\*(.+?)\*\*", para)
+        if not title_m:
+            continue
+        yield ExtractionUnit(
+            kind="invariant",
+            provenance=f"{path.name}#non-obvious-invariants",
+            instruction_hint=f"the olmlx invariant: {title_m.group(1)}",
+            source_context=strip_secrets(para[:_MAX_SOURCE_CHARS]),
+        )

--- a/olmlx/proxy_tuning_pipeline/extract.py
+++ b/olmlx/proxy_tuning_pipeline/extract.py
@@ -41,7 +41,7 @@ def extract_functions(root: str | Path) -> Iterator[ExtractionUnit]:
     root = Path(root)
     for path in _iter_py_files(root):
         try:
-            text = path.read_text()
+            text = path.read_text(encoding="utf-8", errors="replace")
             tree = ast.parse(text)
         except (SyntaxError, UnicodeDecodeError):
             continue
@@ -118,7 +118,7 @@ def extract_tests(tests_dir: str | Path) -> Iterator[ExtractionUnit]:
         if "__pycache__" in path.parts:
             continue
         try:
-            text = path.read_text()
+            text = path.read_text(encoding="utf-8", errors="replace")
             tree = ast.parse(text)
         except (SyntaxError, UnicodeDecodeError):
             continue

--- a/olmlx/proxy_tuning_pipeline/extract.py
+++ b/olmlx/proxy_tuning_pipeline/extract.py
@@ -1,0 +1,21 @@
+"""Mechanical extraction of grounded units from the olmlx repo (no LLM)."""
+
+from __future__ import annotations
+
+import re
+
+from olmlx.proxy_tuning_pipeline.schema import ExtractionUnit
+
+# Token shapes to redact before any text leaves the repo for generation.
+_SECRET_PATTERNS = [
+    re.compile(r"\bsk-[A-Za-z0-9_-]{16,}"),  # OpenAI-style keys
+    re.compile(r"\bhf_[A-Za-z0-9]{16,}"),  # HuggingFace tokens
+    re.compile(r"\b[A-Z][A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD)\s*=\s*\S+"),
+]
+
+
+def strip_secrets(text: str) -> str:
+    """Redact secret-shaped substrings; preserve everything else verbatim."""
+    for pat in _SECRET_PATTERNS:
+        text = pat.sub("[REDACTED]", text)
+    return text

--- a/olmlx/proxy_tuning_pipeline/schema.py
+++ b/olmlx/proxy_tuning_pipeline/schema.py
@@ -44,6 +44,25 @@ class ChatExample:
             ]
         }
 
+    def to_dict(self) -> dict[str, Any]:
+        """Full row (with kind + provenance) for the checkpoint ``raw.jsonl``."""
+        return {
+            "kind": self.kind,
+            "provenance": self.provenance,
+            "user": self.user,
+            "assistant": self.assistant,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "ChatExample":
+        """Inverse of :meth:`to_dict` for reading back ``raw.jsonl``."""
+        return cls(
+            kind=d["kind"],
+            provenance=d["provenance"],
+            user=d["user"],
+            assistant=d["assistant"],
+        )
+
 
 def write_jsonl(path: str | Path, rows: Iterable[dict[str, Any]]) -> int:
     """Write rows as JSON Lines; return the number of rows written."""

--- a/olmlx/proxy_tuning_pipeline/schema.py
+++ b/olmlx/proxy_tuning_pipeline/schema.py
@@ -1,0 +1,68 @@
+"""Data types + JSONL IO for the proxy-tuning data pipeline."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class ExtractionUnit:
+    """A grounded source chunk + a seed describing what to generate from it."""
+
+    kind: str  # "function" | "invariant" | "doc" | "test" | "commit"
+    provenance: str  # "olmlx/foo.py:10" or "git:<sha>"
+    instruction_hint: str  # short seed for the generator
+    source_context: str  # grounding text the generator must answer from
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "provenance": self.provenance,
+            "instruction_hint": self.instruction_hint,
+            "source_context": self.source_context,
+        }
+
+
+@dataclass(frozen=True)
+class ChatExample:
+    """One instruction->response training pair plus provenance metadata."""
+
+    kind: str
+    provenance: str
+    user: str
+    assistant: str
+
+    def to_chat_row(self) -> dict[str, Any]:
+        """mlx-lm chat format — only this shape goes into train.jsonl."""
+        return {
+            "messages": [
+                {"role": "user", "content": self.user},
+                {"role": "assistant", "content": self.assistant},
+            ]
+        }
+
+
+def write_jsonl(path: str | Path, rows: Iterable[dict[str, Any]]) -> int:
+    """Write rows as JSON Lines; return the number of rows written."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    n = 0
+    with path.open("w") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+            n += 1
+    return n
+
+
+def read_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    """Read a JSON Lines file into a list of dicts (blank lines skipped)."""
+    out: list[dict[str, Any]] = []
+    with Path(path).open() as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -46,3 +46,26 @@ def test_chat_example_to_jsonl_row_is_mlx_chat_format():
             {"role": "assistant", "content": "It returns nothing."},
         ]
     }
+
+
+from olmlx.proxy_tuning_pipeline.extract import strip_secrets
+
+
+def test_strip_secrets_redacts_known_token_shapes():
+    text = (
+        "key sk-abc123def456ghi789jkl012mno345pqr and "
+        "hf_AbCdEfGhIjKlMnOpQrStUvWxYz012345 plus "
+        "OLMLX_SECRET=topsecretvalue123 done"
+    )
+    out = strip_secrets(text)
+    assert "sk-abc123" not in out
+    assert "hf_AbCdEf" not in out
+    assert "topsecretvalue123" not in out
+    assert "[REDACTED]" in out
+    # Non-secret text is preserved.
+    assert out.startswith("key ") and out.endswith(" done")
+
+
+def test_strip_secrets_leaves_ordinary_text_untouched():
+    text = "def generate_chat(model, messages): return run(model, messages)"
+    assert strip_secrets(text) == text

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -123,3 +123,26 @@ def test_extract_invariants_parses_bold_lead_paragraphs(tmp_path):
     # The trailing "## Development" content is not captured.
     assert not any("not an invariant" in u.source_context for u in units)
     assert len(units) == 2
+
+
+from olmlx.proxy_tuning_pipeline.extract import extract_docs
+
+
+def test_extract_docs_chunks_by_section(tmp_path):
+    d = tmp_path / "docs"
+    d.mkdir()
+    (d / "a.md").write_text(
+        "# Intro\n\nWelcome to olmlx.\n\n"
+        "## Speculative\n\nDraft then verify.\n\n"
+        "## Flash\n\nSSD-backed MoE.\n"
+    )
+    (d / "nested" / "b.md").parent.mkdir()
+    (d / "nested" / "b.md").write_text("# Nested\n\nbody here\n")
+    units = list(extract_docs(d))
+    headings = [u.instruction_hint for u in units]
+    assert any("Speculative" in h for h in headings)
+    assert any("Flash" in h for h in headings)
+    assert any("Nested" in h for h in headings)
+    assert all(u.kind == "doc" for u in units)
+    spec = next(u for u in units if "Speculative" in u.instruction_hint)
+    assert "Draft then verify" in spec.source_context

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -100,3 +100,26 @@ def test_extract_functions_skips_non_python_and_pycache(tmp_path):
     cache.mkdir()
     (cache / "x.py").write_text("def cached(): pass")
     assert list(extract_functions(tmp_path)) == []
+
+
+from olmlx.proxy_tuning_pipeline.extract import extract_invariants
+
+
+def test_extract_invariants_parses_bold_lead_paragraphs(tmp_path):
+    md = tmp_path / "CLAUDE.md"
+    md.write_text(
+        "# Title\n\n"
+        "## Non-Obvious Invariants\n\n"
+        "**Metal stream hazard** — All inference must run on one stream.\n\n"
+        "**MTP concat order** — embed first, opposite of EAGLE.\n\n"
+        "## Development\n\n"
+        "not an invariant\n"
+    )
+    units = list(extract_invariants(md))
+    titles = [u.instruction_hint for u in units]
+    assert any("Metal stream hazard" in t for t in titles)
+    assert any("MTP concat order" in t for t in titles)
+    assert all(u.kind == "invariant" for u in units)
+    # The trailing "## Development" content is not captured.
+    assert not any("not an invariant" in u.source_context for u in units)
+    assert len(units) == 2

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -500,3 +500,15 @@ def test_run_pipeline_end_to_end(tmp_path):
     assert stats["generated"] >= 2
     assert stats["kept"] == stats["train"] + stats["valid"]
     assert stats["train"] == len(train) and stats["valid"] == len(valid)
+
+
+def test_extract_functions_skips_unparseable_and_non_utf8(tmp_path):
+    # A syntactically broken file and a non-UTF8 file must be skipped, not crash
+    # extraction over the real repo.
+    (tmp_path / "broken.py").write_text("def f(:\n    pass\n")  # SyntaxError
+    (tmp_path / "binary.py").write_bytes(b"\xff\xfe def g(): pass")  # not UTF-8
+    (tmp_path / "ok.py").write_text("def good():\n    return 1\n")
+    units = list(extract_functions(tmp_path))
+    names = [u.instruction_hint for u in units]
+    assert any("good" in n for n in names)
+    assert len(units) == 1  # only the valid file contributed

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -2,6 +2,18 @@
 
 from __future__ import annotations
 
+import subprocess
+
+from olmlx.proxy_tuning_pipeline.extract import (
+    dedupe_units,
+    extract_commits,
+    extract_docs,
+    extract_functions,
+    extract_invariants,
+    extract_repo,
+    extract_tests,
+    strip_secrets,
+)
 from olmlx.proxy_tuning_pipeline.schema import (
     ChatExample,
     ExtractionUnit,
@@ -48,9 +60,6 @@ def test_chat_example_to_jsonl_row_is_mlx_chat_format():
     }
 
 
-from olmlx.proxy_tuning_pipeline.extract import strip_secrets
-
-
 def test_strip_secrets_redacts_known_token_shapes():
     text = (
         "key sk-abc123def456ghi789jkl012mno345pqr and "
@@ -71,18 +80,15 @@ def test_strip_secrets_leaves_ordinary_text_untouched():
     assert strip_secrets(text) == text
 
 
-from olmlx.proxy_tuning_pipeline.extract import extract_functions
-
-
 def test_extract_functions_yields_unit_per_function(tmp_path):
     src = tmp_path / "mod.py"
     src.write_text(
-        'def add(a, b):\n'
+        "def add(a, b):\n"
         '    """Return the sum of a and b."""\n'
-        '    return a + b\n'
-        '\n'
-        'def _private():\n'
-        '    return 1\n'
+        "    return a + b\n"
+        "\n"
+        "def _private():\n"
+        "    return 1\n"
     )
     units = list(extract_functions(tmp_path))
     by_name = {u.provenance: u for u in units}
@@ -100,9 +106,6 @@ def test_extract_functions_skips_non_python_and_pycache(tmp_path):
     cache.mkdir()
     (cache / "x.py").write_text("def cached(): pass")
     assert list(extract_functions(tmp_path)) == []
-
-
-from olmlx.proxy_tuning_pipeline.extract import extract_invariants
 
 
 def test_extract_invariants_parses_bold_lead_paragraphs(tmp_path):
@@ -125,9 +128,6 @@ def test_extract_invariants_parses_bold_lead_paragraphs(tmp_path):
     assert len(units) == 2
 
 
-from olmlx.proxy_tuning_pipeline.extract import extract_docs
-
-
 def test_extract_docs_chunks_by_section(tmp_path):
     d = tmp_path / "docs"
     d.mkdir()
@@ -148,19 +148,16 @@ def test_extract_docs_chunks_by_section(tmp_path):
     assert "Draft then verify" in spec.source_context
 
 
-from olmlx.proxy_tuning_pipeline.extract import extract_tests
-
-
 def test_extract_tests_yields_unit_per_test_function(tmp_path):
     t = tmp_path / "tests"
     t.mkdir()
     (t / "test_thing.py").write_text(
-        'def test_adds():\n'
+        "def test_adds():\n"
         '    """Addition works."""\n'
-        '    assert 1 + 1 == 2\n'
-        '\n'
-        'def helper():\n'
-        '    return 0\n'
+        "    assert 1 + 1 == 2\n"
+        "\n"
+        "def helper():\n"
+        "    return 0\n"
     )
     units = list(extract_tests(t))
     assert len(units) == 1
@@ -168,11 +165,6 @@ def test_extract_tests_yields_unit_per_test_function(tmp_path):
     assert u.kind == "test"
     assert "test_adds" in u.instruction_hint
     assert "assert 1 + 1 == 2" in u.source_context
-
-
-import subprocess
-
-from olmlx.proxy_tuning_pipeline.extract import extract_commits
 
 
 def _git(repo, *args):
@@ -204,9 +196,6 @@ def test_extract_commits_yields_message_and_diff(tmp_path):
     assert "feat: add x constant" in u.source_context
     assert "x = 1" in u.source_context  # diff body included
     assert u.provenance.startswith("git:")
-
-
-from olmlx.proxy_tuning_pipeline.extract import dedupe_units, extract_repo
 
 
 def test_dedupe_units_drops_identical_source_context():

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -502,6 +502,78 @@ def test_run_pipeline_end_to_end(tmp_path):
     assert stats["train"] == len(train) and stats["valid"] == len(valid)
 
 
+def test_run_pipeline_limit_units_bounds_expansion(tmp_path):
+    # A bounded run must process only `limit_units` units (cheap smoke run) and
+    # still write output — without this, a smoke run over the full repo only
+    # writes after expanding every unit, so interrupting it produces nothing.
+    repo = tmp_path / "repo"
+    (repo / "olmlx").mkdir(parents=True)
+    (repo / "olmlx" / "m.py").write_text(
+        'def f():\n    """doc f."""\n    return 1\n\n'
+        'def g():\n    """doc g."""\n    return 2\n'
+    )
+    (repo / "CLAUDE.md").write_text(
+        "## Non-Obvious Invariants\n\n**Inv one** — a real rule about streams.\n"
+    )
+    out_dir = tmp_path / "out"
+
+    class _CountingGenerator:
+        def __init__(self):
+            self.calls = 0
+
+        def generate(self, system: str, user: str) -> str:
+            self.calls += 1
+            return (
+                f'{{"pairs": [{{"instruction": "Q{self.calls} about olmlx?", '
+                f'"response": "A grounded answer about olmlx detail {self.calls}."}}]}}'
+            )
+
+    gen = _CountingGenerator()
+    stats = run_pipeline(
+        repo_root=repo,
+        out_dir=out_dir,
+        generator=gen,
+        n_per_unit=1,
+        valid_frac=0.5,
+        seed=3,
+        limit_units=2,
+    )
+    # Only 2 units expanded despite the repo extracting more.
+    assert gen.calls == 2
+    assert stats["units"] == 2
+    # Output is actually written (the whole point of a bounded smoke run).
+    assert (out_dir / "train.jsonl").exists()
+    assert stats["kept"] == stats["train"] + stats["valid"]
+
+
+def test_run_pipeline_limit_units_none_processes_all(tmp_path):
+    # Default (no limit) must process every extracted unit.
+    repo = tmp_path / "repo"
+    (repo / "olmlx").mkdir(parents=True)
+    (repo / "olmlx" / "m.py").write_text("def f():\n    return 1\n")
+    (repo / "CLAUDE.md").write_text("## Non-Obvious Invariants\n\n**Inv** — rule.\n")
+    n_units = len(extract_repo(repo))
+
+    class _G:
+        def __init__(self):
+            self.calls = 0
+
+        def generate(self, system: str, user: str) -> str:
+            self.calls += 1
+            return '{"pairs": []}'
+
+    gen = _G()
+    run_pipeline(
+        repo_root=repo,
+        out_dir=tmp_path / "out",
+        generator=gen,
+        n_per_unit=1,
+        valid_frac=0.1,
+        seed=0,
+    )
+    assert gen.calls == n_units
+
+
 def test_extract_functions_skips_unparseable_and_non_utf8(tmp_path):
     # A syntactically broken file and a non-UTF8 file must be skipped, not crash
     # extraction over the real repo.

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 
 import pytest
@@ -745,3 +746,92 @@ def test_run_pipeline_adopts_legacy_raw_without_meta(tmp_path):
     # Did not raise; the legacy example is included and a meta sidecar now exists.
     assert stats["generated"] >= 1
     assert (out_dir / "raw.meta.json").exists()
+
+
+from olmlx.proxy_tuning_pipeline.curate import cap_kind_fraction  # noqa: E402
+
+
+def test_cap_kind_fraction_downsamples_to_target_share():
+    ex = [ChatExample("test", f"t{i}", f"Q{i}", f"A{i}") for i in range(30)]
+    ex += [ChatExample("function", f"f{i}", f"Q{i}", f"A{i}") for i in range(10)]
+    out = cap_kind_fraction(ex, kind="test", max_fraction=0.35, seed=1)
+    tests = [e for e in out if e.kind == "test"]
+    others = [e for e in out if e.kind != "test"]
+    assert len(others) == 10  # non-target kinds fully kept
+    # tests/(tests+others) <= 0.35
+    assert len(tests) / len(out) <= 0.35 + 1e-9
+    assert len(tests) == 5  # floor(0.35/0.65 * 10)
+
+
+def test_cap_kind_fraction_noop_when_already_under_cap():
+    ex = [ChatExample("test", f"t{i}", f"Q{i}", f"A{i}") for i in range(3)]
+    ex += [ChatExample("doc", f"d{i}", f"Q{i}", f"A{i}") for i in range(10)]
+    out = cap_kind_fraction(ex, kind="test", max_fraction=0.5, seed=1)
+    assert len(out) == 13  # nothing dropped (tests already < 50%)
+
+
+def test_cap_kind_fraction_deterministic():
+    ex = [ChatExample("test", f"t{i}", f"Q{i}", f"A{i}") for i in range(50)]
+    ex += [ChatExample("function", f"f{i}", f"Q{i}", f"A{i}") for i in range(10)]
+    a = cap_kind_fraction(ex, kind="test", max_fraction=0.35, seed=7)
+    b = cap_kind_fraction(ex, kind="test", max_fraction=0.35, seed=7)
+    assert [e.provenance for e in a] == [e.provenance for e in b]
+
+
+def test_run_pipeline_curate_only_skips_generation(tmp_path):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    # Seed a checkpoint with 4 test + 1 function example.
+    rows = [
+        {
+            "kind": "test",
+            "provenance": f"t{i}",
+            "user": f"Question {i} about behavior?",
+            "assistant": f"Answer {i} long enough.",
+        }
+        for i in range(4)
+    ] + [
+        {
+            "kind": "function",
+            "provenance": "f0",
+            "user": "Question about the function?",
+            "assistant": "Answer f long enough.",
+        }
+    ]
+    (out_dir / "raw.jsonl").write_text("".join(json.dumps(r) + "\n" for r in rows))
+
+    class _Raises:
+        def generate(self, system, user):
+            raise AssertionError("curate_only must not generate")
+
+    stats = run_pipeline(
+        repo_root="/nonexistent",  # not read in curate_only
+        out_dir=out_dir,
+        generator=_Raises(),
+        n_per_unit=2,
+        valid_frac=0.25,
+        seed=0,
+        curate_only=True,
+        cap_kind=("test", 0.5),
+    )
+    # No generation; cap applied (tests downsampled to <=50%).
+    assert stats["units"] == 5
+    assert stats["cap_dropped"] >= 1
+    assert (out_dir / "train.jsonl").exists()
+
+
+def test_run_pipeline_curate_only_requires_checkpoint(tmp_path):
+    class _G:
+        def generate(self, system, user):
+            return "{}"
+
+    with pytest.raises(FileNotFoundError, match="curate-only"):
+        run_pipeline(
+            repo_root=".",
+            out_dir=tmp_path / "missing",
+            generator=_G(),
+            n_per_unit=2,
+            valid_frac=0.1,
+            seed=0,
+            curate_only=True,
+        )

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -15,6 +15,9 @@ from olmlx.proxy_tuning_pipeline.expand import (
     OpenAIGenerator,
     build_messages,
     expand_units,
+    expand_units_checkpointed,
+    load_done_provenances,
+    load_examples,
     parse_pairs,
 )
 from olmlx.proxy_tuning_pipeline.extract import (
@@ -485,6 +488,7 @@ def test_run_pipeline_end_to_end(tmp_path):
         n_per_unit=1,
         valid_frac=0.5,
         seed=7,
+        concurrency=1,
     )
 
     # Artifacts written in mlx-lm chat format.
@@ -537,6 +541,7 @@ def test_run_pipeline_limit_units_bounds_expansion(tmp_path):
         valid_frac=0.5,
         seed=3,
         limit_units=2,
+        concurrency=1,
     )
     # Only 2 units expanded despite the repo extracting more.
     assert gen.calls == 2
@@ -570,6 +575,7 @@ def test_run_pipeline_limit_units_none_processes_all(tmp_path):
         n_per_unit=1,
         valid_frac=0.1,
         seed=0,
+        concurrency=1,
     )
     assert gen.calls == n_units
 
@@ -584,3 +590,97 @@ def test_extract_functions_skips_unparseable_and_non_utf8(tmp_path):
     names = [u.instruction_hint for u in units]
     assert any("good" in n for n in names)
     assert len(units) == 1  # only the valid file contributed
+
+
+# ---------------------------------------------------------------------------
+# Checkpointed + concurrent expansion (full-run hardening)
+# ---------------------------------------------------------------------------
+
+
+class _PairGenerator:
+    """Returns one distinct pair per call; thread-safe call counter."""
+
+    def __init__(self):
+        import threading
+
+        self.calls = 0
+        self._lock = threading.Lock()
+
+    def generate(self, system: str, user: str) -> str:
+        with self._lock:
+            self.calls += 1
+            n = self.calls
+        return (
+            f'{{"pairs": [{{"instruction": "Q{n} about olmlx?", '
+            f'"response": "A grounded answer about olmlx detail {n}."}}]}}'
+        )
+
+
+def test_chat_example_dict_round_trip():
+    ex = ChatExample(kind="function", provenance="a.py:1", user="U", assistant="A")
+    assert ChatExample.from_dict(ex.to_dict()) == ex
+
+
+def test_expand_units_checkpointed_writes_raw_and_returns_count(tmp_path):
+    raw = tmp_path / "raw.jsonl"
+    units = [
+        ExtractionUnit("function", "a.py:1", "fn a", "def a(): pass"),
+        ExtractionUnit("doc", "d.md#s", "doc s", "body"),
+    ]
+    gen = _PairGenerator()
+    written = expand_units_checkpointed(
+        units, gen, n_per_unit=1, raw_path=raw, concurrency=4
+    )
+    assert written == 2
+    examples = load_examples(raw)
+    assert len(examples) == 2
+    assert {e.provenance for e in examples} == {"a.py:1", "d.md#s"}
+    assert all(isinstance(e, ChatExample) for e in examples)
+
+
+def test_expand_units_checkpointed_resume_skips_done_units(tmp_path):
+    raw = tmp_path / "raw.jsonl"
+    units = [
+        ExtractionUnit("function", "a.py:1", "fn a", "def a(): pass"),
+        ExtractionUnit("doc", "d.md#s", "doc s", "body"),
+    ]
+    # First pass over only the first unit.
+    gen1 = _PairGenerator()
+    expand_units_checkpointed(
+        units[:1], gen1, n_per_unit=1, raw_path=raw, concurrency=1
+    )
+    assert gen1.calls == 1
+
+    # Resume over the full list — the already-done unit must be skipped.
+    done = load_done_provenances(raw)
+    assert done == {"a.py:1"}
+    gen2 = _PairGenerator()
+    expand_units_checkpointed(
+        units, gen2, n_per_unit=1, raw_path=raw, concurrency=1, done=done
+    )
+    assert gen2.calls == 1  # only the not-done unit was generated
+    assert {e.provenance for e in load_examples(raw)} == {"a.py:1", "d.md#s"}
+
+
+def test_expand_units_checkpointed_processes_all_units_concurrently(tmp_path):
+    raw = tmp_path / "raw.jsonl"
+    units = [
+        ExtractionUnit("function", f"f{i}.py:1", f"fn {i}", f"def f{i}(): pass")
+        for i in range(25)
+    ]
+    gen = _PairGenerator()
+    written = expand_units_checkpointed(
+        units, gen, n_per_unit=1, raw_path=raw, concurrency=8
+    )
+    # Every unit produced exactly one pair; no loss under concurrency.
+    assert written == 25
+    assert len({e.provenance for e in load_examples(raw)}) == 25
+
+
+def test_load_done_provenances_missing_file_is_empty(tmp_path):
+    assert load_done_provenances(tmp_path / "nope.jsonl") == set()
+
+
+def test_openai_generator_default_max_retries():
+    gen = OpenAIGenerator(client=object())
+    assert gen._max_retries == 6

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -146,3 +146,25 @@ def test_extract_docs_chunks_by_section(tmp_path):
     assert all(u.kind == "doc" for u in units)
     spec = next(u for u in units if "Speculative" in u.instruction_hint)
     assert "Draft then verify" in spec.source_context
+
+
+from olmlx.proxy_tuning_pipeline.extract import extract_tests
+
+
+def test_extract_tests_yields_unit_per_test_function(tmp_path):
+    t = tmp_path / "tests"
+    t.mkdir()
+    (t / "test_thing.py").write_text(
+        'def test_adds():\n'
+        '    """Addition works."""\n'
+        '    assert 1 + 1 == 2\n'
+        '\n'
+        'def helper():\n'
+        '    return 0\n'
+    )
+    units = list(extract_tests(t))
+    assert len(units) == 1
+    u = units[0]
+    assert u.kind == "test"
+    assert "test_adds" in u.instruction_hint
+    assert "assert 1 + 1 == 2" in u.source_context

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -835,3 +835,35 @@ def test_run_pipeline_curate_only_requires_checkpoint(tmp_path):
             seed=0,
             curate_only=True,
         )
+
+
+def test_extract_commits_tolerates_non_utf8_diff(tmp_path):
+    # A commit touching a file with non-UTF8 bytes must not crash extraction.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    (repo / "data.bin").write_bytes(b"\xff\xfe\x00binary\x80content\n")
+    _git(repo, "add", "data.bin")
+    _git(repo, "commit", "-m", "add binary blob")
+    units = list(extract_commits(repo, limit=10))  # must not raise
+    assert len(units) == 1
+    assert "add binary blob" in units[0].source_context
+
+
+def test_openai_generator_ensure_client_is_idempotent():
+    gen = OpenAIGenerator(client=None, model="m")
+    sentinel = object()
+    gen._client = sentinel  # simulate an already-built client
+    assert gen._ensure_client() is sentinel
+    assert gen._ensure_client() is sentinel  # double-checked path returns same
+
+
+def test_split_train_valid_rejects_out_of_range_fraction():
+    ex = [
+        ChatExample("function", f"f{i}", f"Question {i}?", f"Answer {i} here.")
+        for i in range(4)
+    ]
+    with pytest.raises(ValueError, match="valid_frac"):
+        split_train_valid(ex, valid_frac=1.0, seed=0)
+    with pytest.raises(ValueError, match="valid_frac"):
+        split_train_valid(ex, valid_frac=-0.1, seed=0)

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -872,6 +872,8 @@ def test_split_train_valid_rejects_out_of_range_fraction():
 def test_cap_kind_fraction_single_kind_preserves_data():
     # If the whole set is the capped kind, capping is unsatisfiable — keep all
     # rather than silently returning an empty list.
-    ex = [ChatExample("test", f"t{i}", f"Question {i}?", f"Answer {i}.") for i in range(5)]
+    ex = [
+        ChatExample("test", f"t{i}", f"Question {i}?", f"Answer {i}.") for i in range(5)
+    ]
     out = cap_kind_fraction(ex, kind="test", max_fraction=0.35, seed=0)
     assert len(out) == 5

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -411,7 +411,9 @@ def test_quality_filter_drops_too_short_and_too_long():
     )
     too_short_q = _ex("hi", "a real-enough answer here please")
     too_short_a = _ex("A perfectly reasonable question?", "no")
-    too_long = _ex("Q?", "x" * 100_000)
+    # Long-enough user so this exercises the assistant MAX-length guard, not
+    # the user MIN-length guard.
+    too_long = _ex("How does this work in practice?", "x" * 100_000)
     out = quality_filter([good, too_short_q, too_short_a, too_long])
     assert out == [good]
 

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
+
 from olmlx.proxy_tuning_pipeline.cli import run_pipeline
 from olmlx.proxy_tuning_pipeline.curate import (
     dedupe_examples,
@@ -684,3 +686,62 @@ def test_load_done_provenances_missing_file_is_empty(tmp_path):
 def test_openai_generator_default_max_retries():
     gen = OpenAIGenerator(client=object())
     assert gen._max_retries == 6
+
+
+def test_parse_pairs_handles_braces_inside_string_values():
+    # olmlx responses contain code with { } — the string-aware walker must not
+    # miscount depth on braces inside quoted values.
+    text = (
+        '{"pairs": [{"instruction": "Show the dict literal?", '
+        '"response": "Use `cfg = {\\"a\\": 1}` and close with }."}]}'
+    )
+    out = parse_pairs(text)
+    assert len(out) == 1
+    assert out[0][0] == "Show the dict literal?"
+    assert "{" in out[0][1] and "}" in out[0][1]
+
+
+def test_run_pipeline_refuses_mismatched_checkpoint_config(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "olmlx").mkdir(parents=True)
+    (repo / "olmlx" / "m.py").write_text("def f():\n    return 1\n")
+    out_dir = tmp_path / "out"
+
+    class _G:
+        def generate(self, system: str, user: str) -> str:
+            return '{"pairs": [{"instruction": "Q here?", "response": "A here long enough."}]}'
+
+    # First run records n_per_unit=1.
+    run_pipeline(
+        repo, out_dir, _G(), n_per_unit=1, valid_frac=0.5, seed=0, concurrency=1
+    )
+    # Reusing the same out_dir with a different n_per_unit must refuse.
+    with pytest.raises(ValueError, match="different config"):
+        run_pipeline(
+            repo, out_dir, _G(), n_per_unit=4, valid_frac=0.5, seed=0, concurrency=1
+        )
+
+
+def test_run_pipeline_adopts_legacy_raw_without_meta(tmp_path):
+    # A raw.jsonl from an older run (no raw.meta.json) must be resumable, not refused.
+    repo = tmp_path / "repo"
+    (repo / "olmlx").mkdir(parents=True)
+    (repo / "olmlx" / "m.py").write_text("def f():\n    return 1\n")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    # Pre-seed a legacy checkpoint with no meta sidecar.
+    (out_dir / "raw.jsonl").write_text(
+        '{"kind": "function", "provenance": "olmlx/m.py:1", '
+        '"user": "Q?", "assistant": "A long enough answer here."}\n'
+    )
+
+    class _G:
+        def generate(self, system: str, user: str) -> str:
+            return '{"pairs": [{"instruction": "New Q?", "response": "New answer long enough."}]}'
+
+    stats = run_pipeline(
+        repo, out_dir, _G(), n_per_unit=1, valid_frac=0.5, seed=0, concurrency=1
+    )
+    # Did not raise; the legacy example is included and a meta sidecar now exists.
+    assert stats["generated"] >= 1
+    assert (out_dir / "raw.meta.json").exists()

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import subprocess
 
-from olmlx.proxy_tuning_pipeline.expand import build_messages, expand_units, parse_pairs
+from olmlx.proxy_tuning_pipeline.expand import (
+    DEFAULT_MODEL,
+    OpenAIGenerator,
+    build_messages,
+    expand_units,
+    parse_pairs,
+)
 from olmlx.proxy_tuning_pipeline.extract import (
     dedupe_units,
     extract_commits,
@@ -303,3 +309,57 @@ def test_expand_units_skips_units_that_yield_no_pairs():
     units = [ExtractionUnit("doc", "d.md#s", "doc", "body")]
     gen = _FakeGenerator("garbage, not json")
     assert expand_units(units, gen, n_per_unit=3) == []
+
+
+# ---------------------------------------------------------------------------
+# Task 11: OpenAIGenerator (injectable client)
+# ---------------------------------------------------------------------------
+
+
+class _FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content):
+        self.message = _FakeMessage(content)
+
+
+class _FakeCompletion:
+    def __init__(self, content):
+        self.choices = [_FakeChoice(content)]
+
+
+class _FakeOpenAIClient:
+    def __init__(self, content):
+        self._content = content
+        self.last_kwargs = None
+
+        class _Completions:
+            def create(inner, **kwargs):
+                self.last_kwargs = kwargs
+                return _FakeCompletion(self._content)
+
+        class _Chat:
+            completions = _Completions()
+
+        self.chat = _Chat()
+
+
+def test_openai_generator_calls_chat_completions():
+    client = _FakeOpenAIClient('{"pairs": []}')
+    gen = OpenAIGenerator(client=client)
+    out = gen.generate("sys", "usr")
+    assert out == '{"pairs": []}'
+    assert client.last_kwargs["model"] == DEFAULT_MODEL
+    assert client.last_kwargs["messages"] == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "usr"},
+    ]
+
+
+def test_openai_generator_honors_model_override():
+    client = _FakeOpenAIClient("x")
+    OpenAIGenerator(client=client, model="custom-model").generate("s", "u")
+    assert client.last_kwargs["model"] == "custom-model"

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -69,3 +69,34 @@ def test_strip_secrets_redacts_known_token_shapes():
 def test_strip_secrets_leaves_ordinary_text_untouched():
     text = "def generate_chat(model, messages): return run(model, messages)"
     assert strip_secrets(text) == text
+
+
+from olmlx.proxy_tuning_pipeline.extract import extract_functions
+
+
+def test_extract_functions_yields_unit_per_function(tmp_path):
+    src = tmp_path / "mod.py"
+    src.write_text(
+        'def add(a, b):\n'
+        '    """Return the sum of a and b."""\n'
+        '    return a + b\n'
+        '\n'
+        'def _private():\n'
+        '    return 1\n'
+    )
+    units = list(extract_functions(tmp_path))
+    by_name = {u.provenance: u for u in units}
+    # Both functions captured; provenance is file:lineno.
+    assert any(p.endswith("mod.py:1") for p in by_name)
+    add_unit = next(u for u in units if "def add" in u.source_context)
+    assert add_unit.kind == "function"
+    assert "Return the sum" in add_unit.source_context
+    assert "add" in add_unit.instruction_hint
+
+
+def test_extract_functions_skips_non_python_and_pycache(tmp_path):
+    (tmp_path / "note.txt").write_text("def not_python(): pass")
+    cache = tmp_path / "__pycache__"
+    cache.mkdir()
+    (cache / "x.py").write_text("def cached(): pass")
+    assert list(extract_functions(tmp_path)) == []

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 
+from olmlx.proxy_tuning_pipeline.expand import build_messages, parse_pairs
 from olmlx.proxy_tuning_pipeline.extract import (
     dedupe_units,
     extract_commits,
@@ -222,3 +223,44 @@ def test_extract_repo_composes_all_extractors(tmp_path):
     kinds = {u.kind for u in units}
     # Commit extractor finds nothing here (no git repo) — that's fine.
     assert {"function", "invariant", "doc", "test"} <= kinds
+
+
+# ---------------------------------------------------------------------------
+# Task 9: Generator protocol + build_messages + parse_pairs
+# ---------------------------------------------------------------------------
+
+
+def test_build_messages_grounds_in_source_and_requests_json():
+    u = ExtractionUnit("function", "a.py:1", "the `f` function", "def f(): return 1")
+    system, user = build_messages(u, n_pairs=3)
+    assert "ground" in system.lower()  # grounding discipline present
+    assert "JSON" in system or "json" in system
+    assert "def f(): return 1" in user  # source context embedded
+    assert "3" in user  # requested count
+    assert "the `f` function" in user  # instruction hint embedded
+
+
+def test_build_messages_truncates_oversized_source():
+    u = ExtractionUnit("doc", "d.md#s", "a doc", "x" * 99999)
+    _system, user = build_messages(u, n_pairs=2)
+    assert len(user) < 20000  # clamped well below the raw 99999
+
+
+def test_parse_pairs_extracts_valid_pairs():
+    text = '{"pairs": [{"instruction": "Q1", "response": "A1"}, {"instruction": "Q2", "response": "A2"}]}'
+    assert parse_pairs(text) == [("Q1", "A1"), ("Q2", "A2")]
+
+
+def test_parse_pairs_tolerates_code_fences_and_drops_incomplete():
+    text = (
+        "```json\n"
+        '{"pairs": [{"instruction": "Q", "response": "A"}, '
+        '{"instruction": "", "response": "x"}, '
+        '{"instruction": "only-q"}]}\n'
+        "```"
+    )
+    assert parse_pairs(text) == [("Q", "A")]
+
+
+def test_parse_pairs_returns_empty_on_garbage():
+    assert parse_pairs("not json at all") == []

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -867,3 +867,11 @@ def test_split_train_valid_rejects_out_of_range_fraction():
         split_train_valid(ex, valid_frac=1.0, seed=0)
     with pytest.raises(ValueError, match="valid_frac"):
         split_train_valid(ex, valid_frac=-0.1, seed=0)
+
+
+def test_cap_kind_fraction_single_kind_preserves_data():
+    # If the whole set is the capped kind, capping is unsatisfiable — keep all
+    # rather than silently returning an empty list.
+    ex = [ChatExample("test", f"t{i}", f"Question {i}?", f"Answer {i}.") for i in range(5)]
+    out = cap_kind_fraction(ex, kind="test", max_fraction=0.35, seed=0)
+    assert len(out) == 5

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -1,0 +1,48 @@
+"""Tests for the proxy-tuning data pipeline (olmlx/proxy_tuning_pipeline)."""
+
+from __future__ import annotations
+
+from olmlx.proxy_tuning_pipeline.schema import (
+    ChatExample,
+    ExtractionUnit,
+    read_jsonl,
+    write_jsonl,
+)
+
+
+def test_jsonl_round_trip(tmp_path):
+    rows = [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+    path = tmp_path / "out.jsonl"
+    write_jsonl(path, rows)
+    assert read_jsonl(path) == rows
+
+
+def test_extraction_unit_to_dict():
+    u = ExtractionUnit(
+        kind="function",
+        provenance="olmlx/foo.py:10",
+        instruction_hint="explain this",
+        source_context="def f(): ...",
+    )
+    assert u.to_dict() == {
+        "kind": "function",
+        "provenance": "olmlx/foo.py:10",
+        "instruction_hint": "explain this",
+        "source_context": "def f(): ...",
+    }
+
+
+def test_chat_example_to_jsonl_row_is_mlx_chat_format():
+    ex = ChatExample(
+        kind="function",
+        provenance="olmlx/foo.py:10",
+        user="How does f work?",
+        assistant="It returns nothing.",
+    )
+    # mlx-lm chat format: only the `messages` key reaches train.jsonl.
+    assert ex.to_chat_row() == {
+        "messages": [
+            {"role": "user", "content": "How does f work?"},
+            {"role": "assistant", "content": "It returns nothing."},
+        ]
+    }

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -204,3 +204,32 @@ def test_extract_commits_yields_message_and_diff(tmp_path):
     assert "feat: add x constant" in u.source_context
     assert "x = 1" in u.source_context  # diff body included
     assert u.provenance.startswith("git:")
+
+
+from olmlx.proxy_tuning_pipeline.extract import dedupe_units, extract_repo
+
+
+def test_dedupe_units_drops_identical_source_context():
+    u1 = ExtractionUnit("function", "a.py:1", "h", "def f(): pass")
+    u2 = ExtractionUnit("function", "b.py:9", "h2", "def f(): pass")  # same source
+    u3 = ExtractionUnit("function", "c.py:1", "h", "def g(): pass")
+    out = dedupe_units([u1, u2, u3])
+    assert len(out) == 2
+    assert out[0] is u1 and out[1] is u3  # first occurrence kept, order preserved
+
+
+def test_extract_repo_composes_all_extractors(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "olmlx").mkdir(parents=True)
+    (repo / "olmlx" / "m.py").write_text('def f():\n    """doc."""\n    return 1\n')
+    (repo / "CLAUDE.md").write_text(
+        "## Non-Obvious Invariants\n\n**Inv one** — a rule.\n"
+    )
+    (repo / "docs").mkdir()
+    (repo / "docs" / "x.md").write_text("## Sec\n\nbody.\n")
+    (repo / "tests").mkdir()
+    (repo / "tests" / "test_m.py").write_text("def test_f():\n    assert True\n")
+    units = extract_repo(repo)
+    kinds = {u.kind for u in units}
+    # Commit extractor finds nothing here (no git repo) — that's fine.
+    assert {"function", "invariant", "doc", "test"} <= kinds

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 import subprocess
 
+from olmlx.proxy_tuning_pipeline.cli import run_pipeline
+from olmlx.proxy_tuning_pipeline.curate import (
+    dedupe_examples,
+    quality_filter,
+    split_train_valid,
+)
 from olmlx.proxy_tuning_pipeline.expand import (
     DEFAULT_MODEL,
     OpenAIGenerator,
@@ -388,3 +394,107 @@ def test_openai_generator_honors_model_override():
     client = _FakeOpenAIClient("x")
     OpenAIGenerator(client=client, model="custom-model").generate("s", "u")
     assert client.last_kwargs["model"] == "custom-model"
+
+
+# ---------------------------------------------------------------------------
+# Task 12: Curation — quality_filter + dedupe_examples
+# ---------------------------------------------------------------------------
+
+
+def _ex(user, assistant, kind="function", prov="a.py:1"):
+    return ChatExample(kind=kind, provenance=prov, user=user, assistant=assistant)
+
+
+def test_quality_filter_drops_too_short_and_too_long():
+    good = _ex(
+        "How does generate_chat route output?", "It calls parse_model_output ..."
+    )
+    too_short_q = _ex("hi", "a real-enough answer here please")
+    too_short_a = _ex("A perfectly reasonable question?", "no")
+    too_long = _ex("Q?", "x" * 100_000)
+    out = quality_filter([good, too_short_q, too_short_a, too_long])
+    assert out == [good]
+
+
+def test_dedupe_examples_drops_normalized_duplicates():
+    a = _ex("How  does   F work?", "Answer A")
+    b = _ex("how does f work?", "answer a")  # same after normalization
+    c = _ex("Different question?", "Different answer")
+    out = dedupe_examples([a, b, c])
+    assert out == [a, c]  # first kept, order preserved
+
+
+# ---------------------------------------------------------------------------
+# Task 13: Curation — split_train_valid
+# ---------------------------------------------------------------------------
+
+
+def test_split_train_valid_ratio_and_determinism():
+    examples = [_ex(f"Q{i}?", f"answer number {i}") for i in range(100)]
+    train1, valid1 = split_train_valid(examples, valid_frac=0.1, seed=42)
+    assert len(valid1) == 10 and len(train1) == 90
+    # No overlap; union is the whole set.
+    assert {id(e) for e in train1}.isdisjoint({id(e) for e in valid1})
+    assert len(train1) + len(valid1) == 100
+    # Deterministic for a fixed seed.
+    train2, valid2 = split_train_valid(examples, valid_frac=0.1, seed=42)
+    assert [e.user for e in valid1] == [e.user for e in valid2]
+
+
+def test_split_train_valid_guarantees_at_least_one_valid():
+    examples = [_ex("Q?", "a real answer here")]
+    train, valid = split_train_valid(examples, valid_frac=0.1, seed=0)
+    assert len(valid) == 1 and len(train) == 0
+
+
+# ---------------------------------------------------------------------------
+# Task 14: CLI wiring + end-to-end test
+# ---------------------------------------------------------------------------
+
+
+def test_run_pipeline_end_to_end(tmp_path):
+    # Minimal fixture repo.
+    repo = tmp_path / "repo"
+    (repo / "olmlx").mkdir(parents=True)
+    (repo / "olmlx" / "m.py").write_text('def f():\n    """doc."""\n    return 1\n')
+    (repo / "CLAUDE.md").write_text(
+        "## Non-Obvious Invariants\n\n**Inv one** — a real rule about streams.\n"
+    )
+    out_dir = tmp_path / "out"
+
+    # Use a call-varying generator so each unit produces distinct (user, assistant)
+    # pairs that survive dedup and both reach the train/valid split.
+    class _VaryingGenerator:
+        def __init__(self):
+            self.calls = 0
+
+        def generate(self, system: str, user: str) -> str:
+            self.calls += 1
+            return (
+                f'{{"pairs": [{{"instruction": "Explain unit {self.calls} clearly?", '
+                f'"response": "A grounded answer about olmlx unit {self.calls} detail."}}]}}'
+            )
+
+    gen = _VaryingGenerator()
+    stats = run_pipeline(
+        repo_root=repo,
+        out_dir=out_dir,
+        generator=gen,
+        n_per_unit=1,
+        valid_frac=0.5,
+        seed=7,
+    )
+
+    # Artifacts written in mlx-lm chat format.
+    train = read_jsonl(out_dir / "train.jsonl")
+    valid = read_jsonl(out_dir / "valid.jsonl")
+    assert train and valid
+    assert set(train[0].keys()) == {"messages"}
+    roles = [m["role"] for m in train[0]["messages"]]
+    assert roles == ["user", "assistant"]
+
+    # Stats report generated-vs-kept (no silent truncation).
+    assert stats["units"] >= 2  # function + invariant
+    assert stats["generated"] >= 2
+    assert stats["kept"] == stats["train"] + stats["valid"]
+    assert stats["train"] == len(train) and stats["valid"] == len(valid)

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import subprocess
 
-from olmlx.proxy_tuning_pipeline.expand import build_messages, parse_pairs
+from olmlx.proxy_tuning_pipeline.expand import build_messages, expand_units, parse_pairs
 from olmlx.proxy_tuning_pipeline.extract import (
     dedupe_units,
     extract_commits,
@@ -264,3 +264,42 @@ def test_parse_pairs_tolerates_code_fences_and_drops_incomplete():
 
 def test_parse_pairs_returns_empty_on_garbage():
     assert parse_pairs("not json at all") == []
+
+
+# ---------------------------------------------------------------------------
+# Task 10: expand_units driver
+# ---------------------------------------------------------------------------
+
+
+class _FakeGenerator:
+    def __init__(self, reply: str):
+        self.reply = reply
+        self.calls = 0
+
+    def generate(self, system: str, user: str) -> str:
+        self.calls += 1
+        return self.reply
+
+
+def test_expand_units_produces_chat_examples_with_provenance():
+    units = [
+        ExtractionUnit("function", "a.py:1", "fn a", "def a(): pass"),
+        ExtractionUnit("doc", "d.md#s", "doc s", "body"),
+    ]
+    gen = _FakeGenerator(
+        '{"pairs": [{"instruction": "Q1", "response": "A1"}, '
+        '{"instruction": "Q2", "response": "A2"}]}'
+    )
+    examples = expand_units(units, gen, n_per_unit=2)
+    assert gen.calls == 2  # one generation call per unit
+    assert len(examples) == 4  # 2 pairs * 2 units
+    assert all(isinstance(e, ChatExample) for e in examples)
+    first = examples[0]
+    assert first.user == "Q1" and first.assistant == "A1"
+    assert first.provenance == "a.py:1" and first.kind == "function"
+
+
+def test_expand_units_skips_units_that_yield_no_pairs():
+    units = [ExtractionUnit("doc", "d.md#s", "doc", "body")]
+    gen = _FakeGenerator("garbage, not json")
+    assert expand_units(units, gen, n_per_unit=3) == []

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -272,6 +272,17 @@ def test_parse_pairs_returns_empty_on_garbage():
     assert parse_pairs("not json at all") == []
 
 
+def test_parse_pairs_extracts_first_object_from_prose_wrapped_reply():
+    # Model wraps the JSON in prose and emits a trailing object — the balanced
+    # brace walk must grab only the first complete object, not span to the last }.
+    text = (
+        "Here is the JSON you asked for:\n"
+        '{"pairs": [{"instruction": "Q", "response": "A with {braces} inside"}]}\n\n'
+        'Also note: {"unrelated": true}'
+    )
+    assert parse_pairs(text) == [("Q", "A with {braces} inside")]
+
+
 # ---------------------------------------------------------------------------
 # Task 10: expand_units driver
 # ---------------------------------------------------------------------------
@@ -309,6 +320,20 @@ def test_expand_units_skips_units_that_yield_no_pairs():
     units = [ExtractionUnit("doc", "d.md#s", "doc", "body")]
     gen = _FakeGenerator("garbage, not json")
     assert expand_units(units, gen, n_per_unit=3) == []
+    assert gen.calls == 1  # the generator was still invoked
+
+
+def test_expand_units_continues_after_generator_exception():
+    class _ExplodingGenerator:
+        def generate(self, system: str, user: str) -> str:
+            raise RuntimeError("boom")
+
+    units = [
+        ExtractionUnit("doc", "a", "h", "b"),
+        ExtractionUnit("doc", "c", "h", "d"),
+    ]
+    # A raising generator must not abort the run; all-failed -> empty result.
+    assert expand_units(units, _ExplodingGenerator(), n_per_unit=2) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_proxy_tuning_pipeline.py
+++ b/tests/test_proxy_tuning_pipeline.py
@@ -168,3 +168,39 @@ def test_extract_tests_yields_unit_per_test_function(tmp_path):
     assert u.kind == "test"
     assert "test_adds" in u.instruction_hint
     assert "assert 1 + 1 == 2" in u.source_context
+
+
+import subprocess
+
+from olmlx.proxy_tuning_pipeline.extract import extract_commits
+
+
+def _git(repo, *args):
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        env={
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+            "PATH": __import__("os").environ.get("PATH", ""),
+        },
+    )
+
+
+def test_extract_commits_yields_message_and_diff(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    (repo / "f.py").write_text("x = 1\n")
+    _git(repo, "add", "f.py")
+    _git(repo, "commit", "-m", "feat: add x constant")
+    units = list(extract_commits(repo, limit=10))
+    assert len(units) == 1
+    u = units[0]
+    assert u.kind == "commit"
+    assert "feat: add x constant" in u.source_context
+    assert "x = 1" in u.source_context  # diff body included
+    assert u.provenance.startswith("git:")


### PR DESCRIPTION
## Summary

**Stage 1 of 3** of the olmlx-domain proxy-tuning effort (design spec: `docs/superpowers/specs/2026-06-15-olmlx-proxy-tuning-pair-design.md`). This adds an **offline data pipeline** that mines the olmlx repo into a curated, chat-format SFT dataset for training the proxy-tuning expert M⁺.

New importable package `olmlx/proxy_tuning_pipeline/` (**never imported by the running server** — pure offline tooling; `openai` is lazy-imported):

- **Extraction** (`extract.py`) — mines grounded `(source, seed)` units from five sources: functions+docstrings, CLAUDE.md invariants, `docs/` sections, test functions, and git commits (message+diff). Secret-stripped, provenance-tagged, deduped.
- **Expansion** (`expand.py`) — a `Generator` protocol + `OpenAIGenerator` (GPT-5.4-mini, dependency-injected) turns each unit into diverse instruction→response pairs, grounded strictly in the source. Balanced-brace JSON extraction tolerates prose-wrapped replies; systemic-failure logging surfaces an all-failed run.
- **Curation** (`curate.py`) — quality filter, normalized-exact dedup, deterministic seeded train/valid split.
- **CLI** (`cli.py`) — `run_pipeline` (testable core) + `main` wires extract → expand → curate → write `train.jsonl`/`valid.jsonl` in **mlx-lm chat format**, with generated-vs-kept stats (no silent truncation).

Built via subagent-driven TDD (per-task implement + two-stage spec/quality review); a final whole-pipeline review returned **ready to merge**.

## Design choices
- `Generator` is injected → all tests run with no network (a fake client/generator); the real OpenAI call is isolated to one method.
- Dedup is normalized-exact (no embedding/ML deps — YAGNI).
- Intermediate-artifact persistence is a documented deferral; an in-code `TODO` flags adding 429 retry before the full ~1.7hr run.

## Test Plan
- [x] `uv run pytest tests/test_proxy_tuning_pipeline.py` — 30 unit/integration tests (extractors on fixtures incl. a temp git repo; OpenAI mocked via injected client; curation; end-to-end with a fake generator; malformed-file robustness)
- [x] `ruff check` + `ruff format` clean
- [ ] **Manual (yours):** real GPT-5.4-mini dry run on the repo (`OPENAI_API_KEY=... uv run python -m olmlx.proxy_tuning_pipeline.cli --repo . --out /tmp/ptdata_smoke --n-per-unit 1`) to eyeball grounding quality before the full ~10k pass (Task 15 in the plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)