### PR TITLE
refactor(model_manager): consolidate speculative-decoder dispatch

### DIFF
--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2929,6 +2929,57 @@ class ModelManager(SpeculativeLoaderMixin):
 
         return wrapped, tokenizer, is_vlm, caps
 
+    def _build_speculative_decoder(
+        self,
+        model: Any,
+        hf_path: str,
+        spec_config: SpeculativeConfig,
+        *,
+        tokenizer: Any = None,
+        is_vlm: bool = False,
+        unwrap_language_model: bool = False,
+    ) -> Any:
+        """Dispatch ``spec_config.strategy`` to the matching decoder loader.
+
+        Single source of truth for the strategy → ``_load_*_decoder`` mapping,
+        shared by the flash-MoE, VLM, and text branches of ``_load_model``
+        (which previously each carried a near-identical if/elif chain).
+
+        ``is_vlm`` is forwarded to the pld and classic loaders (the only two
+        that accept it). ``unwrap_language_model`` selects the
+        self-speculative target: the VLM path drafts off the inner
+        ``model.language_model`` while the dense/flash-MoE paths draft off the
+        model itself — callers that don't pass it keep the model unwrapped.
+        ``tokenizer`` is consumed only by ``proxy_tuning``.
+
+        Branches for strategies a given caller can't reach (e.g. ``eagle`` /
+        ``mtp`` / ``proxy_tuning`` are rejected upstream on flash-MoE and VLM
+        targets via ``_FLASH_MOE_INCOMPATIBLE_STRATEGIES``) are simply never
+        exercised from that path; keeping them here costs nothing and avoids a
+        silent fall-through to classic speculative.
+        """
+        strategy = spec_config.strategy
+        if strategy == "dflash":
+            return self._load_dflash_decoder(model, spec_config)
+        if strategy == "eagle":
+            return self._load_eagle_decoder(model, spec_config)
+        if strategy == "mtp":
+            return self._load_mtp_decoder(model, spec_config)
+        if strategy == "pld":
+            return self._load_pld_decoder(model, spec_config, is_vlm=is_vlm)
+        if strategy == "self_speculative":
+            target = (
+                getattr(model, "language_model", model)
+                if unwrap_language_model
+                else model
+            )
+            return self._load_self_speculative_decoder(target, spec_config)
+        if strategy == "proxy_tuning":
+            return self._load_proxy_tuning_decoder(model, tokenizer, spec_config)
+        return self._load_speculative_decoder(
+            model, hf_path, spec_config, is_vlm=is_vlm
+        )
+
     def _load_model(
         self,
         hf_path: str,
@@ -3052,18 +3103,13 @@ class ModelManager(SpeculativeLoaderMixin):
                     hf_path, load_path, flash_moe_dir, flash_moe_config=flash_moe_config
                 )
                 if spec_enabled:
-                    if spec_config.strategy == "pld":
-                        decoder = self._load_pld_decoder(
-                            model, spec_config, is_vlm=is_vlm
-                        )
-                    elif spec_config.strategy == "self_speculative":
-                        decoder = self._load_self_speculative_decoder(
-                            model, spec_config
-                        )
-                    else:
-                        decoder = self._load_speculative_decoder(
-                            model, hf_path, spec_config, is_vlm=is_vlm
-                        )
+                    decoder = self._build_speculative_decoder(
+                        model,
+                        hf_path,
+                        spec_config,
+                        tokenizer=tokenizer,
+                        is_vlm=is_vlm,
+                    )
                     return model, tokenizer, is_vlm, caps, decoder
                 return model, tokenizer, is_vlm, caps, None
 
@@ -3185,21 +3231,14 @@ class ModelManager(SpeculativeLoaderMixin):
                         "speculative instead"
                     )
                 if spec_enabled:
-                    if spec_config.strategy == "dflash":
-                        decoder = self._load_dflash_decoder(model, spec_config)
-                    elif spec_config.strategy == "pld":
-                        decoder = self._load_pld_decoder(
-                            model, spec_config, is_vlm=True
-                        )
-                    elif spec_config.strategy == "self_speculative":
-                        spec_target = getattr(model, "language_model", model)
-                        decoder = self._load_self_speculative_decoder(
-                            spec_target, spec_config
-                        )
-                    else:
-                        decoder = self._load_speculative_decoder(
-                            model, hf_path, spec_config, is_vlm=True
-                        )
+                    decoder = self._build_speculative_decoder(
+                        model,
+                        hf_path,
+                        spec_config,
+                        tokenizer=processor,
+                        is_vlm=True,
+                        unwrap_language_model=True,
+                    )
                     return model, processor, True, caps, decoder
                 return model, processor, True, caps, None
             except OSError as exc:
