### PR TITLE
fix(model_manager): honor per-layer quant in gemma4_unified text loader

### DIFF
--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -248,6 +248,42 @@ def _load_with_model_type_fallback(mlx_lm, load_path, **kwargs):
     return model, tokenizer
 
 
+def _quantize_language_tower(
+    model: Any, quant: dict, lang_weights: dict, prefix: str = "language_model."
+) -> None:
+    """Quantize a rebuilt ``gemma4_text`` language tower in place, honoring the
+    checkpoint's *per-layer* quantization overrides.
+
+    mlx-community ``gemma4_unified`` checkpoints carry mixed precision: a global
+    ``bits``/``group_size`` plus per-module overrides (e.g. MLP projections at
+    8-bit) keyed by the full ``language_model.*`` path.  A blanket
+    ``nn.quantize`` at the global bits builds QuantizedLinear params whose packed
+    shapes mismatch the stored 8-bit weights, so the strict load fails.  This
+    mirrors mlx-lm's own ``load_model`` predicate, mapping our stripped tower
+    paths (``model.layers.0.mlp.gate_proj``) back to the prefixed config keys.
+    """
+    import mlx.nn as nn
+
+    def class_predicate(path: str, module: Any) -> bool | dict:
+        # Per-layer override wins: config keys retain the language_model prefix.
+        override = quant.get(f"{prefix}{path}")
+        if isinstance(override, dict):
+            return override
+        if not hasattr(module, "to_quantized"):
+            return False
+        # Otherwise quantize at the global bits only if the checkpoint stored
+        # this module as quantized (a non-quantized module has no .scales).
+        return f"{path}.scales" in lang_weights
+
+    nn.quantize(
+        model,
+        group_size=quant.get("group_size", 64),
+        bits=quant.get("bits", 4),
+        mode=quant.get("mode", "affine"),
+        class_predicate=class_predicate,
+    )
+
+
 def _load_gemma4_unified_text(load_path: str, config: dict) -> tuple[Any, Any]:
     """Load only the *language tower* of a mlx-community ``gemma4_unified``
     checkpoint (e.g. ``gemma-4-12B-it-4bit``) via mlx-lm's ``gemma4_text``.
@@ -266,7 +302,6 @@ def _load_gemma4_unified_text(load_path: str, config: dict) -> tuple[Any, Any]:
     import glob
 
     import mlx.core as mx
-    import mlx.nn as nn
     import mlx_lm
     from mlx_lm.models import gemma4_text
 
@@ -276,14 +311,6 @@ def _load_gemma4_unified_text(load_path: str, config: dict) -> tuple[Any, Any]:
     text_cfg["model_type"] = "gemma4_text"
     args = gemma4_text.ModelArgs.from_dict(text_cfg)
     model = gemma4_text.Model(args)
-
-    quant = config.get("quantization") or config.get("quantization_config")
-    if quant:
-        nn.quantize(
-            model,
-            group_size=quant.get("group_size", 64),
-            bits=quant.get("bits", 4),
-        )
 
     weights: dict[str, Any] = {}
     for shard in sorted(glob.glob(str(Path(load_path) / "*.safetensors"))):
@@ -302,6 +329,15 @@ def _load_gemma4_unified_text(load_path: str, config: dict) -> tuple[Any, Any]:
             f"'{prefix}*' weights; cannot load the language tower."
         )
     lang_weights = model.sanitize(lang_weights)
+
+    # Quantize *before* loading so the packed param shapes match the stored
+    # weights.  These checkpoints carry mixed precision (a global bits plus
+    # per-module 8-bit overrides), so quantize from the per-layer config rather
+    # than a single blanket bits — sanitize first to mirror mlx-lm's order.
+    quant = config.get("quantization") or config.get("quantization_config")
+    if quant:
+        _quantize_language_tower(model, quant, lang_weights, prefix)
+
     model.load_weights(list(lang_weights.items()), strict=True)
     mx.eval(model.parameters())
 

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1123,6 +1123,91 @@ class TestGemma4UnifiedTextLoader:
         assert called["cfg"]["model_type"] == "gemma4_unified"
 
 
+class TestQuantizeLanguageTower:
+    """The rebuilt language tower must honor the checkpoint's *per-layer*
+    quantization overrides.  mlx-community 'gemma4_unified' checkpoints carry
+    mixed precision (a global ``bits``/``group_size`` plus per-module overrides,
+    e.g. MLP projections at 8-bit) keyed by the full ``language_model.*`` path.
+    A blanket ``nn.quantize`` at the global bits builds QuantizedLinear params
+    whose packed shapes mismatch the stored 8-bit weights, so the strict load
+    raises ``Expected shape ... but received shape ...`` — the original failure.
+    """
+
+    def test_honors_per_layer_bit_overrides(self):
+        import mlx.core as mx
+        import mlx.nn as nn
+        from mlx.utils import tree_flatten
+
+        from olmlx.engine.model_manager import _quantize_language_tower
+
+        class Tower(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = [nn.Linear(128, 256, bias=False) for _ in range(2)]
+
+        # Reference checkpoint: layer 0 at 8-bit, layer 1 at the global 4-bit.
+        ref = Tower()
+
+        def ref_predicate(path, module):
+            return {"group_size": 64, "bits": 8 if path == "layers.0" else 4}
+
+        nn.quantize(ref, group_size=64, bits=4, class_predicate=ref_predicate)
+        mx.eval(ref.parameters())
+        lang_weights = dict(tree_flatten(ref.parameters()))
+
+        # 4-bit packs in_features/8 columns, 8-bit packs in_features/4 — so the
+        # mixed precision yields differently shaped weights that only load if
+        # the target is quantized with matching per-layer bits.
+        assert lang_weights["layers.0.weight"].shape == (256, 32)  # 8-bit
+        assert lang_weights["layers.1.weight"].shape == (256, 16)  # 4-bit
+
+        quant = {
+            "group_size": 64,
+            "bits": 4,
+            "mode": "affine",
+            "language_model.layers.0": {"group_size": 64, "bits": 8},
+        }
+        target = Tower()
+        _quantize_language_tower(target, quant, lang_weights)
+
+        # Strict load proves every packed param shape matches the checkpoint.
+        target.load_weights(list(lang_weights.items()), strict=True)
+        assert target.layers[0].bits == 8
+        assert target.layers[1].bits == 4
+
+    def test_skips_unquantized_modules(self):
+        """A module absent from the quant dict and not stored as quantized
+        (no ``.scales``) must be left in full precision."""
+        import mlx.core as mx
+        import mlx.nn as nn
+        from mlx.utils import tree_flatten
+
+        from olmlx.engine.model_manager import _quantize_language_tower
+
+        class Tower(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.quantized = nn.Linear(128, 256, bias=False)
+                self.plain = nn.Linear(128, 256, bias=False)
+
+        ref = Tower()
+        nn.quantize(
+            ref,
+            group_size=64,
+            bits=4,
+            class_predicate=lambda p, m: p == "quantized",
+        )
+        mx.eval(ref.parameters())
+        lang_weights = dict(tree_flatten(ref.parameters()))
+
+        target = Tower()
+        _quantize_language_tower(target, {"group_size": 64, "bits": 4}, lang_weights)
+        target.load_weights(list(lang_weights.items()), strict=True)
+
+        assert hasattr(target.quantized, "bits")  # quantized
+        assert not hasattr(target.plain, "bits")  # left full precision
+
+
 class TestProbeCacheCapabilities:
     """Exercise _probe_cache_capabilities, including the probe-failure path
     promoted to WARNING + non-persistable default in issue #284."""


