### PR TITLE
feat(pull): auto-convert AWQ/GPTQ models to MLX on pull

### DIFF
--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -392,6 +392,18 @@ class Settings(BaseSettings):
     flash_speculative_draft_model: Annotated[str, Field(min_length=1)] | None = None
     flash_speculative_tokens: Annotated[int, Field(gt=0)] = 4
 
+    # AWQ / GPTQ auto-conversion on pull (issue #363).
+    # When detect_format() identifies a downloaded model as AWQ or GPTQ,
+    # olmlx re-quantizes it to MLX int4/int8 via mlx_lm.convert.  The
+    # converted artifact lands in a sibling directory; the original is deleted
+    # when awq_gptq_remove_source=True.
+    # Peak disk: ~2× model size during conversion (src + dst coexist).
+    # Peak RAM: BF16 weights in flight (~2 bytes/param) — large models OOM
+    # on 16-24 GB devices; see issue #363 risks.
+    awq_gptq_convert_bits: Annotated[int, Field(ge=1, le=8)] = 4
+    awq_gptq_convert_group_size: Annotated[int, Field(ge=32)] = 64
+    awq_gptq_remove_source: bool = True
+
     # Autonomous agent (engine/agent/, routers/agent.py — issue #445). The
     # orchestrator drives the existing ``ChatSession`` ReAct loop across many
     # turns toward a goal, with hard budgets, stall detection, SQLite-persisted

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -400,8 +400,10 @@ class Settings(BaseSettings):
     # Peak disk: ~2× model size during conversion (src + dst coexist).
     # Peak RAM: BF16 weights in flight (~2 bytes/param) — large models OOM
     # on 16-24 GB devices; see issue #363 risks.
-    awq_gptq_convert_bits: Annotated[int, Field(ge=1, le=8)] = 4
-    awq_gptq_convert_group_size: Annotated[int, Field(ge=32)] = 64
+    # Restricted to the values mlx's quantizer actually accepts — bits 1 and 7
+    # and group sizes like 16/256 pass a naive range check but crash conversion.
+    awq_gptq_convert_bits: Literal[2, 3, 4, 5, 6, 8] = 4
+    awq_gptq_convert_group_size: Literal[32, 64, 128] = 64
     awq_gptq_remove_source: bool = True
 
     # Autonomous agent (engine/agent/, routers/agent.py — issue #445). The

--- a/olmlx/engine/awq_gptq_converter.py
+++ b/olmlx/engine/awq_gptq_converter.py
@@ -9,9 +9,20 @@ freely.
 
 import json
 import logging
+import shutil
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+def converting_marker(dst: Path) -> Path:
+    """Sibling marker flagging an in-progress or failed conversion to *dst*.
+
+    Kept OUTSIDE *dst* deliberately: ``mlx_lm.convert`` refuses to write to an
+    ``mlx_path`` that already exists, so a marker placed *inside* *dst* would
+    make the directory exist and abort every conversion.
+    """
+    return dst.parent / (dst.name + ".converting")
 
 
 def detect_format(model_dir: Path) -> str | None:
@@ -48,7 +59,13 @@ def detect_format(model_dir: Path) -> str | None:
                 if marker == "gptq":
                     return "gptq"
         except Exception:
-            pass
+            # Corrupt/unreadable config.json — fall through to the
+            # quantize_config.json check, but leave a breadcrumb: an AWQ model
+            # (no quantize_config.json fallback) would otherwise be silently
+            # treated as MLX-native.
+            logger.warning(
+                "Could not parse %s for AWQ/GPTQ detection", config_path, exc_info=True
+            )
 
     if (model_dir / "quantize_config.json").exists():
         return "gptq"
@@ -59,19 +76,25 @@ def detect_format(model_dir: Path) -> str | None:
 def convert_to_mlx(src: Path, dst: Path, bits: int, group_size: int) -> None:
     """Convert an AWQ/GPTQ model at *src* to MLX int4/int8 at *dst*.
 
-    Places a ``.converting`` marker in *dst* before starting; removes it on
-    success and writes ``conversion_source.json`` with provenance.  On
-    failure the marker is left in place so ``_is_valid_mlx_dir()`` in
-    ``store.py`` returns ``False`` — a subsequent re-pull can retry.
+    Places a ``.converting`` marker *beside* *dst* before starting (see
+    ``converting_marker``); removes it on success and writes
+    ``conversion_source.json`` with provenance.  On failure the marker is left
+    in place so ``_is_valid_mlx_dir()`` in ``store.py`` returns ``False`` — a
+    subsequent re-pull can retry (and clears any partial output first).
 
     ``mlx_lm.convert`` is imported here (not at module level) so the import
     chain stays lightweight when the function is not called.
     """
     import mlx_lm
 
-    dst.mkdir(parents=True, exist_ok=True)
-    marker = dst / ".converting"
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    marker = converting_marker(dst)
     marker.touch()
+
+    # mlx_lm.convert refuses a pre-existing mlx_path; clear any partial output
+    # left by an earlier failed attempt before re-converting.
+    if dst.exists():
+        shutil.rmtree(dst)
 
     try:
         mlx_lm.convert(
@@ -82,12 +105,12 @@ def convert_to_mlx(src: Path, dst: Path, bits: int, group_size: int) -> None:
             q_group_size=group_size,
         )
     except Exception:
-        # Intentionally leave .converting so _is_valid_mlx_dir stays False.
+        # Intentionally leave the marker so _is_valid_mlx_dir stays False and a
+        # subsequent re-pull retries (clearing the partial dst above).
         raise
-
-    marker.unlink(missing_ok=True)
 
     fmt = detect_format(src)
     (dst / "conversion_source.json").write_text(
         json.dumps({"original_hf_path": str(src), "format": fmt})
     )
+    marker.unlink(missing_ok=True)

--- a/olmlx/engine/awq_gptq_converter.py
+++ b/olmlx/engine/awq_gptq_converter.py
@@ -20,8 +20,9 @@ def detect_format(model_dir: Path) -> str | None:
     Returns ``"awq"``, ``"gptq"``, or ``None`` for MLX-native / plain FP16.
 
     Detection strategy (in priority order):
-    1. ``config.json`` → ``quantization_config.quant_type`` field (HF
-       standard, used by both AWQ and GPTQ transformers checkpoints).
+    1. ``config.json`` → ``quantization_config`` field. The canonical HF
+       discriminator is ``quant_method`` (written by AutoAWQ / auto_gptq /
+       transformers); ``quant_type`` is accepted as a fallback alias.
     2. Presence of ``quantize_config.json`` — the auto_gptq canonical GPTQ
        marker file.
 
