### PR TITLE
feat(cli): `olmlx models pull --with-draft` co-downloads curated draft (#514)

### DIFF
--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -1886,6 +1886,36 @@ def cmd_models_pull(args):
         async for status in store.pull(args.model_name):
             if msg := status.get("status", ""):
                 print(msg, flush=True)
+        # ``is True`` (not just truthiness): argparse store_true yields a real
+        # bool, so this stays correct while ignoring the truthy MagicMock attrs
+        # bare-mock CLI tests pass for unrelated pull cases.
+        if getattr(args, "with_draft", False) is True:
+            await _pull_draft()
+
+    async def _pull_draft():
+        """Co-download the curated speculative draft for the target (#514)."""
+        from olmlx.engine.registry import lookup_known_draft
+
+        resolved = store.registry.resolve(args.model_name)
+        hf_path = resolved.hf_path if resolved is not None else None
+        draft = lookup_known_draft(hf_path) if hf_path else None
+        if draft is None:
+            print(
+                f"--with-draft: no known speculative draft for "
+                f"{hf_path or args.model_name}; skipping.",
+                flush=True,
+            )
+            return
+        print(f"pulling speculative draft {draft.draft_repo}", flush=True)
+        async for status in store.pull(draft.draft_repo):
+            if msg := status.get("status", ""):
+                print(msg, flush=True)
+        store.register_speculative_draft(args.model_name, hf_path, draft)
+        print(
+            f"wired speculative draft {draft.draft_repo} "
+            f"(strategy={draft.strategy}) into config",
+            flush=True,
+        )
 
     try:
         asyncio.run(_pull())
@@ -3219,6 +3249,12 @@ def build_parser() -> argparse.ArgumentParser:
     mdl_sub.add_parser("list", help="List locally downloaded models")
     pull_p = mdl_sub.add_parser("pull", help="Pull/download a model")
     pull_p.add_argument("model_name", help="Model name or HF path")
+    pull_p.add_argument(
+        "--with-draft",
+        action="store_true",
+        help="Also pull the matching speculative draft (if one is known for "
+        "this target) and wire it into the model's config",
+    )
     show_p = mdl_sub.add_parser("show", help="Show model details")
     show_p.add_argument("model_name", help="Model name or HF path")
     del_p = mdl_sub.add_parser("delete", help="Delete a local model")

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -1895,9 +1895,15 @@ def cmd_models_pull(args):
     async def _pull_draft():
         """Co-download the curated speculative draft for the target (#514)."""
         from olmlx.engine.registry import lookup_known_draft
+        from olmlx.models.store import _strip_ollama_tag
 
         resolved = store.registry.resolve(args.model_name)
         hf_path = resolved.hf_path if resolved is not None else None
+        # The curated map is keyed by the canonical (untagged) hf_path, and a
+        # full-path pull like "org/model:q4" resolves with its tag — strip it
+        # so the lookup matches, mirroring store.pull().
+        if hf_path:
+            hf_path = _strip_ollama_tag(hf_path)
         draft = lookup_known_draft(hf_path) if hf_path else None
         if draft is None:
             print(

--- a/olmlx/models/store.py
+++ b/olmlx/models/store.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import threading
 from collections.abc import AsyncGenerator
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -14,7 +15,7 @@ from olmlx.engine.awq_gptq_converter import (
     converting_marker,
     detect_format,
 )
-from olmlx.engine.registry import ModelRegistry
+from olmlx.engine.registry import KnownDraft, ModelConfig, ModelRegistry
 from olmlx.models.manifest import ModelManifest
 
 logger = logging.getLogger(__name__)
@@ -369,6 +370,29 @@ class ModelStore:
                 self.registry.add_mapping(name, hf_path)
 
             yield {"status": "success"}
+
+    def register_speculative_draft(
+        self, name: str, hf_path: str, draft: KnownDraft
+    ) -> None:
+        """Persist a curated speculative draft onto the target's models.json
+        entry (#514).
+
+        Writes ``speculative=True`` plus the draft's strategy / repo / block
+        size, preserving any existing per-model config on the entry. Like the
+        auto-registration in :meth:`pull`, this mutates the registry and must
+        run on the event-loop thread.
+        """
+        existing = self.registry.resolve(name)
+        base = existing if existing is not None else ModelConfig(hf_path=hf_path)
+        mc = replace(
+            base,
+            hf_path=hf_path,
+            speculative=True,
+            speculative_strategy=draft.strategy,
+            speculative_draft_model=draft.draft_repo,
+            speculative_tokens=draft.block_size,
+        )
+        self.registry.add_mapping(name, hf_path, model_config=mc)
 
     def list_local(self) -> list[ModelManifest]:
         """List all locally stored models, deriving manifests for directories that lack one."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3049,3 +3049,80 @@ class TestFlashWithoutFlashGuards:
         with caplog.at_level(logging.WARNING, logger="olmlx.cli"):
             _apply_serve_overrides(args)
         assert "flash_prefetch is set but flash is not enabled globally" in caplog.text
+
+
+class TestPullWithDraft:
+    """`olmlx models pull --with-draft` co-downloads the curated draft (#514)."""
+
+    @staticmethod
+    def _fake_pull():
+        async def fake_pull(name):
+            yield {"status": f"downloading {name}"}
+            yield {"status": "success"}
+
+        return fake_pull
+
+    def test_with_draft_pulls_and_registers(
+        self, capsys, mock_store, _patch_store, monkeypatch
+    ):
+        from olmlx.engine import registry
+        from olmlx.engine.registry import KnownDraft
+
+        entry = KnownDraft(draft_repo="org/draft", strategy="eagle", block_size=4)
+        monkeypatch.setitem(registry.KNOWN_DRAFTS, "Qwen/Qwen3-32B-MLX", entry)
+
+        mock_store.pull = self._fake_pull()
+        mock_store.registry.resolve.return_value = MagicMock(
+            hf_path="Qwen/Qwen3-32B-MLX"
+        )
+        mock_store.register_speculative_draft = MagicMock()
+
+        args = MagicMock(model_name="qwen3:32b", with_draft=True)
+        cmd_models_pull(args)
+
+        out = capsys.readouterr().out
+        assert "downloading qwen3:32b" in out
+        assert "pulling speculative draft org/draft" in out
+        assert "downloading org/draft" in out
+        assert "wired speculative draft org/draft" in out
+        mock_store.register_speculative_draft.assert_called_once_with(
+            "qwen3:32b", "Qwen/Qwen3-32B-MLX", entry
+        )
+
+    def test_with_draft_no_known_draft_skips(self, capsys, mock_store, _patch_store):
+        mock_store.pull = self._fake_pull()
+        mock_store.registry.resolve.return_value = MagicMock(hf_path="unknown/model")
+        mock_store.register_speculative_draft = MagicMock()
+
+        args = MagicMock(model_name="unknown", with_draft=True)
+        cmd_models_pull(args)
+
+        out = capsys.readouterr().out
+        assert "no known speculative draft" in out
+        assert "pulling speculative draft" not in out
+        mock_store.register_speculative_draft.assert_not_called()
+
+    def test_without_flag_does_not_touch_draft(
+        self, capsys, mock_store, _patch_store, monkeypatch
+    ):
+        from olmlx.engine import registry
+        from olmlx.engine.registry import KnownDraft
+
+        monkeypatch.setitem(
+            registry.KNOWN_DRAFTS,
+            "Qwen/Qwen3-32B-MLX",
+            KnownDraft(draft_repo="org/draft", strategy="eagle", block_size=4),
+        )
+        mock_store.pull = self._fake_pull()
+        mock_store.registry.resolve.return_value = MagicMock(
+            hf_path="Qwen/Qwen3-32B-MLX"
+        )
+        mock_store.register_speculative_draft = MagicMock()
+
+        args = MagicMock(model_name="qwen3:32b", with_draft=False)
+        cmd_models_pull(args)
+
+        out = capsys.readouterr().out
+        assert "downloading qwen3:32b" in out
+        assert "pulling speculative draft" not in out
+        mock_store.register_speculative_draft.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3126,3 +3126,28 @@ class TestPullWithDraft:
         assert "downloading qwen3:32b" in out
         assert "pulling speculative draft" not in out
         mock_store.register_speculative_draft.assert_not_called()
+
+    def test_with_draft_strips_tag_on_full_path_target(
+        self, capsys, mock_store, _patch_store, monkeypatch
+    ):
+        """A full-path pull with a tag (org/model:q4) resolves to the canonical
+        untagged key in the curated map."""
+        from olmlx.engine import registry
+        from olmlx.engine.registry import KnownDraft
+
+        entry = KnownDraft(draft_repo="org/draft", strategy="eagle", block_size=4)
+        monkeypatch.setitem(registry.KNOWN_DRAFTS, "org/Big-Model", entry)
+
+        mock_store.pull = self._fake_pull()
+        # resolve() passes a full path through verbatim, tag included.
+        mock_store.registry.resolve.return_value = MagicMock(hf_path="org/Big-Model:q4")
+        mock_store.register_speculative_draft = MagicMock()
+
+        args = MagicMock(model_name="org/Big-Model:q4", with_draft=True)
+        cmd_models_pull(args)
+
+        out = capsys.readouterr().out
+        assert "pulling speculative draft org/draft" in out
+        mock_store.register_speculative_draft.assert_called_once_with(
+            "org/Big-Model:q4", "org/Big-Model", entry
+        )

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -5,12 +5,66 @@ from pathlib import Path
 
 import pytest
 
+from olmlx.engine.registry import KnownDraft, ModelRegistry
 from olmlx.models.manifest import ModelManifest
 from olmlx.models.store import (
+    ModelStore,
     _dir_size,
     _extract_metadata,
     _safe_dir_name,
 )
+
+
+class TestRegisterSpeculativeDraft:
+    """ModelStore.register_speculative_draft persists curated draft config (#514)."""
+
+    def _store(self, tmp_path, monkeypatch, config):
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+        return ModelStore(reg), config_path
+
+    def test_writes_speculative_fields(self, tmp_path, monkeypatch):
+        store, config_path = self._store(
+            tmp_path, monkeypatch, {"qwen3:latest": "Qwen/Qwen3-32B-MLX"}
+        )
+        draft = KnownDraft(
+            draft_repo="org/Qwen3-32B-eagle", strategy="eagle", block_size=4
+        )
+        store.register_speculative_draft("qwen3:latest", "Qwen/Qwen3-32B-MLX", draft)
+
+        resolved = store.registry.resolve("qwen3:latest")
+        assert resolved.speculative is True
+        assert resolved.speculative_strategy == "eagle"
+        assert resolved.speculative_draft_model == "org/Qwen3-32B-eagle"
+        assert resolved.speculative_tokens == 4
+        # Persisted to disk.
+        assert "org/Qwen3-32B-eagle" in config_path.read_text()
+
+    def test_preserves_existing_per_model_config(self, tmp_path, monkeypatch):
+        store, _ = self._store(
+            tmp_path,
+            monkeypatch,
+            {"qwen3:latest": {"hf_path": "Qwen/Qwen3-32B-MLX", "keep_alive": "30m"}},
+        )
+        draft = KnownDraft(draft_repo="org/draft", strategy="dflash", block_size=8)
+        store.register_speculative_draft("qwen3:latest", "Qwen/Qwen3-32B-MLX", draft)
+        resolved = store.registry.resolve("qwen3:latest")
+        assert resolved.keep_alive == "30m"
+        assert resolved.speculative_draft_model == "org/draft"
+
+    def test_works_for_full_hf_path_target(self, tmp_path, monkeypatch):
+        store, _ = self._store(tmp_path, monkeypatch, {})
+        draft = KnownDraft(draft_repo="org/draft", strategy="classic", block_size=None)
+        store.register_speculative_draft(
+            "Qwen/Qwen3-32B-MLX", "Qwen/Qwen3-32B-MLX", draft
+        )
+        resolved = store.registry.resolve("Qwen/Qwen3-32B-MLX")
+        assert resolved.speculative is True
+        assert resolved.speculative_draft_model == "org/draft"
+        assert resolved.speculative_tokens is None
 
 
 class TestSafeDirName:


### PR DESCRIPTION
Closes #514. Builds on the #513 curated known-drafts map.

## What

A `--with-draft` flag on `olmlx models pull <target>`. When set and a known speculative draft exists for the target (looked up in the #513 `KNOWN_DRAFTS` map), the CLI **also pulls the draft repo** and **writes the `speculative_*` fields into the target's `models.json` entry** — provisioning a ready-to-spec-decode model in one command.

```
olmlx models pull qwen3:32b --with-draft
```

## How

- `ModelStore.register_speculative_draft(name, hf_path, draft)` persists `speculative=True` + the draft's `strategy` / `draft_repo` / `block_size` onto the target's entry through the existing `add_mapping` path. It starts from the resolved entry (`dataclasses.replace`) so **existing per-model config is preserved**.
- `cmd_models_pull` reuses `store.pull()` for the draft download (same progress-printing style) after the target completes; when no draft is known for the target it prints a skip notice. The flag is **opt-in**, so opting out is simply omitting it (matches the issue's opt-out requirement).
- The trigger guard is `with_draft is True` — argparse `store_true` always yields a real `bool`, so this is correct in production while ignoring the truthy auto-attributes that bare-`MagicMock` args produce in unrelated pull tests.

## Interaction with #513's (currently empty) map

The curated map ships empty until the project-org draft repos land (#512), so `--with-draft` prints "no known speculative draft …; skipping" for real targets today. The mechanism is complete and fully tested via injected map entries; it activates automatically as `KNOWN_DRAFTS` is populated.

## Tests

- `tests/test_store.py::TestRegisterSpeculativeDraft` — writes the speculative fields and persists to disk; preserves existing per-model config (`keep_alive`); works for a full-`hf_path` target.
- `tests/test_cli.py::TestPullWithDraft` — `--with-draft` pulls the draft and calls register with the right args; no-known-draft skip; flag-off no-op.

All pass; ruff + pyright clean. Full `test_cli.py` / `test_store.py` / `test_known_drafts.py` green (246 tests).

> Note: issue #514 is labelled `plan:proposed`. Opening this for review; happy to hold for plan approval if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)