### PR TITLE
fix(chat): load gemma-4 unified 12B + clean terminal streaming

### DIFF
--- a/docs/superpowers/plans/2026-06-19-gemma4-terminal-streaming.md
+++ b/docs/superpowers/plans/2026-06-19-gemma4-terminal-streaming.md
@@ -1,0 +1,591 @@
+# Gemma-4 Terminal Streaming Display Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `olmlx chat` stream Gemma-4 output cleanly — route `<|channel>thought…<channel|>` to the thinking channel and suppress `<|tool_call>…<tool_call|>` markup from visible tokens — without changing tool-execution correctness or the HTTP routers.
+
+**Architecture:** Refactor `ThinkingTracker` (chat/session.py) from a bespoke `<think>`-only scanner into a thin adapter over the shared `routers/thinking_split.split_thinking_parts` state machine (which already recognizes both `<think>` and the Gemma-4 channel format), plus a small streaming tool-markup suppressor for the content channel. The raw `accumulated` text is preserved verbatim so the existing turn-end parse path (`parse_model_output` → tool execution) is untouched.
+
+**Tech Stack:** Python 3.11, pytest, mlx-lm; spec at `docs/superpowers/specs/2026-06-19-gemma4-terminal-streaming-design.md`.
+
+---
+
+## File Structure
+
+- `olmlx/chat/session.py` — **Modify.** Add `_ToolMarkupStripper` (new class) and the `_longest_partial_tag_suffix` helper; rewrite `ThinkingTracker` internals to delegate to `split_thinking_parts` + the stripper. Public API of `ThinkingTracker` is unchanged.
+- `olmlx/engine/model_manager.py` — **Already modified** (uncommitted): `gemma4_unified` loader + eos stop-set fix. Committed in Task 1.
+- `tests/test_chat_session_helpers.py`, `tests/test_chat_session.py` — **Existing**, must stay green (11 ThinkingTracker / streaming tests).
+- `tests/test_chat_session_helpers.py` — **Modify**, add the new stripper + Gemma-4 streaming unit tests.
+- `tests/live/test_gemma4_unified_text.py` — **Already created** (uncommitted); extend with a session-splitter assertion in Task 4.
+
+---
+
+### Task 1: Commit the baseline bug fixes
+
+The loading + eos fixes and their tests are already in the working tree and verified green (235 unit tests + 3 live tests pass, ruff clean). Commit them as the baseline before the streaming work.
+
+**Files:**
+- Modify: `olmlx/engine/model_manager.py`
+- Test: `tests/test_model_manager.py`, `tests/live/test_gemma4_unified_text.py`
+
+- [ ] **Step 1: Confirm tests pass and ruff is clean**
+
+Run:
+```bash
+uv run pytest tests/test_model_manager.py -q
+uv run ruff check olmlx/engine/model_manager.py tests/test_model_manager.py tests/live/test_gemma4_unified_text.py
+uv run ruff format --check olmlx/engine/model_manager.py tests/test_model_manager.py tests/live/test_gemma4_unified_text.py
+```
+Expected: `235 passed`; `All checks passed!`; all files formatted.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add olmlx/engine/model_manager.py tests/test_model_manager.py tests/live/test_gemma4_unified_text.py
+git commit -m "fix(engine): load gemma-4 unified 12B language tower + thread eos stop set
+
+mlx-community/gemma-4-12B-it-4bit ships model_type 'gemma4_unified' whose
+vision tower (vision_embedder.*) loads in neither mlx-lm's gemma4_text nor
+mlx-vlm 0.4.4's gemma4. Load the language tower via gemma4_text, dropping
+the multimodal weights; never rewrite config.json on disk. Thread the full
+eos_token_id list ([1,106,50] = <eos>/<turn|>/<|tool_response>) into the
+tokenizer so generation stops at turn/tool boundaries instead of looping.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Streaming tool-markup suppressor
+
+A stateful helper that removes `<|tool_call>…<tool_call|>` spans from a stream of text fragments, holding back partial delimiters across chunk boundaries. Display-only; raw text is preserved elsewhere.
+
+**Files:**
+- Modify: `olmlx/chat/session.py` (add near the other module-level helpers, after the `_THINK_*` constants around line 70-74)
+- Test: `tests/test_chat_session_helpers.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_chat_session_helpers.py`:
+
+```python
+from olmlx.chat.session import _ToolMarkupStripper, _longest_partial_tag_suffix
+
+
+class TestLongestPartialTagSuffix:
+    def test_no_partial(self):
+        assert _longest_partial_tag_suffix("hello", "<|tool_call>") == 0
+
+    def test_full_partial(self):
+        assert _longest_partial_tag_suffix("abc<|to", "<|tool_call>") == 4
+
+    def test_does_not_count_full_tag(self):
+        # A complete tag is not a "partial" — len must be < tag length.
+        assert _longest_partial_tag_suffix("<|tool_call>", "<|tool_call>") < len(
+            "<|tool_call>"
+        )
+
+
+class TestToolMarkupStripper:
+    def test_passes_plain_text(self):
+        s = _ToolMarkupStripper()
+        assert s.feed("hello world") == "hello world"
+        assert s.flush() == ""
+
+    def test_removes_whole_tool_call_in_one_chunk(self):
+        s = _ToolMarkupStripper()
+        out = s.feed("before<|tool_call>call:f{a:1}<tool_call|>after")
+        assert out == "beforeafter"
+        assert s.flush() == ""
+
+    def test_removes_tool_call_split_across_chunks(self):
+        s = _ToolMarkupStripper()
+        out = "".join(
+            [
+                s.feed("vis<|tool_"),
+                s.feed("call>call:f{a:"),
+                s.feed("1}<tool_"),
+                s.feed("call|>tail"),
+            ]
+        )
+        assert out == "vistail"
+        assert s.flush() == ""
+
+    def test_holds_partial_open_then_resolves_as_literal(self):
+        s = _ToolMarkupStripper()
+        # "<|too" looks like a partial open tag, held back...
+        assert s.feed("x<|too") == "x"
+        # ...but the next chunk shows it was literal text.
+        assert s.feed("ls are fun") == "<|tools are fun"
+        assert s.flush() == ""
+
+    def test_flush_emits_held_partial_when_outside(self):
+        s = _ToolMarkupStripper()
+        assert s.feed("done<|tool") == "done"
+        # Stream ended mid partial open-tag; it was literal.
+        assert s.flush() == "<|tool"
+
+    def test_flush_drops_unterminated_tool_call(self):
+        s = _ToolMarkupStripper()
+        assert s.feed("a<|tool_call>call:f{") == "a"
+        # Unterminated tool call (no close) — drop it from display.
+        assert s.flush() == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_chat_session_helpers.py -k "ToolMarkupStripper or LongestPartialTagSuffix" -q`
+Expected: FAIL with `ImportError: cannot import name '_ToolMarkupStripper'`.
+
+- [ ] **Step 3: Implement the helper and class**
+
+In `olmlx/chat/session.py`, after the `_THINK_*` constants (around line 74), add:
+
+```python
+# Gemma-4 native tool-call markup (plain text, not special tokens). Display
+# is suppressed during streaming; the raw markup stays in the tracker's
+# accumulated text so parse_model_output still extracts the call at turn end.
+_TOOL_CALL_OPEN = "<|tool_call>"
+_TOOL_CALL_CLOSE = "<tool_call|>"
+
+
+def _longest_partial_tag_suffix(buf: str, tag: str) -> int:
+    """Largest ``k`` (``0 < k < len(tag)``) such that ``buf[-k:] == tag[:k]``.
+
+    Used to hold back the trailing bytes of *buf* that might be the start of
+    *tag* straddling a chunk boundary.
+    """
+    for k in range(min(len(tag) - 1, len(buf)), 0, -1):
+        if buf[-k:] == tag[:k]:
+            return k
+    return 0
+
+
+class _ToolMarkupStripper:
+    """Remove ``<|tool_call>…<tool_call|>`` spans from a stream of text.
+
+    Holds partial open/close delimiters across chunk boundaries. Display-only:
+    callers keep the raw text elsewhere for parsing.
+    """
+
+    def __init__(self) -> None:
+        self._buf = ""
+        self._inside = False
+
+    def feed(self, text: str) -> str:
+        self._buf += text
+        out: list[str] = []
+        while self._buf:
+            if not self._inside:
+                idx = self._buf.find(_TOOL_CALL_OPEN)
+                if idx != -1:
+                    out.append(self._buf[:idx])
+                    self._buf = self._buf[idx + len(_TOOL_CALL_OPEN) :]
+                    self._inside = True
+                    continue
+                keep = _longest_partial_tag_suffix(self._buf, _TOOL_CALL_OPEN)
+                out.append(self._buf[: len(self._buf) - keep] if keep else self._buf)
+                self._buf = self._buf[len(self._buf) - keep :] if keep else ""
+                break
+            idx = self._buf.find(_TOOL_CALL_CLOSE)
+            if idx != -1:
+                self._buf = self._buf[idx + len(_TOOL_CALL_CLOSE) :]
+                self._inside = False
+                continue
+            keep = _longest_partial_tag_suffix(self._buf, _TOOL_CALL_CLOSE)
+            self._buf = self._buf[len(self._buf) - keep :] if keep else ""
+            break
+        return "".join(out)
+
+    def flush(self) -> str:
+        """Emit any held-back bytes at stream end.
+
+        A partial open-tag held while *outside* a call was literal text. Bytes
+        held while *inside* an unterminated call are dropped (no close arrived).
+        """
+        if self._inside:
+            self._buf = ""
+            return ""
+        out = self._buf
+        self._buf = ""
+        return out
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_chat_session_helpers.py -k "ToolMarkupStripper or LongestPartialTagSuffix" -q`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add olmlx/chat/session.py tests/test_chat_session_helpers.py
+git commit -m "feat(chat): streaming tool-markup suppressor for gemma-4
+
+Removes <|tool_call>…<tool_call|> spans from streamed visible text,
+holding partial delimiters across chunk boundaries. Display-only.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Refactor `ThinkingTracker` to delegate to `split_thinking_parts`
+
+Rewrite the internals so thinking/content separation comes from the shared state machine (handles `<think>` AND Gemma-4 channels) and content is run through the tool-markup stripper. Keep the public API identical so existing tests and the session keep working.
+
+**Files:**
+- Modify: `olmlx/chat/session.py` (`ThinkingTracker`, lines ~217-365; import at top)
+- Test: `tests/test_chat_session_helpers.py` (new Gemma-4 tests), plus all existing tests must stay green.
+
+- [ ] **Step 1: Write the failing Gemma-4 streaming tests**
+
+Add to `tests/test_chat_session_helpers.py`:
+
+```python
+from olmlx.chat.session import ThinkingTracker
+
+
+class TestThinkingTrackerGemma4:
+    def _drain(self, tracker, chunks):
+        think, visible = [], []
+        started = ended = False
+        for c in chunks:
+            td, vd, te, ts = tracker.feed(c)
+            if td:
+                think.append(td)
+            if vd:
+                visible.append(vd)
+            started = started or ts
+            ended = ended or te
+        return "".join(think), "".join(visible), started, ended
+
+    def test_gemma4_channel_split_single_chunk(self):
+        t = ThinkingTracker()
+        raw = "<|channel>thought\nreasoning here<channel|>The answer is 4."
+        think, visible, started, ended = self._drain(t, [raw])
+        assert think == "reasoning here"
+        assert visible == "The answer is 4."
+        assert started and ended
+
+    def test_gemma4_channel_split_across_chunks(self):
+        t = ThinkingTracker()
+        chunks = ["<|channel>thought\nrea", "soning<chan", "nel|>visible"]
+        think, visible, started, ended = self._drain(t, chunks)
+        assert think == "reasoning"
+        assert visible == "visible"
+
+    def test_gemma4_tool_call_suppressed_from_visible(self):
+        t = ThinkingTracker()
+        raw = (
+            "<|channel>thought\nI will call it.<channel|>"
+            '<|tool_call>call:get_weather{city:<|"|>Paris<|"|>}<tool_call|>'
+        )
+        think, visible, _, _ = self._drain(t, [raw])
+        assert think == "I will call it."
+        assert visible == ""
+        # Raw markup is preserved for the turn-end parse.
+        assert "<|tool_call>" in t.accumulated
+        assert "<|channel>thought" in t.accumulated
+
+    def test_accumulated_is_raw(self):
+        t = ThinkingTracker()
+        chunks = ["<|channel>thought\nx<channel|>", "<|tool_call>call:f{}<tool_call|>"]
+        for c in chunks:
+            t.feed(c)
+        assert t.accumulated == "".join(chunks)
+
+    def test_gemma4_thinking_disabled_strips_channel(self):
+        t = ThinkingTracker(thinking_disabled=True)
+        raw = "<|channel>thought\nhidden reasoning<channel|>visible answer"
+        think, visible, started, ended = self._drain(t, [raw])
+        assert think == ""
+        assert visible == "visible answer"
+        assert not started
+
+    def test_gemma4_repetition_strip_truncates_at_channel(self):
+        t = ThinkingTracker()
+        t.feed("<|channel>thought\nlooping looping looping")
+        assert t.in_thinking
+        t.strip_on_repetition()
+        assert "<|channel>thought" not in t.accumulated
+        assert not t.in_thinking
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_chat_session_helpers.py -k "ThinkingTrackerGemma4" -q`
+Expected: FAIL — current `ThinkingTracker` only knows `<think>`, so `think` will be empty / visible will contain the raw channel markup.
+
+- [ ] **Step 3: Add the import**
+
+At the top of `olmlx/chat/session.py`, with the other `olmlx` imports, add:
+
+```python
+from olmlx.routers.thinking_split import (
+    _THINKING_PAIRS,
+    flush_split_thinking,
+    split_thinking_parts,
+)
+```
+
+- [ ] **Step 4: Rewrite `ThinkingTracker` internals**
+
+Replace the entire `ThinkingTracker` class body (lines ~217-365) with:
+
+```python
+class ThinkingTracker:
+    """Splits streaming output into thinking vs visible, with tool markup
+    suppressed from the visible channel.
+
+    Delegates thinking-tag detection to the shared
+    ``routers.thinking_split`` state machine (``<think>…</think>`` AND
+    Gemma-4 ``<|channel>thought\\n…<channel|>``), and runs the visible
+    channel through ``_ToolMarkupStripper`` so Gemma-4's
+    ``<|tool_call>…<tool_call|>`` markup never reaches the display. The raw
+    text is kept verbatim in ``accumulated`` for the turn-end parse step.
+    """
+
+    def __init__(
+        self,
+        implicit_mode: bool = False,
+        thinking_disabled: bool = False,
+        template_has_thinking: bool = False,
+    ):
+        self._thinking_disabled = thinking_disabled
+        self._accumulated = ""
+        self._think_emitted = 0
+        self._visible_emitted = 0
+        self._in_thinking = False
+        self._just_started = False
+        # A template that injects <think> (implicit) or otherwise advertises
+        # thinking widens the splitter's orphan-detection window and enables
+        # the orphan-</think> heuristic.
+        self._split_state: dict = {
+            "thinking_expected": bool(implicit_mode or template_has_thinking),
+        }
+        self._tool_stripper = _ToolMarkupStripper()
+
+    @property
+    def accumulated(self) -> str:
+        return self._accumulated
+
+    @property
+    def in_thinking(self) -> bool:
+        return self._in_thinking
+
+    @property
+    def just_started(self) -> bool:
+        return self._just_started
+
+    @property
+    def think_emitted(self) -> int:
+        return self._think_emitted
+
+    @property
+    def visible_emitted(self) -> int:
+        return self._visible_emitted
+
+    def feed(self, text: str) -> tuple[str | None, str | None, bool, bool]:
+        """Ingest a chunk; return (think_delta, visible_delta, thinking_ended,
+        thinking_started)."""
+        self._accumulated += text
+        parts = split_thinking_parts(text, self._split_state)
+
+        think_parts: list[str] = []
+        visible_parts: list[str] = []
+        thinking_started = False
+        thinking_ended = False
+
+        for channel, fragment in parts:
+            if channel == "thinking":
+                if self._thinking_disabled:
+                    continue
+                if not self._in_thinking:
+                    thinking_started = True
+                    self._in_thinking = True
+                think_parts.append(fragment)
+                self._think_emitted += len(fragment)
+            else:  # content
+                if self._in_thinking:
+                    thinking_ended = True
+                    self._in_thinking = False
+                visible = self._tool_stripper.feed(fragment)
+                if visible:
+                    visible_parts.append(visible)
+                    self._visible_emitted += len(visible)
+
+        self._just_started = thinking_started
+        think_delta = "".join(think_parts) or None
+        visible_delta = "".join(visible_parts) or None
+        return think_delta, visible_delta, thinking_ended, thinking_started
+
+    def flush_disabled(self) -> str | None:
+        """Flush buffered content as visible when thinking is disabled.
+
+        Mirrors the old implicit+no-close+disabled case: at stream end any
+        bytes the splitter still holds (never resolved to a thinking block)
+        are real visible content.
+        """
+        if not self._thinking_disabled:
+            return None
+        _thinking, content = flush_split_thinking(self._split_state)
+        content = self._tool_stripper.feed(content) + self._tool_stripper.flush()
+        if content:
+            self._visible_emitted += len(content)
+            return content
+        return None
+
+    def strip_on_repetition(self) -> int | None:
+        """Truncate accumulated text at the start of the open thinking block.
+
+        Removes an incomplete thinking block so the turn-end parse sees a
+        clean prefix. Searches for the latest open tag of any known pair.
+        """
+        if not self._in_thinking:
+            return None
+        cut = max(
+            (self._accumulated.rfind(open_tag) for open_tag, _ in _THINKING_PAIRS),
+            default=-1,
+        )
+        if cut >= 0:
+            self._accumulated = self._accumulated[:cut]
+            self._visible_emitted = len(self._accumulated)
+            self._in_thinking = False
+            return self._visible_emitted
+        return None
+```
+
+- [ ] **Step 5: Run the new Gemma-4 tests**
+
+Run: `uv run pytest tests/test_chat_session_helpers.py -k "ThinkingTrackerGemma4" -q`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: Run the full chat-session test suites (regression gate)**
+
+Run:
+```bash
+uv run pytest tests/test_chat_session_helpers.py tests/test_chat_session.py -q
+```
+Expected: PASS — all existing ThinkingTracker / streaming / implicit-thinking / repetition tests plus the new ones.
+
+If any existing test fails, the parts→4-tuple mapping diverged from the old contract. Likely culprits and fixes:
+- `<think>` content not emitted: confirm `split_thinking_parts` sees `<think>`/`</think>` (it does via `_THINKING_PAIRS`); ensure `feed` appends to `_accumulated` before splitting.
+- implicit-thinking (no opener, orphan `</think>`): confirm `thinking_expected` is set from `implicit_mode or template_has_thinking` in `__init__`.
+- disabled-thinking flush: confirm `flush_disabled` uses `flush_split_thinking` and only fires when `_thinking_disabled`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add olmlx/chat/session.py tests/test_chat_session_helpers.py
+git commit -m "refactor(chat): ThinkingTracker delegates to shared thinking_split
+
+Route thinking detection through routers.thinking_split.split_thinking_parts
+so the terminal chat understands gemma-4's <|channel>thought…<channel|>
+(and any future tag pair) the same way the HTTP routers do, and suppress
+<|tool_call> markup from visible tokens. accumulated stays raw so the
+turn-end parse + tool execution are unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Live coverage + full verification
+
+**Files:**
+- Modify: `tests/live/test_gemma4_unified_text.py`
+
+- [ ] **Step 1: Add a session-splitter live test**
+
+Append to `tests/live/test_gemma4_unified_text.py`:
+
+```python
+def test_session_tracker_splits_real_gemma4_turn():
+    """Feed a real gemma-4 thinking+tool-call turn through ThinkingTracker and
+    assert the visible channel is free of channel/tool markup while the raw
+    accumulated text still carries the tool call for parsing."""
+    import mlx_lm
+
+    from olmlx.chat.session import ThinkingTracker
+    from olmlx.engine.model_manager import _load_with_model_type_fallback
+    from olmlx.engine.tool_parser import parse_model_output
+
+    model, tokenizer = _load_with_model_type_fallback(mlx_lm, str(_model_dir()))
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "What's the weather in Paris?"}],
+        tools=tools,
+        add_generation_prompt=True,
+        tokenize=False,
+    )
+    raw = mlx_lm.generate(
+        model, tokenizer, prompt=prompt, max_tokens=256, verbose=False
+    )
+
+    tracker = ThinkingTracker(template_has_thinking=True)
+    visible_parts = []
+    # Feed token-by-token to exercise chunk-boundary handling.
+    for ch in raw:
+        _td, vd, _te, _ts = tracker.feed(ch)
+        if vd:
+            visible_parts.append(vd)
+    if flush := tracker.flush_disabled():
+        visible_parts.append(flush)
+    visible = "".join(visible_parts)
+
+    assert "<|channel" not in visible
+    assert "<channel|" not in visible
+    assert "<|tool_call" not in visible
+    # Raw text still parses into a tool call.
+    _thinking, _vis, tool_uses = parse_model_output(
+        tracker.accumulated, has_tools=True, thinking_expected=True
+    )
+    assert tool_uses and tool_uses[0]["name"] == "get_weather"
+```
+
+- [ ] **Step 2: Run the live test**
+
+Run: `uv run pytest tests/live/test_gemma4_unified_text.py -m real_model -q`
+Expected: PASS (5 tests — the 4 existing + this one).
+
+- [ ] **Step 3: Run the full hermetic suite + ruff**
+
+Run:
+```bash
+uv run pytest tests/test_chat_session_helpers.py tests/test_chat_session.py tests/test_model_manager.py -q
+uv run ruff check olmlx/chat/session.py tests/test_chat_session_helpers.py tests/live/test_gemma4_unified_text.py
+uv run ruff format olmlx/chat/session.py tests/test_chat_session_helpers.py tests/live/test_gemma4_unified_text.py
+```
+Expected: all PASS; `All checks passed!`; files formatted.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/live/test_gemma4_unified_text.py olmlx/chat/session.py tests/test_chat_session_helpers.py
+git commit -m "test(chat): live coverage for gemma-4 streaming split
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Component 1 (ThinkingTracker delegation) → Task 3. Component 2 (tool suppressor) → Task 2. `accumulated`-stays-raw invariant → Task 3 (`test_accumulated_is_raw`) + Task 4. `thinking_split.py` untouched → confirmed (only imported). Testing section → Tasks 2-4.
+- **Public API preserved:** constructor signature, `feed` 4-tuple, `accumulated`/`in_thinking`/`just_started`/`think_emitted`/`visible_emitted`, `flush_disabled`, `strip_on_repetition` — all retained in Task 3 Step 4.
+- **Type consistency:** `_ToolMarkupStripper.feed/flush -> str`; `_longest_partial_tag_suffix -> int`; `ThinkingTracker.feed -> tuple[str|None, str|None, bool, bool]`. Names match across tasks.
+- **Risk:** the parts→4-tuple mapping. Task 3 Step 6 is the regression gate against the 11 existing tests, with concrete debugging guidance.

