### PR TITLE
feat(registry): curated known-drafts map for speculative resolution (#513)

### DIFF
--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -307,6 +307,52 @@ class SpeculativeConfig(NamedTuple):
     proxy_alpha: float = 1.0
 
 
+class KnownDraft(NamedTuple):
+    """A curated speculative draft for a known target model (#513).
+
+    ``block_size`` carries the validated token/block count for the draft
+    (``num_tokens`` for classic, the trained block length for dflash/eagle/mtp);
+    ``None`` defers to the strategy/draft default. ``quant`` records the draft's
+    validated quantization for the compatibility matrix (informational).
+    """
+
+    draft_repo: str
+    strategy: SpeculativeStrategy
+    block_size: int | None = None
+    quant: str | None = None
+
+
+# Curated "known drafts" map: target ``hf_path`` -> matching speculative draft.
+#
+# Consulted by ``ModelConfig.resolved_speculative()`` only when neither a
+# per-model nor a global draft is configured, so that
+# ``OLMLX_SPECULATIVE=true olmlx serve`` on a supported target "just works"
+# with no repo ids to memorise. Draft-model precedence is therefore:
+#
+#     explicit per-model > global env (Settings) > curated map > none
+#
+# Entries are validated draft repos — primarily the olmlx-trained dflash/eagle
+# drafts hosted under the project org (#512) — so this map is intentionally
+# empty until those repos land; it grows as drafts are validated. A worked
+# example of the shape:
+#
+#     "mlx-community/Qwen3-32B-4bit": KnownDraft(
+#         draft_repo="<org>/Qwen3-32B-eagle-draft",
+#         strategy="eagle",
+#         block_size=4,
+#         quant="4bit",
+#     ),
+#
+# Only external-draft strategies belong here (classic/dflash/eagle/mtp); the
+# draft-free strategies (pld, self_speculative) never consult the map.
+KNOWN_DRAFTS: dict[str, KnownDraft] = {}
+
+
+def lookup_known_draft(hf_path: str) -> KnownDraft | None:
+    """Return the curated draft for ``hf_path``, or ``None`` if unknown."""
+    return KNOWN_DRAFTS.get(hf_path)
+
+
 @dataclass
 class ModelConfig:
     """Per-model configuration resolved from models.json."""
@@ -716,6 +762,21 @@ class ModelConfig:
             if self.speculative_draft_model is not None
             else settings.speculative_draft_model
         )
