### PR TITLE
feat(spec): track draft–target quant compat at train and load time

### DIFF
--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -286,6 +286,12 @@ class Settings(BaseSettings):
     )
     speculative_proxy_alpha: float = 1.0
 
+    #: Strict quantization compatibility for speculative decoding (issue #516).
+    #: When True, a mismatch between the draft's recorded target_quant and the
+    #: live target's detected quantization raises RuntimeError instead of just
+    #: emitting a warning. Default False (warn only).
+    spec_strict_compat: bool = False
+
     #: Cross-request KV-cache reuse for speculative decoding (issue #421).
     #: Max persisted speculative cache lineages held on the per-model
     #: decoder. Each slot is a full *live* target (+draft) KV snapshot — a

--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -164,6 +164,7 @@ class DFlashDecoder(SpecDecoderBase):
         self._draft = draft_model
         self._config = draft_config
         self._block_size = block_size
+        self._target_quant = draft_config.target_quant or ""
 
         # State (populated by prefill()). The hook/capture lifecycle
         # fields (``_patched``/``_bound``/``_capture``/``_capture_buffer``)

--- a/olmlx/engine/dflash/draft_model.py
+++ b/olmlx/engine/dflash/draft_model.py
@@ -62,6 +62,7 @@ class DraftConfig:
     sliding_window: int | None = None
     final_logit_softcapping: float | None = None
     attention_causal: bool = False
+    target_quant: str | None = None
 
     def __post_init__(self) -> None:
         if not self.layer_types:

--- a/olmlx/engine/dflash/prepare.py
+++ b/olmlx/engine/dflash/prepare.py
@@ -209,6 +209,7 @@ def _build_draft_config(
     num_hidden_layers: int,
     block_size: int,
     mask_token_id: int,
+    target_quant: str | None = None,
 ) -> DraftConfig:
     """Derive a DraftConfig from the target's config.json.
 
@@ -351,6 +352,7 @@ def _build_draft_config(
         # ``{}`` (and ``{}`` carries no useful information either).
         rope_scaling=text_cfg.get("rope_scaling") or target_cfg.get("rope_scaling"),
         final_logit_softcapping=text_cfg.get("final_logit_softcapping"),
+        target_quant=target_quant,
     )
 
 
@@ -963,12 +965,15 @@ def prepare_dflash_draft(
                 "mask_token_id (CLI: --mask-token-id N) for this target."
             )
 
+    from olmlx.engine.speculative_loaders import _quant_descriptor_from_path
+
     draft_config = _build_draft_config(
         target_cfg,
         target_layer_ids=layer_ids,
         num_hidden_layers=num_hidden_layers,
         block_size=block_size,
         mask_token_id=int(mask_token_id),
+        target_quant=_quant_descriptor_from_path(model_path),
     )
 
     draft = DFlashDraftModel(draft_config)
@@ -1472,6 +1477,11 @@ def _draft_config_to_disk(cfg: DraftConfig) -> dict[str, Any]:
             "target_layer_ids": list(cfg.target_layer_ids),
             "mask_token_id": cfg.mask_token_id,
             "dflash_attention_version": 1 if cfg.attention_causal else 2,
+            **(
+                {"target_quant": cfg.target_quant}
+                if cfg.target_quant is not None
+                else {}
+            ),
         },
     }
     if cfg.rope_scaling is not None:

--- a/olmlx/engine/eagle/decoder.py
+++ b/olmlx/engine/eagle/decoder.py
@@ -108,6 +108,7 @@ class EagleDecoder(SpecDecoderBase):
         draft_model: EagleDraftModel,
         block_size: int = 4,
         target_layer_id: int | None = None,
+        target_quant: str | None = None,
     ):
         super().__init__()
         if make_prompt_cache is None:
@@ -120,6 +121,7 @@ class EagleDecoder(SpecDecoderBase):
         self._target = target_model
         self._draft = draft_model
         self._block_size = block_size
+        self._target_quant = target_quant or ""
         # Default to the deepest (last) layer, i.e. ``len(layers) - 1``.
         # In practice trained checkpoints always supply
         # ``target_layer_id`` (recorded by ``olmlx eagle prepare`` from

--- a/olmlx/engine/eagle/draft_model.py
+++ b/olmlx/engine/eagle/draft_model.py
@@ -60,6 +60,7 @@ class EagleConfig:
     max_position_embeddings: int
     block_size: int
     rope_scaling: dict[str, Any] | None = None
+    target_quant: str | None = None
 
     def __post_init__(self) -> None:
         if self.block_size < 1:

--- a/olmlx/engine/eagle/prepare.py
+++ b/olmlx/engine/eagle/prepare.py
@@ -100,6 +100,7 @@ def _build_eagle_config(
     *,
     num_hidden_layers: int,
     block_size: int,
+    target_quant: str | None = None,
 ) -> EagleConfig:
     """Derive an ``EagleConfig`` from the target's config.json."""
     text_cfg = _text_config(target_cfg)