@@ -36,10 +37,15 @@ def detect_format(model_dir: Path) -> str | None:
                 cfg = json.load(f)
             quant_config = cfg.get("quantization_config")
             if isinstance(quant_config, dict):
-                quant_type = quant_config.get("quant_type", "").lower()
-                if quant_type == "awq":
+                # quant_method is the canonical HF key; quant_type is a fallback alias.
+                marker = (
+                    quant_config.get("quant_method")
+                    or quant_config.get("quant_type")
+                    or ""
+                ).lower()
+                if marker == "awq":
                     return "awq"
-                if quant_type == "gptq":
+                if marker == "gptq":
                     return "gptq"
         except Exception:
             pass

--- a/olmlx/engine/awq_gptq_converter.py
+++ b/olmlx/engine/awq_gptq_converter.py
@@ -1,0 +1,87 @@
+"""AWQ / GPTQ → MLX auto-conversion utilities.
+
+Imported by ``olmlx.models.store`` during ``pull()``; no heavy dependencies
+at module level so the server starts without mlx_lm being fully configured.
+``mlx_lm.convert`` is imported lazily inside ``convert_to_mlx`` so test
+suites that mock ``mlx_lm`` at a higher level can still import this module
+freely.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def detect_format(model_dir: Path) -> str | None:
+    """Detect whether *model_dir* contains AWQ or GPTQ weights.
+
+    Returns ``"awq"``, ``"gptq"``, or ``None`` for MLX-native / plain FP16.
+
+    Detection strategy (in priority order):
+    1. ``config.json`` → ``quantization_config.quant_type`` field (HF
+       standard, used by both AWQ and GPTQ transformers checkpoints).
+    2. Presence of ``quantize_config.json`` — the auto_gptq canonical GPTQ
+       marker file.
+
+    MLX-native models carry a top-level ``quantization`` key in
+    ``config.json`` (not ``quantization_config``) and are returned as
+    ``None``.
+    """
+    config_path = model_dir / "config.json"
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                cfg = json.load(f)
+            quant_config = cfg.get("quantization_config")
+            if isinstance(quant_config, dict):
+                quant_type = quant_config.get("quant_type", "").lower()
+                if quant_type == "awq":
+                    return "awq"
+                if quant_type == "gptq":
+                    return "gptq"
+        except Exception:
+            pass
+
+    if (model_dir / "quantize_config.json").exists():
+        return "gptq"
+
+    return None
+
+
+def convert_to_mlx(src: Path, dst: Path, bits: int, group_size: int) -> None:
+    """Convert an AWQ/GPTQ model at *src* to MLX int4/int8 at *dst*.
+
+    Places a ``.converting`` marker in *dst* before starting; removes it on
+    success and writes ``conversion_source.json`` with provenance.  On
+    failure the marker is left in place so ``_is_valid_mlx_dir()`` in
+    ``store.py`` returns ``False`` — a subsequent re-pull can retry.
+
+    ``mlx_lm.convert`` is imported here (not at module level) so the import
+    chain stays lightweight when the function is not called.
+    """
+    import mlx_lm
+
+    dst.mkdir(parents=True, exist_ok=True)
+    marker = dst / ".converting"
+    marker.touch()
+
+    try:
+        mlx_lm.convert(
+            model=str(src),
+            mlx_path=str(dst),
+            quantize=True,
+            q_bits=bits,
+            q_group_size=group_size,
+        )
+    except Exception:
+        # Intentionally leave .converting so _is_valid_mlx_dir stays False.
+        raise
+
+    marker.unlink(missing_ok=True)
+
+    fmt = detect_format(src)
+    (dst / "conversion_source.json").write_text(
+        json.dumps({"original_hf_path": str(src), "format": fmt})
+    )

--- a/olmlx/engine/awq_gptq_converter.py
+++ b/olmlx/engine/awq_gptq_converter.py
@@ -69,7 +69,7 @@ def convert_to_mlx(src: Path, dst: Path, bits: int, group_size: int) -> None:
 
     try:
         mlx_lm.convert(
-            model=str(src),
+            hf_path=str(src),
             mlx_path=str(dst),
             quantize=True,
             q_bits=bits,

--- a/olmlx/models/store.py
+++ b/olmlx/models/store.py
@@ -2,12 +2,14 @@ import asyncio
 import json
 import logging
 import re
+import shutil
 import threading
 from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
 from pathlib import Path
 
 from olmlx.config import settings
+from olmlx.engine.awq_gptq_converter import convert_to_mlx, detect_format
 from olmlx.engine.registry import ModelRegistry
 from olmlx.models.manifest import ModelManifest
 
@@ -72,6 +74,20 @@ def _extract_metadata(model_dir: Path) -> dict:
         if bits:
             meta["quantization_level"] = f"{bits}-bit"
     return meta
+
+
+def _converted_path(models_dir: Path, hf_path: str) -> Path:
+    """Return the canonical directory for the MLX-converted form of *hf_path*."""
+    return models_dir / _safe_dir_name(hf_path + "-mlx-converted")
+
+
+def _is_valid_mlx_dir(path: Path) -> bool:
+    """True when *path* is a complete, ready-to-load MLX model directory."""
+    return (
+        path.exists()
+        and (path / "config.json").exists()
+        and not (path / ".converting").exists()
+    )
 
 
 def _dir_size(path: Path) -> int:
@@ -177,10 +193,18 @@ class ModelStore:
     def ensure_downloaded(self, hf_path: str) -> Path:
         """Download a model if not already present. Returns the local directory.
 
