### PR TITLE
fix(embeddings): report usage.prompt_tokens for /v1/embeddings (#566)

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -4607,8 +4607,12 @@ async def generate_embeddings(
     model_name: str,
     texts: list[str],
     keep_alive: int | str | None = None,
-) -> list[list[float]]:
-    """Generate embeddings using the model's hidden states or embed_tokens layer."""
+) -> tuple[list[list[float]], int]:
+    """Generate embeddings using the model's hidden states or embed_tokens layer.
+
+    Returns ``(embeddings, total_tokens)`` where ``total_tokens`` is the summed
+    token count across all inputs (for OpenAI ``usage.prompt_tokens``).
+    """
     lm = await manager.ensure_loaded(model_name, keep_alive, pin=True)
 
     try:
@@ -4625,6 +4629,7 @@ async def generate_embeddings(
                 _inference_ref(lm, keep_alive=keep_alive, adopt=True),
             ):
                 embeddings = []
+                total_tokens = 0
 
                 tokenizer = lm.text_tokenizer
 
@@ -4636,6 +4641,7 @@ async def generate_embeddings(
 
                 for text in texts:
                     tokens = tokenizer.encode(text)
+                    total_tokens += len(tokens)
                     input_ids = mx.array([tokens])
 
                     if embed_layer is not None:
@@ -4685,7 +4691,7 @@ async def generate_embeddings(
                         "embeddings post-compute sync failed — next inference will crash",
                         exc_info=True,
                     )
-                return embeddings
+                return embeddings, total_tokens
     finally:
         lm.release_ref()
 

--- a/olmlx/routers/embed.py
+++ b/olmlx/routers/embed.py
@@ -18,7 +18,7 @@ async def embed(req: EmbedRequest, request: Request):
     texts = req.input if isinstance(req.input, list) else [req.input]
 
     with Timer() as t:
-        embeddings = await generate_embeddings(
+        embeddings, _ = await generate_embeddings(
             manager, req.model, texts, keep_alive=req.keep_alive
         )
 
@@ -33,7 +33,7 @@ async def embed(req: EmbedRequest, request: Request):
 async def embeddings(req: EmbeddingsRequest, request: Request):
     manager = request.app.state.model_manager
 
-    result = await generate_embeddings(
+    result, _ = await generate_embeddings(
         manager, req.model, [req.prompt], keep_alive=req.keep_alive
     )
 

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -573,7 +573,7 @@ async def openai_list_models(request: Request):
 async def openai_embeddings(req: OpenAIEmbeddingRequest, request: Request):
     manager = request.app.state.model_manager
     texts = req.input if isinstance(req.input, list) else [req.input]
-    embeddings = await generate_embeddings(manager, req.model, texts)
+    embeddings, prompt_tokens = await generate_embeddings(manager, req.model, texts)
     if req.encoding_format == "base64":
         # OpenAI's base64 format packs each embedding as little-endian
         # float32 bytes, then base64-encodes the result into a string.
@@ -594,4 +594,5 @@ async def openai_embeddings(req: OpenAIEmbeddingRequest, request: Request):
     return OpenAIEmbeddingResponse(
         data=data,
         model=req.model,
+        usage=OpenAIUsage(prompt_tokens=prompt_tokens, total_tokens=prompt_tokens),
     )

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2922,7 +2922,7 @@ class TestGenerateEmbeddings:
         model.model = MagicMock()
         model.model.embed_tokens = MagicMock(return_value=mx.zeros((1, 3, 4)))
 
-        result = await generate_embeddings(mock_manager, "qwen3", ["hello"])
+        result, _ = await generate_embeddings(mock_manager, "qwen3", ["hello"])
         assert len(result) == 1
         assert len(result[0]) == 4
 
@@ -2936,7 +2936,7 @@ class TestGenerateEmbeddings:
         model.model = MagicMock(spec=[])  # no embed_tokens attribute
         model.return_value = mx.zeros((3, 4))
 
-        result = await generate_embeddings(mock_manager, "qwen3", ["hello"])
+        result, _ = await generate_embeddings(mock_manager, "qwen3", ["hello"])
         assert len(result) == 1
         assert len(result[0]) == 4
 
@@ -2950,7 +2950,7 @@ class TestGenerateEmbeddings:
         model.model = MagicMock()
         model.model.embed_tokens = MagicMock(return_value=mx.zeros((4,)))
 
-        result = await generate_embeddings(mock_manager, "qwen3", ["hello"])
+        result, _ = await generate_embeddings(mock_manager, "qwen3", ["hello"])
         assert len(result) == 1
         assert len(result[0]) == 4
 
@@ -2964,8 +2964,25 @@ class TestGenerateEmbeddings:
         model.model = MagicMock()
         model.model.embed_tokens = MagicMock(return_value=mx.zeros((1, 3, 4)))
 
-        result = await generate_embeddings(mock_manager, "qwen3", ["hello", "world"])
+        result, _ = await generate_embeddings(mock_manager, "qwen3", ["hello", "world"])
         assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_correct_token_count(self, mock_manager):
+        import mlx.core as mx
+
+        # _setup_tokenizer stubs encode() to return a fixed 3-token list.
+        self._setup_tokenizer(mock_manager)
+
+        model = mock_manager._loaded["qwen3:latest"].model
+        model.model = MagicMock()
+        model.model.embed_tokens = MagicMock(return_value=mx.zeros((1, 3, 4)))
+
+        _result, total_tokens = await generate_embeddings(
+            mock_manager, "qwen3", ["hello", "world"]
+        )
+        # Two texts, each encoding to 3 tokens -> 6 total (accumulated sum).
+        assert total_tokens == 6
 
     @pytest.mark.asyncio
     async def test_sync_mode_none_still_syncs_metal(self, mock_manager):
@@ -2986,7 +3003,7 @@ class TestGenerateEmbeddings:
         model.model.embed_tokens = MagicMock(return_value=mx.zeros((1, 3, 4)))
 
         with patch.object(_inf_mod.mx, "synchronize") as mock_sync:
-            result = await generate_embeddings(mock_manager, "qwen3", ["hello"])
+            result, _ = await generate_embeddings(mock_manager, "qwen3", ["hello"])
         assert len(result) == 1
         # Under sync_mode="none" the lock-boundary _lock_boundary_sync() calls
         # are no-ops (they return before calling mx.synchronize), so any
@@ -3080,7 +3097,7 @@ class TestGenerateEmbeddingsAcquiresLock:
             order.append("lock_released")
 
         # Now it should complete
-        result = await task
+        result, _ = await task
         order.append("embeddings_done")
         assert order == ["lock_released", "embeddings_done"]
         assert len(result) == 1

--- a/tests/test_routers_embed.py
+++ b/tests/test_routers_embed.py
@@ -11,7 +11,7 @@ class TestEmbedRouter:
         with patch(
             "olmlx.routers.embed.generate_embeddings", new_callable=AsyncMock
         ) as mock_emb:
-            mock_emb.return_value = [[0.1, 0.2, 0.3]]
+            mock_emb.return_value = ([[0.1, 0.2, 0.3]], 1)
             resp = await app_client.post(
                 "/api/embed",
                 json={
@@ -31,7 +31,7 @@ class TestEmbedRouter:
         with patch(
             "olmlx.routers.embed.generate_embeddings", new_callable=AsyncMock
         ) as mock_emb:
-            mock_emb.return_value = [[0.1], [0.2]]
+            mock_emb.return_value = ([[0.1], [0.2]], 2)
             resp = await app_client.post(
                 "/api/embed",
                 json={
@@ -49,7 +49,7 @@ class TestEmbedRouter:
         with patch(
             "olmlx.routers.embed.generate_embeddings", new_callable=AsyncMock
         ) as mock_emb:
-            mock_emb.return_value = [[0.5, 0.6]]
+            mock_emb.return_value = ([[0.5, 0.6]], 1)
             resp = await app_client.post(
                 "/api/embeddings",
                 json={

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -414,7 +414,7 @@ class TestOpenAIRouter:
         with patch(
             "olmlx.routers.openai.generate_embeddings", new_callable=AsyncMock
         ) as mock_emb:
-            mock_emb.return_value = [[0.1, 0.2, 0.3]]
+            mock_emb.return_value = ([[0.1, 0.2, 0.3]], 2)
             resp = await app_client.post(
                 "/v1/embeddings",
                 json={
@@ -430,11 +430,27 @@ class TestOpenAIRouter:
         assert data["data"][0]["embedding"] == [0.1, 0.2, 0.3]
 
     @pytest.mark.asyncio
+    async def test_embeddings_usage_reflects_token_count(self, app_client):
+        with patch(
+            "olmlx.routers.openai.generate_embeddings", new_callable=AsyncMock
+        ) as mock_emb:
+            mock_emb.return_value = ([[0.1, 0.2, 0.3]], 5)
+            resp = await app_client.post(
+                "/v1/embeddings",
+                json={"model": "qwen3", "input": "hello world"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["usage"]["prompt_tokens"] == 5
+        assert data["usage"]["total_tokens"] == 5
+        assert data["usage"]["completion_tokens"] == 0
+
+    @pytest.mark.asyncio
     async def test_embeddings_list_input(self, app_client):
         with patch(
             "olmlx.routers.openai.generate_embeddings", new_callable=AsyncMock
         ) as mock_emb:
-            mock_emb.return_value = [[0.1], [0.2]]
+            mock_emb.return_value = ([[0.1], [0.2]], 4)
             resp = await app_client.post(
                 "/v1/embeddings",
                 json={
@@ -455,7 +471,7 @@ class TestOpenAIRouter:
         with patch(
             "olmlx.routers.openai.generate_embeddings", new_callable=AsyncMock
         ) as mock_emb:
-            mock_emb.return_value = [[0.1, 0.2, 0.3]]
+            mock_emb.return_value = ([[0.1, 0.2, 0.3]], 2)
             resp = await app_client.post(
                 "/v1/embeddings",
                 json={
@@ -477,7 +493,7 @@ class TestOpenAIRouter:
         with patch(
             "olmlx.routers.openai.generate_embeddings", new_callable=AsyncMock
         ) as mock_emb:
-            mock_emb.return_value = [[0.1, 0.2, 0.3]]
+            mock_emb.return_value = ([[0.1, 0.2, 0.3]], 2)
             resp = await app_client.post(
                 "/v1/embeddings",
                 json={


### PR DESCRIPTION
## Summary

Fixes #566. The OpenAI-compatible `/v1/embeddings` endpoint always returned `usage: {prompt_tokens: 0, total_tokens: 0}` regardless of input size, because `generate_embeddings` discarded the per-text token counts it already computes and the router never tokenized the input.

- `engine/inference.py` — `generate_embeddings` accumulates `total_tokens` (summed over the batch, reusing the `encode()` already done to build `input_ids`) and returns `(embeddings, total_tokens)`.
- `routers/openai.py` — wires the count into `usage.prompt_tokens` / `usage.total_tokens`; `completion_tokens` stays `0` (embeddings have no completion phase).
- `routers/embed.py` — Ollama `/api/embed` and `/api/embeddings` discard the count; their schemas have no usage field.

## Testing

TDD: failing tests written first, then the fix.

- New `test_embeddings_usage_reflects_token_count` (OpenAI router) and `test_returns_correct_token_count` (inference, verifies the sum across a 2-text batch).
- Mechanical mock/unpack updates for the new tuple return shape.
- Affected suites + `test_app.py` pass; ruff lint + format clean.

No CLAUDE.md invariants affected: the added line is pure Python integer arithmetic and the load-bearing `mx.synchronize()` Metal barrier is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)