### PR TITLE
fix(tool_parser): classify truncated <think>/Gemma4 blocks as thinking content

### DIFF
--- a/olmlx/engine/tool_parser.py
+++ b/olmlx/engine/tool_parser.py
@@ -527,6 +527,10 @@ def _extract_gemma4_blocks(text: str) -> tuple[str, list[str]]:
 
         close = text.find("<channel|>", marker_end)
         if close < 0:
+            # Truncated block: stream ended before the closer was emitted.
+            tail = text[marker_end:].strip()
+            if tail:
+                blocks.append(tail)
             break
 
         content = text[marker_end:close].strip()
@@ -591,6 +595,16 @@ def parse_model_output(
                     else orphan_thinking
                 )
             text = text[orphan_idx + len("</think>") :].lstrip("\n")
+
+    # Detect truncated thinking block: opener present but stream ended before
+    # the matching </think> could be emitted (e.g. max_tokens hit mid-reasoning).
+    open_pos = text.find("<think>")
+    if open_pos != -1 and text.find("</think>", open_pos) == -1:
+        pre = text[:open_pos].strip()
+        partial = text[open_pos + len("<think>") :].strip()
+        if partial:
+            thinking = f"{thinking}\n{partial}".strip() if thinking else partial
+        text = pre
 
     tool_uses: list[dict] = []
     if has_tools:

--- a/tests/test_tool_parser.py
+++ b/tests/test_tool_parser.py
@@ -812,3 +812,35 @@ class TestGemma4Thinking:
         thinking, visible, tools = parse_model_output(text, has_tools=True)
         assert len(tools) == 1
         assert tools[0]["name"] == "func"
+
+
+class TestTruncatedThinking:
+    def test_unclosed_think_opener_classifies_as_thinking(self):
+        """max_tokens hits mid-reasoning: raw <think> must not leak into content."""
+        text = '<think>\nOkay, the user said "Say hi." I need to respond'
+        thinking, visible, tools = parse_model_output(text, has_tools=False)
+        assert "Okay, the user" in thinking
+        assert "<think>" not in visible
+        assert visible == ""
+
+    def test_unclosed_think_with_prior_content(self):
+        """Non-thinking preamble before the opener survives; partial thinking is
+        classified as thinking."""
+        text = "Sure! <think>Let me reason about"
+        thinking, visible, tools = parse_model_output(text, has_tools=False)
+        assert "Let me reason" in thinking
+        assert visible.strip() == "Sure!"
+
+    def test_complete_pair_still_works(self):
+        """Regression guard: complete pairs still extracted correctly."""
+        text = "<think>reasoning</think>The answer is 42."
+        thinking, visible, tools = parse_model_output(text, has_tools=False)
+        assert thinking == "reasoning"
+        assert visible == "The answer is 42."
+
+    def test_truncated_gemma4_block_classifies_as_thinking(self):
+        """Gemma4 opener without closer must not silently drop partial content."""
+        text = "<|channel>thought\nThis is partial reasoning without a close tag"
+        thinking, visible, tools = parse_model_output(text, has_tools=False)
+        assert "partial reasoning" in thinking
+        assert "<|channel>" not in visible


### PR DESCRIPTION
Closes #544

## Summary

When `max_tokens` halts generation while a thinking model is inside its `<think>` block, the unclosed opener and partial content leaked into the visible `content` field of all non-streaming endpoints (OpenAI, Anthropic, Responses). A parallel issue existed for Gemma4 channel blocks — a truncated block (no `<channel|>` closer) silently dropped the partial reasoning.

**Changes in `olmlx/engine/tool_parser.py`:**

- **`parse_model_output`**: After the existing `_THINK_RE`-based extraction and the orphan-`</think>` heuristic, detect an unclosed `<think>` opener (opener present, no matching `</think>` in remaining text). Reclassify the partial content as thinking; text before the opener is preserved as visible content.

- **`_extract_gemma4_blocks`**: When the `<channel|>` closer is absent, append the tail from the opener to end-of-string into `blocks` (thinking) instead of `break`-ing and silently discarding the content.

## Tests added (`tests/test_tool_parser.py` — `TestTruncatedThinking`)

| Test | What it checks |
|------|----------------|
| `test_unclosed_think_opener_classifies_as_thinking` | Raw `<think>` with no closer → partial reasoning goes to thinking, visible is empty |
| `test_unclosed_think_with_prior_content` | Preamble before opener preserved as visible; partial thinking classified correctly |
| `test_complete_pair_still_works` | Regression guard: complete `<think>…</think>` pairs still work |
| `test_truncated_gemma4_block_classifies_as_thinking` | Gemma4 opener without `<channel|>` closer → content routed to thinking |

## CLAUDE.md invariants checked

- **No Metal-stream or inference-lock involvement** — this is pure text-parsing, executed after the generator is fully drained on the async event loop.
- The fix mirrors the contract already enforced on the streaming Anthropic path (`flush_split_thinking` maps `phase="in_think"` → `(buf, "")`, routing orphaned content to thinking and leaving visible empty).
- No router changes required; all three non-streaming surfaces already call `parse_model_output`.