--- a/docs/superpowers/specs/2026-06-19-gemma4-terminal-streaming-design.md
+++ b/docs/superpowers/specs/2026-06-19-gemma4-terminal-streaming-design.md
@@ -1,0 +1,210 @@
+# Gemma‑4 terminal streaming display — design
+
+**Date:** 2026-06-19
+**Status:** Approved (ready for implementation plan)
+**Scope:** `olmlx chat` (in‑process terminal agent) only. HTTP routers and the
+engine are out of scope — they already handle Gemma‑4.
+
+## Background
+
+`mlx-community/gemma-4-*` models use a bespoke **text** (non‑special‑token)
+output format:
+
+- Turns: `<|turn>role\n … <turn|>\n`
+- Thinking channel: `<|channel>thought\n … <channel|>`
+- Tool calls: `<|tool_call>call:NAME{key:value,…}<tool_call|>` — bare keys,
+  string values wrapped in `<|"|> … <|"|>`, numbers/booleans bare, nested
+  `{…}` / `[…]`.
+- Tool results: `<|tool_response> … <tool_response|>`
+
+Real captured output (verified against the loaded 12B):
+
+```
+<|channel>thought\nThe user is asking … the get_weather tool seems appropriate.<channel|><|tool_call>call:get_weather{city:<|"|>Paris<|"|>,days:3,units:<|"|>c<|"|>}<tool_call|>
+```
+
+### What already works (do not rebuild)
+
+- **Loading** (`gemma4_unified` 12B language tower) and the **eos stop set**
+  (`<eos>`/`<turn|>`/`<|tool_response>` = 1/106/50) are fixed in
+  `engine/model_manager.py`. Generation now stops cleanly at turn/tool
+  boundaries instead of looping.
+- **Backend parsing** is already implemented and verified:
+  `tool_parser._try_gemma4` parses `<|tool_call>call:NAME{…}<tool_call|>`, and
+  `tool_parser._extract_gemma4_blocks` + `routers/thinking_split.py` handle the
+  `<|channel>thought…<channel|>` thinking channel. The terminal chat's
+  `_parse_turn_output` → `parse_model_output` → `_execute_tool_calls` path runs
+  all of this at turn end, so **tool calls already parse and execute and the
+  final assistant message is already clean.**
+
+### The one remaining gap
+
+The terminal chat's **live streaming display**. `ThinkingTracker`
+(`chat/session.py`) keys solely on the literal `<think>` / `</think>` tags, so
+while streaming a Gemma‑4 turn it prints the raw `<|channel>thought…<channel|>`
+and `<|tool_call>…<tool_call|>` markup as visible `token` events. The end
+state is correct; only the live scroll is wrong.
+
+## Goal
+
+While streaming a Gemma‑4 turn in `olmlx chat`:
+
+- `<|channel>thought…<channel|>` is routed to the **thinking** channel
+  (`thinking_start` / `thinking_token` / `thinking_end` events), respecting the
+  `--thinking`/`config.thinking` toggle.
+- `<|tool_call>…<tool_call|>` markup is **suppressed** from visible `token`
+  events (the `tool_call` event is still emitted later by the existing
+  turn‑end parse path).
+- Existing `<think>`‑family behavior (Qwen etc.), implicit thinking, the
+  thinking‑disabled strip, and repetition handling are unchanged.
+
+## Non‑goals
+
+- No changes to `routers/thinking_split.py` (shared with the HTTP routers — it
+  already recognizes Gemma‑4 channels). The Gemma‑4 work reuses it as‑is.
+- No changes to tool‑execution correctness or `parse_model_output` — those are
+  already verified.
+- No streaming display of `<|tool_response>`/`<|turn>` markup handling beyond
+  what stopping generation already gives us (the model does not emit these in a
+  normal assistant turn; they are stop tokens / harness‑injected).
+
+## Architecture
+
+Refactor `ThinkingTracker` from a bespoke `<think>`‑only scanner into a thin
+adapter over the shared `thinking_split.split_thinking_parts` state machine
+(which already recognizes both `<think>…</think>` and
+`<|channel>thought\n…<channel|>`), plus a small **streaming tool‑markup
+suppressor** applied to the content channel.
+
+### Component 1 — `ThinkingTracker` (rewritten internals, identical public API)
+
+Preserved public surface (the session and tests depend on all of it):
+
+- `feed(text) -> (think_delta, visible_delta, thinking_ended, thinking_started)`
+- properties: `accumulated`, `in_thinking`, `just_started`, `think_emitted`,
+  `visible_emitted`
+- `flush_disabled() -> str | None`
+- `strip_on_repetition() -> int | None`
+- constructor: `ThinkingTracker(implicit_mode, thinking_disabled, template_has_thinking)`
+
+Internals:
+
+- `self._accumulated` keeps the **raw** text (all markup) — appended verbatim
+  in `feed`. This is the invariant that keeps the turn‑end parse path
+  untouched.
+- `self._split_state` — the dict passed to `split_thinking_parts`. Seed
+  `state["thinking_expected"] = implicit_mode or template_has_thinking` so the
+  orphan‑`</think>` heuristic and channel detection behave as today for
+  implicit‑thinking models.
+- `feed`:
+  1. append raw text to `_accumulated`.
+  2. `parts = split_thinking_parts(text, self._split_state)`.
+  3. for each `(channel, fragment)`:
+     - `thinking` → if not `thinking_disabled`, append to think delta and mark
+       `thinking_started` on the first thinking fragment of the turn; if
+       disabled, discard (already removed from visible).
+     - `content` → pass through the tool‑markup suppressor (Component 2);
+       append the suppressor's output to visible delta. A transition from
+       thinking→content sets `thinking_ended`.
+  4. update `_think_emitted` / `_visible_emitted` counters and `_in_thinking`.
+  5. return `(think_delta or None, visible_delta or None, thinking_ended, thinking_started)`.
+- `flush_disabled`: when `thinking_disabled` and the stream ended without ever
+  resolving (mirrors the current implicit+no‑close case), flush any buffered
+  content as visible. Implemented via `flush_split_thinking(state)` + suppressor
+  flush, content channel only.
+- `strip_on_repetition`: truncate `_accumulated` at the start of the currently
+  open thinking block. With the delegated splitter, "currently open" = split
+  state `phase == "in_think"`; record the byte offset where the open tag began
+  so the truncation point is known. Reset `_in_thinking`.
+
+Mapping ordered parts → the 4‑tuple is the crux: accumulate `think_delta` and
+`visible_delta` across all parts in the chunk; `thinking_started` fires once on
+the first thinking fragment seen this turn; `thinking_ended` fires when a
+content fragment follows thinking.
+
+### Component 2 — streaming tool‑markup suppressor
+
+A small stateful helper that removes `<|tool_call> … <tool_call|>` spans from a
+stream of content fragments, holding back partial delimiters across chunk
+boundaries (the same hold‑back‑partial‑tag technique `thinking_split` uses).
+
+- Interface: `feed(fragment) -> str` (visible text with tool spans removed) and
+  `flush() -> str` (emit any held‑back partial that turned out to be literal).
+- State: `phase` ∈ {`outside`, `inside`}, `buffer` for partial delimiters.
+- `outside`: scan for `<|tool_call>`; emit text before it; on a partial
+  open‑tag suffix at the end of the buffer, hold it back. On full open, switch
+  to `inside`.
+- `inside`: scan for `<tool_call|>`; drop everything up to and including it;
+  switch to `outside`. Hold partial close‑tag suffixes.
+- Lives in the chat layer (`chat/session.py` or a sibling module), not in the
+  shared `thinking_split.py`.
+
+This is display‑only; the raw markup remains in `accumulated` for the
+turn‑end parse.
+
+## Data flow
+
+```
+generate_chat tokens
+  → ThinkingTracker.feed(text)
+      → _accumulated += text                       (raw, untouched)
+      → split_thinking_parts(text, split_state)     (thinking vs content)
+      → tool suppressor over content fragments       (drop <|tool_call> spans)
+      → fold parts → (think_delta, visible_delta, thinking_ended, thinking_started)
+  → session yields thinking_start / thinking_token / thinking_end / token
+turn end:
+  → flush_split_thinking + suppressor.flush          (emit any held bytes)
+  → result["full_text"] = tracker.accumulated         (RAW)
+  → _parse_turn_output → parse_model_output            (existing, unchanged)
+  → tool_uses executed via _execute_tool_calls         (existing, unchanged)
+```
+
+## Error handling / edge cases
+
+- **Chunk‑straddling delimiters:** both the splitter and the suppressor hold
+  back partial open/close tags and resolve them on the next chunk; `flush`
+  emits leftovers as content at stream end.
+- **Thinking disabled (`--thinking` off):** thinking fragments are dropped from
+  emission but still removed from the visible channel; the gemma channel is
+  thereby stripped from display. `flush_disabled` covers the no‑close tail.
+- **Repetition stop:** unchanged; `strip_on_repetition` truncates the raw
+  accumulated text at the open thinking block so the parse path sees a clean
+  prefix.
+- **Non‑Gemma models:** `<think>` handling is byte‑for‑byte the same because the
+  shared splitter already drove it; suppressor is a no‑op when no `<|tool_call>`
+  appears.
+- **Tool markup with no surrounding thinking** (rare): suppressor still removes
+  it from content; parse path still extracts it from `accumulated`.
+
+## Testing (TDD)
+
+Preserve green:
+
+- all 11 `ThinkingTracker` tests (`tests/test_chat_session_helpers.py`)
+- chat‑session tests (`tests/test_chat_session.py`)
+
+New unit tests:
+
+- Gemma‑4 `<|channel>thought\n…<channel|>` split into thinking vs visible,
+  including the open and close tags arriving in separate `feed` chunks.
+- `<|tool_call>…<tool_call|>` removed from visible deltas, including the
+  delimiters split across chunk boundaries; the tool call is still recoverable
+  from `accumulated`.
+- `accumulated` equals the concatenation of all raw fed text (invariant).
+- `thinking_disabled=True` drops the Gemma channel from both thinking and
+  visible emission.
+- `strip_on_repetition` with a Gemma channel truncates at the channel opener.
+
+Live (`tests/live/test_gemma4_unified_text.py`, `real_model`):
+
+- Feed the captured real Gemma‑4 turn (thinking + tool call) through a
+  `ThinkingTracker` and assert: visible delta contains no `<|channel`,
+  `<channel|`, or `<|tool_call` markup; thinking delta contains the reasoning;
+  `accumulated` still contains the raw `<|tool_call>` so `parse_model_output`
+  extracts the call.
+
+## Risks
+
+- The 4‑tuple/transition mapping is the subtlest part; the existing 11 tests pin
+  the contract and the new chunk‑boundary tests cover the rest.
+- Keeping `thinking_split.py` untouched avoids any HTTP‑router regression.

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -419,10 +419,12 @@ class ThinkingTracker:
             self._think_emitted += len(think_text)
             think_delta = think_text
 