@@ -3225,20 +3264,9 @@ class ModelManager(SpeculativeLoaderMixin):
             )
 
         if spec_enabled:
-            if spec_config.strategy == "dflash":
-                decoder = self._load_dflash_decoder(model, spec_config)
-            elif spec_config.strategy == "eagle":
-                decoder = self._load_eagle_decoder(model, spec_config)
-            elif spec_config.strategy == "mtp":
-                decoder = self._load_mtp_decoder(model, spec_config)
-            elif spec_config.strategy == "pld":
-                decoder = self._load_pld_decoder(model, spec_config)
-            elif spec_config.strategy == "self_speculative":
-                decoder = self._load_self_speculative_decoder(model, spec_config)
-            elif spec_config.strategy == "proxy_tuning":
-                decoder = self._load_proxy_tuning_decoder(model, tokenizer, spec_config)
-            else:
-                decoder = self._load_speculative_decoder(model, hf_path, spec_config)
+            decoder = self._build_speculative_decoder(
+                model, hf_path, spec_config, tokenizer=tokenizer
+            )
             return model, tokenizer, is_vlm, caps, decoder
 
         return model, tokenizer, is_vlm, caps, None

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -6252,3 +6252,134 @@ class TestWhisperLoad:
         manager._close_loaded_model(lm)
 
         assert whisper_transcribe.ModelHolder.model is other
+
+
+class TestBuildSpeculativeDecoder:
+    """Unit tests for the consolidated ``_build_speculative_decoder`` dispatch.
+
+    This helper replaces three near-identical ``spec_config.strategy``
+    if/elif chains in ``_load_model`` (flash-MoE, VLM, and text paths). Each
+    case pins that a given strategy routes to the right ``_load_*_decoder``
+    method with the right arguments, including the per-path variations:
+    ``is_vlm`` (pld / classic) and ``unwrap_language_model`` (self-speculative
+    target unwrap on the VLM path).
+    """
+
+    def _manager(self, registry, mock_store):
+        manager = ModelManager(registry, mock_store)
+        # Replace every concrete loader with a recording stub returning a
+        # unique sentinel so we can assert both dispatch target and that the
+        # helper propagates the loader's return value unchanged.
+        for name in (
+            "_load_dflash_decoder",
+            "_load_eagle_decoder",
+            "_load_mtp_decoder",
+            "_load_pld_decoder",
+            "_load_self_speculative_decoder",
+            "_load_proxy_tuning_decoder",
+            "_load_speculative_decoder",
+        ):
+            setattr(manager, name, MagicMock(return_value=f"{name}-result"))
+        return manager
+
+    def test_dflash(self, registry, mock_store):
+        manager = self._manager(registry, mock_store)
+        model = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True, draft_model=None, num_tokens=None, strategy="dflash"
+        )
+        result = manager._build_speculative_decoder(model, "hf/path", cfg)
+        manager._load_dflash_decoder.assert_called_once_with(model, cfg)
+        assert result == "_load_dflash_decoder-result"
+
+    def test_eagle(self, registry, mock_store):
+        manager = self._manager(registry, mock_store)
+        model = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True, draft_model=None, num_tokens=None, strategy="eagle"
+        )
+        result = manager._build_speculative_decoder(model, "hf/path", cfg)
+        manager._load_eagle_decoder.assert_called_once_with(model, cfg)
+        assert result == "_load_eagle_decoder-result"
+
+    def test_mtp(self, registry, mock_store):
+        manager = self._manager(registry, mock_store)
+        model = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True, draft_model=None, num_tokens=None, strategy="mtp"
+        )
+        result = manager._build_speculative_decoder(model, "hf/path", cfg)
+        manager._load_mtp_decoder.assert_called_once_with(model, cfg)
+        assert result == "_load_mtp_decoder-result"
+
+    def test_pld_text(self, registry, mock_store):
+        manager = self._manager(registry, mock_store)
+        model = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True, draft_model=None, num_tokens=None, strategy="pld"
+        )
+        manager._build_speculative_decoder(model, "hf/path", cfg)
+        manager._load_pld_decoder.assert_called_once_with(model, cfg, is_vlm=False)
+
+    def test_pld_vlm(self, registry, mock_store):
+        manager = self._manager(registry, mock_store)
+        model = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True, draft_model=None, num_tokens=None, strategy="pld"
+        )
+        manager._build_speculative_decoder(model, "hf/path", cfg, is_vlm=True)
+        manager._load_pld_decoder.assert_called_once_with(model, cfg, is_vlm=True)
+
+    def test_self_speculative_no_unwrap(self, registry, mock_store):
+        manager = self._manager(registry, mock_store)
+        model = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True, draft_model=None, num_tokens=None, strategy="self_speculative"
+        )
+        manager._build_speculative_decoder(model, "hf/path", cfg)
+        manager._load_self_speculative_decoder.assert_called_once_with(model, cfg)
+
+    def test_self_speculative_unwrap_language_model(self, registry, mock_store):
+        manager = self._manager(registry, mock_store)
+        model = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True, draft_model=None, num_tokens=None, strategy="self_speculative"
+        )
+        manager._build_speculative_decoder(
+            model, "hf/path", cfg, is_vlm=True, unwrap_language_model=True
+        )
+        manager._load_self_speculative_decoder.assert_called_once_with(
+            model.language_model, cfg
+        )
+
+    def test_proxy_tuning(self, registry, mock_store):
+        manager = self._manager(registry, mock_store)
+        model = MagicMock()
+        tok = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True, draft_model=None, num_tokens=None, strategy="proxy_tuning"
+        )
+        manager._build_speculative_decoder(model, "hf/path", cfg, tokenizer=tok)
+        manager._load_proxy_tuning_decoder.assert_called_once_with(model, tok, cfg)
+
+    def test_classic_text(self, registry, mock_store):
+        manager = self._manager(registry, mock_store)
+        model = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True, draft_model=None, num_tokens=None, strategy="classic"
+        )
+        manager._build_speculative_decoder(model, "hf/path", cfg)
+        manager._load_speculative_decoder.assert_called_once_with(
+            model, "hf/path", cfg, is_vlm=False
+        )
+
+    def test_classic_vlm(self, registry, mock_store):
+        manager = self._manager(registry, mock_store)
+        model = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True, draft_model=None, num_tokens=None, strategy="classic"
+        )
+        manager._build_speculative_decoder(model, "hf/path", cfg, is_vlm=True)
+        manager._load_speculative_decoder.assert_called_once_with(
+            model, "hf/path", cfg, is_vlm=True
+        )


