### PR TITLE
feat(engine): lookahead (Jacobi) decoding — draft-free speculative (#502)

### DIFF
--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -1044,9 +1044,10 @@ def _audit_speculative_config(
             continue
         # Strategies that legitimately run without a ``speculative_draft_model``:
         # ``self_speculative`` (target's own early layers), ``pld`` (n-gram
-        # prompt lookup), and ``proxy_tuning`` (steers via expert/anti-expert
-        # models configured under their own ``speculative_proxy_*`` knobs).
-        _draftless = {"self_speculative", "pld", "proxy_tuning"}
+        # prompt lookup), ``lookahead`` (draft-free Jacobi iteration), and
+        # ``proxy_tuning`` (steers via expert/anti-expert models configured
+        # under their own ``speculative_proxy_*`` knobs).
+        _draftless = {"self_speculative", "pld", "lookahead", "proxy_tuning"}
         if enabled and not draft and strategy not in _draftless:
             bad.append(name)
         elif not enabled and mc.speculative_draft_model:
@@ -3146,6 +3147,7 @@ def build_parser() -> argparse.ArgumentParser:
             "dflash",
             "eagle",
             "pld",
+            "lookahead",
             "self_speculative",
             "proxy_tuning",
         ),

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -255,7 +255,13 @@ class Settings(BaseSettings):
     # the draft model's pre-trained ``block_size`` for DFlash and EAGLE.
     speculative: bool = False
     speculative_strategy: Literal[
-        "classic", "dflash", "eagle", "pld", "self_speculative", "proxy_tuning"
+        "classic",
+        "dflash",
+        "eagle",
+        "pld",
+        "lookahead",
+        "self_speculative",
+        "proxy_tuning",
     ] = "classic"
     speculative_draft_model: Annotated[str, Field(min_length=1)] | None = None
     speculative_tokens: Annotated[int, Field(gt=0)] | None = None

--- a/olmlx/engine/lookahead_decoder.py
+++ b/olmlx/engine/lookahead_decoder.py
@@ -1,0 +1,261 @@
+"""Lookahead (Jacobi) decoding — a draft-free speculative strategy (#502).
+
+PLD (``PromptLookupDecoder``) is the only other draft-free strategy, but it
+can only propose n-grams that already appeared in the prompt/history. Lookahead
+decoding generates *novel* n-grams in parallel via Jacobi iteration — no draft
+model, no training — then verifies them against the target with the same greedy
+verify the other strategies use. It is therefore complementary to PLD on fresh
+text (prose, novel code) where prompt-lookup finds no match.
+
+Algorithm (a linear-verify variant of Fu et al. 2024, "Break the Sequential
+Dependency of LLM Inference Using Lookahead Decoding"):
+
+- Maintain a single Jacobi *guess* trajectory of ``W`` tokens for the next
+  ``W`` positions. Each step feeds ``[pending] + guess`` through the target in
+  ONE forward, then takes ``argmax`` at every position. Those argmaxes ARE one
+  Jacobi iteration: ``refined[i]`` is the target's greedy token at position ``i``
+  conditioned on the current guess prefix. The refined tail seeds the next
+  step's guess (a parallel fixed-point iteration that converges over steps).
+- Simultaneously, the *same* logits drive the standard greedy verify: the longest
+  guess prefix that matches the target's argmax is accepted, plus a bonus token.
+  Because acceptance is exactly the greedy-verify rule, **output is identical to
+  plain greedy decoding regardless of guess quality** — the guess only affects
+  speed (tokens-per-step), never correctness.
+- An n-gram pool keyed by the preceding token caches refined trajectories across
+  steps, warm-starting the guess after a full-acceptance step (when the Jacobi
+  tail is exhausted) and on token recurrence.
+
+Unlike the full Fu et al. method this keeps a single linear trajectory (no 2-D
+lookahead window / custom attention mask), so it reuses ``verify_draft_greedy``
+and the cache-trim arithmetic unchanged — the same machinery PLD uses. Like PLD
+it needs no draft model and so composes with Flash-MoE (which blocks the
+hidden-state strategies dflash/eagle/mtp). GDN rollback is reused for hybrid
+linear-attention targets. Not thread-safe: one instance serves one request.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from olmlx.engine.gdn_rollback import GDNBuffer, GDNStateCapture, find_gdn_class
+from olmlx.engine.spec_decoder_base import SpecDecoderBase
+from olmlx.engine.speculative import (
+    _logits,
+    _prefill_last_logit,
+    make_prompt_cache,
+    trim_prompt_cache,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Cap on distinct keys retained in the n-gram pool, so a long generation with
+#: a large vocabulary can't grow it without bound. Insertion-ordered eviction.
+_POOL_MAX_KEYS = 8192
+
+
+class LookaheadDecoder(SpecDecoderBase):
+    """Draft-free Jacobi lookahead decoder. See module docstring."""
+
+    def __init__(
+        self,
+        target_model: nn.Module,
+        num_speculative_tokens: int = 5,
+    ):
+        super().__init__()
+        if trim_prompt_cache is None or make_prompt_cache is None:
+            raise RuntimeError(
+                "mlx_lm.models.cache imports failed (trim_prompt_cache / "
+                "make_prompt_cache unavailable); lookahead requires both — fail "
+                "fast at construction rather than crashing on first prefill"
+            )
+        if num_speculative_tokens < 1:
+            raise ValueError(
+                f"num_speculative_tokens must be >= 1, got {num_speculative_tokens}"
+            )
+        self._target = target_model
+        #: Jacobi window width = max draft length proposed per step.
+        self._window = num_speculative_tokens
+
+        # Persistent per-request state (populated by prefill/step).
+        self._target_cache: list | None = None
+        self._cache_seq_len: int = 0
+        self._pending_token: int | None = None
+        #: The Jacobi guess trajectory for the next ``_window`` positions.
+        self._guess: list[int] = []
+        #: token -> recently-observed length-``_window`` continuation n-gram.
+        self._pool: dict[int, list[int]] = {}
+
+        # GDN rollback for hybrid linear-attention targets (Qwen3.5/3.6
+        # GatedDeltaNet). Draft-free, so only the target is patched — mirrors
+        # PromptLookupDecoder exactly.
+        self._gdn_capture: GDNStateCapture | None = None
+        self._target_gdn_buffer: GDNBuffer | None = None
+        target_gdn_cls = find_gdn_class(target_model)
+        if target_gdn_cls is not None:
+            self._gdn_capture = GDNStateCapture(target_gdn_cls)
+            try:
+                self._target_gdn_buffer = self._gdn_capture.create_buffer(target_model)
+            except Exception:
+                self._gdn_capture.close()
+                self._gdn_capture = None
+                self._target_gdn_buffer = None
+                raise
+
+    def close(self) -> None:
+        """Release the decoder-lifetime GDN capture (idempotent), then reset.
+
+        Mirrors ``PromptLookupDecoder.close``: the GDN capture is created in
+        ``__init__`` (decoder-lifetime), so the base ``reset()`` never touches
+        it — release it here under a ``finally`` so a failing close still drops
+        the working cache.
+        """
+        try:
+            if self._gdn_capture is not None:
+                self._gdn_capture.close()
+                self._gdn_capture = None
+                self._target_gdn_buffer = None
+        finally:
+            self.reset()
+
+    def _reset_state(self) -> None:
+        self._target_cache = None
+        self._cache_seq_len = 0
+        self._pending_token = None
+        self._guess = []
+        self._pool = {}
+
+    def _stats_extra(self) -> dict[str, Any]:
+        return {"window": self._window}
+
+    def _prefill_impl(
+        self,
+        prompt: mx.array,
+        *,
+        segmented: Any = None,
+        cancel_event: threading.Event | None = None,
+    ) -> int:
+        """Process the prompt through the target, populating its KV cache.
+
+        Cross-request KV reuse (#421) is not implemented for lookahead v1; the
+        ``segmented`` argument is accepted and ignored. A single straight
+        prefill keeps the strategy simple while the win is in decode throughput.
+        """
+        self._target_cache = make_prompt_cache(self._target)
+
+        # Same VLM cache-reset rationale as the other decoders.
+        for attr in ("_position_ids", "_rope_deltas"):
+            if hasattr(self._target, attr):
+                setattr(self._target, attr, None)
+
+        # No rollback needed for the prompt forward.
+        if self._gdn_capture is not None:
+            self._gdn_capture.use_buffer(None)
+
+        last_logit = _prefill_last_logit(
+            self._target, prompt, self._target_cache, cancel_event=cancel_event
+        )
+        mx.eval(last_logit)
+        self._cache_seq_len = prompt.shape[1]
+
+        first_token = int(mx.argmax(last_logit).item())
+        self._pending_token = first_token
+        # Seed the Jacobi window with the most recent prompt tokens — a weak
+        # but non-empty starting trajectory that the per-step refinement
+        # converges away from. (Any seed is correctness-safe; verify guarantees
+        # exactness.)
+        seq = prompt[0].tolist()
+        self._guess = seq[-self._window :] if len(seq) >= self._window else list(seq)
+        return first_token
+
+    def _step_impl(self) -> tuple[list[int], int]:
+        """One lookahead step: propose the Jacobi guess, verify greedily,
+        trim, and refine the trajectory for the next step.
+
+        Returns ``(accepted_tokens, num_draft_proposed)``.
+        """
+        if self._target_cache is None or self._pending_token is None:
+            raise RuntimeError(
+                "LookaheadDecoder.step() called before prefill(); "
+                "call prefill(prompt) first"
+            )
+
+        pending_token = self._pending_token
+        draft_tokens = list(self._guess[: self._window])
+        num_drafted = len(draft_tokens)
+
+        # Target forward on [pending, guess_1..guess_num_drafted].
+        if self._gdn_capture is not None:
+            if self._target_gdn_buffer is not None:
+                self._target_gdn_buffer.clear()
+            self._gdn_capture.use_buffer(self._target_gdn_buffer)
+        all_tokens = mx.array([[pending_token] + draft_tokens])
+        target_out = _logits(self._target(all_tokens, cache=self._target_cache))
+        choices = mx.argmax(target_out[0], axis=-1)  # (num_drafted + 1,)
+        mx.eval(choices)
+        if self._gdn_capture is not None:
+            self._gdn_capture.use_buffer(None)
+        refined = choices.tolist()
+
+        # Greedy verification — identical primitive to every other strategy, so
+        # the emitted tokens are exactly plain-greedy output. ``refined`` is the
+        # argmax per position; ``verify_draft_greedy`` recomputes the same
+        # argmax internally, but passing logits keeps the shared contract.
+        accepted = self._verify_greedy(draft_tokens, target_out[0])
+        num_accepted = len(accepted)
+
+        # Trim the target cache to the accepted prefix (fed num_drafted+1,
+        # keep num_accepted). GDN targets roll back recurrent state instead.
+        trim_target = max(num_drafted + 1 - num_accepted, 0)
+        if trim_target > 0:
+            if self._target_gdn_buffer is not None and self._gdn_capture is not None:
+                self._gdn_capture.rollback_single(
+                    self._target_gdn_buffer,
+                    self._target_cache,
+                    accepted=num_accepted - 1,
+                    trim=trim_target,
+                )
+            else:
+                trim_prompt_cache(self._target_cache, trim_target)
+
+        # Refine the Jacobi trajectory for the next step. ``refined`` is the
+        # one-iteration update of [pending] + guess; ``refined[:num_accepted]``
+        # equals ``accepted`` (verify accepts only argmax matches), so the
+        # not-yet-committed tail ``refined[num_accepted:]`` seeds the next
+        # window. Record the refined continuation in the pool keyed by the token
+        # we just advanced past, then warm-start any shortfall from it.
+        new_pending = accepted[-1]
+        self._remember_pool(pending_token, refined[: self._window])
+        next_guess = refined[num_accepted:]
+        if len(next_guess) < self._window:
+            next_guess = next_guess + self._pool.get(new_pending, [])
+        self._guess = next_guess[: self._window]
+
+        # Cache now holds prompt + pending + accepted[:-1]; the bonus
+        # (accepted[-1]) is the new pending and is not yet in the cache.
+        self._cache_seq_len += num_accepted
+        self._pending_token = int(new_pending)
+
+        num_accepted_draft = min(num_accepted - 1, num_drafted)
+        self._stats_steps += 1
+        self._stats_proposed += num_drafted
+        self._stats_accepted_draft += num_accepted_draft
+
+        return accepted, num_drafted
+
+    def _remember_pool(self, key: int, ngram: list[int]) -> None:
+        """Record ``ngram`` as the continuation following ``key`` (insertion-
+        ordered LRU, capped at ``_POOL_MAX_KEYS``)."""
+        if not ngram:
+            return
+        # Refresh recency: re-inserting moves the key to the end.
+        self._pool.pop(key, None)
+        self._pool[key] = ngram
+        if len(self._pool) > _POOL_MAX_KEYS:
+            # Drop the oldest key (FIFO ~ LRU given the refresh above).
+            oldest = next(iter(self._pool))
+            del self._pool[oldest]

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -3031,6 +3031,8 @@ class ModelManager(SpeculativeLoaderMixin):
             return self._load_mtp_decoder(model, spec_config)
         if strategy == "pld":
             return self._load_pld_decoder(model, spec_config, is_vlm=is_vlm)
+        if strategy == "lookahead":
+            return self._load_lookahead_decoder(model, spec_config, is_vlm=is_vlm)
         if strategy == "self_speculative":
             target = (
                 getattr(model, "language_model", model)

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -17,10 +17,26 @@ from olmlx.config import FlashMoeConfig, SyncMode, settings
 from olmlx.utils.loop_affinity import assert_loop_thread
 
 SpeculativeStrategy = Literal[
-    "classic", "dflash", "eagle", "pld", "self_speculative", "mtp", "proxy_tuning"
+    "classic",
+    "dflash",
+    "eagle",
+    "pld",
+    "lookahead",
+    "self_speculative",
+    "mtp",
+    "proxy_tuning",
 ]
 _VALID_SPECULATIVE_STRATEGIES: frozenset[str] = frozenset(
-    ("classic", "dflash", "eagle", "pld", "self_speculative", "mtp", "proxy_tuning")
+    (
+        "classic",
+        "dflash",
+        "eagle",
+        "pld",
+        "lookahead",
+        "self_speculative",
+        "mtp",
+        "proxy_tuning",
+    )
 )
 # Strategies that consume target hidden states / run a feature-conditioned
 # verify forward and therefore can't compose with flash_moe's per-token expert

--- a/olmlx/engine/speculative_loaders.py
+++ b/olmlx/engine/speculative_loaders.py
@@ -900,9 +900,7 @@ class SpeculativeLoaderMixin:
             raise RuntimeError(
                 "_load_lookahead_decoder called with spec_config.enabled=False"
             )
-        num_tokens = (
-            spec_config.num_tokens if spec_config.num_tokens is not None else 5
-        )
+        num_tokens = spec_config.num_tokens if spec_config.num_tokens is not None else 5
         if spec_config.draft_model:
             logger.warning(
                 "speculative_strategy='lookahead' ignores speculative_draft_model "

--- a/olmlx/engine/speculative_loaders.py
+++ b/olmlx/engine/speculative_loaders.py
@@ -879,6 +879,53 @@ class SpeculativeLoaderMixin:
             cache_slots=settings.speculative_cache_slots,
         )
 
+    def _load_lookahead_decoder(
+        self,
+        target_model: Any,
+        spec_config: SpeculativeConfig,
+        *,
+        is_vlm: bool = False,
+    ) -> Any:
+        """Construct a LookaheadDecoder (draft-free Jacobi; no draft model).
+
+        Like PLD, lookahead needs no draft model and runs on the unwrapped
+        language model for VLM targets. ``num_tokens`` is the Jacobi window
+        width (max draft per step); it defaults to 5 — a modest window keeps
+        the per-step target forward cheap while still amortising several tokens
+        on convergent text.
+        """
+        from olmlx.engine.lookahead_decoder import LookaheadDecoder
+
+        if not spec_config.enabled:
+            raise RuntimeError(
+                "_load_lookahead_decoder called with spec_config.enabled=False"
+            )
+        num_tokens = (
+            spec_config.num_tokens if spec_config.num_tokens is not None else 5
+        )
+        if spec_config.draft_model:
+            logger.warning(
+                "speculative_strategy='lookahead' ignores speculative_draft_model "
+                "(%s) — lookahead is draft-free.",
+                spec_config.draft_model,
+            )
+
+        if is_vlm:
+            la_target = getattr(target_model, "language_model", None)
+            if la_target is None:
+                raise ValueError(
+                    "VLM model does not expose .language_model; lookahead "
+                    "requires direct access to the text decoder"
+                )
+        else:
+            la_target = target_model
+
+        logger.info("Constructing lookahead decoder (window=%d)", num_tokens)
+        return LookaheadDecoder(
+            target_model=la_target,
+            num_speculative_tokens=num_tokens,
+        )
+
     def _load_self_speculative_decoder(
         self,
         target_model: Any,

--- a/olmlx/utils/metrics.py
+++ b/olmlx/utils/metrics.py
@@ -173,6 +173,7 @@ _STRATEGY_BY_CLASS = {
     "SpeculativeDecoder": "classic",
     "SpeculativeFlashDecoder": "classic",
     "PromptLookupDecoder": "pld",
+    "LookaheadDecoder": "lookahead",
     "DFlashDecoder": "dflash",
     "EagleDecoder": "eagle",
     "MTPDecoder": "mtp",

--- a/tests/test_lookahead.py
+++ b/tests/test_lookahead.py
@@ -1,0 +1,204 @@
+"""Tests for lookahead (Jacobi) decoding (engine/lookahead_decoder.py, #502).
+
+Uses the CPU-friendly MockModel (a real nn.Module with KV-cache support, shared
+with the PLD tests) so the full prefill/step/trim loop runs without a GPU or a
+model download. The headline test is exactness: lookahead output must equal
+plain greedy decoding token-for-token, which is the strategy's core guarantee.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from tests.test_flash_speculative import MockModel
+
+
+class TestLookaheadConstruction:
+    def test_rejects_zero_window(self):
+        from olmlx.engine.lookahead_decoder import LookaheadDecoder
+
+        with pytest.raises(ValueError, match="num_speculative_tokens must be >= 1"):
+            LookaheadDecoder(target_model=MockModel(32, 16), num_speculative_tokens=0)
+
+    def test_no_gdn_capture_for_plain_model(self):
+        from olmlx.engine.lookahead_decoder import LookaheadDecoder
+
+        dec = LookaheadDecoder(target_model=MockModel(32, 16))
+        # MockModel is not a hybrid GatedDeltaNet target.
+        assert dec._gdn_capture is None
+        assert dec._target_gdn_buffer is None
+
+
+class TestLookaheadDecoder:
+    @pytest.fixture()
+    def decoder(self):
+        from olmlx.engine.lookahead_decoder import LookaheadDecoder
+
+        return LookaheadDecoder(
+            target_model=MockModel(32, 16), num_speculative_tokens=4
+        )
+
+    def test_prefill_populates_state(self, decoder):
+        prompt = mx.array([[1, 2, 3, 4, 5]])
+        first_token = decoder.prefill(prompt)
+        assert decoder._target_cache is not None
+        assert decoder._cache_seq_len == 5
+        assert isinstance(first_token, int)
+        assert 0 <= first_token < 32
+        assert decoder._pending_token == first_token
+        # Jacobi window seeded from the last `window` prompt tokens.
+        assert decoder._guess == [2, 3, 4, 5]
+
+    def test_prefill_seed_shorter_than_window(self, decoder):
+        first = decoder.prefill(mx.array([[7, 9]]))
+        assert decoder._guess == [7, 9]
+        assert isinstance(first, int)
+
+    def test_step_returns_at_least_one_token(self, decoder):
+        decoder.prefill(mx.array([[1, 2, 3, 4, 5]]))
+        accepted, num_drafted = decoder.step()
+        assert len(accepted) >= 1
+        assert 0 <= num_drafted <= decoder._window
+        assert len(accepted) <= num_drafted + 1
+
+    def test_step_advances_cache(self, decoder):
+        decoder.prefill(mx.array([[1, 2, 3, 4, 5]]))
+        accepted, _ = decoder.step()
+        # Cache grows by exactly num_accepted positions and stays aligned.
+        assert decoder._cache_seq_len == 5 + len(accepted)
+        assert decoder._target_cache[0].offset == decoder._cache_seq_len
+
+    def test_reset_clears_state(self, decoder):
+        decoder.prefill(mx.array([[1, 2, 3]]))
+        decoder.step()
+        decoder.reset()
+        assert decoder._target_cache is None
+        assert decoder._cache_seq_len == 0
+        assert decoder._pending_token is None
+        assert decoder._guess == []
+        assert decoder._pool == {}
+
+    def test_multi_step_cache_alignment(self, decoder):
+        prompt_ids = [1, 2, 3, 4, 5]
+        decoder.prefill(mx.array([prompt_ids]))
+        emitted = 1  # the prefill bonus token
+        for _ in range(6):
+            accepted, _ = decoder.step()
+            assert len(accepted) >= 1
+            emitted += len(accepted)
+            # KV cache stays in lockstep with emitted-minus-pending.
+            assert decoder._target_cache[0].offset == decoder._cache_seq_len
+            assert decoder._cache_seq_len == len(prompt_ids) + emitted - 1
+
+    def test_stats_summary_shape(self, decoder):
+        decoder.prefill(mx.array([[1, 2, 3]]))
+        decoder.step()
+        s = decoder.stats_summary()
+        for k in (
+            "steps",
+            "proposed",
+            "accepted_draft",
+            "acceptance_rate",
+            "avg_tokens_per_step",
+            "window",
+        ):
+            assert k in s, f"missing stats key: {k}"
+        assert s["steps"] == 1
+        assert 0 <= s["acceptance_rate"] <= 1
+        assert s["window"] == decoder._window
+
+    def test_protocol_conformance(self, decoder):
+        assert callable(getattr(decoder, "prefill", None))
+        assert callable(getattr(decoder, "step", None))
+        assert callable(getattr(decoder, "reset", None))
+
+
+class TestLookaheadExactness:
+    """The core guarantee: lookahead emits exactly the greedy sequence."""
+
+    def test_output_matches_greedy_reference(self):
+        from olmlx.engine.lookahead_decoder import LookaheadDecoder
+        from olmlx.engine.speculative import _logits, _prefill_last_logit
+
+        target = MockModel(vocab_size=32, hidden_size=16)
+        # Repetition gives the Jacobi guess something to converge on, exercising
+        # the accept (not just no-match) branches.
+        prompt = mx.array([[3, 7, 1, 5, 9, 2, 4, 6, 8, 3, 7, 1]])
+        max_steps = 16
+
+        # Greedy reference on the same model instance.
+        from mlx_lm.models.cache import make_prompt_cache
+
+        ref_cache = make_prompt_cache(target)
+        first_logit = _prefill_last_logit(target, prompt, ref_cache)
+        mx.eval(first_logit)
+        ref_tokens = [int(mx.argmax(first_logit).item())]
+        for _ in range(max_steps - 1):
+            inp = mx.array([[ref_tokens[-1]]])
+            out = _logits(target(inp, cache=ref_cache))[0, -1, :]
+            mx.eval(out)
+            ref_tokens.append(int(mx.argmax(out).item()))
+
+        # Lookahead: prefill + repeated step() until we have >= max_steps.
+        dec = LookaheadDecoder(target_model=target, num_speculative_tokens=4)
+        la_tokens = [dec.prefill(prompt)]
+        while len(la_tokens) < max_steps:
+            accepted, _ = dec.step()
+            la_tokens.extend(accepted)
+        la_tokens = la_tokens[:max_steps]
+
+        assert la_tokens == ref_tokens, (
+            "lookahead diverged from greedy reference: "
+            f"la={la_tokens} greedy={ref_tokens}"
+        )
+
+    def test_exactness_with_window_one(self):
+        """Window=1 still matches greedy (degenerate single-token guess)."""
+        from olmlx.engine.lookahead_decoder import LookaheadDecoder
+        from olmlx.engine.speculative import _logits, _prefill_last_logit
+        from mlx_lm.models.cache import make_prompt_cache
+
+        target = MockModel(vocab_size=24, hidden_size=12)
+        prompt = mx.array([[2, 4, 6, 2, 4, 6]])
+        max_steps = 10
+
+        ref_cache = make_prompt_cache(target)
+        fl = _prefill_last_logit(target, prompt, ref_cache)
+        mx.eval(fl)
+        ref = [int(mx.argmax(fl).item())]
+        for _ in range(max_steps - 1):
+            out = _logits(target(mx.array([[ref[-1]]]), cache=ref_cache))[0, -1, :]
+            mx.eval(out)
+            ref.append(int(mx.argmax(out).item()))
+
+        dec = LookaheadDecoder(target_model=target, num_speculative_tokens=1)
+        got = [dec.prefill(prompt)]
+        while len(got) < max_steps:
+            accepted, _ = dec.step()
+            got.extend(accepted)
+        assert got[:max_steps] == ref
+
+
+class TestLookaheadRegistration:
+    def test_registered_strategy(self):
+        from olmlx.engine.registry import (
+            _FLASH_MOE_INCOMPATIBLE_STRATEGIES,
+            _VALID_SPECULATIVE_STRATEGIES,
+        )
+
+        assert "lookahead" in _VALID_SPECULATIVE_STRATEGIES
+        # Draft-free → composes with Flash-MoE, like PLD.
+        assert "lookahead" not in _FLASH_MOE_INCOMPATIBLE_STRATEGIES
+
+    def test_settings_accepts_lookahead(self):
+        from olmlx.config import Settings
+
+        s = Settings(speculative_strategy="lookahead", _env_file=None)
+        assert s.speculative_strategy == "lookahead"
+
+    def test_metrics_strategy_label(self):
+        from olmlx.engine.lookahead_decoder import LookaheadDecoder
+        from olmlx.utils.metrics import _STRATEGY_BY_CLASS
+
+        assert _STRATEGY_BY_CLASS[LookaheadDecoder.__name__] == "lookahead"


### PR DESCRIPTION
Closes #502.

## What

A new **draft-free** speculative strategy, `LookaheadDecoder` (`speculative_strategy="lookahead"`). PLD can only propose n-grams that already appeared in the prompt/history; lookahead generates *novel* n-grams in parallel via Jacobi iteration — no draft model, no training — so it's **complementary to PLD on fresh text** (prose, novel code) where prompt-lookup finds no match.

## How it works

Each step feeds `[pending] + guess` (a `W`-token Jacobi trajectory) through the target in **one** forward. The per-position `argmax`:
- **is one Jacobi iteration** — `refined[i]` is the target's greedy token at position `i` given the current guess prefix; the not-yet-committed tail seeds the next step's guess (a parallel fixed-point iteration that converges over steps), and
- **drives the standard greedy verify** — the longest guess prefix matching the target's argmax is accepted, plus a bonus token.

Because acceptance is exactly the greedy-verify rule, **output is identical to plain greedy decoding regardless of guess quality** — the guess only affects tokens-per-step, never correctness. An n-gram pool keyed by the preceding token warm-starts the guess after a full-acceptance step and on token recurrence.

This is the **linear-verify variant** of Fu et al. 2024 (a single trajectory, not the full 2-D lookahead window + custom attention mask), which lets it reuse `verify_draft_greedy`, the cache-trim arithmetic, and GDN rollback **unchanged** — the same machinery PLD uses. Being draft-free it composes with Flash-MoE (which blocks the hidden-state strategies dflash/eagle/mtp), a rare property worth preserving.

## Wiring

Registered end-to-end: `SpeculativeStrategy` literal + `_VALID_SPECULATIVE_STRATEGIES` (registry), `Settings.speculative_strategy` (config), the CLI `--speculative-strategy` choices and the draftless config-audit set, the loader dispatch (`_load_lookahead_decoder`), and the metrics strategy map. Window width = `speculative_tokens` (default 5). Not added to `_FLASH_MOE_INCOMPATIBLE_STRATEGIES` (draft-free).

## Tests — `tests/test_lookahead.py`

The headline test is **exactness**: lookahead output equals a token-for-token greedy reference on the shared CPU `MockModel` (tested at window 4 and the degenerate window 1). Plus prefill/step/trim and cache-offset-alignment invariants, stats-summary shape, no-GDN-for-plain-model, and registration assertions. These run on CPU and are exercised by CI on Apple Silicon. Verified locally: 15/15 pass; related suites (PLD, config, spec-base, metrics, CLI) unaffected.

## Verification note

Correctness is *structural* (greedy verify ⇒ exact greedy output) and covered by the exactness tests. Acceptance rate (the speed win) depends on how convergent the text is and is best measured with the bench harness on real models — not asserted here, since it's a performance characteristic, not a correctness one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)