+        # ``flush_split_thinking`` only yields content in the ``detect``/
+        # ``passthrough`` phases, both of which leave ``_in_thinking`` False —
+        # so flush returns thinking XOR visible, never a think→visible
+        # transition needing a ``thinking_end`` between them.
         visible_delta: str | None = None
         if content_buf:
-            if self._in_thinking:
-                self._in_thinking = False
             visible = (
                 self._tool_stripper.feed(content_buf) + self._tool_stripper.flush()
             )

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -73,6 +73,74 @@ _THINK_CLOSE = "</think>"
 _THINK_BLOCK_RE = re.compile(r"<think>.*?</think>", re.DOTALL)
 _THINK_CONTENT_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
 
+# Gemma-4 native tool-call markup (plain text, not special tokens). Display
+# is suppressed during streaming; the raw markup stays in the tracker's
+# accumulated text so parse_model_output still extracts the call at turn end.
+_TOOL_CALL_OPEN = "<|tool_call>"
+_TOOL_CALL_CLOSE = "<tool_call|>"
+
+
+def _longest_partial_tag_suffix(buf: str, tag: str) -> int:
+    """Largest ``k`` (``0 < k < len(tag)``) such that ``buf[-k:] == tag[:k]``.
+
+    Used to hold back the trailing bytes of *buf* that might be the start of
+    *tag* straddling a chunk boundary.
+    """
+    for k in range(min(len(tag) - 1, len(buf)), 0, -1):
+        if buf[-k:] == tag[:k]:
+            return k
+    return 0
+
+
+class _ToolMarkupStripper:
+    """Remove ``<|tool_call>…<tool_call|>`` spans from a stream of text.
+
+    Holds partial open/close delimiters across chunk boundaries. Display-only:
+    callers keep the raw text elsewhere for parsing.
+    """
+
+    def __init__(self) -> None:
+        self._buf = ""
+        self._inside = False
+
+    def feed(self, text: str) -> str:
+        self._buf += text
+        out: list[str] = []
+        while self._buf:
+            if not self._inside:
+                idx = self._buf.find(_TOOL_CALL_OPEN)
+                if idx != -1:
+                    out.append(self._buf[:idx])
+                    self._buf = self._buf[idx + len(_TOOL_CALL_OPEN) :]
+                    self._inside = True
+                    continue
+                keep = _longest_partial_tag_suffix(self._buf, _TOOL_CALL_OPEN)
+                out.append(self._buf[: len(self._buf) - keep] if keep else self._buf)
+                self._buf = self._buf[len(self._buf) - keep :] if keep else ""
+                break
+            idx = self._buf.find(_TOOL_CALL_CLOSE)
+            if idx != -1:
+                self._buf = self._buf[idx + len(_TOOL_CALL_CLOSE) :]
+                self._inside = False
+                continue
+            keep = _longest_partial_tag_suffix(self._buf, _TOOL_CALL_CLOSE)
+            self._buf = self._buf[len(self._buf) - keep :] if keep else ""
+            break
+        return "".join(out)
+
+    def flush(self) -> str:
+        """Emit any held-back bytes at stream end.
+
+        A partial open-tag held while *outside* a call was literal text. Bytes
+        held while *inside* an unterminated call are dropped (no close arrived).
+        """
+        if self._inside:
+            self._buf = ""
+            return ""
+        out = self._buf
+        self._buf = ""
+        return out
+
 
 class _TokenEvent(TypedDict):
     type: Literal["token"]

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -419,18 +419,21 @@ class ThinkingTracker:
             self._think_emitted += len(think_text)
             think_delta = think_text
 
