### PR TITLE
feat(spec): auto-detect bundled draft dir for dflash/eagle

### DIFF
--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2959,6 +2959,27 @@ class ModelManager(SpeculativeLoaderMixin):
         silent fall-through to classic speculative.
         """
         strategy = spec_config.strategy
+
+        # Bundled-subdir probe: when no draft is configured and the strategy
+        # supports training a draft alongside the target, check whether
+        # <target-local-dir>/<strategy>/ exists and looks like a valid checkpoint.
+        # Precedence: explicit draft_model > curated map (#513, future) > probe.
+        if strategy in {"dflash", "eagle"} and not spec_config.draft_model:
+            from olmlx.engine.speculative_loaders import _probe_bundled_draft_dir
+
+            _target_local: Path | None = None
+            if Path(hf_path).is_absolute():
+                _target_local = Path(hf_path)
+            elif self.store is not None:
+                _target_local = self.store.local_path(hf_path)
+            if _target_local is not None:
+                _bundled = _probe_bundled_draft_dir(_target_local, strategy)
+                if _bundled is not None:
+                    logger.info(
+                        "Auto-detected bundled %s draft at %s", strategy, _bundled
+                    )
+                    spec_config = spec_config._replace(draft_model=str(_bundled))
+
         if strategy == "dflash":
             return self._load_dflash_decoder(model, spec_config)
         if strategy == "eagle":

--- a/olmlx/engine/speculative_loaders.py
+++ b/olmlx/engine/speculative_loaders.py
@@ -153,6 +153,28 @@ def _resolve_attention_causal(dflash_cfg: dict) -> bool:
     return True
 
 
+def _probe_bundled_draft_dir(local_dir: Path, strategy: str) -> Path | None:
+    """Return ``local_dir / strategy`` if it looks like a valid draft checkpoint.
+
+    A candidate is valid when ``config.json`` exists and at least one
+    ``.safetensors`` file is present — the same validity bar applied by
+    ``_load_dflash_decoder`` / ``_load_eagle_decoder`` after path resolution.
+    The check is intentionally shallow: full schema validation still runs
+    inside those loaders, so a malformed-but-present draft surfaces as a
+    clear schema error rather than a "no draft configured" message.
+
+    Returns ``None`` when the subdir is absent or fails either criterion.
+
+    # Future: curated-map lookup (#513) inserts before this call in
+    # ``_build_speculative_decoder`` — bundled probe is the last fallback
+    # before raising an error.
+    """
+    candidate = local_dir / strategy
+    if (candidate / "config.json").exists() and any(candidate.glob("*.safetensors")):
+        return candidate
+    return None
+
+
 class SpeculativeLoaderMixin:
     """Draft-model loading for speculative decoding (mixed into ModelManager)."""
 
@@ -242,9 +264,11 @@ class SpeculativeLoaderMixin:
             )
         if not spec_config.draft_model:
             raise ValueError(
-                "speculative_strategy='dflash' requires speculative_draft_model "
-                "to be set (OLMLX_SPECULATIVE_DRAFT_MODEL or per-model "
-                "'speculative_draft_model' in models.json)"
+                "speculative_strategy='dflash' requires a draft model but none "
+                "was found. Tried: OLMLX_SPECULATIVE_DRAFT_MODEL / per-model "
+                "'speculative_draft_model' in models.json, and a bundled "
+                "<target-dir>/dflash/ subdir probe. "
+                "Set speculative_draft_model or run 'olmlx dflash prepare'."
             )
 
         logger.info("Loading dflash draft model %s", spec_config.draft_model)
@@ -459,9 +483,11 @@ class SpeculativeLoaderMixin:
             )
         if not spec_config.draft_model:
             raise ValueError(
-                "speculative_strategy='eagle' requires speculative_draft_model "
-                "to be set (OLMLX_SPECULATIVE_DRAFT_MODEL or per-model "
-                "'speculative_draft_model' in models.json)"
+                "speculative_strategy='eagle' requires a draft model but none "
+                "was found. Tried: OLMLX_SPECULATIVE_DRAFT_MODEL / per-model "
+                "'speculative_draft_model' in models.json, and a bundled "
+                "<target-dir>/eagle/ subdir probe. "
+                "Set speculative_draft_model or run 'olmlx eagle prepare'."
             )
 
         logger.info("Loading EAGLE draft model %s", spec_config.draft_model)

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -6383,3 +6383,182 @@ class TestBuildSpeculativeDecoder:
         manager._load_speculative_decoder.assert_called_once_with(
             model, "hf/path", cfg, is_vlm=True
         )
+
+
+class TestProbeBundledDraft:
+    """Unit tests for ``_probe_bundled_draft_dir`` pure helper."""
+
+    def test_probe_returns_path_when_both_present(self, tmp_path):
+        from olmlx.engine.speculative_loaders import _probe_bundled_draft_dir
+
+        d = tmp_path / "dflash"
+        d.mkdir()
+        (d / "config.json").write_text("{}")
+        (d / "model.safetensors").write_bytes(b"")
+        assert _probe_bundled_draft_dir(tmp_path, "dflash") == d
+
+    def test_probe_returns_path_for_eagle(self, tmp_path):
+        from olmlx.engine.speculative_loaders import _probe_bundled_draft_dir
+
+        d = tmp_path / "eagle"
+        d.mkdir()
+        (d / "config.json").write_text("{}")
+        (d / "weights.safetensors").write_bytes(b"")
+        assert _probe_bundled_draft_dir(tmp_path, "eagle") == d
+
+    def test_probe_returns_none_when_dir_missing(self, tmp_path):
+        from olmlx.engine.speculative_loaders import _probe_bundled_draft_dir
+
+        assert _probe_bundled_draft_dir(tmp_path, "dflash") is None
+
+    def test_probe_returns_none_when_config_missing(self, tmp_path):
+        from olmlx.engine.speculative_loaders import _probe_bundled_draft_dir
+
+        d = tmp_path / "dflash"
+        d.mkdir()
+        (d / "model.safetensors").write_bytes(b"")
+        assert _probe_bundled_draft_dir(tmp_path, "dflash") is None
+
+    def test_probe_returns_none_when_weights_missing(self, tmp_path):
+        from olmlx.engine.speculative_loaders import _probe_bundled_draft_dir
+
+        d = tmp_path / "dflash"
+        d.mkdir()
+        (d / "config.json").write_text("{}")
+        assert _probe_bundled_draft_dir(tmp_path, "dflash") is None
+
+
+class TestBuildSpeculativeDecoderBundledProbe:
+    """Integration tests: ``_build_speculative_decoder`` auto-detects bundled draft."""
+
+    def _manager_with_mocks(self, registry, mock_store):
+        manager = ModelManager(registry, mock_store)
+        for name in (
+            "_load_dflash_decoder",
+            "_load_eagle_decoder",
+            "_load_speculative_decoder",
+        ):
+            setattr(manager, name, MagicMock(return_value=f"{name}-result"))
+        return manager
+
+    def test_build_speculative_uses_bundled_draft_when_unset(
+        self, tmp_path, registry, mock_store
+    ):
+        """When draft_model is None and a bundled subdir is present, it is used."""
+        bundled = tmp_path / "dflash"
+        bundled.mkdir()
+        (bundled / "config.json").write_text("{}")
+        (bundled / "model-00001-of-00001.safetensors").write_bytes(b"")
+
+        mock_store.local_path = MagicMock(return_value=tmp_path)
+
+        manager = self._manager_with_mocks(registry, mock_store)
+        model = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True, draft_model=None, num_tokens=None, strategy="dflash"
+        )
+        manager._build_speculative_decoder(model, "ns/model", cfg)
+
+        call_args = manager._load_dflash_decoder.call_args
+        used_cfg = call_args[0][1]
+        assert used_cfg.draft_model == str(bundled)
+
+    def test_build_speculative_explicit_draft_wins_over_bundled(
+        self, tmp_path, registry, mock_store
+    ):
+        """Explicit draft_model path takes precedence over a bundled probe."""
+        bundled = tmp_path / "dflash"
+        bundled.mkdir()
+        (bundled / "config.json").write_text("{}")
+        (bundled / "model.safetensors").write_bytes(b"")
+
+        mock_store.local_path = MagicMock(return_value=tmp_path)
+
+        manager = self._manager_with_mocks(registry, mock_store)
+        model = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True,
+            draft_model="/explicit/path",
+            num_tokens=None,
+            strategy="dflash",
+        )
+        manager._build_speculative_decoder(model, "ns/model", cfg)
+
+        call_args = manager._load_dflash_decoder.call_args
+        used_cfg = call_args[0][1]
+        assert used_cfg.draft_model == "/explicit/path"
+
+    def test_build_speculative_no_probe_for_classic_strategy(
+        self, tmp_path, registry, mock_store
+    ):
+        """The bundled-probe is never run for the 'classic' strategy."""
+        bundled = tmp_path / "dflash"
+        bundled.mkdir()
+        (bundled / "config.json").write_text("{}")
+        (bundled / "model.safetensors").write_bytes(b"")
+
+        mock_store.local_path = MagicMock(return_value=tmp_path)
+
+        manager = self._manager_with_mocks(registry, mock_store)
+        model = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True, draft_model=None, num_tokens=None, strategy="classic"
+        )
+        manager._build_speculative_decoder(model, "ns/model", cfg)
+
+        # classic routes to _load_speculative_decoder, not dflash
+        manager._load_speculative_decoder.assert_called_once()
+        manager._load_dflash_decoder.assert_not_called()
+        # The cfg passed through should be unchanged (draft_model still None)
+        call_args = manager._load_speculative_decoder.call_args
+        used_cfg = call_args[0][2]
+        assert used_cfg.draft_model is None
+
+    def test_build_speculative_uses_bundled_draft_eagle(
+        self, tmp_path, registry, mock_store
+    ):
+        """Bundled probe also works for the eagle strategy."""
+        bundled = tmp_path / "eagle"
+        bundled.mkdir()
+        (bundled / "config.json").write_text("{}")
+        (bundled / "weights.safetensors").write_bytes(b"")
+
+        mock_store.local_path = MagicMock(return_value=tmp_path)
+
+        manager = self._manager_with_mocks(registry, mock_store)
+        model = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True, draft_model=None, num_tokens=None, strategy="eagle"
+        )
+        manager._build_speculative_decoder(model, "ns/model", cfg)
+
+        call_args = manager._load_eagle_decoder.call_args
+        used_cfg = call_args[0][1]
+        assert used_cfg.draft_model == str(bundled)
+
+    def test_build_speculative_absolute_hf_path_uses_probe(
+        self, tmp_path, registry, mock_store
+    ):
+        """For absolute hf_path, the probe uses the path directly (no store lookup)."""
+        target_dir = tmp_path / "local_model"
+        target_dir.mkdir()
+        bundled = target_dir / "dflash"
+        bundled.mkdir()
+        (bundled / "config.json").write_text("{}")
+        (bundled / "model.safetensors").write_bytes(b"")
+
+        mock_local_path = MagicMock(return_value=tmp_path)
+        mock_store.local_path = mock_local_path
+
+        manager = self._manager_with_mocks(registry, mock_store)
+        model = MagicMock()
+        cfg = SpeculativeConfig(
+            enabled=True, draft_model=None, num_tokens=None, strategy="dflash"
+        )
+        manager._build_speculative_decoder(model, str(target_dir), cfg)
+
+        call_args = manager._load_dflash_decoder.call_args
+        used_cfg = call_args[0][1]
+        assert used_cfg.draft_model == str(bundled)
+        # store.local_path must NOT have been called for absolute hf_path
+        mock_local_path.assert_not_called()


### PR DESCRIPTION
Closes #515

## Summary

When `speculative_draft_model` is unset and `strategy` is `dflash` or `eagle`, the loader now probes `<target-local-dir>/<strategy>/` for a valid draft checkpoint before raising a hard error. This enables zero-config speculative decoding for models prepared locally with `olmlx dflash prepare` / `olmlx eagle prepare`.

Resolution precedence (mirrors `_find_spectral_dir` / `_find_shard_dir`):
1. Explicit `draft_model` (OLMLX_SPECULATIVE_DRAFT_MODEL or models.json)
2. Curated map (#513 — future, comment marks the slot)
3. Bundled `<target-local-dir>/<strategy>/` subdir probe ← **new**
4. Error

## Changes

- **`olmlx/engine/speculative_loaders.py`** — Added `_probe_bundled_draft_dir(local_dir, strategy) -> Path | None`: pure function that returns `local_dir / strategy` when `config.json` + any `.safetensors` are present, else `None`. Updated `_load_dflash_decoder` and `_load_eagle_decoder` error messages to say that both explicit config and the bundled probe were already tried, and tell the user to run `olmlx dflash prepare` / `olmlx eagle prepare`.
- **`olmlx/engine/model_manager.py`** — In `_build_speculative_decoder`, before dispatching to the strategy loaders, probe the bundled subdir when `strategy in {"dflash", "eagle"}` and `draft_model` is unset. Absolute `hf_path` → direct probe; relative/HF-ID → `store.local_path(hf_path)`. Guard on `store is not None`.

## Tests added

`tests/test_model_manager.py` — 10 new tests (TDD):

**`TestProbeBundledDraft`** (unit, pure function):
- `test_probe_returns_path_when_both_present` — config.json + safetensors → returns path
- `test_probe_returns_path_for_eagle` — same for eagle/
- `test_probe_returns_none_when_dir_missing` — no subdir → None
- `test_probe_returns_none_when_config_missing` — safetensors only → None
- `test_probe_returns_none_when_weights_missing` — config.json only → None

**`TestBuildSpeculativeDecoderBundledProbe`** (integration, dispatch layer):
- `test_build_speculative_uses_bundled_draft_when_unset` — bundled dflash/ used when draft_model=None
- `test_build_speculative_explicit_draft_wins_over_bundled` — explicit path wins
- `test_build_speculative_no_probe_for_classic_strategy` — probe not invoked for classic
- `test_build_speculative_uses_bundled_draft_eagle` — same probe works for eagle
- `test_build_speculative_absolute_hf_path_uses_probe` — absolute hf_path probes directly, no store.local_path call

## CLAUDE.md invariants checked

- **Metal stream hazard**: The probe is a pure filesystem check; it runs before any model weights are loaded or MLX computation is scheduled. No stream mixing.
- **Speculative exactness**: Only `spec_config.draft_model` is populated from a new source — the decoder loading path (`_load_dflash_decoder` / `_load_eagle_decoder`) and all its Metal-stream/cache logic are unchanged.
- **Proxy-tuning / MTP / self-speculative**: `strategy in {"dflash", "eagle"}` guard ensures these are never affected.
- **Grammar disabling**: Handled downstream in the loaders; the probe does not touch that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)