+        # Curated "known drafts" map (#513): only when no explicit per-model or
+        # global draft is configured. The map entry describes a specific draft,
+        # so its strategy/block_size come along with it — but an explicit
+        # per-model strategy / token override still wins.
+        if draft is None:
+            curated = lookup_known_draft(self.hf_path)
+            if curated is not None:
+                draft = curated.draft_repo
+                if self.speculative_strategy is None:
+                    strategy = curated.strategy
+                if (
+                    self.speculative_tokens is None
+                    and settings.speculative_tokens is None
+                ):
+                    tokens = curated.block_size
         return SpeculativeConfig(
             enabled=True,
             draft_model=draft,

--- a/tests/test_known_drafts.py
+++ b/tests/test_known_drafts.py
@@ -1,0 +1,140 @@
+"""Tests for the curated "known drafts" map (#513).
+
+The map auto-fills the speculative draft for a known target when the user
+enables speculative without naming a draft. Resolution precedence for the
+draft model is:
+
+    explicit per-model > global env > curated map > none
+
+When the curated map supplies the draft, it also supplies the matching
+strategy and block_size (those describe that specific draft), but an explicit
+per-model strategy / token override still wins.
+
+Precedence is verified by injecting entries into ``KNOWN_DRAFTS`` with
+monkeypatch so the tests are independent of whatever the shipped map contains.
+"""
+
+import pytest
+
+from olmlx.engine.registry import KnownDraft, ModelConfig, lookup_known_draft
+
+
+@pytest.fixture
+def curated(monkeypatch):
+    """Inject a deterministic curated entry for ``target/model``."""
+    from olmlx.engine import registry
+
+    entry = KnownDraft(
+        draft_repo="curated/draft",
+        strategy="eagle",
+        block_size=5,
+        quant="4bit",
+    )
+    monkeypatch.setitem(registry.KNOWN_DRAFTS, "target/model", entry)
+    return entry
+
+
+def test_lookup_returns_none_for_unknown_target():
+    assert lookup_known_draft("nobody/here") is None
+
+
+def test_curated_fills_draft_when_none_configured(curated, monkeypatch):
+    monkeypatch.setattr("olmlx.config.settings.speculative_draft_model", None)
+    mc = ModelConfig(hf_path="target/model", speculative=True)
+    resolved = mc.resolved_speculative()
+    assert resolved.enabled is True
+    assert resolved.draft_model == "curated/draft"
+    # The map entry's strategy + block_size come along with the draft.
+    assert resolved.strategy == "eagle"
+    assert resolved.num_tokens == 5
+
+
+def test_explicit_per_model_draft_beats_curated(curated):
+    mc = ModelConfig(
+        hf_path="target/model",
+        speculative=True,
+        speculative_draft_model="explicit/draft",
+    )
+    resolved = mc.resolved_speculative()
+    assert resolved.draft_model == "explicit/draft"
+    # The curated strategy must NOT leak in when the map was not the source.
+    assert resolved.strategy == "classic"
+
+
+def test_global_env_draft_beats_curated(curated, monkeypatch):
+    monkeypatch.setattr("olmlx.config.settings.speculative", True)
+    monkeypatch.setattr("olmlx.config.settings.speculative_draft_model", "global/draft")
+    mc = ModelConfig(hf_path="target/model")
+    resolved = mc.resolved_speculative()
+    assert resolved.draft_model == "global/draft"
+    assert resolved.strategy == "classic"
+
+
+def test_per_model_strategy_beats_curated_strategy(curated, monkeypatch):
+    monkeypatch.setattr("olmlx.config.settings.speculative_draft_model", None)
+    mc = ModelConfig(
+        hf_path="target/model",
+        speculative=True,
+        speculative_strategy="dflash",
+    )
+    resolved = mc.resolved_speculative()
+    assert resolved.draft_model == "curated/draft"
+    assert resolved.strategy == "dflash"
+
+
+def test_per_model_tokens_beats_curated_block_size(curated, monkeypatch):
+    monkeypatch.setattr("olmlx.config.settings.speculative_draft_model", None)
+    monkeypatch.setattr("olmlx.config.settings.speculative_tokens", None)
+    mc = ModelConfig(
+        hf_path="target/model",
+        speculative=True,
+        speculative_tokens=12,
+    )
+    resolved = mc.resolved_speculative()
+    assert resolved.draft_model == "curated/draft"
+    assert resolved.num_tokens == 12
+
+
+def test_global_tokens_beats_curated_block_size(curated, monkeypatch):
+    monkeypatch.setattr("olmlx.config.settings.speculative_draft_model", None)
+    monkeypatch.setattr("olmlx.config.settings.speculative_tokens", 9)
+    mc = ModelConfig(hf_path="target/model", speculative=True)
+    resolved = mc.resolved_speculative()
+    assert resolved.draft_model == "curated/draft"
+    assert resolved.num_tokens == 9
+
+
+def test_curated_not_consulted_when_disabled(curated):
+    mc = ModelConfig(hf_path="target/model", speculative=False)
+    resolved = mc.resolved_speculative()
+    assert resolved.enabled is False
+    assert resolved.draft_model is None
+
+
+def test_unknown_target_resolves_to_none(monkeypatch):
+    monkeypatch.setattr("olmlx.config.settings.speculative_draft_model", None)
+    mc = ModelConfig(hf_path="not/in-map", speculative=True)
+    resolved = mc.resolved_speculative()
+    assert resolved.draft_model is None
+
+
+class TestShippedMapWellFormed:
+    """Whatever entries ship in KNOWN_DRAFTS must be structurally valid."""
+
+    def test_entries_well_formed(self):
+        from olmlx.engine.registry import (
+            _VALID_SPECULATIVE_STRATEGIES,
+            KNOWN_DRAFTS,
+        )
+
+        for target, entry in KNOWN_DRAFTS.items():
+            assert isinstance(entry, KnownDraft)
+            # Keys and draft repos are "owner/repo" HF ids.
+            assert target.count("/") == 1, target
+            assert entry.draft_repo.count("/") == 1, entry.draft_repo
+            assert entry.strategy in _VALID_SPECULATIVE_STRATEGIES
+            # Draft-free strategies don't belong in a draft map.
+            assert entry.strategy not in ("pld", "self_speculative")
+            assert entry.block_size is None or (
+                isinstance(entry.block_size, int) and entry.block_size > 0
+            )


### PR DESCRIPTION
Implements the resolution machinery for #513.

## What

A static curated map in the registry — `KNOWN_DRAFTS: dict[hf_path, KnownDraft]` where `KnownDraft = {draft_repo, strategy, block_size, quant}` — that auto-fills the speculative draft for a known target. When a user enables speculative on a supported target *without* naming a draft, the draft is resolved from the map, so:

```
OLMLX_SPECULATIVE=true olmlx serve
```

"just works" on a supported model with no repo ids to memorise.

## How

- `KnownDraft` NamedTuple + `KNOWN_DRAFTS` map + `lookup_known_draft(hf_path)` in `engine/registry.py`.
- The lookup is wired into `ModelConfig.resolved_speculative()` — the **single resolution point** the model loader already consumes — so the load path needs no separate change.
- **Draft-model precedence:** `explicit per-model > global env (Settings) > curated map > none` (exactly as specified in the issue).
- When the map supplies the draft, its `strategy` and `block_size` come along (they describe that specific draft), but an explicit per-model `speculative_strategy` / `speculative_tokens` override still wins. Draft-free strategies (`pld`, `self_speculative`) never consult the map.

## Scope / dependency on #512

The map **ships empty with a documented entry shape**. Its entries are meant to reference the olmlx-trained dflash/eagle drafts hosted under the project org (#512), which don't exist yet — so populating it is deliberately deferred to as those repos are validated, rather than shipping unverifiable repo ids now. This PR lands the resolution mechanism + precedence + tests (the in-scope checkboxes that don't depend on #512). Adding an entry later is a one-line change guarded by the structural test.

## Tests (`tests/test_known_drafts.py`, TDD — written first)

Precedence is verified by injecting entries into `KNOWN_DRAFTS` via `monkeypatch`, so the tests are independent of the shipped (empty) map:
- map fills draft when none configured (and brings its strategy + block_size)
- explicit per-model draft beats curated; global env draft beats curated
- per-model strategy / tokens beat curated; global tokens beat curated block_size
- map not consulted when speculative disabled; unknown target → `None`
- a structural test asserts any shipped entry is well-formed (valid `owner/repo` shape, external-draft strategy, positive `block_size`)

All 10 pass; `test_config.py` / `test_proxy_tuning_config.py` unaffected. Ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)