+        # Always flush the tool stripper, even when the splitter left no
+        # content: it may hold a partial ``<|tool_call>`` open-tag from an
+        # earlier streamed fragment that turned out to be literal visible text
+        # (dropping it would lose visible bytes at stream end).
         # ``flush_split_thinking`` only yields content in the ``detect``/
         # ``passthrough`` phases, both of which leave ``_in_thinking`` False —
         # so flush returns thinking XOR visible, never a think→visible
         # transition needing a ``thinking_end`` between them.
+        visible = (
+            self._tool_stripper.feed(content_buf or "") + self._tool_stripper.flush()
+        )
         visible_delta: str | None = None
-        if content_buf:
-            visible = (
-                self._tool_stripper.feed(content_buf) + self._tool_stripper.flush()
-            )
-            if visible:
-                self._visible_emitted += len(visible)
-                visible_delta = visible
+        if visible:
+            self._visible_emitted += len(visible)
+            visible_delta = visible
 
         return think_delta, visible_delta, thinking_started
 

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -22,6 +22,11 @@ from olmlx.engine.inference import (
 )
 from olmlx.engine.model_manager import LoadedModel, ModelManager
 from olmlx.engine.tool_parser import parse_model_output
+from olmlx.routers.thinking_split import (
+    _THINKING_PAIRS,
+    flush_split_thinking,
+    split_thinking_parts,
+)
 from olmlx.utils import memory as memory_utils
 from olmlx.utils import tracing as _tracing
 
@@ -283,12 +288,15 @@ class _TurnStreamResult(TypedDict):
 
 
 class ThinkingTracker:
-    """Tracks <think> tag boundaries during streaming generation.
+    """Splits streaming output into thinking vs visible, with tool markup
+    suppressed from the visible channel.
 