@@ -177,6 +178,7 @@ def _build_eagle_config(
             if "rope_scaling" in text_cfg
             else target_cfg.get("rope_scaling")
         ),
+        target_quant=target_quant,
     )
 
 
@@ -310,6 +312,8 @@ def _config_to_disk(
         # distribution at inference (~5% acceptance vs ~50% expected).
         # Persist it here so ``_load_eagle_decoder`` can wire it in.
         eagle_block["target_layer_id"] = int(target_layer_id)
+    if cfg.target_quant is not None:
+        eagle_block["target_quant"] = cfg.target_quant
     return {
         "hidden_size": cfg.hidden_size,
         "num_hidden_layers": cfg.num_hidden_layers,
@@ -409,10 +413,13 @@ def prepare_eagle_draft(
     if hasattr(target, "freeze"):
         target.freeze()
 
+    from olmlx.engine.speculative_loaders import _quant_descriptor_from_path
+
     eagle_cfg = _build_eagle_config(
         target_cfg,
         num_hidden_layers=num_hidden_layers,
         block_size=block_size,
+        target_quant=_quant_descriptor_from_path(model_path),
     )
 
     draft = EagleDraftModel(eagle_cfg)

--- a/olmlx/engine/spec_decoder_base.py
+++ b/olmlx/engine/spec_decoder_base.py
@@ -209,6 +209,10 @@ class SpecDecoderBase(abc.ABC):
         self._stats_proposed: int = 0
         self._stats_accepted_draft: int = 0
 
+        # Quant descriptor of the target the draft was trained against.
+        # Set by subclasses from the draft config's target_quant field.
+        self._target_quant: str = ""
+
         # Tracing label, resolved once — span() evaluates its kwargs
         # eagerly even with tracing disabled, and step()/_verify_greedy
         # run per decode step, so a per-call lookup would re-execute
@@ -419,6 +423,7 @@ class SpecDecoderBase(abc.ABC):
             "accepted_draft": accepted_draft,
             "acceptance_rate": accepted_draft / proposed if proposed else 0.0,
             "avg_tokens_per_step": (accepted_draft + steps) / steps if steps else 0.0,
+            "target_quant": self._target_quant,
         }
         summary.update(self._stats_extra())
         return summary

--- a/olmlx/engine/speculative_loaders.py
+++ b/olmlx/engine/speculative_loaders.py
@@ -51,7 +51,8 @@ def _quant_descriptor_from_path(model_path: Path) -> str:
 
     if quant_block and isinstance(quant_block, dict):
         bits = quant_block.get("bits")
-        group_size = quant_block.get("group_size") or 64
+        group_size_raw = quant_block.get("group_size")
+        group_size = group_size_raw if group_size_raw is not None else 64
         if bits is not None:
             return f"q{bits}_g{group_size}"
 

--- a/olmlx/engine/speculative_loaders.py
+++ b/olmlx/engine/speculative_loaders.py
@@ -640,6 +640,7 @@ class SpeculativeLoaderMixin:
             draft_model=draft_model,
             block_size=block_size,
             target_layer_id=target_layer_id,
+            target_quant=draft_config.target_quant,
         )
 
     def _load_mtp_decoder(

--- a/olmlx/engine/speculative_loaders.py
+++ b/olmlx/engine/speculative_loaders.py
@@ -38,6 +38,11 @@ def _quant_descriptor_from_path(model_path: Path) -> str:
     try:
         cfg = json.loads(cfg_path.read_text()) if cfg_path.exists() else {}
     except Exception:
+        logger.warning(
+            "_quant_descriptor_from_path: failed to read/parse %s — defaulting to bf16",
+            cfg_path,
+            exc_info=True,
+        )
         cfg = {}
 
     quant_block = cfg.get("quantization") or cfg.get("quantization_config")
@@ -47,6 +52,11 @@ def _quant_descriptor_from_path(model_path: Path) -> str:
             try:
                 quant_block = json.loads(gptq_path.read_text())
             except Exception:
+                logger.warning(
+                    "_quant_descriptor_from_path: failed to read/parse %s — defaulting to bf16",
+                    gptq_path,
+                    exc_info=True,
+                )
                 quant_block = None
 
     if quant_block and isinstance(quant_block, dict):
@@ -75,7 +85,10 @@ def _detect_live_quant(model: Any) -> str:
                 group_size = module.group_size
                 return f"q{bits}_g{group_size}"
     except Exception:
-        pass
+        logger.debug(
+            "_detect_live_quant: named_modules() inspection failed — defaulting to bf16",
+            exc_info=True,
+        )
     return "bf16"
 
 

--- a/olmlx/engine/speculative_loaders.py
+++ b/olmlx/engine/speculative_loaders.py
@@ -51,7 +51,7 @@ def _quant_descriptor_from_path(model_path: Path) -> str:
 
     if quant_block and isinstance(quant_block, dict):
         bits = quant_block.get("bits")
-        group_size = quant_block.get("group_size", 64)
+        group_size = quant_block.get("group_size") or 64
         if bits is not None:
             return f"q{bits}_g{group_size}"
 

--- a/olmlx/engine/speculative_loaders.py
+++ b/olmlx/engine/speculative_loaders.py
@@ -95,15 +95,16 @@ def _check_quant_compat(
         return
     if draft_quant == live_quant:
         return
-    msg = (
+    base_msg = (
         f"DFlash/EAGLE draft at {draft_path} was trained on a '{draft_quant}' "
         f"target but the loaded target is '{live_quant}' — acceptance rate may "
-        "degrade to ~0.4%%. Retrain the draft against the current target or "
-        "set OLMLX_SPEC_STRICT_COMPAT=1 to treat this as an error."
+        "degrade to ~0.4%. Retrain the draft against the current target."
     )
     if settings.spec_strict_compat:
-        raise RuntimeError(msg)
-    logger.warning(msg)
+        raise RuntimeError(base_msg)
+    logger.warning(
+        "%s Set OLMLX_SPEC_STRICT_COMPAT=1 to treat this as an error.", base_msg
+    )
 
 
 def _resolve_attention_causal(dflash_cfg: dict) -> bool:

--- a/olmlx/engine/speculative_loaders.py
+++ b/olmlx/engine/speculative_loaders.py
@@ -25,6 +25,86 @@ from olmlx.engine.registry import SpeculativeConfig
 logger = logging.getLogger(__name__)
 
 
+def _quant_descriptor_from_path(model_path: Path) -> str:
+    """Return a quant descriptor string for a model at *model_path*.
+
+    Reads ``config.json`` and looks for a ``"quantization"`` or
+    ``"quantization_config"`` block (the same fields ``model_manager.py``
+    already uses for ``nn.quantize``). Falls back to ``quantize_config.json``
+    (GPTQ format). Returns ``f"q{bits}_g{group_size}"`` or ``"bf16"`` if no
+    quantization block is present.
+    """
+    cfg_path = model_path / "config.json"
+    try:
+        cfg = json.loads(cfg_path.read_text()) if cfg_path.exists() else {}
+    except Exception:
+        cfg = {}
+
+    quant_block = cfg.get("quantization") or cfg.get("quantization_config")
+    if not quant_block:
+        gptq_path = model_path / "quantize_config.json"
+        if gptq_path.exists():
+            try:
+                quant_block = json.loads(gptq_path.read_text())
+            except Exception:
+                quant_block = None
+
+    if quant_block and isinstance(quant_block, dict):
+        bits = quant_block.get("bits")
+        group_size = quant_block.get("group_size", 64)
+        if bits is not None:
+            return f"q{bits}_g{group_size}"
+
+    return "bf16"
+
+
+def _detect_live_quant(model: Any) -> str:
+    """Return a quant descriptor by inspecting a loaded MLX model.
+
+    Walks the model looking for the first ``nn.QuantizedLinear`` via
+    ``module.modules()``. Returns ``f"q{bits}_g{group_size}"`` or ``"bf16"``
+    if none are found.
+    """
+    import mlx.nn as nn
+
+    try:
+        for _name, module in model.named_modules():
+            if isinstance(module, nn.QuantizedLinear):
+                bits = module.bits
+                group_size = module.group_size
+                return f"q{bits}_g{group_size}"
+    except Exception:
+        pass
+    return "bf16"
+
+
+def _check_quant_compat(
+    draft_quant: str | None,
+    live_quant: str,
+    *,
+    draft_path: Path,
+) -> None:
+    """Warn (or raise, in strict mode) when the draft's recorded target quant
+    does not match the live target's effective quantization.
+
+    ``draft_quant=None`` means the draft checkpoint predates this field; skip
+    silently (backwards compatibility).
+    """
+    if draft_quant is None:
+        return
+    if draft_quant == live_quant:
+        return
+    msg = (
+        f"DFlash/EAGLE draft at {draft_path} was trained on a '{draft_quant}' "
+        f"target but the loaded target is '{live_quant}' — acceptance rate may "
+        "degrade to ~0.4%%. Retrain the draft against the current target or "
+        "set OLMLX_SPEC_STRICT_COMPAT=1 to treat this as an error."
+    )
+    if settings.spec_strict_compat:
+        raise RuntimeError(msg)
+    logger.warning(msg)
+
+
 def _resolve_attention_causal(dflash_cfg: dict) -> bool:
     """Detect legacy draft checkpoints that were trained with causal attention.
 
@@ -199,6 +279,7 @@ class SpeculativeLoaderMixin:
             or ["full_attention"] * draft_cfg_dict["num_hidden_layers"]
         )
 
+        draft_quant_raw = dflash_cfg.get("target_quant")
         draft_config = DraftConfig(
             hidden_size=draft_cfg_dict["hidden_size"],
             num_hidden_layers=draft_cfg_dict["num_hidden_layers"],
@@ -219,6 +300,7 @@ class SpeculativeLoaderMixin:
             sliding_window=draft_cfg_dict.get("sliding_window"),
             final_logit_softcapping=draft_cfg_dict.get("final_logit_softcapping"),
             attention_causal=_resolve_attention_causal(dflash_cfg),
+            target_quant=draft_quant_raw,
         )
 
         draft_model = DFlashDraftModel(draft_config)
@@ -289,6 +371,14 @@ class SpeculativeLoaderMixin:
                 f"not match target vocab_size ({target_vocab}). The draft "
                 "must be trained against a target with the same vocabulary."
             )
+
+        # Quant compatibility check: warn (or raise in strict mode) when the
+        # draft was trained on a target with a different quantization.
+        _check_quant_compat(
+            draft_config.target_quant,
+            _detect_live_quant(target_model),
+            draft_path=Path(load_path),
+        )
 
         # ``draft_config.block_size`` is treated as the *draft token
         # count* directly (matching the convention #287 ships with —
@@ -399,6 +489,7 @@ class SpeculativeLoaderMixin:
                 f"keys: {missing}"
             )
 
+        eagle_draft_quant_raw = eagle_cfg.get("target_quant")
         draft_config = EagleConfig(
             hidden_size=draft_cfg_dict["hidden_size"],
             num_hidden_layers=draft_cfg_dict["num_hidden_layers"],
@@ -412,6 +503,7 @@ class SpeculativeLoaderMixin:
             max_position_embeddings=draft_cfg_dict["max_position_embeddings"],
             block_size=int(eagle_cfg["block_size"]),
             rope_scaling=draft_cfg_dict.get("rope_scaling"),
+            target_quant=eagle_draft_quant_raw,
         )
 
         draft_model = EagleDraftModel(draft_config)
@@ -498,6 +590,14 @@ class SpeculativeLoaderMixin:
                 "mismatch would crash inside input_proj at the first "
                 "prefill. Retrain the draft against the current target."
             )
+
+        # Quant compatibility check: warn (or raise in strict mode) when the
+        # draft was trained on a target with a different quantization.
+        _check_quant_compat(
+            draft_config.target_quant,
+            _detect_live_quant(target_model),
+            draft_path=Path(load_path),
+        )
 
         block_size = (
             spec_config.num_tokens

--- a/tests/test_draft_quant_compat.py
+++ b/tests/test_draft_quant_compat.py
@@ -74,6 +74,18 @@ def test_quant_descriptor_null_group_size(tmp_path: Path) -> None:
     assert _quant_descriptor_from_path(tmp_path) == "q4_g64"
 
 
+def test_quant_descriptor_zero_group_size(tmp_path: Path) -> None:
+    """config.json with group_size: 0 → preserves 0, not replaced with 64."""
+    cfg = {
+        "quantization": {"bits": 4, "group_size": 0},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(cfg))
+
+    from olmlx.engine.speculative_loaders import _quant_descriptor_from_path
+
+    assert _quant_descriptor_from_path(tmp_path) == "q4_g0"
+
+
 def test_quant_descriptor_from_gptq_config(tmp_path: Path) -> None:
     """quantize_config.json (GPTQ format) with only bits → 'q4_g64' (default group_size)."""
     cfg = {"hidden_size": 512, "vocab_size": 1000}

--- a/tests/test_draft_quant_compat.py
+++ b/tests/test_draft_quant_compat.py
@@ -1,0 +1,316 @@
+"""Tests for DFlash/EAGLE draft quantization compatibility tracking (#516).
+
+Covers:
+- ``_quant_descriptor_from_path``: parse target config.json for quant desc
+- ``_detect_live_quant``: walk a loaded model for QuantizedLinear layers
+- ``_check_quant_compat``: warn / raise on mismatch
+- DraftConfig / EagleConfig roundtrip with ``target_quant``
+- stats_summary includes ``target_quant``
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _quant_descriptor_from_path
+# ---------------------------------------------------------------------------
+
+
+def test_quant_descriptor_from_bf16_config(tmp_path: Path) -> None:
+    """No quantization block → 'bf16'."""
+    cfg = {"hidden_size": 512, "vocab_size": 1000}
+    (tmp_path / "config.json").write_text(json.dumps(cfg))
+
+    from olmlx.engine.speculative_loaders import _quant_descriptor_from_path
+
+    assert _quant_descriptor_from_path(tmp_path) == "bf16"
+
+
+def test_quant_descriptor_from_q4_config(tmp_path: Path) -> None:
+    """config.json with quantization block → 'q4_g64'."""
+    cfg = {
+        "hidden_size": 512,
+        "vocab_size": 1000,
+        "quantization": {"bits": 4, "group_size": 64},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(cfg))
+
+    from olmlx.engine.speculative_loaders import _quant_descriptor_from_path
+
+    assert _quant_descriptor_from_path(tmp_path) == "q4_g64"
+
+
+def test_quant_descriptor_from_quantization_config(tmp_path: Path) -> None:
+    """config.json with quantization_config block → 'q4_g32'."""
+    cfg = {
+        "hidden_size": 512,
+        "vocab_size": 1000,
+        "quantization_config": {"bits": 4, "group_size": 32},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(cfg))
+
+    from olmlx.engine.speculative_loaders import _quant_descriptor_from_path
+
+    assert _quant_descriptor_from_path(tmp_path) == "q4_g32"
+
+
+def test_quant_descriptor_from_gptq_config(tmp_path: Path) -> None:
+    """quantize_config.json (GPTQ format) with only bits → 'q4_g64' (default group_size)."""
+    cfg = {"hidden_size": 512, "vocab_size": 1000}
+    (tmp_path / "config.json").write_text(json.dumps(cfg))
+    # GPTQ uses quantize_config.json with bits; no group_size → fallback to 64
+    (tmp_path / "quantize_config.json").write_text(json.dumps({"bits": 4}))
+
+    from olmlx.engine.speculative_loaders import _quant_descriptor_from_path
+
+    assert _quant_descriptor_from_path(tmp_path) == "q4_g64"
+
+
+# ---------------------------------------------------------------------------
+# DraftConfig / _draft_config_to_disk roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_dflash_config_roundtrip_with_target_quant() -> None:
+    """DraftConfig(target_quant=...) roundtrips through _draft_config_to_disk."""
+    from olmlx.engine.dflash.draft_model import DraftConfig
+    from olmlx.engine.dflash.prepare import _draft_config_to_disk
+
+    cfg = DraftConfig(
+        hidden_size=256,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=64,
+        intermediate_size=512,
+        vocab_size=1000,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        max_position_embeddings=512,
+        block_size=4,
+        num_target_layers=2,
+        target_layer_ids=[1, 3],
+        mask_token_id=0,
+        target_quant="q4_g64",
+    )
+    on_disk = _draft_config_to_disk(cfg)
+    assert on_disk["dflash_config"]["target_quant"] == "q4_g64"
+
+
+def test_dflash_config_roundtrip_no_target_quant() -> None:
+    """DraftConfig without target_quant → dflash_config has no target_quant key."""
+    from olmlx.engine.dflash.draft_model import DraftConfig
+    from olmlx.engine.dflash.prepare import _draft_config_to_disk
+
+    cfg = DraftConfig(
+        hidden_size=256,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=64,
+        intermediate_size=512,
+        vocab_size=1000,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        max_position_embeddings=512,
+        block_size=4,
+        num_target_layers=2,
+        target_layer_ids=[1, 3],
+        mask_token_id=0,
+    )
+    on_disk = _draft_config_to_disk(cfg)
+    assert "target_quant" not in on_disk["dflash_config"]
+
+
+# ---------------------------------------------------------------------------
+# EagleConfig / _config_to_disk roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_eagle_config_roundtrip_with_target_quant() -> None:
+    """EagleConfig(target_quant=...) roundtrips through _config_to_disk."""
+    from olmlx.engine.eagle.draft_model import EagleConfig
+    from olmlx.engine.eagle.prepare import _config_to_disk
+
+    cfg = EagleConfig(
+        hidden_size=256,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=64,
+        intermediate_size=512,
+        vocab_size=1000,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        max_position_embeddings=512,
+        block_size=4,
+        target_quant="q4_g64",
+    )
+    on_disk = _config_to_disk(cfg)
+    assert on_disk["eagle_config"]["target_quant"] == "q4_g64"
+
+
+def test_eagle_config_roundtrip_no_target_quant() -> None:
+    """EagleConfig without target_quant → eagle_config has no target_quant key."""
+    from olmlx.engine.eagle.draft_model import EagleConfig
+    from olmlx.engine.eagle.prepare import _config_to_disk
+
+    cfg = EagleConfig(
+        hidden_size=256,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=64,
+        intermediate_size=512,
+        vocab_size=1000,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        max_position_embeddings=512,
+        block_size=4,
+    )
+    on_disk = _config_to_disk(cfg)
+    assert "target_quant" not in on_disk["eagle_config"]
+
+
+# ---------------------------------------------------------------------------
+# _check_quant_compat
+# ---------------------------------------------------------------------------
+
+
+def test_compat_check_matching_no_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """Matching quant descriptors → no warning."""
+    from olmlx.engine.speculative_loaders import _check_quant_compat
+
+    with caplog.at_level(logging.WARNING, logger="olmlx.engine.speculative_loaders"):
+        _check_quant_compat("q4_g64", "q4_g64", draft_path=Path("/fake/draft"))
+    assert not caplog.records
+
+
+def test_compat_check_mismatch_warns(caplog: pytest.LogCaptureFixture) -> None:
+    """Mismatched quant descriptors → warning in log."""
+    from olmlx.engine.speculative_loaders import _check_quant_compat
+
+    with caplog.at_level(logging.WARNING, logger="olmlx.engine.speculative_loaders"):
+        _check_quant_compat("q4_g64", "bf16", draft_path=Path("/fake/draft"))
+    assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+
+def test_compat_check_none_skips(caplog: pytest.LogCaptureFixture) -> None:
+    """draft_quant=None (old checkpoint) → no warning, no error."""
+    from olmlx.engine.speculative_loaders import _check_quant_compat
+
+    with caplog.at_level(logging.WARNING, logger="olmlx.engine.speculative_loaders"):
+        _check_quant_compat(None, "bf16", draft_path=Path("/fake/draft"))
+    assert not caplog.records
+
+
+def test_compat_check_strict_raises() -> None:
+    """Mismatch with spec_strict_compat=True → RuntimeError."""
+    from olmlx.engine.speculative_loaders import _check_quant_compat
+
+    with patch("olmlx.engine.speculative_loaders.settings") as mock_settings:
+        mock_settings.spec_strict_compat = True
+        with pytest.raises(RuntimeError, match="q4_g64"):
+            _check_quant_compat("q4_g64", "bf16", draft_path=Path("/fake/draft"))
+
+
+# ---------------------------------------------------------------------------
+# _detect_live_quant
+# ---------------------------------------------------------------------------
+
+
+def test_detect_live_quant_bf16_model() -> None:
+    """Model with no QuantizedLinear → 'bf16'."""
+    import mlx.nn as nn
+
+    from olmlx.engine.speculative_loaders import _detect_live_quant
+
+    class _PlainModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = nn.Linear(16, 16, bias=False)
+
+    model = _PlainModel()
+    assert _detect_live_quant(model) == "bf16"
+
+
+def test_detect_live_quant_quantized_model() -> None:
+    """Model with QuantizedLinear child → 'q4_g64'."""
+    import mlx.nn as nn
+
+    from olmlx.engine.speculative_loaders import _detect_live_quant
+
+    # Build a real QuantizedLinear to avoid relying on mock internals.
+    # The last input dimension must be divisible by group_size (64).
+    ql = nn.QuantizedLinear(64, 64, bits=4, group_size=64)
+
+    class _QuantModel(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = ql
+
+    model = _QuantModel()
+    result = _detect_live_quant(model)
+    assert result == "q4_g64"
+
+
+# ---------------------------------------------------------------------------
+# stats_summary includes target_quant
+# ---------------------------------------------------------------------------
+
+
+def test_stats_summary_includes_target_quant() -> None:
+    """SpecDecoderBase.stats_summary includes target_quant when set."""
+    from olmlx.engine.spec_decoder_base import SpecDecoderBase
+
+    class _ConcreteDecoder(SpecDecoderBase):
+        def __init__(self) -> None:
+            super().__init__()
+            self._target = MagicMock()
+            self._draft = MagicMock()
+
+        def _prefill_impl(self, prompt: Any, **kwargs: Any) -> int:
+            return 0
+
+        def _step_impl(self) -> tuple[list[int], int]:
+            return [], 0
+
+        def _reset_state(self) -> None:
+            pass
+
+    dec = _ConcreteDecoder()
+    dec._target_quant = "q4_g64"
+    summary = dec.stats_summary()
+    assert summary["target_quant"] == "q4_g64"
+
+
+def test_stats_summary_target_quant_default_empty() -> None:
+    """stats_summary target_quant is empty string by default."""
+    from olmlx.engine.spec_decoder_base import SpecDecoderBase
+
+    class _ConcreteDecoder(SpecDecoderBase):
+        def __init__(self) -> None:
+            super().__init__()
+            self._target = MagicMock()
+            self._draft = MagicMock()
+
+        def _prefill_impl(self, prompt: Any, **kwargs: Any) -> int:
+            return 0
+
+        def _step_impl(self) -> tuple[list[int], int]:
+            return [], 0
+
+        def _reset_state(self) -> None:
+            pass
+
+    dec = _ConcreteDecoder()
+    summary = dec.stats_summary()
+    assert summary["target_quant"] == ""

--- a/tests/test_draft_quant_compat.py
+++ b/tests/test_draft_quant_compat.py
@@ -62,6 +62,18 @@ def test_quant_descriptor_from_quantization_config(tmp_path: Path) -> None:
     assert _quant_descriptor_from_path(tmp_path) == "q4_g32"
 
 
+def test_quant_descriptor_null_group_size(tmp_path: Path) -> None:
+    """config.json with group_size: null → falls back to 64, not 'q4_gNone'."""
+    cfg = {
+        "quantization": {"bits": 4, "group_size": None},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(cfg))
+
+    from olmlx.engine.speculative_loaders import _quant_descriptor_from_path
+
+    assert _quant_descriptor_from_path(tmp_path) == "q4_g64"
+
+
 def test_quant_descriptor_from_gptq_config(tmp_path: Path) -> None:
     """quantize_config.json (GPTQ format) with only bits → 'q4_g64' (default group_size)."""
     cfg = {"hidden_size": 512, "vocab_size": 1000}

--- a/tests/test_draft_quant_compat.py
+++ b/tests/test_draft_quant_compat.py
@@ -263,6 +263,130 @@ def test_detect_live_quant_quantized_model() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Decoder constructors propagate target_quant to _target_quant
+# ---------------------------------------------------------------------------
+
+
+def test_dflash_decoder_sets_target_quant() -> None:
+    """DFlashDecoder.__init__ propagates draft_config.target_quant to _target_quant."""
+    import mlx.nn as nn
+
+    from olmlx.engine.dflash.decoder import DFlashDecoder
+    from olmlx.engine.dflash.draft_model import DraftConfig, DFlashDraftModel
+
+    cfg = DraftConfig(
+        hidden_size=256,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=64,
+        intermediate_size=512,
+        vocab_size=1000,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        max_position_embeddings=512,
+        block_size=4,
+        num_target_layers=2,
+        target_layer_ids=[1, 3],
+        mask_token_id=0,
+        target_quant="q4_g64",
+    )
+    target = MagicMock(spec=nn.Module)
+    draft = DFlashDraftModel(cfg)
+    decoder = DFlashDecoder(
+        target_model=target, draft_model=draft, draft_config=cfg, block_size=4
+    )
+    assert decoder._target_quant == "q4_g64"
+
+
+def test_dflash_decoder_target_quant_none_defaults_empty() -> None:
+    """DFlashDecoder._target_quant is '' when draft_config.target_quant is None."""
+    import mlx.nn as nn
+
+    from olmlx.engine.dflash.decoder import DFlashDecoder
+    from olmlx.engine.dflash.draft_model import DraftConfig, DFlashDraftModel
+
+    cfg = DraftConfig(
+        hidden_size=256,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=64,
+        intermediate_size=512,
+        vocab_size=1000,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        max_position_embeddings=512,
+        block_size=4,
+        num_target_layers=2,
+        target_layer_ids=[1, 3],
+        mask_token_id=0,
+    )
+    target = MagicMock(spec=nn.Module)
+    draft = DFlashDraftModel(cfg)
+    decoder = DFlashDecoder(
+        target_model=target, draft_model=draft, draft_config=cfg, block_size=4
+    )
+    assert decoder._target_quant == ""
+
+
+def test_eagle_decoder_sets_target_quant() -> None:
+    """EagleDecoder.__init__ propagates target_quant to _target_quant."""
+    import mlx.nn as nn
+
+    from olmlx.engine.eagle.decoder import EagleDecoder
+    from olmlx.engine.eagle.draft_model import EagleConfig, EagleDraftModel
+
+    cfg = EagleConfig(
+        hidden_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=32,
+        intermediate_size=128,
+        vocab_size=1000,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        max_position_embeddings=512,
+        block_size=4,
+    )
+    target = MagicMock(spec=nn.Module)
+    target.layers = [MagicMock()]
+    draft = EagleDraftModel(cfg)
+    decoder = EagleDecoder(
+        target_model=target, draft_model=draft, block_size=4, target_quant="q4_g64"
+    )
+    assert decoder._target_quant == "q4_g64"
+
+
+def test_eagle_decoder_target_quant_none_defaults_empty() -> None:
+    """EagleDecoder._target_quant is '' when target_quant is not passed."""
+    import mlx.nn as nn
+
+    from olmlx.engine.eagle.decoder import EagleDecoder
+    from olmlx.engine.eagle.draft_model import EagleConfig, EagleDraftModel
+
+    cfg = EagleConfig(
+        hidden_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=32,
+        intermediate_size=128,
+        vocab_size=1000,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        max_position_embeddings=512,
+        block_size=4,
+    )
+    target = MagicMock(spec=nn.Module)
+    target.layers = [MagicMock()]
+    draft = EagleDraftModel(cfg)
+    decoder = EagleDecoder(target_model=target, draft_model=draft, block_size=4)
+    assert decoder._target_quant == ""
+
+
+# ---------------------------------------------------------------------------
 # stats_summary includes target_quant
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #516

## Summary

- Adds `target_quant: str | None` to `DraftConfig` and `EagleConfig` (optional, backwards-compatible — `None` on old checkpoints skips checks silently).
- Three new helpers in `engine/speculative_loaders.py`:
  - `_quant_descriptor_from_path(path)` — reads `config.json`/`quantization_config.json`/`quantize_config.json` → `"q4_g64"` or `"bf16"`.
  - `_detect_live_quant(model)` — walks loaded MLX model for `nn.QuantizedLinear` → descriptor.
  - `_check_quant_compat(draft_quant, live_quant, *, draft_path)` — warns on mismatch; raises `RuntimeError` when `OLMLX_SPEC_STRICT_COMPAT=1`.
- `_load_dflash_decoder` and `_load_eagle_decoder` now read `target_quant` from the draft config and call `_check_quant_compat` after existing vocab/hidden-size checks.
- `prepare_dflash_draft` and `prepare_eagle_draft` compute `target_quant` at training time and persist it in `dflash_config.target_quant` / `eagle_config.target_quant` inside `config.json`.
- `SpecDecoderBase` gains `_target_quant: str = ""` and exposes it in `stats_summary()`.
- `config.py`: new `spec_strict_compat: bool = False` (`OLMLX_SPEC_STRICT_COMPAT` env var).

## Tests added

`tests/test_draft_quant_compat.py` — 16 tests:
- `_quant_descriptor_from_path`: bf16, q4 via `quantization`, q4 via `quantization_config`, GPTQ `quantize_config.json`
- DraftConfig / EagleConfig roundtrip with and without `target_quant`
- `_check_quant_compat`: match (no warn), mismatch (warn), None (skip), strict-mode (raise)
- `_detect_live_quant`: bf16 model, quantized model
- `stats_summary` includes `target_quant`

## CLAUDE.md invariants checked

- **Metal stream / load ordering**: all new logic runs inside the existing `_load_dflash_decoder` / `_load_eagle_decoder` call sites after weight loading and vocab checks, before the decoder is returned. No inference path is touched.
- **No vocab/hidden-size check ordering change**: quant check is additive — runs after, not instead of, structural checks.
- **Backwards compatibility**: `target_quant=None` (absent from old checkpoints) skips silently.
- **Strict mode is opt-in**: default warns; `OLMLX_SPEC_STRICT_COMPAT=1` promotes to error.
- **Grammar / proxy-tuning / other strategies**: not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)