### PR TITLE
fix(factory): stop --allowedTools from disabling GitHub MCP tools

### DIFF
--- a/.github/workflows/factory-babysit.yml
+++ b/.github/workflows/factory-babysit.yml
@@ -108,7 +108,12 @@ jobs:
           # FACTORY_PAT so pushed fixes re-trigger CI/reviews and so the agent
           # can merge. See .github/factory/README.md.
           github_token: ${{ secrets.FACTORY_PAT }}
-          claude_args: --max-turns 80 --allowedTools "Edit,Read,Write,Bash,Grep,Glob"
+          # No --allowedTools: that flag REPLACES claude-code-action's default
+          # tool set, and an explicit code-tool list silently drops the GitHub
+          # MCP tools (PR comments, reviews, labels, merge) the babysitter needs
+          # to triage and merge. The action's defaults include both the code
+          # tools and the GitHub tools; behavior is scoped via the prompt.
+          claude_args: --max-turns 80
           prompt: |
             You are the BABYSIT agent for the olmlx software factory, driving
             PR #${{ steps.resolve.outputs.pr }} to a decision: FIX or MERGE.

--- a/.github/workflows/factory-explore.yml
+++ b/.github/workflows/factory-explore.yml
@@ -40,7 +40,12 @@ jobs:
           # FACTORY_PAT so the issues you file actually trigger Factory · Plan
           # (issues opened with GITHUB_TOKEN do not trigger workflows).
           github_token: ${{ secrets.FACTORY_PAT }}
-          claude_args: --max-turns 120 --allowedTools "Edit,Read,Write,Bash,Grep,Glob"
+          # No --allowedTools: that flag REPLACES claude-code-action's default
+          # tool set, and an explicit code-tool list silently drops the GitHub
+          # MCP tools (issue create/search), leaving the explorer unable to file
+          # issues. The action's defaults already include the code tools + the
+          # GitHub tools, so we rely on those and scope behavior via the prompt.
+          claude_args: --max-turns 120
           prompt: |
             You are the EXPLORATORY TESTER for olmlx. Your job is to find real
             bugs by exercising the running server across its use cases, and to

--- a/.github/workflows/factory-implement.yml
+++ b/.github/workflows/factory-implement.yml
@@ -61,7 +61,12 @@ jobs:
           # babysitter would never fire and the loop would stall. See
           # .github/factory/README.md.
           github_token: ${{ secrets.FACTORY_PAT }}
-          claude_args: --max-turns 80 --allowedTools "Edit,Read,Write,Bash,Grep,Glob"
+          # No --allowedTools: that flag REPLACES claude-code-action's default
+          # tool set, and an explicit code-tool list silently drops the GitHub
+          # MCP tools (PR create, comments), which the implementer needs to open
+          # its PR. The action's defaults include both the code tools and the
+          # GitHub tools; behavior is scoped via the prompt + branch naming.
+          claude_args: --max-turns 80
           prompt: |
             You are the IMPLEMENTATION agent for the olmlx software factory.
 

--- a/.github/workflows/factory-plan.yml
+++ b/.github/workflows/factory-plan.yml
@@ -57,10 +57,15 @@ jobs:
           # body drive code to merge. The plan comment doesn't need to trigger
           # anything downstream, so GITHUB_TOKEN is sufficient.
           #
-          # Read-only code tools: the planner must never edit/push (it also
-          # only has contents:read). GitHub comment/label/close tools are
-          # provided by the action and remain available.
-          claude_args: --max-turns 40 --allowedTools "Read,Grep,Glob"
+          # Read-only on code: the planner must never edit/push (it also only
+          # has contents:read). We DISALLOW the code-mutating tools rather than
+          # allow-listing read tools, because claude-code-action's
+          # `--allowedTools` REPLACES the default tool set — an allow-list of
+          # "Read,Grep,Glob" silently drops the GitHub MCP tools too, leaving
+          # the planner unable to comment/label/close (it just burns turns on
+          # permission denials and exits as a no-op). `--disallowedTools` keeps
+          # every GitHub tool available while still blocking Edit/Write/Bash.
+          claude_args: --max-turns 40 --disallowedTools "Edit,Write,Bash"
           prompt: |
             You are the PLANNING agent for the olmlx software factory.
 


### PR DESCRIPTION
## Problem

A live smoke test of **Factory · Plan** (issue #535) ran **41 turns**, hit `permission_denials_count: 17`, and exited `success` having posted **no comment, applied no label, and closed nothing** — a silent no-op.

## Root cause

In `anthropics/claude-code-action@v1`, `claude_args`'s `--allowedTools` **replaces** the action's default tool set rather than merging with it. The planner's allowlist `"Read,Grep,Glob"` therefore stripped out every GitHub MCP tool, so it could explore the repo but had **no permitted tool to comment / label / close** the issue.

All four factory workflows made the same mistake. `explore`/`implement`/`babysit` only limped along via their `Bash`+`gh` fallback; the planner has no `Bash`, so it was fully dead.

## Fix

| Workflow | Before | After |
|---|---|---|
| `factory-plan` (read-only on code) | `--allowedTools "Read,Grep,Glob"` | `--disallowedTools "Edit,Write,Bash"` |
| `factory-explore` | `--allowedTools "Edit,Read,Write,Bash,Grep,Glob"` | *(flag dropped)* |
| `factory-implement` | `--allowedTools "Edit,Read,Write,Bash,Grep,Glob"` | *(flag dropped)* |
| `factory-babysit` | `--allowedTools "Edit,Read,Write,Bash,Grep,Glob"` | *(flag dropped)* |

`--disallowedTools` keeps the planner read-only on code (preserving the original security posture) while restoring all GitHub tools. The other three rely on the action's defaults, which include both code tools and GitHub tools.

## Verification

- Confirmed via the failed smoke run that the org runner, the `agent` label, and the `FACTORY_PAT`/OIDC auth path all work — the tool allowlist was the only blocker.
- Re-test plan after merge: reopen issue #535 (a `reopened` event re-triggers Factory · Plan) and confirm it now posts a plan or triage-closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)