-    Handles both explicit ``<think>...</think>`` tags and implicit
-    thinking (template-injected ``<think>`` at position 0). State
-    mutations are deterministic — callers check ``has_content()``
-    after each ``feed()`` to emit events.
+    Delegates thinking-tag detection to the shared
+    ``routers.thinking_split`` state machine (``<think>…</think>`` AND
+    Gemma-4 ``<|channel>thought\\n…<channel|>``), and runs the visible
+    channel through ``_ToolMarkupStripper`` so Gemma-4's
+    ``<|tool_call>…<tool_call|>`` markup never reaches the display. The raw
+    text is kept verbatim in ``accumulated`` for the turn-end parse step.
     """
 
     def __init__(
@@ -297,18 +305,24 @@ class ThinkingTracker:
         thinking_disabled: bool = False,
         template_has_thinking: bool = False,
     ):
-        self._implicit_mode = implicit_mode
         self._thinking_disabled = thinking_disabled
-        self._template_has_thinking = template_has_thinking
         self._accumulated = ""
-        self._open_pos = -1
-        self._close_pos = -1
-        self._scan_pos = 0
         self._think_emitted = 0
         self._visible_emitted = 0
         self._in_thinking = False
         self._just_started = False
-        self._thinking_start_emitted = False
+        # A template that injects <think> (implicit) or otherwise advertises
+        # thinking widens the splitter's orphan-detection window and enables
+        # the orphan-</think> heuristic; pre-tag content is then held as
+        # potential thinking. When thinking is NOT expected, drive the detect
+        # window to 0 so plain content streams token-by-token (an explicit
+        # <think>/channel opener — full or split across chunks — is still
+        # caught via find() + the partial-tag hold-back).
+        expected = bool(implicit_mode or template_has_thinking)
+        self._split_state: dict = {"thinking_expected": expected}
+        if not expected:
+            self._split_state["detect_limit"] = 0
+        self._tool_stripper = _ToolMarkupStripper()
 
     @property
     def accumulated(self) -> str:
@@ -332,104 +346,110 @@ class ThinkingTracker:
         return self._visible_emitted
 
     def feed(self, text: str) -> tuple[str | None, str | None, bool, bool]:
-        """Ingest a chunk of text.
-
-        Returns ``(think_delta, visible_delta, thinking_ended, thinking_started)`` where
-        each delta is a new substring to emit (or None) and
-        ``thinking_ended`` is True when a visible delta transitions out
-        of thinking mode, ``thinking_started`` on the first thinking chunk.
-        """
+        """Ingest a chunk; return (think_delta, visible_delta, thinking_ended,
+        thinking_started)."""
         self._accumulated += text
+        parts = split_thinking_parts(text, self._split_state)
 
-        # Scan for tag boundaries
-        new_scan = max(0, self._scan_pos - len(_THINK_CLOSE) + 1)
-        self._scan_pos = len(self._accumulated)
+        think_parts: list[str] = []
+        visible_parts: list[str] = []
+        thinking_started = False
+        thinking_ended = False
 
-        if self._open_pos == -1:
-            pos = self._accumulated.find(_THINK_OPEN, new_scan)
-            if pos != -1:
-                self._open_pos = pos
-                self._implicit_mode = False
+        for channel, fragment in parts:
+            if channel == "thinking":
+                if self._thinking_disabled:
+                    continue
+                if not self._in_thinking:
+                    thinking_started = True
+                    self._in_thinking = True
+                think_parts.append(fragment)
+                self._think_emitted += len(fragment)
+            else:  # content
+                if self._in_thinking:
+                    thinking_ended = True
+                    self._in_thinking = False
+                visible = self._tool_stripper.feed(fragment)
+                if visible:
+                    visible_parts.append(visible)
+                    self._visible_emitted += len(visible)
 
-        if self._close_pos == -1:
-            search_from = max(
-                (self._open_pos + len(_THINK_OPEN)) if self._open_pos >= 0 else 0,
-                new_scan,
+        self._just_started = thinking_started
+        think_delta = "".join(think_parts) or None
+        visible_delta = "".join(visible_parts) or None
+        return think_delta, visible_delta, thinking_ended, thinking_started
+
+    def flush(self) -> tuple[str | None, str | None, bool]:
+        """Flush the splitter's held buffer at stream end.
+
+        Returns ``(think_delta, visible_delta, thinking_started)``. Classifies
+        the leftover by phase:
+
+        - thinking disabled → everything surfaces as visible (thinking is
+          never shown; an unconfirmed/implicit block can't be hidden);
+        - still in ``detect`` with thinking expected → implicit thinking that
+          never saw a close tag, surfaced as thinking (the old implicit-mode
+          contract);
+        - ``in_think`` (unterminated explicit block) → thinking;
+        - otherwise (plain/passthrough leftover) → visible.
+        """
+        phase = self._split_state.get("phase", "detect")
+        thinking_expected = bool(self._split_state.get("thinking_expected"))
+        thinking_buf, content_buf = flush_split_thinking(self._split_state)
+
+        if self._thinking_disabled:
+            leftover = (thinking_buf or "") + (content_buf or "")
+            visible = self._tool_stripper.feed(leftover) + self._tool_stripper.flush()
+            if visible:
+                self._visible_emitted += len(visible)
+                return None, visible, False
+            return None, None, False
+
+        think_text = thinking_buf or ""
+        if phase == "detect" and thinking_expected and content_buf:
+            think_text += content_buf
+            content_buf = ""
+
+        think_delta: str | None = None
+        thinking_started = False
+        if think_text:
+            if not self._in_thinking:
+                thinking_started = True
+                self._in_thinking = True
+            self._think_emitted += len(think_text)
+            think_delta = think_text
+
+        visible_delta: str | None = None
+        if content_buf:
+            if self._in_thinking:
+                self._in_thinking = False
+            visible = (
+                self._tool_stripper.feed(content_buf) + self._tool_stripper.flush()
             )
-            pos = self._accumulated.find(_THINK_CLOSE, search_from)
-            if pos != -1:
-                self._close_pos = pos
+            if visible:
+                self._visible_emitted += len(visible)
+                visible_delta = visible
 
-        think_content, visible = self._classify()
-        self._just_started = bool(not self._in_thinking and think_content)
-        think_delta = self._emit_think(think_content)
-        visible_delta, thinking_ended = self._emit_visible(visible)
-        return think_delta, visible_delta, thinking_ended, self._just_started
-
-    def flush_disabled(self) -> str | None:
-        """Flush buffered content as visible when thinking is disabled."""
-        if self._implicit_mode and self._close_pos == -1 and self._thinking_disabled:
-            if len(self._accumulated) > self._visible_emitted:
-                text = self._accumulated[self._visible_emitted :]
-                self._visible_emitted = len(self._accumulated)
-                return text
-        return None
+        return think_delta, visible_delta, thinking_started
 
     def strip_on_repetition(self) -> int | None:
-        """Truncate accumulated text at the open tag position.
+        """Truncate accumulated text at the start of the open thinking block.
 
-        Cuts before the opening <think> tag to fully remove the incomplete block.
+        Removes an incomplete thinking block so the turn-end parse sees a
+        clean prefix. Searches for the latest open tag of any known pair.
         """
-        if self._in_thinking and self._open_pos >= 0:
-            self._accumulated = self._accumulated[: self._open_pos]
+        if not self._in_thinking:
+            return None
+        cut = max(
+            (self._accumulated.rfind(open_tag) for open_tag, _ in _THINKING_PAIRS),
+            default=-1,
+        )
+        if cut >= 0:
+            self._accumulated = self._accumulated[:cut]
             self._visible_emitted = len(self._accumulated)
             self._in_thinking = False
             return self._visible_emitted
         return None
-
-    def _classify(self) -> tuple[str, str]:
-        has_thinking = self._open_pos >= 0 or self._implicit_mode
-        implicit_strip = (
-            self._thinking_disabled
-            and self._template_has_thinking
-            and self._open_pos == -1
-            and self._close_pos >= 0
-        )
-        if has_thinking:
-            cs = (self._open_pos + len(_THINK_OPEN)) if self._open_pos >= 0 else 0
-            if self._close_pos >= 0:
-                think_content = self._accumulated[cs : self._close_pos]
-                visible = self._accumulated[self._close_pos + len(_THINK_CLOSE) :]
-            else:
-                think_content = self._accumulated[cs:]
-                visible = ""
-            if self._thinking_disabled:
-                think_content = ""
-        elif implicit_strip:
-            think_content = ""
-            visible = self._accumulated[self._close_pos + len(_THINK_CLOSE) :]
-        else:
-            think_content = ""
-            visible = self._accumulated
-        return think_content, visible
-
-    def _emit_think(self, think_content: str) -> str | None:
-        if len(think_content) > self._think_emitted:
-            self._in_thinking = True
-            delta = think_content[self._think_emitted :]
-            self._think_emitted = len(think_content)
-            return delta
-        return None
-
-    def _emit_visible(self, visible: str) -> tuple[str | None, bool]:
-        if len(visible) > self._visible_emitted:
-            thinking_ended = self._in_thinking
-            if thinking_ended:
-                self._in_thinking = False
-            delta = visible[self._visible_emitted :]
-            self._visible_emitted = len(visible)
-            return delta, thinking_ended
-        return None, False
 
 
 class ChatSession:
@@ -1082,16 +1102,24 @@ class ChatSession:
                     yield {"type": "repetition_detected"}
                     break
 
-        # Flush disabled-thinking content
-        if flush_text := tracker.flush_disabled():
-            yield {"type": "token", "text": flush_text}
+        # Flush the splitter's held buffer at stream end (skip on repetition —
+        # that output is being discarded by strip_on_repetition below).
+        if not repetition_stopped:
+            flush_think, flush_visible, flush_started = tracker.flush()
+            if flush_started:
+                yield {"type": "thinking_start"}
+            if flush_think:
+                yield {"type": "thinking_token", "text": flush_think}
+            if flush_visible:
+                yield {"type": "token", "text": flush_visible}
 
         # Strip incomplete thinking on repetition BEFORE yielding final events
         was_in_thinking = tracker.in_thinking
         if repetition_stopped:
             tracker.strip_on_repetition()
 
-        # Close any open thinking block (only if content was stripped mid-think)
+        # Close any open thinking block (unclosed <think>/channel block, or
+        # content stripped mid-think on repetition)
         if was_in_thinking:
             yield {"type": "thinking_end"}
 

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -194,7 +194,10 @@ def _load_with_model_type_fallback(mlx_lm, load_path, **kwargs):
     """
     # mlx-community 'gemma4_unified' text checkpoints (e.g. gemma-4-12B-it-4bit)
     # need a dedicated loader: their model_type has no mlx-lm module and their
-    # multimodal weights must be dropped to load the language tower.
+    # multimodal weights must be dropped to load the language tower. The loader
+    # materializes weights eagerly and ignores kwargs like ``lazy`` — these
+    # checkpoints are dense text towers, so the lazy flash-MoE caller never
+    # routes here.
     gemma4_unified = _maybe_load_gemma4_unified_text(str(load_path))
     if gemma4_unified is not None:
         return gemma4_unified

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -192,6 +192,13 @@ def _load_with_model_type_fallback(mlx_lm, load_path, **kwargs):
     So we load the model first with the real config, then patch config.json
     temporarily to load only the tokenizer.
     """
+    # mlx-community 'gemma4_unified' text checkpoints (e.g. gemma-4-12B-it-4bit)
+    # need a dedicated loader: their model_type has no mlx-lm module and their
+    # multimodal weights must be dropped to load the language tower.
+    gemma4_unified = _maybe_load_gemma4_unified_text(str(load_path))
+    if gemma4_unified is not None:
+        return gemma4_unified
+
     _sanitize_model_config_in_place(load_path)
     kwargs.setdefault("tokenizer_config", {"trust_remote_code": True})
     try:
@@ -236,6 +243,106 @@ def _load_with_model_type_fallback(mlx_lm, load_path, **kwargs):
     # trigger the model-type remapping fallback with a misleading error.
     _ensure_tokenizer_eos_in_stops(tokenizer)
     return model, tokenizer
+
+
+def _load_gemma4_unified_text(load_path: str, config: dict) -> tuple[Any, Any]:
+    """Load only the *language tower* of a mlx-community ``gemma4_unified``
+    checkpoint (e.g. ``gemma-4-12B-it-4bit``) via mlx-lm's ``gemma4_text``.
+
+    These repos ship the full multimodal checkpoint under a non-standard
+    ``gemma4_unified`` model_type whose vision tower is stored under a
+    ``vision_embedder.*`` prefix.  That layout matches neither mlx-lm's
+    ``gemma4_text`` module (it wants the language tower under ``model.*``) nor
+    mlx-vlm 0.4.4's ``gemma4`` module (it models the vision tower as
+    ``vision_tower`` + ``embed_vision``, so the 11 ``vision_embedder.*`` params
+    have no home).  For text inference we build ``gemma4_text`` from
+    ``text_config``, load the ``language_model.*`` weights (stripping the
+    prefix), and drop the multimodal weights.  Standard ``gemma4`` checkpoints
+    (e4b/31b) are unaffected and keep their normal mlx-vlm routing.
+    """
+    import glob
+
+    import mlx.core as mx
+    import mlx.nn as nn
+    import mlx_lm
+    from mlx_lm.models import gemma4_text
+
+    text_cfg = dict(config.get("text_config", {}))
+    # gemma4_text's own module_type; the checkpoint carries
+    # "gemma4_unified_text" which the mlx-lm ModelArgs doesn't recognise.
+    text_cfg["model_type"] = "gemma4_text"
+    args = gemma4_text.ModelArgs.from_dict(text_cfg)
+    model = gemma4_text.Model(args)
+
+    quant = config.get("quantization") or config.get("quantization_config")
+    if quant:
+        nn.quantize(
+            model,
+            group_size=quant.get("group_size", 64),
+            bits=quant.get("bits", 4),
+        )
+
+    weights: dict[str, Any] = {}
+    for shard in sorted(glob.glob(str(Path(load_path) / "*.safetensors"))):
+        weights.update(mx.load(shard))
+    # Keep only the language tower; the multimodal weights (vision_embedder,
+    # embed_vision, embed_audio) are intentionally dropped for the text path.
+    prefix = "language_model."
+    lang_weights = {
+        k[len(prefix) :]: v for k, v in weights.items() if k.startswith(prefix)
+    }
+    if not lang_weights:
+        raise ValueError(
+            f"gemma4_unified checkpoint at {load_path} has no "
+            f"'{prefix}*' weights; cannot load the language tower."
+        )
+    lang_weights = model.sanitize(lang_weights)
+    model.load_weights(list(lang_weights.items()), strict=True)
+    mx.eval(model.parameters())
+
+    # Thread the full eos_token_id list into the tokenizer's stop set.  Gemma 4
+    # terminates turns with ``<turn|>`` (id 106) and pauses for tool results at
+    # ``<|tool_response>`` (id 50) — both are stop tokens alongside ``<eos>``
+    # (id 1).  Without them generation runs past every turn/tool boundary and
+    # degenerates into a repetition loop.  generation_config.json wins over
+    # config.json (mirrors mlx-lm's load_config precedence).
+    eos_token_ids = config.get("eos_token_id")
+    gen_config_file = Path(load_path) / "generation_config.json"
+    if gen_config_file.exists():
+        try:
+            gen_config = json.loads(gen_config_file.read_text())
+        except (OSError, ValueError):
+            gen_config = {}
+        if gen_config.get("eos_token_id") is not None:
+            eos_token_ids = gen_config["eos_token_id"]
+
+    tokenizer = mlx_lm.utils.load_tokenizer(
+        Path(load_path),
+        {"trust_remote_code": True},
+        eos_token_ids=eos_token_ids,
+    )
+    _ensure_tokenizer_eos_in_stops(tokenizer)
+    return model, tokenizer
+
+
+def _maybe_load_gemma4_unified_text(load_path: str) -> tuple[Any, Any] | None:
+    """Return ``(model, tokenizer)`` for a text-routable ``gemma4_unified``
+    checkpoint, or ``None`` if this isn't one (so callers fall through to the
+    normal mlx-lm load).  Reads config.json only — never mutates it.
+    """
+    config_file = Path(load_path) / "config.json"
+    if not config_file.exists():
+        return None
+    try:
+        config = json.loads(config_file.read_text())
+    except (OSError, ValueError):
+        return None
+    if config.get("model_type", "").lower() != "gemma4_unified":
+        return None
+    text_model_type = config.get("text_config", {}).get("model_type", "").lower()
+    if text_model_type != "gemma4_unified_text":
+        return None
+    return _load_gemma4_unified_text(load_path, config)
 
 
 def _is_serializable_cache(cache: list) -> bool:
@@ -1740,6 +1847,22 @@ class ModelManager(SpeculativeLoaderMixin):
                 return "unknown"
 
         model_type = config.get("model_type", "").lower()
+
+        # mlx-community ships some Gemma 4 checkpoints (e.g. gemma-4-12B-it-4bit)
+        # under a non-standard 'gemma4_unified' model_type whose multimodal
+        # weight layout (vision_embedder.*) loads in neither mlx-lm's
+        # gemma4_text nor mlx-vlm 0.4.4's gemma4 module.  The language tower
+        # (language_model.*) loads cleanly via mlx-lm's gemma4_text, so route
+        # to the text path (_load_with_model_type_fallback dispatches to
+        # _load_gemma4_unified_text).  Standard 'gemma4' checkpoints (e4b/31b)
+        # don't carry this model_type and keep their normal VLM routing.
+        # NOTE: in-memory inspection only — never rewrite config.json on disk.
+        if model_type == "gemma4_unified":
+            text_model_type = (
+                config.get("text_config", {}).get("model_type", "").lower()
+            )
+            if text_model_type == "gemma4_unified_text":
+                return "text"
 
         # Whisper STT (issue #366). Check before the empty-model_type return:
         # mlx-community whisper repos ship a non-HF config.json carrying

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -287,7 +287,9 @@ def _load_gemma4_unified_text(load_path: str, config: dict) -> tuple[Any, Any]:
 
     weights: dict[str, Any] = {}
     for shard in sorted(glob.glob(str(Path(load_path) / "*.safetensors"))):
-        weights.update(mx.load(shard))
+        # mx.load is typed Union[array, dict, tuple]; the dict case is what
+        # safetensors returns. Same suppression as pre_shard.py / flash loaders.
+        weights.update(mx.load(shard))  # pyright: ignore[reportCallIssue]
     # Keep only the language tower; the multimodal weights (vision_embedder,
     # embed_vision, embed_audio) are intentionally dropped for the text path.
     prefix = "language_model."

--- a/tests/live/test_gemma4_unified_text.py
+++ b/tests/live/test_gemma4_unified_text.py
@@ -1,0 +1,113 @@
+"""Live test for mlx-community 'gemma4_unified' text loading.
+
+Loads the REAL ``gemma-4-12B-it-4bit`` checkpoint and verifies that olmlx
+loads its language tower via mlx-lm's ``gemma4_text`` module and generates
+coherent text.  This repo is an outlier: its top-level model_type is
+``gemma4_unified`` and its vision tower is stored under ``vision_embedder.*``,
+a layout that loads in neither mlx-lm's ``gemma4_text`` nor mlx-vlm 0.4.4's
+``gemma4`` module.  olmlx drops the multimodal weights and loads the language
+tower for text inference.
+
+Lives OUTSIDE ``tests/integration/`` on purpose: that package's autouse
+``mock_mlx_primitives`` fixture patches ``mlx_lm.load`` etc., so any test there
+runs against mocks.  Here only the top-level ``tests/conftest`` applies.
+
+Skipped in CI via ``-m "not real_model"``, and additionally skipped when the
+model is not already downloaded so it never triggers a multi-GB download.
+"""
+
+import pytest
+
+from olmlx.config import settings
+
+MODEL = "mlx-community/gemma-4-12B-it-4bit"
+
+
+def _model_dir():
+    from olmlx.models.store import _safe_dir_name
+
+    return settings.models_dir / _safe_dir_name(MODEL)
+
+
+def _model_present() -> bool:
+    return (_model_dir() / "config.json").exists()
+
+
+pytestmark = [
+    pytest.mark.real_model,
+    pytest.mark.skipif(
+        not _model_present(),
+        reason=f"{MODEL} not downloaded in {settings.models_dir}",
+    ),
+]
+
+
+def test_loads_language_tower_and_generates():
+    import mlx_lm
+
+    from olmlx.engine.model_manager import _load_with_model_type_fallback
+
+    load_path = str(_model_dir())
+    model, tokenizer = _load_with_model_type_fallback(mlx_lm, load_path)
+
+    # mlx-lm gemma4_text module, not an mlx-vlm wrapper.
+    assert type(model).__module__.endswith("gemma4_text")
+
+    # The full eos set must be threaded in: <eos> (1), <turn|> (106, turn
+    # terminator) and <|tool_response> (50, tool-call boundary).  Without 106
+    # and 50 generation runs past every turn and degenerates into a repetition
+    # loop (the originally reported symptom).
+    eos_ids = set(getattr(tokenizer, "eos_token_ids", None) or [])
+    assert {1, 106, 50} <= eos_ids
+
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "Reply with exactly: hello world"}],
+        add_generation_prompt=True,
+        tokenize=False,
+    )
+    out = mlx_lm.generate(model, tokenizer, prompt=prompt, max_tokens=24, verbose=False)
+    assert isinstance(out, str) and out.strip()
+
+
+def test_generation_terminates_without_repetition_loop():
+    """Regression for the runaway loop: with the turn terminator (<turn|>, id
+    106) in the stop set, a normal chat turn must terminate on its own well
+    before a generous max_tokens, rather than spinning on empty thought
+    channels until a length cap.
+    """
+    import mlx_lm
+
+    from olmlx.engine.model_manager import _load_with_model_type_fallback
+
+    model, tokenizer = _load_with_model_type_fallback(mlx_lm, str(_model_dir()))
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "What is 2+2? Answer in one short sentence."}],
+        add_generation_prompt=True,
+        tokenize=False,
+    )
+    out = mlx_lm.generate(
+        model, tokenizer, prompt=prompt, max_tokens=512, verbose=False
+    )
+    # A self-terminated turn is far shorter than the cap and is not a tail of
+    # repeated thought-channel openers.
+    assert len(tokenizer.encode(out)) < 400
+    assert out.count("<|channel>thought") <= 1
+
+
+def test_load_does_not_mutate_config_on_disk():
+    """The store's config.json must remain 'gemma4_unified' — the loader reads
+    it but never rewrites it (a prior approach corrupted the shared copy).
+    """
+    import json
+
+    import mlx_lm
+
+    from olmlx.engine.model_manager import _load_with_model_type_fallback
+
+    config_path = _model_dir() / "config.json"
+    before = config_path.read_text()
+    assert json.loads(before)["model_type"] == "gemma4_unified"
+
+    _load_with_model_type_fallback(mlx_lm, str(_model_dir()))
+
+    assert config_path.read_text() == before

