### PR TITLE
feat(ui): minimal operator dashboard at / (#373)

### DIFF
--- a/olmlx/app.py
+++ b/olmlx/app.py
@@ -4,9 +4,12 @@ import traceback
 import uuid
 from contextlib import asynccontextmanager
 
+from pathlib import Path
+
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from olmlx.config import settings
@@ -446,6 +449,14 @@ def create_app() -> FastAPI:
     app.include_router(audio.router)
     app.include_router(anthropic.router)
     app.include_router(metrics_router.router)
+
+    # Operator web UI (#373): the single-page dashboard's static assets
+    # (app.js, style.css, index.html) are served from olmlx/ui/. The root "/"
+    # itself content-negotiates in status.router so heartbeat clients keep the
+    # plain-text response.
+    ui_dir = Path(__file__).resolve().parent / "ui"
+    if ui_dir.is_dir():
+        app.mount("/ui", StaticFiles(directory=ui_dir), name="ui")
 
     # Autonomous agent (#445): the HTTP surface and run registry only exist
     # when explicitly enabled. The service resolves the model manager lazily

--- a/olmlx/routers/status.py
+++ b/olmlx/routers/status.py
@@ -1,8 +1,9 @@
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 
 from fastapi import APIRouter, Request
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import FileResponse, PlainTextResponse
 
 from olmlx import __version__
 from olmlx.schemas.models import ModelDetails
@@ -10,9 +11,20 @@ from olmlx.schemas.status import PsResponse, RunningModel, VersionResponse
 
 router = APIRouter()
 
+_UI_INDEX = Path(__file__).resolve().parent.parent / "ui" / "index.html"
+
+
+def _wants_html(request: Request) -> bool:
+    """Browsers send ``Accept: text/html``; API/heartbeat clients (curl, the
+    Ollama Go client) send ``*/*`` or a JSON type. Only browsers get the UI so
+    existing ``/`` heartbeat integrations keep their plain-text response."""
+    return "text/html" in request.headers.get("accept", "") and _UI_INDEX.exists()
+
 
 @router.get("/")
-async def root():
+async def root(request: Request):
+    if _wants_html(request):
+        return FileResponse(_UI_INDEX, media_type="text/html")
     return PlainTextResponse("Ollama is running")
 
 

--- a/olmlx/ui/app.js
+++ b/olmlx/ui/app.js
@@ -7,6 +7,16 @@ const POLL_MS = 3000;
 
 const $ = (id) => document.getElementById(id);
 
+// Append text cells safely — model names are untrusted (a model can be pulled
+// under an arbitrary name), so values go through textContent, never innerHTML.
+function addCells(tr, values) {
+  for (const v of values) {
+    const td = document.createElement("td");
+    td.textContent = v;
+    tr.appendChild(td);
+  }
+}
+
 function fmtBytes(n) {
   if (!n || n <= 0) return "–";
   const units = ["B", "KB", "MB", "GB", "TB"];
@@ -52,7 +62,11 @@ function parseMetrics(text) {
     const labels = {};
     if (br >= 0) {
       const inner = left.slice(br + 1, left.lastIndexOf("}"));
-      for (const m of inner.matchAll(/(\w+)="([^"]*)"/g)) labels[m[1]] = m[2];
+      // Label values are quoted with \\, \" and \n escapes per the Prometheus
+      // exposition format; match across escapes, then unescape.
+      for (const m of inner.matchAll(/(\w+)="((?:\\.|[^"\\])*)"/g)) {
+        labels[m[1]] = m[2].replace(/\\n/g, "\n").replace(/\\(["\\])/g, "$1");
+      }
     }
     (out[name] ||= []).push({ labels, value });
   }
@@ -129,9 +143,7 @@ function renderRunning(models) {
   for (const m of models) {
     const tr = document.createElement("tr");
     const quant = m.details?.quantization_level || "–";
-    tr.innerHTML =
-      `<td>${m.name}</td><td>${fmtBytes(m.size)}</td><td>${quant}</td>` +
-      `<td>${m.active_refs ?? 0}</td><td>${fmtExpires(m.expires_at)}</td>`;
+    addCells(tr, [m.name, fmtBytes(m.size), quant, m.active_refs ?? 0, fmtExpires(m.expires_at)]);
     const td = document.createElement("td");
     const btn = document.createElement("button");
     btn.textContent = "Unload";
@@ -153,7 +165,7 @@ function renderAvailable(models, runningNames) {
   }
   for (const m of models) {
     const tr = document.createElement("tr");
-    tr.innerHTML = `<td>${m.name}</td><td>${fmtBytes(m.size)}</td>`;
+    addCells(tr, [m.name, fmtBytes(m.size)]);
     const td = document.createElement("td");
     if (!runningNames.has(m.name)) {
       const btn = document.createElement("button");
@@ -225,6 +237,16 @@ async function pull(model) {
           log.textContent += `${line}\n`;
         }
         log.scrollTop = log.scrollHeight;
+      }
+    }
+    // Flush any trailing partial line the stream ended without a newline.
+    buf += decoder.decode();
+    if (buf.trim()) {
+      try {
+        const obj = JSON.parse(buf);
+        log.textContent += `${obj.status || JSON.stringify(obj)}\n`;
+      } catch {
+        log.textContent += `${buf}\n`;
       }
     }
     log.textContent += "done.\n";

--- a/olmlx/ui/app.js
+++ b/olmlx/ui/app.js
@@ -1,0 +1,246 @@
+"use strict";
+
+// Minimal operator dashboard for olmlx (#373). No framework, no build step:
+// polls the existing JSON + Prometheus endpoints and renders plain DOM.
+
+const POLL_MS = 3000;
+
+const $ = (id) => document.getElementById(id);
+
+function fmtBytes(n) {
+  if (!n || n <= 0) return "–";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let i = 0;
+  let v = n;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v.toFixed(v >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function fmtExpires(iso) {
+  if (!iso) return "–";
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "–";
+  const secs = Math.round((t - Date.now()) / 1000);
+  if (secs <= 0) return "expired";
+  if (secs < 60) return `${secs}s`;
+  if (secs < 3600) return `${Math.round(secs / 60)}m`;
+  return `${Math.round(secs / 3600)}h`;
+}
+
+function setConn(ok) {
+  const el = $("conn");
+  el.textContent = ok ? "connected" : "disconnected";
+  el.className = `badge ${ok ? "ok" : "down"}`;
+}
+
+// Parse Prometheus text exposition into {name: [{labels, value}]}.
+function parseMetrics(text) {
+  const out = {};
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const sp = line.lastIndexOf(" ");
+    if (sp < 0) continue;
+    const left = line.slice(0, sp);
+    const value = parseFloat(line.slice(sp + 1));
+    if (Number.isNaN(value)) continue;
+    const br = left.indexOf("{");
+    const name = br < 0 ? left : left.slice(0, br);
+    const labels = {};
+    if (br >= 0) {
+      const inner = left.slice(br + 1, left.lastIndexOf("}"));
+      for (const m of inner.matchAll(/(\w+)="([^"]*)"/g)) labels[m[1]] = m[2];
+    }
+    (out[name] ||= []).push({ labels, value });
+  }
+  return out;
+}
+
+function sumSeries(series) {
+  return (series || []).reduce((a, s) => a + s.value, 0);
+}
+
+function histogramAvg(metrics, base) {
+  const sum = sumSeries(metrics[`${base}_sum`]);
+  const count = sumSeries(metrics[`${base}_count`]);
+  return count > 0 ? sum / count : null;
+}
+
+function renderStats(metrics, runningCount) {
+  $("stat-loaded").textContent =
+    runningCount != null ? runningCount : sumSeries(metrics.olmlx_loaded_models) || "0";
+
+  const tps =
+    histogramAvg(metrics, "olmlx_inference_decode_tokens_per_second") ??
+    sumSeries(metrics.olmlx_inference_decode_tokens_per_second);
+  $("stat-tps").textContent = tps ? tps.toFixed(1) : "–";
+
+  const inflight = sumSeries(metrics.olmlx_http_requests_in_flight);
+  $("stat-inflight").textContent = Number.isFinite(inflight) ? inflight : "–";
+
+  const lookups = metrics.olmlx_prompt_cache_lookups_total || [];
+  let hits = 0;
+  let total = 0;
+  for (const s of lookups) {
+    total += s.value;
+    const r = (s.labels.result || s.labels.outcome || "").toLowerCase();
+    if (r === "hit") hits += s.value;
+  }
+  $("stat-cache").textContent = total > 0 ? `${Math.round((hits / total) * 100)}%` : "–";
+}
+
+async function unload(name, btn) {
+  btn.disabled = true;
+  try {
+    await fetch("/api/unload", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: name }),
+    });
+  } finally {
+    refresh();
+  }
+}
+
+async function warmup(name, btn) {
+  btn.disabled = true;
+  btn.textContent = "loading…";
+  try {
+    await fetch("/api/warmup", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: name }),
+    });
+  } finally {
+    refresh();
+  }
+}
+
+function renderRunning(models) {
+  const body = $("running-body");
+  body.innerHTML = "";
+  if (!models.length) {
+    body.innerHTML = '<tr><td colspan="6" class="muted">no models loaded</td></tr>';
+    return;
+  }
+  for (const m of models) {
+    const tr = document.createElement("tr");
+    const quant = m.details?.quantization_level || "–";
+    tr.innerHTML =
+      `<td>${m.name}</td><td>${fmtBytes(m.size)}</td><td>${quant}</td>` +
+      `<td>${m.active_refs ?? 0}</td><td>${fmtExpires(m.expires_at)}</td>`;
+    const td = document.createElement("td");
+    const btn = document.createElement("button");
+    btn.textContent = "Unload";
+    btn.className = "danger";
+    btn.disabled = (m.active_refs ?? 0) > 0;
+    btn.onclick = () => unload(m.name, btn);
+    td.appendChild(btn);
+    tr.appendChild(td);
+    body.appendChild(tr);
+  }
+}
+
+function renderAvailable(models, runningNames) {
+  const body = $("available-body");
+  body.innerHTML = "";
+  if (!models.length) {
+    body.innerHTML = '<tr><td colspan="3" class="muted">no models installed</td></tr>';
+    return;
+  }
+  for (const m of models) {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `<td>${m.name}</td><td>${fmtBytes(m.size)}</td>`;
+    const td = document.createElement("td");
+    if (!runningNames.has(m.name)) {
+      const btn = document.createElement("button");
+      btn.textContent = "Load";
+      btn.onclick = () => warmup(m.name, btn);
+      td.appendChild(btn);
+    } else {
+      td.innerHTML = '<span class="muted">loaded</span>';
+    }
+    tr.appendChild(td);
+    body.appendChild(tr);
+  }
+}
+
+async function refresh() {
+  try {
+    const [psRes, tagsRes, metricsRes, verRes] = await Promise.all([
+      fetch("/api/ps"),
+      fetch("/api/tags"),
+      fetch("/metrics"),
+      fetch("/api/version"),
+    ]);
+    const ps = await psRes.json();
+    const tags = await tagsRes.json();
+    const metrics = parseMetrics(await metricsRes.text());
+    const ver = await verRes.json().catch(() => ({}));
+
+    const running = ps.models || [];
+    const runningNames = new Set(running.map((m) => m.name));
+    renderRunning(running);
+    renderAvailable(tags.models || [], runningNames);
+    renderStats(metrics, running.length);
+    if (ver.version) $("version").textContent = `v${ver.version}`;
+    setConn(true);
+  } catch (e) {
+    setConn(false);
+  }
+}
+
+async function pull(model) {
+  const log = $("pull-log");
+  log.hidden = false;
+  log.textContent = `Pulling ${model}…\n`;
+  try {
+    const res = await fetch("/api/pull", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model, stream: true }),
+    });
+    if (!res.body) {
+      log.textContent += await res.text();
+      return;
+    }
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      const lines = buf.split("\n");
+      buf = lines.pop();
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const obj = JSON.parse(line);
+          log.textContent += `${obj.status || JSON.stringify(obj)}\n`;
+        } catch {
+          log.textContent += `${line}\n`;
+        }
+        log.scrollTop = log.scrollHeight;
+      }
+    }
+    log.textContent += "done.\n";
+  } catch (e) {
+    log.textContent += `error: ${e}\n`;
+  } finally {
+    refresh();
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  $("pull-form").addEventListener("submit", (e) => {
+    e.preventDefault();
+    const v = $("pull-input").value.trim();
+    if (v) pull(v);
+  });
+  refresh();
+  setInterval(refresh, POLL_MS);
+});

