### PR TITLE
fix(grammar): constrain json_object mode to JSON objects, not any JSON value

### DIFF
--- a/olmlx/engine/grammar.py
+++ b/olmlx/engine/grammar.py
@@ -53,9 +53,9 @@ _JSON_SCHEMA_TYPES = frozenset(
 class GrammarSpec:
     """Describes a grammar constraint for a single request.
 
-    ``kind="json_object"`` allows any well-formed JSON value (xgrammar's
-    builtin JSON grammar). ``kind="json_schema"`` requires ``schema`` to be
-    a JSON-Schema dict.
+    ``kind="json_object"`` constrains output to a JSON object (``{}``),
+    matching the OpenAI spec guarantee. ``kind="json_schema"`` requires
+    ``schema`` to be a JSON-Schema dict.
 
     Note: ``frozen=True`` would normally generate ``__hash__``, but the
     ``schema`` field is a dict and not hashable, so attempting to hash a
@@ -219,7 +219,7 @@ def compile_for_tokenizer(tokenizer: Any, vocab_size: int, spec: GrammarSpec) ->
     # Compile outside the lock — see docstring.
     compiler = _get_compiler(tokenizer, vocab_size)
     if spec.kind == "json_object":
-        compiled = compiler.compile_builtin_json_grammar()
+        compiled = compiler.compile_json_schema({"type": "object"})
     else:
         assert spec.schema is not None  # post_init enforces
         compiled = compiler.compile_json_schema(spec.schema)

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -193,6 +193,29 @@ class TestCompileCache:
         c2 = compile_for_tokenizer(gpt2_tokenizer, gpt2_tokenizer.vocab_size, s2)
         assert c1 is not c2
 
+    def test_json_object_uses_object_schema_not_builtin_grammar(self, gpt2_tokenizer):
+        """Regression for #550: json_object mode must call compile_json_schema
+        with {"type": "object"}, NOT compile_builtin_json_grammar (which allows arrays)."""
+        import xgrammar as xgr
+
+        spec = GrammarSpec("json_object")
+        compiled = compile_for_tokenizer(
+            gpt2_tokenizer, gpt2_tokenizer.vocab_size, spec
+        )
+
+        matcher = xgr.GrammarMatcher(compiled)
+        lbracket_ids = [
+            tid
+            for tid, tok in enumerate(
+                gpt2_tokenizer.convert_ids_to_tokens(range(gpt2_tokenizer.vocab_size))
+            )
+            if tok is not None and tok.strip() == "["
+        ]
+        if lbracket_ids:
+            assert not matcher.accept_token(lbracket_ids[0]), (
+                "json_object grammar must reject '[' as first token"
+            )
+
     def test_drop_for_tokenizer_removes_entries(self, gpt2_tokenizer):
         """Wire-up safety: ``drop_for_tokenizer`` must remove the cache
         entries for the *specific* tokenizer being unloaded so that a
@@ -376,9 +399,9 @@ class TestLogitsProcessor:
         logits = mx.zeros((1, gpt2_tokenizer.vocab_size))
         # Prompt tokens — should not be fed to the matcher.
         out = proc([1, 2, 3], logits)
-        # Some tokens must be masked to -inf (the JSON grammar starts with
-        # whitespace or `{`/`[`/`"`/digit/`-`/`t`/`f`/`n`); ordinary words
-        # should be -inf.
+        # Some tokens must be masked to -inf (json_object mode constrains the
+        # root to `{`, so only `{` and leading whitespace are allowed);
+        # ordinary words should be -inf.
         out_np = (out == -mx.inf).sum().item()
         assert out_np > 0, "expected at least one token to be masked"
 
@@ -414,6 +437,32 @@ class TestLogitsProcessor:
         logits = mx.zeros((1, gpt2_tokenizer.vocab_size), dtype=mx.float16)
         out = proc([1, 2, 3], logits)
         assert out.dtype == mx.float16
+
+    def test_json_object_masks_array_start(self, gpt2_tokenizer):
+        """json_object mode must not allow a JSON array at the root.
+
+        After the initial prompt call, tokens that would start a JSON array
+        ('[') must all be masked to -inf.
+        """
+        spec = GrammarSpec("json_object")
+        proc = make_processor(gpt2_tokenizer, gpt2_tokenizer.vocab_size, spec)
+        logits = mx.zeros((1, gpt2_tokenizer.vocab_size))
+        proc([1, 2, 3], logits)  # prompt call — does not advance matcher
+
+        bracket_ids = [
+            tid
+            for tid, tok in enumerate(
+                gpt2_tokenizer.convert_ids_to_tokens(range(gpt2_tokenizer.vocab_size))
+            )
+            if tok is not None and "[" in tok
+        ]
+        assert bracket_ids, "gpt2 tokenizer must contain '[' tokens"
+
+        mask_out = proc([1, 2, 3], logits)
+        mask_np = mask_out.squeeze(0).tolist()
+        assert all(mask_np[tid] == float("-inf") for tid in bracket_ids), (
+            "json_object mode must mask all '[' tokens; compile_builtin_json_grammar allows them"
+        )
 
     def test_terminated_matcher_returns_logits_unmodified(self, gpt2_tokenizer):
         """When the matcher is fully terminated, the processor should


### PR DESCRIPTION
Closes #550

## Summary

- `response_format: {"type": "json_object"}` now calls `compiler.compile_json_schema({"type": "object"})` instead of `compiler.compile_builtin_json_grammar()`, which previously permitted arrays, strings, numbers, booleans, and null at the root — violating the OpenAI spec guarantee that `json_object` mode produces only a JSON object (`{}`).
- Updated the `GrammarSpec.kind` docstring to reflect the corrected semantics.
- Updated a misleading comment in `test_first_call_treats_tokens_as_prompt` that listed `[` as an allowed first token.

## Tests added

- **`TestLogitsProcessor::test_json_object_masks_array_start`** — after the prompt call, all `[`-containing tokens must be masked to `-inf`. Fails on `compile_builtin_json_grammar()`, passes after the fix.
- **`TestCompileCache::test_json_object_uses_object_schema_not_builtin_grammar`** — uses `xgr.GrammarMatcher` directly to assert that `[` is rejected as the first token by the compiled grammar. Same failure/pass pattern.

Both tests fail on current `main` and pass after the one-line change.

## CLAUDE.md invariants checked

- **Grammar tokenizer identity** — `drop_for_tokenizer` and weakref identity validation are untouched; `cache_key()` for `json_object` remains the stable string `"json_object"`. An in-process server that already cached the old permissive grammar continues serving it until the next model unload, which is the documented bounded exposure window.
- No Metal stream, speculative decoding, prefill chunking, or distributed paths are involved in the grammar CPU-side token-mask path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)