--- a/tests/live/test_gemma4_unified_text.py
+++ b/tests/live/test_gemma4_unified_text.py
@@ -111,3 +111,60 @@ def test_load_does_not_mutate_config_on_disk():
     _load_with_model_type_fallback(mlx_lm, str(_model_dir()))
 
     assert config_path.read_text() == before
+
+
+def test_session_tracker_splits_real_gemma4_turn():
+    """Feed a real gemma-4 thinking+tool-call turn through ThinkingTracker and
+    assert the visible channel is free of channel/tool markup while the raw
+    accumulated text still carries the tool call for parsing."""
+    import mlx_lm
+
+    from olmlx.chat.session import ThinkingTracker
+    from olmlx.engine.model_manager import _load_with_model_type_fallback
+    from olmlx.engine.tool_parser import parse_model_output
+
+    model, tokenizer = _load_with_model_type_fallback(mlx_lm, str(_model_dir()))
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "What's the weather in Paris?"}],
+        tools=tools,
+        add_generation_prompt=True,
+        tokenize=False,
+    )
+    raw = mlx_lm.generate(
+        model, tokenizer, prompt=prompt, max_tokens=256, verbose=False
+    )
+
+    tracker = ThinkingTracker(template_has_thinking=True)
+    visible_parts = []
+    # Feed token-by-token to exercise chunk-boundary handling.
+    for ch in raw:
+        _td, vd, _te, _ts = tracker.feed(ch)
+        if vd:
+            visible_parts.append(vd)
+    f_think, f_visible, _started = tracker.flush()
+    if f_visible:
+        visible_parts.append(f_visible)
+    visible = "".join(visible_parts)
+
+    assert "<|channel" not in visible
+    assert "<channel|" not in visible
+    assert "<|tool_call" not in visible
+    # Raw text still parses into a tool call.
+    _thinking, _vis, tool_uses = parse_model_output(
+        tracker.accumulated, has_tools=True, thinking_expected=True
+    )
+    assert tool_uses and tool_uses[0]["name"] == "get_weather"