--- a/olmlx/ui/index.html
+++ b/olmlx/ui/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>olmlx · dashboard</title>
+  <link rel="stylesheet" href="/ui/style.css" />
+</head>
+<body>
+  <header>
+    <h1>olmlx</h1>
+    <span id="version" class="muted"></span>
+    <span id="conn" class="badge"></span>
+  </header>
+
+  <main>
+    <section id="stats-section">
+      <h2>Live stats</h2>
+      <div class="cards" id="stat-cards">
+        <div class="card"><div class="card-label">Loaded models</div><div class="card-value" id="stat-loaded">–</div></div>
+        <div class="card"><div class="card-label">Decode tokens/sec</div><div class="card-value" id="stat-tps">–</div></div>
+        <div class="card"><div class="card-label">In-flight requests</div><div class="card-value" id="stat-inflight">–</div></div>
+        <div class="card"><div class="card-label">Prompt-cache hit ratio</div><div class="card-value" id="stat-cache">–</div></div>
+      </div>
+    </section>
+
+    <section id="running-section">
+      <h2>Running models</h2>
+      <table id="running-table">
+        <thead>
+          <tr><th>Name</th><th>Size</th><th>Quant</th><th>Refs</th><th>Expires</th><th></th></tr>
+        </thead>
+        <tbody id="running-body"><tr><td colspan="6" class="muted">loading…</td></tr></tbody>
+      </table>
+    </section>
+
+    <section id="pull-section">
+      <h2>Pull a model</h2>
+      <form id="pull-form">
+        <input type="text" id="pull-input" placeholder="e.g. mlx-community/Qwen3-4B-4bit" autocomplete="off" />
+        <button type="submit">Pull</button>
+      </form>
+      <pre id="pull-log" class="log" hidden></pre>
+    </section>
+
+    <section id="available-section">
+      <h2>Available models</h2>
+      <table id="available-table">
+        <thead><tr><th>Name</th><th>Size</th><th></th></tr></thead>
+        <tbody id="available-body"><tr><td colspan="3" class="muted">loading…</td></tr></tbody>
+      </table>
+    </section>
+  </main>
+
+  <footer class="muted">olmlx operator dashboard · polls every 3s</footer>
+  <script src="/ui/app.js"></script>
+</body>
+</html>

