### PR TITLE
feat(openai): include locally-stored models in GET /v1/models

### DIFF
--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -555,10 +555,20 @@ async def openai_completions(req: OpenAICompletionRequest, request: Request):
     response_model_exclude_none=True,
 )
 async def openai_list_models(request: Request):
+    store = request.app.state.model_store
     registry = request.app.state.registry
     created = int(time.time())
-    models = registry.list_models()
-    data = [OpenAIModel(id=name, created=created) for name in models]
+
+    local_models = store.list_local()
+    local_names = {m.name for m in local_models}
+    data = [OpenAIModel(id=m.name, created=created) for m in local_models]
+
+    # Add configured-but-not-yet-downloaded registry entries
+    for name in registry.list_models():
+        normalized = registry.normalize_name(name)
+        if normalized not in local_names:
+            data.append(OpenAIModel(id=normalized, created=created))
+
     # Synthetic panel models have no weights but are selectable by name, so
     # clients (opencode, etc.) need to see them in the model list.
     data += [OpenAIModel(id=name, created=created) for name in registry.list_panels()]

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -308,6 +308,23 @@ class TestOpenAIRouter:
         assert len(data["data"]) >= 2
 
     @pytest.mark.asyncio
+    async def test_list_models_includes_local_only(self, app_client):
+        from olmlx.models.manifest import ModelManifest
+
+        store = app_client._transport.app.state.model_store
+        model_dir = store.models_dir / "mlx-community_Qwen3-4B-4bit"
+        model_dir.mkdir(parents=True, exist_ok=True)
+        ModelManifest(
+            name="mlx-community/Qwen3-4B-4bit:latest",
+            hf_path="mlx-community/Qwen3-4B-4bit",
+        ).save(model_dir / "manifest.json")
+
+        resp = await app_client.get("/v1/models")
+        assert resp.status_code == 200
+        ids = [m["id"] for m in resp.json()["data"]]
+        assert "mlx-community/Qwen3-4B-4bit:latest" in ids
+
+    @pytest.mark.asyncio
     async def test_chat_completions_non_streaming(self, app_client):
         stats = TimingStats(prompt_eval_count=10, eval_count=20)
         mock_result = {"text": "Hello!", "done": True, "stats": stats}


### PR DESCRIPTION
Closes #546

## Summary

- `GET /v1/models` previously read only from the in-memory registry (`models.json` entries), silently omitting any model pulled directly by HuggingFace path that lives on disk but was never added to `models.json`.
- This PR mirrors the two-source pattern already used by `GET /api/tags`: call `store.list_local()` first to seed the list from local manifests, then add configured-but-not-yet-downloaded registry entries not already covered by a local manifest.
- Panel entries continue to be appended at the end, unchanged.

## Tests added

- `TestOpenAIRouter::test_list_models_includes_local_only` — writes a manifest for `mlx-community/Qwen3-4B-4bit:latest` (absent from the registry) into the `mock_store`'s `models_dir`, then asserts it appears in `GET /v1/models`. Confirmed failing before the fix and passing after.

## CLAUDE.md invariants checked

This change is a pure FastAPI route read — it accesses only already-loaded data structures (`ModelStore`, `ModelRegistry`) with no MLX, Metal streams, KV cache, speculative decoding, or threading implications. No CLAUDE.md invariants are involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)