--- a/tests/test_chat_session_helpers.py
+++ b/tests/test_chat_session_helpers.py
@@ -396,6 +396,18 @@ class TestThinkingTrackerGemma4:
         assert vd == "plain answer"
         assert t.flush() == (None, None, False)
 
+    def test_flush_emits_stripper_held_partial_open_tag(self):
+        # Visible content ends with bytes that look like a partial
+        # <|tool_call> open tag; the stripper holds them. At stream end, with
+        # no trailing splitter content, flush() must still surface them as
+        # visible rather than dropping them (aider review).
+        t = ThinkingTracker()
+        _td, vd, _te, _ts = t.feed("answer<|too")
+        assert vd == "answer"
+        think_delta, visible_delta, _started = t.flush()
+        assert think_delta is None
+        assert visible_delta == "<|too"
+
     def test_flush_disabled_surfaces_buffer_as_visible(self):
         # Thinking disabled + implicit + no close → the buffered (would-be
         # thinking) content is surfaced as visible, never as thinking.

--- a/tests/test_chat_session_helpers.py
+++ b/tests/test_chat_session_helpers.py
@@ -10,7 +10,12 @@ All tests are hermetic: generate_chat is mocked, no model, no GPU.
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from olmlx.chat.config import ChatConfig
-from olmlx.chat.session import ChatSession, _parse_turn_output
+from olmlx.chat.session import (
+    ChatSession,
+    _parse_turn_output,
+    _ToolMarkupStripper,
+    _longest_partial_tag_suffix,
+)
 from olmlx.engine.template_caps import TemplateCaps
 
 
@@ -230,3 +235,63 @@ class TestStreamOneTurn:
         assert result["repetition_stopped"] is True
         # Incomplete think block stripped from the accumulated text
         assert "<think>" not in result["full_text"]
+
+
+class TestLongestPartialTagSuffix:
+    def test_no_partial(self):
+        assert _longest_partial_tag_suffix("hello", "<|tool_call>") == 0
+
+    def test_full_partial(self):
+        assert _longest_partial_tag_suffix("abc<|to", "<|tool_call>") == 4
+
+    def test_does_not_count_full_tag(self):
+        # A complete tag is not a "partial" — len must be < tag length.
+        assert _longest_partial_tag_suffix("<|tool_call>", "<|tool_call>") < len(
+            "<|tool_call>"
+        )
+
+
+class TestToolMarkupStripper:
+    def test_passes_plain_text(self):
+        s = _ToolMarkupStripper()
+        assert s.feed("hello world") == "hello world"
+        assert s.flush() == ""
+
+    def test_removes_whole_tool_call_in_one_chunk(self):
+        s = _ToolMarkupStripper()
+        out = s.feed("before<|tool_call>call:f{a:1}<tool_call|>after")
+        assert out == "beforeafter"
+        assert s.flush() == ""
+
+    def test_removes_tool_call_split_across_chunks(self):
+        s = _ToolMarkupStripper()
+        out = "".join(
+            [
+                s.feed("vis<|tool_"),
+                s.feed("call>call:f{a:"),
+                s.feed("1}<tool_"),
+                s.feed("call|>tail"),
+            ]
+        )
+        assert out == "vistail"
+        assert s.flush() == ""
+
+    def test_holds_partial_open_then_resolves_as_literal(self):
+        s = _ToolMarkupStripper()
+        # "<|too" looks like a partial open tag, held back...
+        assert s.feed("x<|too") == "x"
+        # ...but the next chunk shows it was literal text.
+        assert s.feed("ls are fun") == "<|tools are fun"
+        assert s.flush() == ""
+
+    def test_flush_emits_held_partial_when_outside(self):
+        s = _ToolMarkupStripper()
+        assert s.feed("done<|tool") == "done"
+        # Stream ended mid partial open-tag; it was literal.
+        assert s.flush() == "<|tool"
+
+    def test_flush_drops_unterminated_tool_call(self):
+        s = _ToolMarkupStripper()
+        assert s.feed("a<|tool_call>call:f{") == "a"
+        # Unterminated tool call (no close) — drop it from display.
+        assert s.flush() == ""

--- a/tests/test_chat_session_helpers.py
+++ b/tests/test_chat_session_helpers.py
@@ -245,10 +245,12 @@ class TestLongestPartialTagSuffix:
         assert _longest_partial_tag_suffix("abc<|to", "<|tool_call>") == 4
 
     def test_does_not_count_full_tag(self):
-        # A complete tag is not a "partial" — len must be < tag length.
-        assert _longest_partial_tag_suffix("<|tool_call>", "<|tool_call>") < len(
-            "<|tool_call>"
-        )
+        # A complete tag is not a "partial" — must return exactly 0.
+        assert _longest_partial_tag_suffix("<|tool_call>", "<|tool_call>") == 0
+
+    def test_partial_close_tag(self):
+        assert _longest_partial_tag_suffix("done<tool_", "<tool_call|>") == 6
+        assert _longest_partial_tag_suffix("done", "<tool_call|>") == 0
 
 
 class TestToolMarkupStripper:
@@ -294,4 +296,13 @@ class TestToolMarkupStripper:
         s = _ToolMarkupStripper()
         assert s.feed("a<|tool_call>call:f{") == "a"
         # Unterminated tool call (no close) — drop it from display.
+        assert s.flush() == ""
+
+    def test_removes_two_consecutive_tool_calls(self):
+        s = _ToolMarkupStripper()
+        out = s.feed(
+            "before<|tool_call>call:f1{}<tool_call|>mid"
+            "<|tool_call>call:f2{}<tool_call|>after"
+        )
+        assert out == "beforemidafter"
         assert s.flush() == ""

--- a/tests/test_chat_session_helpers.py
+++ b/tests/test_chat_session_helpers.py
@@ -337,6 +337,9 @@ class TestThinkingTrackerGemma4:
         think, visible, started, ended = self._drain(t, chunks)
         assert think == "reasoning"
         assert visible == "visible"
+        # Event flags must fire correctly even when the delimiters straddle
+        # chunk boundaries.
+        assert started and ended
 
     def test_gemma4_tool_call_suppressed_from_visible(self):
         t = ThinkingTracker()
@@ -373,3 +376,32 @@ class TestThinkingTrackerGemma4:
         t.strip_on_repetition()
         assert "<|channel>thought" not in t.accumulated
         assert not t.in_thinking
+
+    def test_flush_implicit_thinking_no_close_routes_to_thinking(self):
+        # thinking expected (implicit), buffered content, never a close tag →
+        # flushed as thinking (the old implicit-mode contract).
+        t = ThinkingTracker(template_has_thinking=True)
+        td, vd, _te, _ts = t.feed("Still thinking")
+        assert td is None and vd is None  # held in the detect buffer
+        think_delta, visible_delta, started = t.flush()
+        assert think_delta == "Still thinking"
+        assert visible_delta is None
+        assert started and t.in_thinking
+
+    def test_flush_plain_content_routes_to_visible(self):
+        # No thinking expected → plain content streams during feed; flush adds
+        # nothing.
+        t = ThinkingTracker()
+        td, vd, _te, _ts = t.feed("plain answer")
+        assert vd == "plain answer"
+        assert t.flush() == (None, None, False)
+
+    def test_flush_disabled_surfaces_buffer_as_visible(self):
+        # Thinking disabled + implicit + no close → the buffered (would-be
+        # thinking) content is surfaced as visible, never as thinking.
+        t = ThinkingTracker(thinking_disabled=True, template_has_thinking=True)
+        t.feed("buffered content")
+        think_delta, visible_delta, started = t.flush()
+        assert think_delta is None
+        assert visible_delta == "buffered content"
+        assert not started