### PR DESCRIPTION
## Problem

Pulling `mlx-community/gemma-4-12B-4bit` (a `gemma4_unified` checkpoint) and requesting it fails with a 400. The log shows:

```
mlx-lm failed for mlx-community/gemma-4-12B-4bit (Expected shape (15360, 480)
  but received shape (15360, 960) for parameter model.layers.0.mlp.gate_proj.weight),
  trying mlx-vlm
Model type gemma4_unified not supported. Error: No module named 'mlx_vlm.models.gemma4_unified'
```

The dedicated `gemma4_unified` text loader **does** fire, but `_load_gemma4_unified_text` quantized the rebuilt language tower with a single blanket `bits`. This checkpoint ships **mixed-precision** quantization — a global 4-bit plus per-module **8-bit** overrides on the MLP projections (`gate_proj`/`up_proj`/`down_proj`), keyed by the full `language_model.*` path:

```json
"quantization": {
  "group_size": 64, "bits": 4,
  "language_model.model.layers.0.mlp.gate_proj": { "group_size": 64, "bits": 8 },
  ...
}
```

`gate_proj` is `[15360, 3840]`: 4-bit packs to 3840/8 = **480** cols, 8-bit to 3840/4 = **960**. Blanket 4-bit builds 480-col params while the checkpoint stored 960 → `load_weights(strict=True)` mismatches → falls back to mlx-vlm (no `gemma4_unified` module) → 400.

## Fix

- New `_quantize_language_tower()` with a `class_predicate` mirroring mlx-lm's own `load_model`: per-layer overrides win (mapping the stripped tower paths back to the prefixed config keys), and modules left in full precision by the checkpoint (no `.scales`) are skipped.
- Reorder the loader to `sanitize -> quantize-with-predicate -> strict-load`, matching mlx-lm's order.

## Tests

- `tests/test_model_manager.py::TestQuantizeLanguageTower` — TDD, written failing first: builds a tiny mixed-precision checkpoint and asserts the strict load succeeds and per-layer bits are preserved; a second test confirms unquantized modules are left alone.
- Verified on the **real** `gemma-4-12B-4bit` weights: tower loads with `mlp.gate_proj` at 8-bit / `self_attn.q_proj` at 4-bit and generates coherent text.
- Full `tests/test_model_manager.py` (258) passes; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)