+        Checks the converted directory first: if a prior pull already
+        converted this model to MLX format, return that immediately without
+        triggering a new download.
+
         Uses a .downloading marker to track incomplete downloads.
         Partial directories are kept on failure so snapshot_download can resume.
         Thread-safe: concurrent calls for the same hf_path are serialized.
         """
+        converted_dir = _converted_path(self.models_dir, hf_path)
+        if _is_valid_mlx_dir(converted_dir):
+            return converted_dir
+
         local_dir = self.local_path(hf_path)
         if self.is_downloaded(hf_path):
             return local_dir
@@ -220,7 +244,14 @@ class ModelStore:
             return local_dir
 
     async def pull(self, name: str) -> AsyncGenerator[dict, None]:
-        """Pull a model from HuggingFace, yielding progress dicts."""
+        """Pull a model from HuggingFace, yielding progress dicts.
+
+        If the downloaded model is detected as AWQ or GPTQ, it is
+        automatically re-quantised to MLX int4 (configurable via
+        OLMLX_AWQ_GPTQ_CONVERT_BITS / OLMLX_AWQ_GPTQ_CONVERT_GROUP_SIZE).
+        The converted artifact lands in a sibling directory and the original
+        is removed when OLMLX_AWQ_GPTQ_REMOVE_SOURCE=true (default).
+        """
         resolved = self.registry.resolve(name)
         hf_path = resolved.hf_path if resolved is not None else None
         if hf_path is None:
@@ -232,8 +263,10 @@ class ModelStore:
         # Strip Ollama-style tag before passing to HF.
         hf_path = _strip_ollama_tag(hf_path)
 
-        # Fast path: skip lock if already downloaded
-        if self.is_downloaded(hf_path):
+        converted_dir = _converted_path(self.models_dir, hf_path)
+
+        # Fast path: skip lock if already downloaded or already converted
+        if self.is_downloaded(hf_path) or _is_valid_mlx_dir(converted_dir):
             yield {"status": "pulling manifest"}
             yield {"status": "already downloaded"}
             yield {"status": "success"}
@@ -243,12 +276,12 @@ class ModelStore:
 
         async with self._pull_lock(hf_path):
             # Re-check after acquiring lock — another coroutine may have
-            # completed the download while we waited.
-            if self.is_downloaded(hf_path):
+            # completed the download (or conversion) while we waited.
+            converted_dir = _converted_path(self.models_dir, hf_path)
+            if self.is_downloaded(hf_path) or _is_valid_mlx_dir(converted_dir):
                 yield {"status": "pulling manifest"}
                 yield {"status": "already downloaded"}
                 yield {"status": "success"}
-                # Ensure registered
                 if "/" not in name:
                     self.registry.add_mapping(name, hf_path)
                 return
@@ -260,11 +293,27 @@ class ModelStore:
             # hf_path — that lock serializes the sync download path used by
             # ModelManager._load_model().  The asyncio lock here serializes the
             # async pull path (is_downloaded check → download → manifest write).
-            local_dir = await asyncio.to_thread(self.ensure_downloaded, hf_path)
+            raw_local_dir = await asyncio.to_thread(self.ensure_downloaded, hf_path)
+            local_dir = raw_local_dir
+
+            fmt = detect_format(raw_local_dir)
+            if fmt:
+                yield {"status": f"converting {fmt} → mlx"}
+                await asyncio.to_thread(
+                    convert_to_mlx,
+                    raw_local_dir,
+                    converted_dir,
+                    settings.awq_gptq_convert_bits,
+                    settings.awq_gptq_convert_group_size,
+                )
+                local_dir = converted_dir
+                if settings.awq_gptq_remove_source:
+                    await asyncio.to_thread(shutil.rmtree, raw_local_dir)
 
             yield {"status": "verifying"}
 
-            # Write manifest
+            # Write manifest — after conversion, local_dir is the MLX artifact
+            # and _extract_metadata reads its config.json for quant info.
             meta = _extract_metadata(local_dir)
             size = _dir_size(local_dir)
             normalized = self.registry.normalize_name(name)

--- a/olmlx/models/store.py
+++ b/olmlx/models/store.py
@@ -9,7 +9,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from olmlx.config import settings
-from olmlx.engine.awq_gptq_converter import convert_to_mlx, detect_format
+from olmlx.engine.awq_gptq_converter import (
+    convert_to_mlx,
+    converting_marker,
+    detect_format,
+)
 from olmlx.engine.registry import ModelRegistry
 from olmlx.models.manifest import ModelManifest
 
@@ -77,8 +81,14 @@ def _extract_metadata(model_dir: Path) -> dict:
 
 
 def _converted_path(models_dir: Path, hf_path: str) -> Path:
-    """Return the canonical directory for the MLX-converted form of *hf_path*."""
-    return models_dir / _safe_dir_name(hf_path + "-mlx-converted")
+    """Return the canonical directory for the MLX-converted form of *hf_path*.
+
+    The ``@`` separator can never appear in a raw download directory name
+    (``_safe_dir_name`` maps it to ``_``), so this path cannot collide with the
+    download directory of any real HF repo — including one literally named
+    ``owner/model@mlx`` or ``owner/model-mlx-converted``.
+    """
+    return models_dir / (_safe_dir_name(hf_path) + "@mlx")
 
 
 def _is_valid_mlx_dir(path: Path) -> bool:
@@ -86,7 +96,7 @@ def _is_valid_mlx_dir(path: Path) -> bool:
     return (
         path.exists()
         and (path / "config.json").exists()
-        and not (path / ".converting").exists()
+        and not converting_marker(path).exists()
     )
 
 
@@ -164,6 +174,14 @@ class ModelStore:
         hf_path = resolved.hf_path if resolved is not None else None
         if hf_path is not None:
             hf_path = _strip_ollama_tag(hf_path)
+            # An AWQ/GPTQ model may have been converted to a sibling directory
+            # (and its raw download removed), so check the converted path before
+            # the raw one — otherwise delete()/show() can't find it by name.
+            converted = _converted_path(self.models_dir, hf_path)
+            if (converted / "manifest.json").exists():
+                return (converted, True)
+            if _is_valid_mlx_dir(converted):
+                return (converted, False)
             d = self.local_path(hf_path)
             if (d / "manifest.json").exists():
                 return (d, True)
@@ -178,6 +196,20 @@ class ModelStore:
             if (d / "config.json").exists():
                 return (d, False)
         return None
+
+    def _pull_complete(self, hf_path: str) -> bool:
+        """True when no (further) pull work is needed for *hf_path*.
+
+        Either a valid converted MLX artifact exists, or the model is already
+        downloaded AND needs no conversion. A downloaded-but-unconverted
+        AWQ/GPTQ model (e.g. a prior conversion failed) returns False so the
+        conversion is retried rather than reported as already complete.
+        """
+        if _is_valid_mlx_dir(_converted_path(self.models_dir, hf_path)):
+            return True
+        if self.is_downloaded(hf_path):
+            return detect_format(self.local_path(hf_path)) is None
+        return False
 
     def _pull_lock(self, hf_path: str) -> asyncio.Lock:
         """Return a per-path async lock, creating one if needed."""
@@ -265,8 +297,10 @@ class ModelStore:
 
         converted_dir = _converted_path(self.models_dir, hf_path)
 
-        # Fast path: skip lock if already downloaded or already converted
-        if self.is_downloaded(hf_path) or _is_valid_mlx_dir(converted_dir):
+        # Fast path: skip lock if the model is fully ready (downloaded with no
+        # conversion needed, or already converted). A downloaded-but-unconverted
+        # AWQ/GPTQ model is NOT complete — fall through so conversion is retried.
+        if self._pull_complete(hf_path):
             yield {"status": "pulling manifest"}
             yield {"status": "already downloaded"}
             yield {"status": "success"}
@@ -278,7 +312,7 @@ class ModelStore:
             # Re-check after acquiring lock — another coroutine may have
             # completed the download (or conversion) while we waited.
             converted_dir = _converted_path(self.models_dir, hf_path)
-            if self.is_downloaded(hf_path) or _is_valid_mlx_dir(converted_dir):
+            if self._pull_complete(hf_path):
                 yield {"status": "pulling manifest"}
                 yield {"status": "already downloaded"}
                 yield {"status": "success"}

--- a/tests/integration/test_awq_gptq_pull.py
+++ b/tests/integration/test_awq_gptq_pull.py
@@ -1,0 +1,247 @@
+"""Integration tests for AWQ/GPTQ auto-conversion on model pull."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from olmlx.models.manifest import ModelManifest
+from olmlx.models.store import _converted_path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_awq_dir(path: Path, fmt: str = "awq") -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen2",
+                "hidden_size": 512,
+                "num_hidden_layers": 4,
+                "quantization_config": {"quant_type": fmt},
+            }
+        )
+    )
+
+
+def _fake_convert_to_mlx(src: Path, dst: Path, bits: int, group_size: int) -> None:
+    """Simulates mlx_lm.convert: creates a minimal MLX model dir."""
+    dst.mkdir(parents=True, exist_ok=True)
+    (dst / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen2",
+                "quantization": {"bits": bits, "group_size": group_size},
+            }
+        )
+    )
+    (dst / "conversion_source.json").write_text(
+        json.dumps({"original_hf_path": str(src), "format": "awq"})
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pull_awq_triggers_conversion_and_updates_local_dir(
+    mock_store, monkeypatch
+):
+    hf_path = "org/awq-model"
+    raw_dir = mock_store.local_path(hf_path)
+
+    def fake_ensure_downloaded(path: str) -> Path:
+        _make_awq_dir(raw_dir, fmt="awq")
+        return raw_dir
+
+    monkeypatch.setattr(mock_store, "ensure_downloaded", fake_ensure_downloaded)
+
+    with patch("olmlx.models.store.convert_to_mlx", side_effect=_fake_convert_to_mlx):
+        events = []
+        async for event in mock_store.pull(hf_path):
+            events.append(event)
+
+    assert any(e["status"] == "success" for e in events)
+
+    converted_dir = _converted_path(mock_store.models_dir, hf_path)
+    assert converted_dir.exists()
+    manifest = ModelManifest.load(converted_dir / "manifest.json")
+    assert manifest.format == "mlx"
+    assert manifest.quantization_level == "4-bit"
+
+
+@pytest.mark.asyncio
+async def test_pull_gptq_triggers_conversion(mock_store, monkeypatch):
+    hf_path = "org/gptq-model"
+    raw_dir = mock_store.local_path(hf_path)
+
+    def fake_ensure_downloaded(path: str) -> Path:
+        _make_awq_dir(raw_dir, fmt="gptq")
+        return raw_dir
+
+    monkeypatch.setattr(mock_store, "ensure_downloaded", fake_ensure_downloaded)
+
+    convert_calls: list[tuple] = []
+
+    def tracking_convert(src, dst, bits, group_size):
+        convert_calls.append((src, dst, bits, group_size))
+        _fake_convert_to_mlx(src, dst, bits, group_size)
+
+    with patch("olmlx.models.store.convert_to_mlx", side_effect=tracking_convert):
+        async for _ in mock_store.pull(hf_path):
+            pass
+
+    assert len(convert_calls) == 1
+    _, dst, _, _ = convert_calls[0]
+    assert dst == _converted_path(mock_store.models_dir, hf_path)
+
+
+@pytest.mark.asyncio
+async def test_pull_non_awq_gptq_skips_conversion(mock_store, monkeypatch):
+    hf_path = "org/plain-fp16"
+    raw_dir = mock_store.local_path(hf_path)
+
+    def fake_ensure_downloaded(path: str) -> Path:
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        (raw_dir / "config.json").write_text(
+            json.dumps({"model_type": "qwen2", "hidden_size": 512})
+        )
+        return raw_dir
+
+    monkeypatch.setattr(mock_store, "ensure_downloaded", fake_ensure_downloaded)
+
+    convert_called = []
+
+    with patch(
+        "olmlx.models.store.convert_to_mlx",
+        side_effect=lambda *a, **kw: convert_called.append(a),
+    ):
+        async for _ in mock_store.pull(hf_path):
+            pass
+
+    assert convert_called == [], "convert_to_mlx must NOT be called for plain FP16"
+
+
+@pytest.mark.asyncio
+async def test_pull_already_converted_skips_download_and_conversion(
+    mock_store, monkeypatch
+):
+    hf_path = "org/awq-already-converted"
+    converted_dir = _converted_path(mock_store.models_dir, hf_path)
+    # Pre-create a valid converted dir (simulates a prior pull)
+    _fake_convert_to_mlx(Path("/fake/src"), converted_dir, bits=4, group_size=64)
+
+    ensure_called = []
+    monkeypatch.setattr(
+        mock_store,
+        "ensure_downloaded",
+        lambda p: ensure_called.append(p) or Path(p),
+    )
+    convert_called = []
+
+    with patch(
+        "olmlx.models.store.convert_to_mlx",
+        side_effect=lambda *a, **kw: convert_called.append(a),
+    ):
+        events = []
+        async for event in mock_store.pull(hf_path):
+            events.append(event)
+
+    assert any(e["status"] == "already downloaded" for e in events)
+    assert ensure_called == [], "ensure_downloaded must NOT be called"
+    assert convert_called == [], "convert_to_mlx must NOT be called"
+
+
+@pytest.mark.asyncio
+async def test_pull_progress_events_include_converting_status(mock_store, monkeypatch):
+    hf_path = "org/awq-progress-test"
+    raw_dir = mock_store.local_path(hf_path)
+
+    def fake_ensure_downloaded(path: str) -> Path:
+        _make_awq_dir(raw_dir, fmt="awq")
+        return raw_dir
+
+    monkeypatch.setattr(mock_store, "ensure_downloaded", fake_ensure_downloaded)
+
+    with patch("olmlx.models.store.convert_to_mlx", side_effect=_fake_convert_to_mlx):
+        events = []
+        async for event in mock_store.pull(hf_path):
+            events.append(event)
+
+    statuses = [e.get("status", "") for e in events]
+    assert any("converting" in s for s in statuses), (
+        f"Expected a 'converting' status event; got: {statuses}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pull_removes_source_when_flag_set(mock_store, monkeypatch):
+    hf_path = "org/awq-remove-src"
+    raw_dir = mock_store.local_path(hf_path)
+
+    def fake_ensure_downloaded(path: str) -> Path:
+        _make_awq_dir(raw_dir, fmt="awq")
+        return raw_dir
+
+    monkeypatch.setattr(mock_store, "ensure_downloaded", fake_ensure_downloaded)
+    monkeypatch.setattr("olmlx.models.store.settings.awq_gptq_remove_source", True)
+
+    with patch("olmlx.models.store.convert_to_mlx", side_effect=_fake_convert_to_mlx):
+        async for _ in mock_store.pull(hf_path):
+            pass
+
+    assert not raw_dir.exists(), (
+        "source dir must be deleted when awq_gptq_remove_source=True"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pull_keeps_source_when_flag_cleared(mock_store, monkeypatch):
+    hf_path = "org/awq-keep-src"
+    raw_dir = mock_store.local_path(hf_path)
+
+    def fake_ensure_downloaded(path: str) -> Path:
+        _make_awq_dir(raw_dir, fmt="awq")
+        return raw_dir
+
+    monkeypatch.setattr(mock_store, "ensure_downloaded", fake_ensure_downloaded)
+    monkeypatch.setattr("olmlx.models.store.settings.awq_gptq_remove_source", False)
+
+    with patch("olmlx.models.store.convert_to_mlx", side_effect=_fake_convert_to_mlx):
+        async for _ in mock_store.pull(hf_path):
+            pass
+
+    assert raw_dir.exists(), "source dir must be kept when awq_gptq_remove_source=False"
+
+
+@pytest.mark.asyncio
+async def test_pull_mlx_native_dir_not_re_converted(mock_store, monkeypatch):
+    """An already-MLX model (top-level 'quantization') must not trigger conversion."""
+    hf_path = "mlx-community/already-mlx-4bit"
+    raw_dir = mock_store.local_path(hf_path)
+
+    def fake_ensure_downloaded(path: str) -> Path:
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        (raw_dir / "config.json").write_text(
+            json.dumps({"model_type": "qwen2", "quantization": {"bits": 4}})
+        )
+        return raw_dir
+
+    monkeypatch.setattr(mock_store, "ensure_downloaded", fake_ensure_downloaded)
+
+    convert_called = []
+    with patch(
+        "olmlx.models.store.convert_to_mlx",
+        side_effect=lambda *a, **kw: convert_called.append(a),
+    ):
+        async for _ in mock_store.pull(hf_path):
+            pass
+
+    assert convert_called == []

--- a/tests/integration/test_awq_gptq_pull.py
+++ b/tests/integration/test_awq_gptq_pull.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from olmlx.models.manifest import ModelManifest
-from olmlx.models.store import _converted_path
+from olmlx.models.store import _converted_path, _is_valid_mlx_dir
 
 
 # ---------------------------------------------------------------------------
@@ -245,3 +245,41 @@ async def test_pull_mlx_native_dir_not_re_converted(mock_store, monkeypatch):
             pass
 
     assert convert_called == []
+
+
+@pytest.mark.asyncio
+async def test_pull_retries_conversion_when_source_present_but_unconverted(mock_store):
+    """A downloaded-but-unconverted AWQ model must trigger conversion.
+
+    Regression: the fast path keyed on is_downloaded() reported a prior-failed
+    conversion as 'already downloaded' and never retried, leaving the raw
+    AWQ weights in place.
+    """
+    hf_path = "org/awq-needs-retry"
+    raw_dir = mock_store.local_path(hf_path)
+    _make_awq_dir(raw_dir, fmt="awq")  # downloaded earlier; conversion never finished
+
+    convert_calls: list[Path] = []
+
+    def tracking_convert(src, dst, bits, group_size):
+        convert_calls.append(dst)
+        _fake_convert_to_mlx(src, dst, bits, group_size)
+
+    with patch("olmlx.models.store.convert_to_mlx", side_effect=tracking_convert):
+        events = [e async for e in mock_store.pull(hf_path)]
+
+    assert len(convert_calls) == 1, "conversion must run even though raw source exists"
+    assert any(e["status"] == "success" for e in events)
+    assert _is_valid_mlx_dir(_converted_path(mock_store.models_dir, hf_path))
+
+
+@pytest.mark.asyncio
+async def test_delete_finds_converted_model(mock_store):
+    """delete() must locate a converted model whose raw source was removed."""
+    hf_path = "org/awq-del"
+    converted = _converted_path(mock_store.models_dir, hf_path)
+    _fake_convert_to_mlx(Path("/fake/src"), converted, bits=4, group_size=64)
+    assert _is_valid_mlx_dir(converted)
+
+    assert mock_store.delete(hf_path) is True
+    assert not converted.exists()

--- a/tests/test_awq_gptq_converter.py
+++ b/tests/test_awq_gptq_converter.py
@@ -6,7 +6,10 @@ from unittest.mock import patch
 
 import pytest
 
-from olmlx.engine.awq_gptq_converter import convert_to_mlx
+from olmlx.engine.awq_gptq_converter import (
+    convert_to_mlx,
+    converting_marker,
+)
 
 
 def _make_awq_src(tmp_path: Path, fmt: str = "awq") -> Path:
@@ -18,11 +21,26 @@ def _make_awq_src(tmp_path: Path, fmt: str = "awq") -> Path:
     return src
 
 
+def _fake_mlx_convert(*, hf_path, mlx_path, **kwargs):
+    """Faithful stand-in for ``mlx_lm.convert``.
+
+    Mirrors the real contract: it REFUSES a pre-existing ``mlx_path`` (the real
+    one raises ``ValueError`` in that case) and otherwise creates the output
+    directory.  Using this as the mock is what guards against the regression of
+    pre-creating ``dst`` before calling convert.
+    """
+    p = Path(mlx_path)
+    if p.exists():
+        raise ValueError(f"Cannot save to the path {p} as it already exists.")
+    p.mkdir(parents=True)
+    (p / "config.json").write_text(json.dumps({"quantization": {"bits": 4}}))
+
+
 def test_convert_calls_mlx_lm_convert_with_correct_args(tmp_path):
     src = _make_awq_src(tmp_path)
     dst = tmp_path / "dst"
 
-    with patch("mlx_lm.convert") as mock_convert:
+    with patch("mlx_lm.convert", side_effect=_fake_mlx_convert) as mock_convert:
         convert_to_mlx(src, dst, bits=4, group_size=64)
 
     mock_convert.assert_called_once_with(
@@ -34,11 +52,48 @@ def test_convert_calls_mlx_lm_convert_with_correct_args(tmp_path):
     )
 
 
+def test_convert_does_not_precreate_mlx_path(tmp_path):
+    """Regression: dst must NOT exist when mlx_lm.convert is called.
+
+    The real mlx_lm.convert raises ValueError if mlx_path already exists, so
+    convert_to_mlx must let convert own the directory creation.
+    """
+    src = _make_awq_src(tmp_path)
+    dst = tmp_path / "dst"
+
+    seen_existing: list[bool] = []
+
+    def check_not_preexisting(*, hf_path, mlx_path, **kwargs):
+        seen_existing.append(Path(mlx_path).exists())
+        _fake_mlx_convert(hf_path=hf_path, mlx_path=mlx_path, **kwargs)
+
+    with patch("mlx_lm.convert", side_effect=check_not_preexisting):
+        convert_to_mlx(src, dst, bits=4, group_size=64)
+
+    assert seen_existing == [False], "dst must not exist when convert is called"
+    assert (dst / "config.json").exists()
+
+
+def test_convert_clears_partial_dst_from_prior_failure(tmp_path):
+    """A leftover partial dst from a failed attempt is cleared before retry."""
+    src = _make_awq_src(tmp_path)
+    dst = tmp_path / "dst"
+    # Simulate a partial dir left by a previous failed conversion.
+    dst.mkdir()
+    (dst / "garbage.bin").write_text("partial")
+
+    with patch("mlx_lm.convert", side_effect=_fake_mlx_convert):
+        convert_to_mlx(src, dst, bits=4, group_size=64)
+
+    assert (dst / "config.json").exists()
+    assert not (dst / "garbage.bin").exists(), "partial output must be cleared"
+
+
 def test_convert_writes_conversion_source_json(tmp_path):
     src = _make_awq_src(tmp_path, fmt="awq")
     dst = tmp_path / "dst"
 
-    with patch("mlx_lm.convert"):
+    with patch("mlx_lm.convert", side_effect=_fake_mlx_convert):
         convert_to_mlx(src, dst, bits=4, group_size=64)
 
     provenance = dst / "conversion_source.json"
@@ -52,7 +107,7 @@ def test_convert_writes_gptq_format_in_provenance(tmp_path):
     src = _make_awq_src(tmp_path, fmt="gptq")
     dst = tmp_path / "dst"
 
-    with patch("mlx_lm.convert"):
+    with patch("mlx_lm.convert", side_effect=_fake_mlx_convert):
         convert_to_mlx(src, dst, bits=4, group_size=64)
 
     data = json.loads((dst / "conversion_source.json").read_text())
@@ -62,29 +117,35 @@ def test_convert_writes_gptq_format_in_provenance(tmp_path):
 def test_convert_sets_and_clears_converting_marker(tmp_path):
     src = _make_awq_src(tmp_path)
     dst = tmp_path / "dst"
+    marker = converting_marker(dst)
 
     marker_states: list[bool] = []
 
-    def capture_marker_state(hf_path, mlx_path, **kwargs):
-        marker_states.append((Path(mlx_path) / ".converting").exists())
+    def capture_marker_state(*, hf_path, mlx_path, **kwargs):
+        marker_states.append(marker.exists())
+        _fake_mlx_convert(hf_path=hf_path, mlx_path=mlx_path, **kwargs)
 
     with patch("mlx_lm.convert", side_effect=capture_marker_state):
         convert_to_mlx(src, dst, bits=4, group_size=64)
 
-    assert marker_states == [True], ".converting must be present during mlx_lm.convert"
-    assert not (dst / ".converting").exists(), ".converting must be removed on success"
+    assert marker_states == [True], "marker must be present during mlx_lm.convert"
+    assert not marker.exists(), "marker must be removed on success"
+    # The marker lives OUTSIDE dst so it can't make mlx_path "already exist".
+    assert marker.parent == dst.parent
+    assert not (dst / ".converting").exists()
 
 
 def test_convert_leaves_converting_marker_on_failure(tmp_path):
     src = _make_awq_src(tmp_path)
     dst = tmp_path / "dst"
+    marker = converting_marker(dst)
 
     with patch("mlx_lm.convert", side_effect=RuntimeError("OOM")):
         with pytest.raises(RuntimeError, match="OOM"):
             convert_to_mlx(src, dst, bits=4, group_size=64)
 
-    assert (dst / ".converting").exists(), (
-        ".converting must remain after failure so _is_valid_mlx_dir stays False"
+    assert marker.exists(), (
+        "marker must remain after failure so _is_valid_mlx_dir stays False"
     )
     assert not (dst / "conversion_source.json").exists()
 
@@ -93,7 +154,7 @@ def test_convert_creates_dst_directory(tmp_path):
     src = _make_awq_src(tmp_path)
     dst = tmp_path / "nested" / "dst"  # parent doesn't exist yet
 
-    with patch("mlx_lm.convert"):
+    with patch("mlx_lm.convert", side_effect=_fake_mlx_convert):
         convert_to_mlx(src, dst, bits=4, group_size=64)
 
     assert dst.exists()
@@ -103,7 +164,7 @@ def test_convert_uses_caller_supplied_bits_and_group_size(tmp_path):
     src = _make_awq_src(tmp_path)
     dst = tmp_path / "dst"
 
-    with patch("mlx_lm.convert") as mock_convert:
+    with patch("mlx_lm.convert", side_effect=_fake_mlx_convert) as mock_convert:
         convert_to_mlx(src, dst, bits=8, group_size=128)
 
     _, kwargs = mock_convert.call_args

--- a/tests/test_awq_gptq_converter.py
+++ b/tests/test_awq_gptq_converter.py
@@ -1,0 +1,111 @@
+"""Unit tests for convert_to_mlx() in olmlx.engine.awq_gptq_converter."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from olmlx.engine.awq_gptq_converter import convert_to_mlx
+
+
+def _make_awq_src(tmp_path: Path, fmt: str = "awq") -> Path:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "config.json").write_text(
+        json.dumps({"model_type": "qwen2", "quantization_config": {"quant_type": fmt}})
+    )
+    return src
+
+
+def test_convert_calls_mlx_lm_convert_with_correct_args(tmp_path):
+    src = _make_awq_src(tmp_path)
+    dst = tmp_path / "dst"
+
+    with patch("mlx_lm.convert") as mock_convert:
+        convert_to_mlx(src, dst, bits=4, group_size=64)
+
+    mock_convert.assert_called_once_with(
+        model=str(src),
+        mlx_path=str(dst),
+        quantize=True,
+        q_bits=4,
+        q_group_size=64,
+    )
+
+
+def test_convert_writes_conversion_source_json(tmp_path):
+    src = _make_awq_src(tmp_path, fmt="awq")
+    dst = tmp_path / "dst"
+
+    with patch("mlx_lm.convert"):
+        convert_to_mlx(src, dst, bits=4, group_size=64)
+
+    provenance = dst / "conversion_source.json"
+    assert provenance.exists(), "conversion_source.json should be written on success"
+    data = json.loads(provenance.read_text())
+    assert data["original_hf_path"] == str(src)
+    assert data["format"] == "awq"
+
+
+def test_convert_writes_gptq_format_in_provenance(tmp_path):
+    src = _make_awq_src(tmp_path, fmt="gptq")
+    dst = tmp_path / "dst"
+
+    with patch("mlx_lm.convert"):
+        convert_to_mlx(src, dst, bits=4, group_size=64)
+
+    data = json.loads((dst / "conversion_source.json").read_text())
+    assert data["format"] == "gptq"
+
+
+def test_convert_sets_and_clears_converting_marker(tmp_path):
+    src = _make_awq_src(tmp_path)
+    dst = tmp_path / "dst"
+
+    marker_states: list[bool] = []
+
+    def capture_marker_state(model, mlx_path, **kwargs):
+        marker_states.append((Path(mlx_path) / ".converting").exists())
+
+    with patch("mlx_lm.convert", side_effect=capture_marker_state):
+        convert_to_mlx(src, dst, bits=4, group_size=64)
+
+    assert marker_states == [True], ".converting must be present during mlx_lm.convert"
+    assert not (dst / ".converting").exists(), ".converting must be removed on success"
+
+
+def test_convert_leaves_converting_marker_on_failure(tmp_path):
+    src = _make_awq_src(tmp_path)
+    dst = tmp_path / "dst"
+
+    with patch("mlx_lm.convert", side_effect=RuntimeError("OOM")):
+        with pytest.raises(RuntimeError, match="OOM"):
+            convert_to_mlx(src, dst, bits=4, group_size=64)
+
+    assert (dst / ".converting").exists(), (
+        ".converting must remain after failure so _is_valid_mlx_dir stays False"
+    )
+    assert not (dst / "conversion_source.json").exists()
+
+
+def test_convert_creates_dst_directory(tmp_path):
+    src = _make_awq_src(tmp_path)
+    dst = tmp_path / "nested" / "dst"  # parent doesn't exist yet
+
+    with patch("mlx_lm.convert"):
+        convert_to_mlx(src, dst, bits=4, group_size=64)
+
+    assert dst.exists()
+
+
+def test_convert_uses_caller_supplied_bits_and_group_size(tmp_path):
+    src = _make_awq_src(tmp_path)
+    dst = tmp_path / "dst"
+
+    with patch("mlx_lm.convert") as mock_convert:
+        convert_to_mlx(src, dst, bits=8, group_size=128)
+
+    _, kwargs = mock_convert.call_args
+    assert kwargs["q_bits"] == 8
+    assert kwargs["q_group_size"] == 128

--- a/tests/test_awq_gptq_converter.py
+++ b/tests/test_awq_gptq_converter.py
@@ -26,7 +26,7 @@ def test_convert_calls_mlx_lm_convert_with_correct_args(tmp_path):
         convert_to_mlx(src, dst, bits=4, group_size=64)
 
     mock_convert.assert_called_once_with(
-        model=str(src),
+        hf_path=str(src),
         mlx_path=str(dst),
         quantize=True,
         q_bits=4,
@@ -65,7 +65,7 @@ def test_convert_sets_and_clears_converting_marker(tmp_path):
 
     marker_states: list[bool] = []
 
-    def capture_marker_state(model, mlx_path, **kwargs):
+    def capture_marker_state(hf_path, mlx_path, **kwargs):
         marker_states.append((Path(mlx_path) / ".converting").exists())
 
     with patch("mlx_lm.convert", side_effect=capture_marker_state):

--- a/tests/test_awq_gptq_detection.py
+++ b/tests/test_awq_gptq_detection.py
@@ -14,6 +14,33 @@ def test_detect_awq_via_quantization_config_quant_type(tmp_path):
     assert detect_format(tmp_path) == "awq"
 
 
+def test_detect_awq_via_quantization_config_quant_method(tmp_path):
+    """Canonical HF AutoAWQ checkpoints carry quant_method, not quant_type."""
+    config = {
+        "model_type": "qwen2",
+        "quantization_config": {"quant_method": "awq", "bits": 4, "version": "gemm"},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    assert detect_format(tmp_path) == "awq"
+
+
+def test_detect_gptq_via_quantization_config_quant_method(tmp_path):
+    """Canonical HF GPTQ checkpoints carry quant_method, not quant_type."""
+    config = {
+        "model_type": "qwen2",
+        "quantization_config": {"quant_method": "gptq", "bits": 4, "group_size": 128},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    assert detect_format(tmp_path) == "gptq"
+
+
+def test_detect_case_insensitive_quant_method(tmp_path):
+    """quant_method is normalised to lowercase before comparison."""
+    config = {"quantization_config": {"quant_method": "GPTQ"}}
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    assert detect_format(tmp_path) == "gptq"
+
+
 def test_detect_gptq_via_quantize_config_json(tmp_path):
     """quantize_config.json present (auto_gptq convention) → gptq."""
     (tmp_path / "config.json").write_text(json.dumps({"model_type": "qwen2"}))

--- a/tests/test_awq_gptq_detection.py
+++ b/tests/test_awq_gptq_detection.py
@@ -1,0 +1,83 @@
+"""Unit tests for detect_format() in olmlx.engine.awq_gptq_converter."""
+
+import json
+
+from olmlx.engine.awq_gptq_converter import detect_format
+
+
+def test_detect_awq_via_quantization_config_quant_type(tmp_path):
+    config = {
+        "model_type": "qwen2",
+        "quantization_config": {"quant_type": "awq", "version": "gemm"},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    assert detect_format(tmp_path) == "awq"
+
+
+def test_detect_gptq_via_quantize_config_json(tmp_path):
+    """quantize_config.json present (auto_gptq convention) → gptq."""
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "qwen2"}))
+    (tmp_path / "quantize_config.json").write_text(
+        json.dumps({"bits": 4, "group_size": 128})
+    )
+    assert detect_format(tmp_path) == "gptq"
+
+
+def test_detect_gptq_via_quantization_config_quant_type(tmp_path):
+    config = {
+        "model_type": "qwen2",
+        "quantization_config": {"quant_type": "gptq"},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    assert detect_format(tmp_path) == "gptq"
+
+
+def test_detect_none_for_mlx_native(tmp_path):
+    """MLX-native quantization (top-level 'quantization' key, no quant_type) → None."""
+    config = {
+        "model_type": "qwen2",
+        "quantization": {"bits": 4, "group_size": 64},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    assert detect_format(tmp_path) is None
+
+
+def test_detect_none_for_plain_fp16(tmp_path):
+    """No quantization keys at all → None."""
+    config = {"model_type": "qwen2", "hidden_size": 4096}
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    assert detect_format(tmp_path) is None
+
+
+def test_detect_none_when_no_config_json(tmp_path):
+    """No config.json and no quantize_config.json → None."""
+    assert detect_format(tmp_path) is None
+
+
+def test_detect_gptq_fallback_without_config_json(tmp_path):
+    """quantize_config.json alone (no config.json) → gptq."""
+    (tmp_path / "quantize_config.json").write_text(json.dumps({"bits": 4}))
+    assert detect_format(tmp_path) == "gptq"
+
+
+def test_detect_case_insensitive_quant_type(tmp_path):
+    """quant_type is normalised to lowercase before comparison."""
+    config = {"quantization_config": {"quant_type": "AWQ"}}
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    assert detect_format(tmp_path) == "awq"
+
+
+def test_detect_none_for_malformed_config(tmp_path):
+    """Invalid JSON in config.json → None (graceful fallback)."""
+    (tmp_path / "config.json").write_text("{not valid json")
+    assert detect_format(tmp_path) is None
+
+
+def test_detect_awq_ignores_top_level_quantization(tmp_path):
+    """quantization_config.quant_type=awq wins even when top-level quantization exists."""
+    config = {
+        "quantization": {"bits": 4},
+        "quantization_config": {"quant_type": "awq"},
+    }
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    assert detect_format(tmp_path) == "awq"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -570,3 +570,30 @@ def test_tracing_env_toggle(monkeypatch):
     from olmlx.config import Settings
 
     assert Settings().tracing is True
+
+
+def test_awq_gptq_convert_bits_rejects_unsupported(monkeypatch):
+    """mlx supports bits {2,3,4,5,6,8}; 1 and 7 must be rejected, not just range-checked."""
+    monkeypatch.setenv("OLMLX_AWQ_GPTQ_CONVERT_BITS", "7")
+    from olmlx.config import Settings
+
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+def test_awq_gptq_convert_group_size_rejects_unsupported(monkeypatch):
+    monkeypatch.setenv("OLMLX_AWQ_GPTQ_CONVERT_GROUP_SIZE", "16")
+    from olmlx.config import Settings
+
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+def test_awq_gptq_convert_defaults(monkeypatch):
+    for key in ("OLMLX_AWQ_GPTQ_CONVERT_BITS", "OLMLX_AWQ_GPTQ_CONVERT_GROUP_SIZE"):
+        monkeypatch.delenv(key, raising=False)
+    from olmlx.config import Settings
+
+    s = Settings()
+    assert s.awq_gptq_convert_bits == 4
+    assert s.awq_gptq_convert_group_size == 64


### PR DESCRIPTION
Closes #363

## Summary

- Adds `olmlx/engine/awq_gptq_converter.py` with two public functions:
  - `detect_format(model_dir)` → `"awq" | "gptq" | None` — reads `config.json` (`quantization_config.quant_type`) and checks for `quantize_config.json` (auto_gptq convention); returns `None` for MLX-native and plain FP16 models.
  - `convert_to_mlx(src, dst, bits, group_size)` — wraps `mlx_lm.convert`; places a `.converting` marker before starting (removed on success, left on failure); writes `conversion_source.json` provenance on success.
- Wires conversion into `ModelStore.pull()`: after `ensure_downloaded`, `detect_format` is called; if AWQ/GPTQ is detected, a `"converting <fmt> → mlx"` status event is emitted, `mlx_lm.convert` runs in `asyncio.to_thread`, and the manifest is written to the converted dir. The source dir is removed when `OLMLX_AWQ_GPTQ_REMOVE_SOURCE=true` (default).
- `ensure_downloaded` and `pull`'s fast path both check the converted directory first, so re-pulls of already-converted models return "already downloaded" without triggering a new download or conversion.
- Three new `OLMLX_`-prefixed settings: `awq_gptq_convert_bits` (default 4), `awq_gptq_convert_group_size` (default 64), `awq_gptq_remove_source` (default `true`).

## Tests added

- `tests/test_awq_gptq_detection.py` — 10 unit tests for `detect_format()` (pure filesystem, no Metal/MLX).
- `tests/test_awq_gptq_converter.py` — 7 unit tests for `convert_to_mlx()` (mocks `mlx_lm.convert`).
- `tests/integration/test_awq_gptq_pull.py` — 8 integration tests for the `pull()` flow (mocks `ensure_downloaded` and `convert_to_mlx`), covering AWQ trigger, GPTQ trigger, FP16 skip, already-converted fast path, progress events, source removal/retention.

All 25 new tests pass; full suite (5251 tests, `not real_model`) green.

## CLAUDE.md invariants checked

- **Metal stream hazard** — conversion runs entirely in `asyncio.to_thread` via `mlx_lm.convert`; no `mx` graph operations are started, and no model is loaded into `ModelManager` during pull.
- **Grammar tokenizer identity** — no model is loaded during pull; `drop_for_tokenizer` is irrelevant.
- **Flash prefetcher teardown** — conversion happens at pull time, before any model load; teardown order is unaffected.
- **Pure-RotatingKVCache prefill** — no routing change; converted artifacts load via the standard `_load_with_model_type_fallback` path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)