--- a/tests/test_chat_session_helpers.py
+++ b/tests/test_chat_session_helpers.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from olmlx.chat.config import ChatConfig
 from olmlx.chat.session import (
     ChatSession,
+    ThinkingTracker,
     _parse_turn_output,
     _ToolMarkupStripper,
     _longest_partial_tag_suffix,
@@ -306,3 +307,69 @@ class TestToolMarkupStripper:
         )
         assert out == "beforemidafter"
         assert s.flush() == ""
+
+
+class TestThinkingTrackerGemma4:
+    def _drain(self, tracker, chunks):
+        think, visible = [], []
+        started = ended = False
+        for c in chunks:
+            td, vd, te, ts = tracker.feed(c)
+            if td:
+                think.append(td)
+            if vd:
+                visible.append(vd)
+            started = started or ts
+            ended = ended or te
+        return "".join(think), "".join(visible), started, ended
+
+    def test_gemma4_channel_split_single_chunk(self):
+        t = ThinkingTracker()
+        raw = "<|channel>thought\nreasoning here<channel|>The answer is 4."
+        think, visible, started, ended = self._drain(t, [raw])
+        assert think == "reasoning here"
+        assert visible == "The answer is 4."
+        assert started and ended
+
+    def test_gemma4_channel_split_across_chunks(self):
+        t = ThinkingTracker()
+        chunks = ["<|channel>thought\nrea", "soning<chan", "nel|>visible"]
+        think, visible, started, ended = self._drain(t, chunks)
+        assert think == "reasoning"
+        assert visible == "visible"
+
+    def test_gemma4_tool_call_suppressed_from_visible(self):
+        t = ThinkingTracker()
+        raw = (
+            "<|channel>thought\nI will call it.<channel|>"
+            '<|tool_call>call:get_weather{city:<|"|>Paris<|"|>}<tool_call|>'
+        )
+        think, visible, _, _ = self._drain(t, [raw])
+        assert think == "I will call it."
+        assert visible == ""
+        # Raw markup is preserved for the turn-end parse.
+        assert "<|tool_call>" in t.accumulated
+        assert "<|channel>thought" in t.accumulated
+
+    def test_accumulated_is_raw(self):
+        t = ThinkingTracker()
+        chunks = ["<|channel>thought\nx<channel|>", "<|tool_call>call:f{}<tool_call|>"]
+        for c in chunks:
+            t.feed(c)
+        assert t.accumulated == "".join(chunks)
+
+    def test_gemma4_thinking_disabled_strips_channel(self):
+        t = ThinkingTracker(thinking_disabled=True)
+        raw = "<|channel>thought\nhidden reasoning<channel|>visible answer"
+        think, visible, started, ended = self._drain(t, [raw])
+        assert think == ""
+        assert visible == "visible answer"
+        assert not started
+
+    def test_gemma4_repetition_strip_truncates_at_channel(self):
+        t = ThinkingTracker()
+        t.feed("<|channel>thought\nlooping looping looping")
+        assert t.in_thinking
+        t.strip_on_repetition()
+        assert "<|channel>thought" not in t.accumulated
+        assert not t.in_thinking

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1024,6 +1024,104 @@ class TestDetectModelKind:
             kind = manager._detect_model_kind("test/model")
         assert kind == "text"
 
+    def test_gemma4_unified_text_routes_to_text(self, registry, mock_store):
+        """mlx-community 'gemma4_unified' text checkpoints (e.g.
+        gemma-4-12B-it-4bit) route to the mlx-lm text path (language tower
+        only); their multimodal weight layout (vision_embedder.*) loads in
+        neither mlx-lm's gemma4_text nor mlx-vlm 0.4.4's gemma4.  Detection must
+        NOT rewrite config.json on disk — the earlier approach corrupted the
+        shared store copy.
+        """
+        local_dir = mock_store.local_path("mlx-community/gemma-4-12B-it-4bit")
+        local_dir.mkdir(parents=True)
+        config = {
+            "model_type": "gemma4_unified",
+            "architectures": ["Gemma4UnifiedForConditionalGeneration"],
+            "text_config": {"model_type": "gemma4_unified_text"},
+            "vision_config": {"model_type": "gemma4_unified_vision"},
+            "audio_config": {"model_type": "gemma4_unified_audio"},
+        }
+        cfg_path = local_dir / "config.json"
+        original = json.dumps(config)
+        cfg_path.write_text(original)
+
+        manager = self._make_manager(registry, mock_store)
+        kind = manager._detect_model_kind("mlx-community/gemma-4-12B-it-4bit")
+
+        assert kind == "text"
+        # config.json must be byte-for-byte untouched on disk.
+        assert cfg_path.read_text() == original
+        assert json.loads(cfg_path.read_text())["model_type"] == "gemma4_unified"
+
+    def test_standard_gemma4_vlm_unaffected(self, tmp_path, registry, mock_store):
+        """Standard 'gemma4' checkpoints (e4b/31b) keep their VLM routing."""
+        config_path = self._make_config(
+            tmp_path,
+            {"model_type": "gemma4", "vision_config": {"hidden_size": 1024}},
+        )
+        manager = self._make_manager(registry, mock_store)
+        with patch("huggingface_hub.hf_hub_download", return_value=config_path):
+            kind = manager._detect_model_kind("test/gemma4")
+        assert kind == "vlm"
+
+
+class TestGemma4UnifiedTextLoader:
+    """Dispatch logic for loading the language tower of 'gemma4_unified'
+    checkpoints (the heavy weight load itself is covered by the live test).
+    """
+
+    def _write_config(self, d, cfg):
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "config.json").write_text(json.dumps(cfg))
+
+    def test_dispatch_missing_config(self, tmp_path):
+        from olmlx.engine.model_manager import _maybe_load_gemma4_unified_text
+
+        assert _maybe_load_gemma4_unified_text(str(tmp_path)) is None
+
+    def test_dispatch_skips_non_unified(self, tmp_path):
+        from olmlx.engine.model_manager import _maybe_load_gemma4_unified_text
+
+        self._write_config(tmp_path, {"model_type": "gemma4", "vision_config": {}})
+        assert _maybe_load_gemma4_unified_text(str(tmp_path)) is None
+
+    def test_dispatch_skips_unified_non_text(self, tmp_path):
+        from olmlx.engine.model_manager import _maybe_load_gemma4_unified_text
+
+        self._write_config(
+            tmp_path,
+            {
+                "model_type": "gemma4_unified",
+                "text_config": {"model_type": "something_else"},
+            },
+        )
+        assert _maybe_load_gemma4_unified_text(str(tmp_path)) is None
+
+    def test_dispatch_invokes_loader_for_unified_text(self, tmp_path, monkeypatch):
+        import olmlx.engine.model_manager as mm
+
+        self._write_config(
+            tmp_path,
+            {
+                "model_type": "gemma4_unified",
+                "text_config": {"model_type": "gemma4_unified_text"},
+            },
+        )
+        sentinel = (object(), object())
+        called = {}
+
+        def fake_loader(load_path, cfg):
+            called["load_path"] = load_path
+            called["cfg"] = cfg
+            return sentinel
+
+        monkeypatch.setattr(mm, "_load_gemma4_unified_text", fake_loader)
+        result = mm._maybe_load_gemma4_unified_text(str(tmp_path))
+
+        assert result is sentinel
+        assert called["load_path"] == str(tmp_path)
+        assert called["cfg"]["model_type"] == "gemma4_unified"
+
 
 class TestProbeCacheCapabilities:
     """Exercise _probe_cache_capabilities, including the probe-failure path


### PR DESCRIPTION
## Summary

Fixes `olmlx chat mlx-community/gemma-4-12B-it-4bit`, which failed to load and — once loading was fixed — mis-rendered gemma-4's bespoke output format in the terminal.

- **Loading** (`engine/model_manager.py`): the repo ships `model_type: gemma4_unified` whose vision tower (`vision_embedder.*`) loads in neither mlx-lm's `gemma4_text` nor mlx-vlm 0.4.4's `gemma4` (the other gemma-4 repos use the standard `gemma4`/`vision_tower` layout and are unaffected). New `_load_gemma4_unified_text` / `_maybe_load_gemma4_unified_text` load only the language tower via mlx-lm `gemma4_text`, dropping the multimodal weights, **without rewriting `config.json` on disk** (a prior attempt corrupted the shared store copy).
- **Repetition loop** (`engine/model_manager.py`): the loader now threads the full `eos_token_id` list `[1, 106, 50]` (`<eos>` / `<turn|>` / `<|tool_response>`) into the tokenizer, so generation stops at turn/tool boundaries instead of looping on empty thought channels.
- **Terminal streaming display** (`chat/session.py`): `ThinkingTracker` now delegates to the shared `routers/thinking_split` state machine, so `olmlx chat` understands gemma-4's `<|channel>thought…<channel|>` thinking the same way the HTTP routers do; a new `_ToolMarkupStripper` suppresses `<|tool_call>…<tool_call|>` markup from visible tokens. `accumulated` stays raw, so the turn-end `parse_model_output` + tool execution are unchanged.

Backend tool-call parsing for gemma-4 already existed (`tool_parser._try_gemma4` / `_extract_gemma4_blocks`); the loop fix alone restored functional tool execution, and this PR makes the live stream render cleanly.

## Test Plan
- [x] `uv run pytest tests/test_chat_session_helpers.py tests/test_chat_session.py tests/test_model_manager.py` (hermetic)
- [x] Router regression: `tests/test_routers_{chat,openai,anthropic}.py` (583 passed overall)
- [x] `ruff check` + `ruff format` clean
- [x] Live (`-m real_model`, model present): `tests/live/test_gemma4_unified_text.py` — language-tower load, full eos set, no config mutation, terminates without loop, and an end-to-end tracker round-trip that strips channel/tool markup from the visible stream while still parsing the tool call from raw text.

Design + plan: `docs/superpowers/specs/2026-06-19-gemma4-terminal-streaming-design.md`, `docs/superpowers/plans/2026-06-19-gemma4-terminal-streaming.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)