### PR TITLE
feat(prompt_cache): disk spill for the VLM prompt cache (#491)

### DIFF
--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -122,8 +122,15 @@ class Settings(BaseSettings):
     prompt_cache: bool = True
     # Number of per-cache_id VLM KV-cache slots retained for cross-turn image-prefix
     # reuse (mlx_vlm PromptCacheState). 0 disables VLM prompt caching entirely.
-    # In-memory only (no disk spill / radix / KV-quant); 2 slots bound the memory.
+    # 2 slots bound the in-memory tier; cold entries spill to disk when
+    # vlm_prompt_cache_disk is on (#491).
     vlm_prompt_cache_slots: int = 2
+    # Disk spill for the VLM prompt cache (#491): mirrors the text-path
+    # prompt_cache_disk_* knobs. Off by default — the common single-conversation
+    # case is fully covered by the in-memory slots.
+    vlm_prompt_cache_disk: bool = False
+    vlm_prompt_cache_disk_path: Path = Path.home() / ".olmlx" / "cache" / "vlm"
+    vlm_prompt_cache_disk_max_gb: Annotated[float, Field(gt=0)] = 10.0
     prompt_cache_max_tokens: Annotated[int, Field(gt=0)] | None = 32768
     prompt_cache_max_slots: Annotated[int, Field(gt=0)] = 4
     prompt_cache_disk: bool = False

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1961,7 +1961,7 @@ async def _setup_via_checkpoint_path(
     )
 
 
-def _setup_vlm_prompt_cache(
+async def _setup_vlm_prompt_cache(
     lm: LoadedModel,
     prompt_tokens: list[int] | None,
     gen_kwargs: dict,
@@ -1993,7 +1993,7 @@ def _setup_vlm_prompt_cache(
         mx.clear_cache()
         _safe_sync()
 
-    state = store.get(cache_id)
+    state = await store.async_get(cache_id)
     if state is not None:
         read = state.find_prefix_length(prompt_tokens)
         # A full-prefix re-request reuses everything but the seed; clamp so we
@@ -2002,7 +2002,7 @@ def _setup_vlm_prompt_cache(
         store.note_hit(reused_tokens=read)
     else:
         state = PromptCacheState()
-        store.insert(cache_id, state)
+        await store.async_insert(cache_id, state)
         read = 0
         store.note_miss()
 
@@ -3263,7 +3263,7 @@ async def _stream_completion(
         if use_prompt_cache and lm.is_vlm:
             # VLM: attach an mlx_vlm PromptCacheState. ``prompt`` stays the full
             # str — mlx_vlm tokenizes it and reuses the KV prefix internally.
-            read, creation = _setup_vlm_prompt_cache(
+            read, creation = await _setup_vlm_prompt_cache(
                 lm, prompt_tokens, gen_kwargs, cache_id=cache_id
             )
             cs = _CacheSetupResult(
@@ -3794,7 +3794,10 @@ async def _full_completion(
                     # VLM: attach an mlx_vlm PromptCacheState. Leave ``prompt``
                     # as the full str — mlx_vlm tokenizes it and reuses the KV
                     # prefix internally (no suffix-only trimming on this path).
-                    cache_read_tokens, cache_creation_tokens = _setup_vlm_prompt_cache(
+                    (
+                        cache_read_tokens,
+                        cache_creation_tokens,
+                    ) = await _setup_vlm_prompt_cache(
                         lm, prompt_tokens, gen_kwargs, cache_id=cache_id
                     )
                     # Leave full_prompt_tokens None: the text-tokenizer count

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -750,8 +750,21 @@ class LoadedModel:
         if self.is_vlm and self.vlm_prompt_cache_store is None:
             from olmlx.engine.prompt_cache.vlm_state import VlmPromptCacheStore
 
+            vlm_disk_path = (
+                settings.vlm_prompt_cache_disk_path
+                if settings.vlm_prompt_cache_disk
+                else None
+            )
+            vlm_disk_max_bytes = (
+                int(settings.vlm_prompt_cache_disk_max_gb * 1024**3)
+                if settings.vlm_prompt_cache_disk
+                else None
+            )
             self.vlm_prompt_cache_store = VlmPromptCacheStore(
-                capacity=settings.vlm_prompt_cache_slots
+                capacity=settings.vlm_prompt_cache_slots,
+                disk_path=vlm_disk_path,
+                model_name=self.name,
+                disk_max_bytes=vlm_disk_max_bytes,
             )
 
     def acquire_ref(self) -> None:

--- a/olmlx/engine/prompt_cache/vlm_state.py
+++ b/olmlx/engine/prompt_cache/vlm_state.py
@@ -12,20 +12,54 @@ Mirrors the speculative ``_SpecCacheStore`` ergonomics: all inference is
 serialized under the inference lock, so no internal locking is needed;
 ``capacity == 0`` is the kill switch (``OLMLX_VLM_PROMPT_CACHE_SLOTS=0``).
 
-v1 limits (documented in CLAUDE.md): in-memory only — no radix-takeover, no
-disk spill, no KV-quant.  At the small default slot count, keying on
-``cache_id`` (rather than a longest-prefix scan) is sufficient.
+Disk spill (#491): when an entry is evicted from the in-memory LRU and disk
+spill is enabled (``OLMLX_VLM_PROMPT_CACHE_DISK=1``), its KV state is written
+to a per-model ``.safetensors`` file so a later request for the same
+``cache_id`` can restore it instead of re-prefilling. Mirrors the text-path
+design (``prompt_cache/store.py``): ``mlx_lm``'s ``save_prompt_cache`` /
+``load_prompt_cache`` serialize the per-layer KV (``PromptCacheState`` carries
+only ``cache`` + ``token_ids``, so ``token_ids`` rides in the safetensors
+metadata sidecar), disk I/O is offloaded with ``asyncio.to_thread`` via the
+``async_get`` / ``async_insert`` methods, and a byte-capped oldest-mtime
+cleanup bounds disk use. Remaining v1 limits: no radix-takeover, no KV-quant.
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
+import logging
+import re
+from pathlib import Path
 from typing import Any
 
+import mlx.core as mx
+
+from olmlx.engine.prompt_cache.checkpoint import flatten_cache_state
 from olmlx.utils.loop_affinity import assert_loop_thread
+
+try:
+    from mlx_lm.models.cache import load_prompt_cache, save_prompt_cache
+except ImportError:  # pragma: no cover - mlx_lm always present in practice
+    load_prompt_cache = None  # type: ignore[assignment]
+    save_prompt_cache = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_name(name: str) -> str:
+    return re.sub(r"[^\w\-.]", "_", name) or "_default"
 
 
 class VlmPromptCacheStore:
-    def __init__(self, capacity: int) -> None:
+    def __init__(
+        self,
+        capacity: int,
+        *,
+        disk_path: Path | None = None,
+        model_name: str = "",
+        disk_max_bytes: int | None = None,
+    ) -> None:
         self._capacity = max(int(capacity), 0)
         # Insertion-ordered dict as an LRU: first key is least-recently-used.
         self._entries: dict[str, Any] = {}
@@ -33,6 +67,17 @@ class VlmPromptCacheStore:
         self._hits = 0
         self._misses = 0
         self._tokens_reused = 0
+
+        # Disk spill (#491). Enabled only when a path is configured AND the
+        # mlx_lm serialization helpers imported.
+        self._disk_path = disk_path
+        self._model_name = model_name
+        self._disk_max_bytes = disk_max_bytes
+        self._disk_enabled = (
+            disk_path is not None
+            and save_prompt_cache is not None
+            and load_prompt_cache is not None
+        )
 
     @property
     def capacity(self) -> int:
@@ -48,6 +93,10 @@ class VlmPromptCacheStore:
         Deliberately NOT loop-affine (#463): like PromptCacheStore.clear, the
         production caller is the worker-thread close path in
         ``_close_loaded_model``, which owns the store exclusively by then.
+
+        Disk files are left in place: they are a cold tier keyed by cache_id,
+        not request state, and the byte cap bounds them. A model unload drops
+        the in-memory tier; the disk tier is reclaimed lazily by the cap.
         """
         self._entries.clear()
 
@@ -67,7 +116,9 @@ class VlmPromptCacheStore:
 
     def get(self, cache_id: str) -> Any | None:
         """Return the PromptCacheState for ``cache_id`` and promote it to
-        most-recently-used, or ``None`` on miss / when disabled."""
+        most-recently-used, or ``None`` on miss / when disabled.
+
+        Memory tier only — callers wanting the disk tier use ``async_get``."""
         assert_loop_thread("VlmPromptCacheStore.get")
         if not self.enabled():
             return None
@@ -78,14 +129,136 @@ class VlmPromptCacheStore:
         return state
 
     def insert(self, cache_id: str, state: Any) -> None:
-        """Store ``state`` under ``cache_id`` as most-recently-used, evicting
-        the least-recently-used entries past ``capacity``. No-op when disabled."""
+        """Store ``state`` as most-recently-used, dropping evicted entries.
+
+        Memory tier only — callers wanting evictees spilled to disk use
+        ``async_insert``. No-op when disabled."""
+        for _id, _state in self._insert_capture(cache_id, state):
+            pass
+
+    def _insert_capture(self, cache_id: str, state: Any) -> list[tuple[str, Any]]:
+        """Memory insert that returns the entries evicted past capacity (instead
+        of dropping them), so the async wrappers can spill them to disk."""
         assert_loop_thread("VlmPromptCacheStore.insert")
         if not self.enabled():
-            return
+            return []
         self._entries.pop(cache_id, None)  # refresh position if already present
         self._entries[cache_id] = state
+        evicted: list[tuple[str, Any]] = []
         while len(self._entries) > self._capacity:
-            # Pop the oldest (least-recently-used) entry.
             oldest = next(iter(self._entries))
-            del self._entries[oldest]
+            evicted.append((oldest, self._entries.pop(oldest)))
+        return evicted
+
+    # ----- disk tier (#491) --------------------------------------------------
+
+    async def async_get(self, cache_id: str) -> Any | None:
+        """Memory-first lookup; on a memory miss, restore from disk (offloaded).
+
+        A disk hit is promoted back into the memory LRU; any entry that gets
+        evicted by that promotion is spilled to disk in a worker thread."""
+        mem = self.get(cache_id)
+        if mem is not None:
+            return mem
+        if not self._disk_enabled or not self.enabled():
+            return None
+        loaded = await asyncio.to_thread(self._load_from_disk, cache_id)
+        if loaded is None:
+            return None
+        # Promote the restored entry; spill whatever it evicts.
+        for over_id, over_state in self._insert_capture(cache_id, loaded):
+            await self._spill(over_id, over_state)
+        return loaded
+
+    async def async_insert(self, cache_id: str, state: Any) -> None:
+        """Insert into memory; spill any evicted entry to disk (offloaded)."""
+        for over_id, over_state in self._insert_capture(cache_id, state):
+            await self._spill(over_id, over_state)
+
+    async def _spill(self, cache_id: str, state: Any) -> None:
+        """Eager-eval the KV state on the loop thread (so no lazy Metal-stream
+        graph crosses into the worker thread, #284), then write it to disk in a
+        worker thread."""
+        if not self._disk_enabled:
+            return
+        cache = getattr(state, "cache", None)
+        if not cache:
+            return  # never-filled state (inserted empty, evicted before use)
+        try:
+            states = flatten_cache_state(cache)
+            if states:
+                mx.eval(states)
+        except Exception:
+            logger.warning(
+                "VLM disk spill: eager-eval failed for '%s'; skipping save",
+                cache_id,
+                exc_info=True,
+            )
+            return
+        await asyncio.to_thread(self._save_to_disk, cache_id, state)
+
+    def _disk_dir(self) -> Path:
+        assert self._disk_path is not None  # _disk_enabled guards callers
+        return self._disk_path / _safe_name(self._model_name)
+
+    def _disk_file_path(self, cache_id: str) -> Path:
+        return self._disk_dir() / f"{_safe_name(cache_id)}.safetensors"
+
+    def _save_to_disk(self, cache_id: str, state: Any) -> None:
+        """Serialize one PromptCacheState to disk. Best-effort: a save failure
+        (non-serializable cache, full disk) must never fail the request."""
+        cache = getattr(state, "cache", None)
+        if not self._disk_enabled or not cache:
+            return
+        try:
+            self._disk_dir().mkdir(parents=True, exist_ok=True)
+            file_path = self._disk_file_path(cache_id)
+            token_ids = getattr(state, "token_ids", None) or []
+            save_prompt_cache(
+                str(file_path), cache, {"token_ids": json.dumps(token_ids)}
+            )
+            self._cleanup_disk()
+        except Exception:
+            logger.warning(
+                "VLM disk spill: failed to save '%s'", cache_id, exc_info=True
+            )
+
+    def _load_from_disk(self, cache_id: str) -> Any | None:
+        """Reconstruct a PromptCacheState from disk, or None if absent/unreadable."""
+        if not self._disk_enabled:
+            return None
+        file_path = self._disk_file_path(cache_id)
+        if not file_path.exists():
+            return None
+        try:
+            from mlx_vlm.generate import PromptCacheState
+
+            cache, metadata = load_prompt_cache(str(file_path), return_metadata=True)
+            token_ids = json.loads(metadata.get("token_ids", "[]"))
+            state = PromptCacheState()
+            state.update(token_ids, cache)
+            return state
+        except Exception:
+            logger.warning(
+                "VLM disk spill: failed to load '%s'", cache_id, exc_info=True
+            )
+            return None
+
+    def _cleanup_disk(self) -> None:
+        """Evict oldest-mtime disk files until total size is under the cap."""
+        if not self._disk_enabled or self._disk_max_bytes is None:
+            return
+        try:
+            files = sorted(
+                self._disk_dir().glob("*.safetensors"),
+                key=lambda p: p.stat().st_mtime,
+            )
+            total = sum(p.stat().st_size for p in files)
+            for p in files:
+                if total <= self._disk_max_bytes:
+                    break
+                size = p.stat().st_size
+                p.unlink(missing_ok=True)
+                total -= size
+        except Exception:
+            logger.warning("VLM disk spill: cleanup failed", exc_info=True)

--- a/olmlx/engine/prompt_cache/vlm_state.py
+++ b/olmlx/engine/prompt_cache/vlm_state.py
@@ -179,6 +179,10 @@ class VlmPromptCacheStore:
         """Eager-eval the KV state on the loop thread (so no lazy Metal-stream
         graph crosses into the worker thread, #284), then write it to disk in a
         worker thread."""
+        # The eager-eval below must run on the loop thread (the offloaded
+        # _save_to_disk then sees concrete arrays); guard for consistency with
+        # get/insert/_insert_capture.
+        assert_loop_thread("VlmPromptCacheStore._spill")
         if not self._disk_enabled:
             return
         cache = getattr(state, "cache", None)

--- a/tests/test_vlm_prompt_cache_store.py
+++ b/tests/test_vlm_prompt_cache_store.py
@@ -80,3 +80,102 @@ def test_metrics_counters():
         "vlm_cache_misses": 1,
         "vlm_cache_tokens_reused": 15,
     }
+
+
+# --- Disk spill (#491) -------------------------------------------------------
+
+import mlx.core as mx  # noqa: E402
+
+
+def _filled_state(token_ids):
+    """A real mlx_vlm PromptCacheState backed by a serializable KVCache, so the
+    safetensors round-trip exercises the real save/load helpers (no model)."""
+    from mlx_lm.models.cache import KVCache
+    from mlx_vlm.generate import PromptCacheState
+
+    layer = KVCache()
+    keys = mx.ones((1, 2, len(token_ids), 4), dtype=mx.float16)
+    vals = mx.zeros((1, 2, len(token_ids), 4), dtype=mx.float16)
+    layer.update_and_fetch(keys, vals)
+    state = PromptCacheState()
+    state.update(token_ids, [layer])
+    return state
+
+
+def _disk_store(tmp_path, capacity=1, max_bytes=None):
+    return VlmPromptCacheStore(
+        capacity=capacity,
+        disk_path=tmp_path,
+        model_name="test-vlm:latest",
+        disk_max_bytes=max_bytes,
+    )
+
+
+def test_disk_disabled_without_path():
+    store = VlmPromptCacheStore(capacity=1)
+    assert store._disk_enabled is False
+
+
+async def test_no_disk_write_when_disk_disabled(tmp_path):
+    """A plain (no disk_path) store must not write files even on eviction."""
+    store = VlmPromptCacheStore(capacity=1)
+    await store.async_insert("a", _filled_state([1, 2, 3]))
+    await store.async_insert("b", _filled_state([4, 5, 6]))  # evicts "a"
+    assert list(tmp_path.iterdir()) == []
+
+
+async def test_evicted_entry_spills_to_disk(tmp_path):
+    store = _disk_store(tmp_path)
+    await store.async_insert("a", _filled_state([1, 2, 3]))
+    await store.async_insert("b", _filled_state([4, 5, 6]))  # evicts "a"
+    # "a" left memory but its KV is now on disk.
+    assert store.get("a") is None
+    spilled = list((tmp_path / "test-vlm_latest").glob("*.safetensors"))
+    assert len(spilled) == 1
+
+
+async def test_restore_from_disk_round_trips(tmp_path):
+    store = _disk_store(tmp_path)
+    await store.async_insert("a", _filled_state([1, 2, 3]))
+    await store.async_insert("b", _filled_state([4, 5, 6]))  # evicts "a" to disk
+
+    restored = await store.async_get("a")
+    assert restored is not None
+    assert restored.token_ids == [1, 2, 3]
+    assert restored.cache is not None
+    assert restored.cache[0].offset == 3  # KV history length round-tripped
+
+
+async def test_async_get_memory_hit_skips_disk(tmp_path):
+    store = _disk_store(tmp_path, capacity=2)
+    state = _filled_state([1, 2, 3])
+    await store.async_insert("a", state)
+    got = await store.async_get("a")
+    assert got is state  # same in-memory object, not a disk reconstruction
+
+
+async def test_async_get_miss_returns_none(tmp_path):
+    store = _disk_store(tmp_path)
+    assert await store.async_get("never-stored") is None
+
+
+async def test_empty_state_not_spilled(tmp_path):
+    """A never-filled state (cache is None) evicted before use writes nothing."""
+    from mlx_vlm.generate import PromptCacheState
+
+    store = _disk_store(tmp_path)
+    await store.async_insert("a", PromptCacheState())  # cache=None
+    await store.async_insert("b", _filled_state([4, 5, 6]))  # evicts empty "a"
+    a_file = tmp_path / "test-vlm_latest" / "a.safetensors"
+    assert not a_file.exists()
+
+
+async def test_cleanup_respects_byte_cap(tmp_path):
+    # Cap below one entry's size → the oldest spilled file is reclaimed.
+    store = _disk_store(tmp_path, capacity=1, max_bytes=1)
+    await store.async_insert("a", _filled_state([1, 2, 3]))
+    await store.async_insert("b", _filled_state([4, 5, 6]))  # evict a → save → cleanup
+    await store.async_insert("c", _filled_state([7, 8, 9]))  # evict b → save → cleanup
+    spilled = list((tmp_path / "test-vlm_latest").glob("*.safetensors"))
+    # Byte cap keeps disk bounded; not every evictee survives on disk.
+    assert len(spilled) <= 1


### PR DESCRIPTION
Closes #491.

## What

The VLM prompt cache (`VlmPromptCacheStore`) was **in-memory only**: an entry evicted past `OLMLX_VLM_PROMPT_CACHE_SLOTS` (default 2) was lost, forcing a full re-prefill on the next request for that `cache_id`. This adds a **cold disk tier**, mirroring the text-path design (`prompt_cache/store.py`).

## Why it's a clean mirror

The key open question from the issue was `PromptCacheState` serializability. It turns out to carry **only** `cache` (per-layer mlx-lm KV) and `token_ids` — no image hashes / rope deltas as separate fields. So it serializes exactly like the text path:
- `cache` → `mlx_lm.save_prompt_cache` / `load_prompt_cache` (safetensors)
- `token_ids` → safetensors metadata sidecar

## How

- New `async_get` / `async_insert` offload disk I/O with `asyncio.to_thread`. The KV state is **eager-`mx.eval`'d on the loop thread** before crossing into the worker thread, so no lazy Metal-stream graph escapes (#284).
- A **byte-capped, oldest-mtime** cleanup bounds disk use.
- Disk save is **best-effort** — a non-serializable cache or full disk never fails the in-flight request.
- **Never-filled states** (`cache=None`, inserted empty and evicted before mlx_vlm fills them) are skipped.
- `_setup_vlm_prompt_cache` is now `async` to await the disk tier; both call sites (`_stream_completion`, `_full_completion`) are already async.
- The in-memory `get`/`insert` API is unchanged (existing callers/tests unaffected); `insert` just routes through an evictee-capturing helper.

## Config (opt-in, mirrors the text knobs)

`OLMLX_VLM_PROMPT_CACHE_DISK` (default **off** — the common single-conversation case is fully covered by the in-memory slots), `OLMLX_VLM_PROMPT_CACHE_DISK_PATH`, `OLMLX_VLM_PROMPT_CACHE_DISK_MAX_GB`.

## Tests (`tests/test_vlm_prompt_cache_store.py`)

No real VLM required — a real `KVCache` filled with small arrays exercises the actual `save_prompt_cache`/`load_prompt_cache` round-trip:
- KV round-trips (restored `cache[0].offset` survives), spill-on-eviction, restore-on-memory-miss, memory-hit-skips-disk, empty-state skip, byte-cap cleanup, and disk-disabled no-op.

Verified locally on Apple Silicon: VLM store + inference cache + config + model_manager + prompt_cache suites green.

## Scope note

This is the v1 disk tier (cache_id-keyed, no radix-takeover, no KV-quant), matching the issue. Cross-request integration is exercised by the async unit tests; the end-to-end win is realised when a real VLM evicts and later restores a conversation across the configured slot count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)