### PR TITLE
fix(store): strip :latest tag in _resolve_model_dir

### DIFF
--- a/olmlx/models/store.py
+++ b/olmlx/models/store.py
@@ -147,6 +147,7 @@ class ModelStore:
         resolved = self.registry.resolve(name)
         hf_path = resolved.hf_path if resolved is not None else None
         if hf_path is not None:
+            hf_path = _strip_ollama_tag(hf_path)
             d = self.local_path(hf_path)
             if (d / "manifest.json").exists():
                 return (d, True)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -592,6 +592,59 @@ class TestResolveModelDir:
         assert path == local_dir
         assert has_manifest is False
 
+    def test_resolve_hf_path_with_latest_tag_and_manifest(self, mock_store):
+        """_resolve_model_dir finds the stripped path when name carries :latest tag."""
+        # pull() strips the tag before writing to disk; dir is keyed on stripped path
+        stripped_dir = mock_store.local_path("mlx-community/Qwen3-4B-4bit")
+        stripped_dir.mkdir(parents=True)
+        (stripped_dir / "config.json").write_text("{}")
+        (stripped_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "name": "mlx-community/Qwen3-4B-4bit:latest",
+                    "hf_path": "mlx-community/Qwen3-4B-4bit",
+                }
+            )
+        )
+
+        result = mock_store._resolve_model_dir("mlx-community/Qwen3-4B-4bit:latest")
+        assert result is not None
+        path, has_manifest = result
+        assert path == stripped_dir
+        assert has_manifest is True
+
+    def test_resolve_hf_path_with_latest_tag_config_only(self, mock_store):
+        """_resolve_model_dir returns (path, False) for :latest-tagged HF paths with only config.json."""
+        stripped_dir = mock_store.local_path("mlx-community/Qwen3-4B-4bit")
+        stripped_dir.mkdir(parents=True)
+        (stripped_dir / "config.json").write_text("{}")
+
+        result = mock_store._resolve_model_dir("mlx-community/Qwen3-4B-4bit:latest")
+        assert result is not None
+        path, has_manifest = result
+        assert path == stripped_dir
+        assert has_manifest is False
+
+
+class TestShowHfPathWithTag:
+    def test_show_hf_path_with_latest_tag(self, mock_store):
+        """show() returns a ModelManifest for an HF-path name carrying :latest tag."""
+        stripped_dir = mock_store.local_path("mlx-community/Qwen3-4B-4bit")
+        stripped_dir.mkdir(parents=True)
+        (stripped_dir / "config.json").write_text(json.dumps({"model_type": "qwen2"}))
+        (stripped_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "name": "mlx-community/Qwen3-4B-4bit:latest",
+                    "hf_path": "mlx-community/Qwen3-4B-4bit",
+                }
+            )
+        )
+
+        result = mock_store.show("mlx-community/Qwen3-4B-4bit:latest")
+        assert result is not None
+        assert isinstance(result, ModelManifest)
+
 
 class TestListLocalWithoutManifest:
     def test_list_local_includes_dirs_without_manifest(self, mock_store, tmp_path):


### PR DESCRIPTION
Closes #542

## Summary

- `_resolve_model_dir` in `olmlx/models/store.py` now calls `_strip_ollama_tag(hf_path)` before passing the resolved HF path to `local_path()`. This is a one-line change on the already-present helper.
- `pull()` strips the tag before writing to disk, so the on-disk directory is always keyed on the stripped path (e.g. `mlx-community_Qwen3-4B-4bit`). Without this fix, `_resolve_model_dir` looked up `mlx-community_Qwen3-4B-4bit_latest` — a directory that never exists — and returned `None`, causing `/api/show` and `/api/delete` to return 404 for any HF-path model with a `:latest` tag.
- `delete()` calls `_resolve_model_dir` too, so this fix covers deletion as well at no extra cost.

## Tests added (`tests/test_store.py`)

Three new tests, all in the TDD-first order (written failing, then made green):

- `TestResolveModelDir::test_resolve_hf_path_with_latest_tag_and_manifest` — directory has `manifest.json`; asserts `(stripped_dir, True)` is returned.
- `TestResolveModelDir::test_resolve_hf_path_with_latest_tag_config_only` — directory has only `config.json`; asserts `(stripped_dir, False)` is returned.
- `TestShowHfPathWithTag::test_show_hf_path_with_latest_tag` — end-to-end `show()` call returns a non-None `ModelManifest`.

All 5196 non-`real_model` tests pass.

## CLAUDE.md invariants checked

This change touches only the model-store directory-lookup path (`_resolve_model_dir`). No inference, Metal streams, speculative decoding, KV cache, grammar tokenizer, or distributed paths are affected. No CLAUDE.md invariants are at risk.