### PR TITLE
fix(engine,routers): emit finish_reason='length' when max_tokens exhausted

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -2993,6 +2993,7 @@ async def _stream_completion_batched(
     stop_hit = False
     timed_out = False
     lagged = False
+    max_tokens_hit = False
     terminal_seen = False
     start_ns = time.monotonic_ns()
     first_token_ns: int | None = None
@@ -3060,6 +3061,7 @@ async def _stream_completion_batched(
                                 "Batched generation truncated: consumer lag "
                                 "exceeded the backpressure limit"
                             )
+                        max_tokens_hit = event["reason"] == "length"
                         if event["reason"] == "cancelled" and not (
                             stop_hit or timed_out or lagged
                         ):
@@ -3161,6 +3163,9 @@ async def _stream_completion_batched(
             done_chunk["done_reason"] = "timeout"
         elif stop_hit:
             done_chunk["done_reason"] = "stop"
+        elif max_tokens_hit:
+            # Scheduler exhausted the token budget — mirrors exclusive path.
+            done_chunk["done_reason"] = "length"
         try:
             _metrics.observe_inference(lm.name, surface_var.get(), stats)
         except Exception:
@@ -3582,8 +3587,12 @@ async def _stream_completion(
             done_chunk["raw_text"] = raw_text
         if timed_out:
             done_chunk["done_reason"] = "timeout"
-        if stop_hit:
+        elif stop_hit:
             done_chunk["done_reason"] = "stop"
+        elif max_tokens > 0 and stats.eval_count >= max_tokens:
+            # Stream terminated at the token budget (no EOS / stop sequence).
+            # "length" mirrors OpenAI's finish_reason and the batched path.
+            done_chunk["done_reason"] = "length"
         try:
             _metrics.observe_inference(lm.name, surface_var.get(), stats)
         except Exception:

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -470,7 +470,7 @@ async def _stream_buffered_with_tools(
 
     if tool_uses:
         stop_reason = "tool_use"
-    elif done_reason == "timeout":
+    elif done_reason in ("timeout", "length"):
         stop_reason = "max_tokens"
     else:
         stop_reason = "end_turn"
@@ -614,7 +614,9 @@ async def _stream_thinking_state_machine(result):
         block_idx += 1
 
     yield {
-        "stop_reason": "max_tokens" if done_reason == "timeout" else "end_turn",
+        "stop_reason": "max_tokens"
+        if done_reason in ("timeout", "length")
+        else "end_turn",
         "output_tokens": output_tokens,
     }
 
@@ -908,7 +910,7 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
         done_reason = result.get("done_reason")
         if tool_uses:
             stop_reason = "tool_use"
-        elif done_reason == "timeout":
+        elif done_reason in ("timeout", "length"):
             stop_reason = "max_tokens"
         else:
             stop_reason = "end_turn"

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -127,7 +127,7 @@ async def _stream_openai_sse(
                 done_reason = chunk.get("done_reason")
                 finish_reason = (
                     "length"
-                    if done_reason == "timeout"
+                    if done_reason in ("timeout", "length")
                     else format_done().get("finish_reason", "stop")
                 )
                 done_choice = format_done()
@@ -247,7 +247,7 @@ async def _stream_openai_sse_with_tools(
             yield f"data: {_chunk({'delta': {'role': 'assistant', 'content': None}, 'finish_reason': None})}\n\n"
             if visible_text:
                 yield f"data: {_chunk({'delta': {'content': visible_text}, 'finish_reason': None})}\n\n"
-            fr = "length" if done_reason == "timeout" else "stop"
+            fr = "length" if done_reason in ("timeout", "length") else "stop"
             yield f"data: {_chunk({'delta': {}, 'finish_reason': fr})}\n\n"
 
         yield "data: [DONE]\n\n"
@@ -460,7 +460,7 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
         done_reason = result.get("done_reason")
         if tool_uses:
             finish_reason = "tool_calls"
-        elif done_reason == "timeout":
+        elif done_reason in ("timeout", "length"):
             finish_reason = "length"
         else:
             finish_reason = "stop"
@@ -541,7 +541,7 @@ async def openai_completions(req: OpenAICompletionRequest, request: Request):
                     index=0,
                     text=result.get("text", ""),
                     finish_reason="length"
-                    if result.get("done_reason") == "timeout"
+                    if result.get("done_reason") in ("timeout", "length")
                     else "stop",
                 )
             ],

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -287,7 +287,7 @@ def _build_response_object(
 ) -> ResponsesResponse:
     incomplete = None
     status = "completed"
-    if done_reason == "timeout":
+    if done_reason in ("timeout", "length"):
         status = "incomplete"
         incomplete = {"reason": "max_output_tokens"}
     return ResponsesResponse(
@@ -460,7 +460,9 @@ async def _stream_response(
                 {"output_index": out_index, "item": item},
             )
 
-        final_status = "incomplete" if done_reason == "timeout" else "completed"
+        final_status = (
+            "incomplete" if done_reason in ("timeout", "length") else "completed"
+        )
         final = base_response(final_status, output_items, stats, done_reason)
         yield ev("response.completed", {"response": final})
 

--- a/tests/test_finish_reason.py
+++ b/tests/test_finish_reason.py
@@ -1,0 +1,219 @@
+"""Tests that finish_reason='length' / stop_reason='max_tokens' is propagated
+when max_tokens is exhausted (issue #543).
+
+Router-level tests: mock generate_chat/generate_completion to return
+done_reason='length' and verify each API surface maps it correctly.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from olmlx.utils.timing import TimingStats
+
+
+def _done_chunk(done_reason=None):
+    chunk = {"text": "hi", "done": True, "stats": TimingStats(eval_count=1)}
+    if done_reason is not None:
+        chunk["done_reason"] = done_reason
+    return chunk
+
+
+class TestOpenAIFinishReasonLength:
+    @pytest.mark.asyncio
+    async def test_chat_completions_non_streaming_length(self, app_client):
+        with patch(
+            "olmlx.routers.openai.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = _done_chunk("length")
+            resp = await app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 1,
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["choices"][0]["finish_reason"] == "length"
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_non_streaming_stop_unchanged(self, app_client):
+        """EOS (no done_reason) must still produce finish_reason='stop'."""
+        with patch(
+            "olmlx.routers.openai.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = _done_chunk()
+            resp = await app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["choices"][0]["finish_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_streaming_length(self, app_client):
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": "hi", "done": False}
+                yield {
+                    "text": "",
+                    "done": True,
+                    "stats": TimingStats(),
+                    "done_reason": "length",
+                }
+
+            return gen()
+
+        with patch("olmlx.routers.openai.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 1,
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        text = resp.text
+        chunks = [
+            json.loads(line[len("data: ") :])
+            for line in text.splitlines()
+            if line.startswith("data: ") and line != "data: [DONE]"
+        ]
+        # The last non-DONE chunk carries finish_reason
+        finish_chunks = [
+            c
+            for c in chunks
+            if c.get("choices") and c["choices"][0].get("finish_reason") is not None
+        ]
+        assert finish_chunks, "No chunk with finish_reason found"
+        assert finish_chunks[-1]["choices"][0]["finish_reason"] == "length"
+
+    @pytest.mark.asyncio
+    async def test_completions_non_streaming_length(self, app_client):
+        with patch(
+            "olmlx.routers.openai.generate_completion", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = _done_chunk("length")
+            resp = await app_client.post(
+                "/v1/completions",
+                json={
+                    "model": "qwen3",
+                    "prompt": "Hello",
+                    "max_tokens": 1,
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["choices"][0]["finish_reason"] == "length"
+
+
+class TestAnthropicStopReasonMaxTokens:
+    @pytest.mark.asyncio
+    async def test_messages_non_streaming_max_tokens(self, app_client):
+        with patch(
+            "olmlx.routers.anthropic.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = _done_chunk("length")
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 1,
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["stop_reason"] == "max_tokens"
+
+    @pytest.mark.asyncio
+    async def test_messages_non_streaming_end_turn_unchanged(self, app_client):
+        """EOS (no done_reason) must still produce stop_reason='end_turn'."""
+        with patch(
+            "olmlx.routers.anthropic.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = _done_chunk()
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 100,
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["stop_reason"] == "end_turn"
+
+    @pytest.mark.asyncio
+    async def test_messages_streaming_max_tokens(self, app_client):
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": "hi", "done": False}
+                yield {
+                    "text": "",
+                    "done": True,
+                    "stats": TimingStats(),
+                    "done_reason": "length",
+                }
+
+            return gen()
+
+        with patch("olmlx.routers.anthropic.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 1,
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        text = resp.text
+        # Find the message_delta event which carries stop_reason
+        delta_data = [
+            json.loads(line[len("data: ") :])
+            for line in text.splitlines()
+            if line.startswith("data: ") and "message_delta" in line
+        ]
+        assert delta_data, "No message_delta found in stream"
+        assert delta_data[0]["delta"]["stop_reason"] == "max_tokens"
+
+
+class TestResponsesFinishReasonLength:
+    @pytest.mark.asyncio
+    async def test_responses_non_streaming_incomplete(self, app_client):
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = _done_chunk("length")
+            resp = await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": "hi",
+                    "max_output_tokens": 1,
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "incomplete"
+        assert data["incomplete_details"]["reason"] == "max_output_tokens"

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -5685,3 +5685,181 @@ def test_completion_functions_accept_audio_param():
         inf._full_completion_inner,
     ):
         assert "audio" in inspect.signature(fn).parameters, fn.__name__
+
+
+class TestFinishReasonLength:
+    """Tests that done_reason='length' is emitted when max_tokens is exhausted."""
+
+    def _make_stream(self, n_tokens: int):
+        """Create a mock CancellableStream that yields exactly n_tokens tokens."""
+        mock_stream = MagicMock(spec=CancellableStream)
+        mock_stream.drain_and_join = AsyncMock()
+        mock_stream._thread = None
+
+        tokens = [
+            StreamToken(
+                text=f"tok{i}",
+                token=i,
+                prompt_tokens=5,
+                generation_tokens=i + 1,
+                prompt_tps=100.0,
+                generation_tps=50.0,
+            )
+            for i in range(n_tokens)
+        ]
+        token_iter = iter(tokens)
+
+        async def anext_impl():
+            try:
+                return next(token_iter)
+            except StopIteration:
+                raise StopAsyncIteration
+
+        mock_stream.__aiter__ = lambda self: self
+        mock_stream.__anext__ = lambda self: anext_impl()
+        return mock_stream
+
+    @pytest.mark.asyncio
+    async def test_exclusive_path_emits_length_when_max_tokens_exhausted(
+        self, mock_manager
+    ):
+        """Exclusive path: stream terminates after exactly max_tokens tokens.
+        done_chunk must have done_reason=='length'."""
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.inference_timeout = None
+
+        mock_stream = self._make_stream(3)
+
+        with (
+            patch("olmlx.engine.inference.mx"),
+            patch("olmlx.engine.inference.settings") as mock_settings,
+            patch("olmlx.engine.inference.async_mlx_stream", return_value=mock_stream),
+        ):
+            mock_settings.inference_queue_timeout = None
+            mock_settings.inference_timeout = None
+            mock_settings.prompt_cache = False
+            mock_settings.memory_limit_fraction = 0.9
+            mock_settings.sync_mode = "full"
+            gen = await generate_completion(
+                mock_manager,
+                "qwen3",
+                "Hello",
+                max_tokens=3,
+                stream=True,
+            )
+            chunks = []
+            async for chunk in gen:
+                chunks.append(chunk)
+
+        done_chunk = chunks[-1]
+        assert done_chunk["done"] is True
+        assert done_chunk.get("done_reason") == "length"
+        text_chunks = [c for c in chunks if not c.get("done") and "text" in c]
+        assert len(text_chunks) == 3
+
+    @pytest.mark.asyncio
+    async def test_exclusive_path_no_length_on_eos_before_limit(self, mock_manager):
+        """Exclusive path: stream ends before max_tokens (EOS). done_reason must
+        not be 'length'."""
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.inference_timeout = None
+
+        mock_stream = self._make_stream(2)
+
+        with (
+            patch("olmlx.engine.inference.mx"),
+            patch("olmlx.engine.inference.settings") as mock_settings,
+            patch("olmlx.engine.inference.async_mlx_stream", return_value=mock_stream),
+        ):
+            mock_settings.inference_queue_timeout = None
+            mock_settings.inference_timeout = None
+            mock_settings.prompt_cache = False
+            mock_settings.memory_limit_fraction = 0.9
+            mock_settings.sync_mode = "full"
+            gen = await generate_completion(
+                mock_manager,
+                "qwen3",
+                "Hello",
+                max_tokens=10,
+                stream=True,
+            )
+            chunks = []
+            async for chunk in gen:
+                chunks.append(chunk)
+
+        done_chunk = chunks[-1]
+        assert done_chunk["done"] is True
+        assert done_chunk.get("done_reason") != "length"
+
+    @pytest.mark.asyncio
+    async def test_batched_path_propagates_length_reason(self, mock_manager):
+        """Batched path: a done event with reason='length' from the scheduler
+        must produce done_chunk['done_reason']=='length'."""
+        import asyncio
+
+        from olmlx.engine.inference import _stream_completion_batched
+        from olmlx.utils.timing import TimingStats
+
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.inference_timeout = None
+        lm.inference_queue_timeout = None
+
+        # Build a mock sequence whose out queue delivers:
+        # one token event then a done event with reason='length'
+        mock_seq = MagicMock()
+        mock_seq.note_consumed = MagicMock()
+        mock_seq.want_cache = True
+        out_queue: asyncio.Queue = asyncio.Queue()
+
+        async def _get():
+            return await out_queue.get()
+
+        mock_seq.out = MagicMock()
+        mock_seq.out.get = _get
+
+        # Detokenizer mock
+        lm.tokenizer.detokenizer = MagicMock()
+        lm.tokenizer.detokenizer.add_token = MagicMock()
+        lm.tokenizer.detokenizer.last_segment = "hi"
+        lm.tokenizer.detokenizer.finalize = MagicMock()
+
+        mock_scheduler = MagicMock()
+        mock_scheduler.submit = AsyncMock(return_value=mock_seq)
+        mock_scheduler.cancel = MagicMock()
+
+        # Populate the out queue: one token then done with length reason
+        await out_queue.put({"type": "token", "token": 42})
+        await out_queue.put({"type": "done", "reason": "length"})
+
+        with (
+            patch("olmlx.engine.inference.settings") as mock_settings,
+            patch(
+                "olmlx.engine.inference._get_batch_scheduler",
+                return_value=mock_scheduler,
+            ),
+            patch("olmlx.engine.inference._batched_kv_preflight"),
+            patch(
+                "olmlx.engine.inference.tokenize_for_cache",
+                return_value=[1, 2, 3],
+            ),
+        ):
+            mock_settings.inference_queue_timeout = None
+            mock_settings.inference_timeout = None
+            mock_settings.prompt_cache = False
+            mock_settings.memory_limit_fraction = 0.9
+            mock_settings.sync_mode = "full"
+
+            stats = TimingStats()
+            chunks = []
+            async for chunk in _stream_completion_batched(
+                lm,
+                "Hello",
+                max_tokens=5,
+                gen_kwargs={},
+                stats=stats,
+            ):
+                chunks.append(chunk)
+
+        done_chunk = chunks[-1]
+        assert done_chunk["done"] is True
+        assert done_chunk.get("done_reason") == "length"


### PR DESCRIPTION
Closes #543

## Summary

`finish_reason` (OpenAI/Responses) and `stop_reason` (Anthropic) were always reported as `stop`/`end_turn` even when generation ended because `max_tokens` was exhausted. Two engine paths both failed to set `done_reason`, and all routers only mapped `timeout` → `length`.

**Engine fixes:**
- **Exclusive path** (`_stream_completion`): Added `elif max_tokens > 0 and stats.eval_count >= max_tokens` branch that sets `done_reason="length"`. Changed the second `if stop_hit` to `elif` (was already mutually exclusive with `timed_out`).
- **Batched path** (`_stream_completion_batched`): Track `max_tokens_hit = event["reason"] == "length"` when the scheduler's done event arrives (mlx-lm's `BatchGenerator` already emits `finish_reason="length"` at token budget). Emit `done_reason="length"` in the done-chunk builder.

**Router fixes** (`openai.py`, `anthropic.py`, `responses.py`): Extended all 10 `== "timeout"` checks to `in ("timeout", "length")` across streaming and non-streaming paths. Ollama routers pass `done_reason` through verbatim — no changes needed.

## Tests added

**`tests/test_inference.py::TestFinishReasonLength`** (3 tests, written failing first):
- Exclusive path emits `done_reason="length"` when exactly `max_tokens` tokens are produced
- Regression guard: EOS before `max_tokens` produces no `done_reason`
- Batched path propagates `reason="length"` from scheduler done event

**`tests/test_finish_reason.py`** (8 tests):
- OpenAI `/v1/chat/completions` non-streaming + streaming → `finish_reason="length"`
- OpenAI `/v1/completions` non-streaming → `finish_reason="length"`
- Anthropic `/v1/messages` non-streaming + streaming → `stop_reason="max_tokens"`
- Responses `/v1/responses` non-streaming → `status="incomplete"`
- Regression guards: EOS → `stop`/`end_turn` unchanged

## CLAUDE.md invariants checked

- **Metal stream hazard**: no change to forward-pass logic or stream selection — `done_reason` is populated post-generation
- **Speculative decoder exactness**: `stats.eval_count >= max_tokens` fires correctly for both `async_speculative_stream` and `async_mlx_stream`; speculative loop terminates the same way
- **Pure-RotatingKVCache prefill**: unaffected — done_reason populated after generation completes
- **Batching done events**: `batching.py` already emits `reason="length"` from mlx-lm's `BatchGenerator` — this fix just propagates it rather than silently discarding it

🤖 Generated with [Claude Code](https://claude.com/claude-code)