--- a/olmlx/ui/style.css
+++ b/olmlx/ui/style.css
@@ -1,0 +1,127 @@
+:root {
+  --bg: #0f1115;
+  --panel: #1a1d24;
+  --border: #2a2f3a;
+  --text: #e6e8eb;
+  --muted: #8b93a1;
+  --accent: #4f9cf9;
+  --danger: #e5534b;
+  --ok: #3fb950;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+header h1 { margin: 0; font-size: 1.4rem; }
+
+main {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+section { margin-bottom: 2rem; }
+
+h2 {
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.4rem;
+}
+
+.muted { color: var(--muted); font-size: 0.85rem; }
+
+.badge {
+  margin-left: auto;
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+.badge.ok { color: var(--ok); border-color: var(--ok); }
+.badge.down { color: var(--danger); border-color: var(--danger); }
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1rem;
+}
+.card-label { font-size: 0.8rem; color: var(--muted); }
+.card-value { font-size: 1.6rem; font-weight: 600; margin-top: 0.25rem; }
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+th, td {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border);
+}
+th { color: var(--muted); font-weight: 500; }
+
+button {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.4rem 0.8rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+button:hover { filter: brightness(1.1); }
+button.danger { background: var(--danger); }
+button:disabled { opacity: 0.5; cursor: default; }
+
+#pull-form { display: flex; gap: 0.5rem; }
+#pull-input {
+  flex: 1;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.9rem;
+}
+
+.log {
+  background: #000;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.75rem;
+  margin-top: 0.75rem;
+  max-height: 220px;
+  overflow-y: auto;
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+}
+
+footer {
+  text-align: center;
+  padding: 1.5rem;
+}

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,64 @@
+"""Tests for the minimal operator web UI mounted at / (#373).
+
+The UI is served via content negotiation: browsers (Accept: text/html) get the
+single-page dashboard, while API/heartbeat clients (curl, the Ollama Go client)
+continue to receive the plain-text "Ollama is running" response so existing
+integrations keep working.
+"""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_root_serves_html_to_browsers(app_client):
+    resp = await app_client.get("/", headers={"Accept": "text/html"})
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    body = resp.text
+    assert "<title>olmlx" in body
+    # The dashboard loads its script and stylesheet from the static mount.
+    assert "/ui/app.js" in body
+    assert "/ui/style.css" in body
+
+
+@pytest.mark.asyncio
+async def test_root_plain_text_for_api_clients(app_client):
+    resp = await app_client.get("/", headers={"Accept": "application/json"})
+    assert resp.status_code == 200
+    assert resp.text == "Ollama is running"
+    assert "text/plain" in resp.headers["content-type"]
+
+
+@pytest.mark.asyncio
+async def test_root_default_accept_is_plain_text(app_client):
+    """Default httpx Accept is */* — heartbeat clients must keep the plain text."""
+    resp = await app_client.get("/")
+    assert resp.status_code == 200
+    assert resp.text == "Ollama is running"
+
+
+@pytest.mark.asyncio
+async def test_head_root_ok(app_client):
+    resp = await app_client.head("/")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_static_app_js_served(app_client):
+    resp = await app_client.get("/ui/app.js")
+    assert resp.status_code == 200
+    assert "javascript" in resp.headers["content-type"]
+
+
+@pytest.mark.asyncio
+async def test_static_style_css_served(app_client):
+    resp = await app_client.get("/ui/style.css")
+    assert resp.status_code == 200
+    assert "css" in resp.headers["content-type"]
+
+
+@pytest.mark.asyncio
+async def test_index_html_served_from_static_mount(app_client):
+    resp = await app_client.get("/ui/index.html")
+    assert resp.status_code == 200
+    assert "<title>olmlx" in resp.text


### PR DESCRIPTION
Closes #373.

## What

A no-build, single-page **operator dashboard** served at `/`, for the Ollama-desktop crowd who expect a UI at the server root. This is an operator dashboard (models loaded, memory, hit ratios), **not** a chat UI — terminal chat remains the chat experience.

## How

- New static assets under `olmlx/ui/` — `index.html`, `app.js`, `style.css`. Vanilla JS, no framework, no build step, no runtime dev-server. Bundle is a few KB (well under the 1 MB budget).
- Mounted at `/ui` via `StaticFiles` in `create_app()`.
- Root `/` **content-negotiates**: browsers (`Accept: text/html`) get the dashboard; API/heartbeat clients (curl, the Ollama Go client, `*/*`) keep the plain-text `"Ollama is running"` response — existing `/` integrations are unaffected. `HEAD /` is unchanged.
- The dashboard polls existing endpoints every 3s:
  - `/api/ps` — running models (size, quant, refs, expiry)
  - `/api/tags` — installed models
  - `/metrics` — Prometheus text, parsed client-side for decode tokens/sec, in-flight requests, prompt-cache hit ratio
  - `/api/version`
- Buttons wired end-to-end: **Pull** (`/api/pull`, streamed ndjson log), **Load** (`/api/warmup`), **Unload** (`/api/unload`).

## Acceptance criteria

- [x] Page loads on `localhost:11434`, shows loaded models and live tokens/sec
- [x] Pull / Load / Unload buttons call the real endpoints
- [x] Bundle well under 1 MB gzipped (vanilla JS, a few KB)
- [x] Static assets land in the hatchling wheel build (verified by building the wheel and inspecting its contents)

## Tests

`tests/test_ui.py` (TDD — written first): root serves HTML to browsers, plain text to API clients (incl. default `*/*`), `HEAD /` ok, and `/ui/app.js` · `/ui/style.css` · `/ui/index.html` are served from the static mount.

## Note on verification

Server-side behaviour (content negotiation, static mount, packaging) is covered by the test suite and a wheel-build check. The client-side metric parsing / polling JS is exercised against the live endpoints in a browser and is written defensively (degrades to "–" / a disconnected badge on any fetch error), but is not unit-tested in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)