### PR DESCRIPTION
## What

The flash-MoE, VLM, and text branches of `_load_model` each carried a near-identical `spec_config.strategy` if/elif chain mapping a strategy to its `_load_*_decoder` method. This extracts a single `_build_speculative_decoder` helper as the one source of truth for that mapping.

## Why

Three copies of the same dispatch drift independently — a new strategy or a changed argument has to be threaded through all three (and the flash-MoE/VLM copies already differed in which strategies they handled). Consolidating removes ~41 lines of duplicated control flow and gives one place to reason about the strategy → loader mapping.

## Behavior preservation

Exact behavior is preserved by capturing the two genuine per-path variations as explicit parameters rather than inferring them:

- **`is_vlm`** — forwarded to the `pld` and `classic` loaders (the only two that accept it).
- **`unwrap_language_model`** — selects the self-speculative target. Only the VLM path drafts off the inner `model.language_model`; dense/flash-MoE draft off the model itself. Kept separate from `is_vlm` so a flash-MoE model that returns `is_vlm=True` via the VLM fallback still does **not** unwrap (which matches the prior behavior).
- **`tokenizer`** — consumed only by `proxy_tuning`.

Strategies a given path can't reach (`eagle`/`mtp`/`proxy_tuning` are rejected upstream via `_FLASH_MOE_INCOMPATIBLE_STRATEGIES` on flash-MoE/VLM targets) keep their branches in the helper — harmless, and it removes the prior silent fall-through to classic speculative.

## Tests

TDD: added `TestBuildSpeculativeDecoder` (10 cases) pinning each strategy → loader mapping plus the `is_vlm` / `unwrap_language_model` / `tokenizer` variations; watched them fail before implementing.

- New tests: 10 passed
- `test_model_manager.py` + coverage suite: 302 passed
- speculative / self-speculative / mtp / proxy-tuning / rerank loader suites: 90 passed
- `ruff check` clean, `ruff format` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)