### PR TITLE
feat(engine): StreamingLLM sink+window KV eviction for full-attention models (#505)

### DIFF
--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -80,6 +80,34 @@ def validate_kv_cache_quant_format(v: str | None) -> str | None:
     return v
 
 
+def validate_kv_eviction_format(v: str | None) -> str | None:
+    """Validate a ``kv_eviction`` value of the form ``'<sink>:<window>'`` (#505).
+
+    StreamingLLM-style eviction keeps the first ``sink`` tokens (attention
+    sinks) plus the last ``window`` tokens, dropping the middle. ``sink >= 0``,
+    ``window >= 1``. Validated for both the env var and ``models.json`` paths.
+    """
+    if v is None:
+        return v
+    parts = v.split(":", 1)
+    if len(parts) != 2:
+        raise ValueError(
+            f"Invalid kv_eviction={v!r}. Expected '<sink>:<window>' (e.g. '4:512')."
+        )
+    try:
+        sink, window = int(parts[0]), int(parts[1])
+    except ValueError:
+        raise ValueError(
+            f"Invalid kv_eviction={v!r}. Both sink and window must be integers "
+            f"(e.g. '4:512')."
+        ) from None
+    if sink < 0 or window < 1:
+        raise ValueError(
+            f"Invalid kv_eviction={v!r}. Require sink >= 0 and window >= 1."
+        )
+    return v
+
+
 class Settings(BaseSettings):
     # Note: ``validate_assignment=True`` applies to *all* fields, not just
     # the new speculative ones. Programmatic writes that previously
@@ -191,6 +219,14 @@ class Settings(BaseSettings):
     # bits ∈ {2, 4} for turboquant/spectral, {2, 4, 8} for shard. Per-model
     # overrides live on ``ModelConfig`` in ``olmlx.engine.registry``.
     kv_cache_quant: str | None = None
+
+    # StreamingLLM-style sink+window KV eviction (#505): '<sink>:<window>'
+    # keeps the first <sink> tokens + last <window> tokens and drops the middle,
+    # bounding KV *count* (per-step attention compute + memory) for long
+    # contexts. Lossy and opt-in; applied only to pure full-attention models
+    # (RotatingKVCache under the hood). Takes effect when kv_cache_quant is
+    # unset. Per-model overrides live on ``ModelConfig``.
+    kv_eviction: str | None = None
 
     # Fused Metal decode path for shard KV quant (#377 Tier 2): attention
     # over the compressed middle is computed from the packed form (no FP16
@@ -601,6 +637,11 @@ class Settings(BaseSettings):
     @classmethod
     def validate_kv_cache_quant(cls, v: str | None) -> str | None:
         return validate_kv_cache_quant_format(v)
+
+    @field_validator("kv_eviction")
+    @classmethod
+    def validate_kv_eviction(cls, v: str | None) -> str | None:
+        return validate_kv_eviction_format(v)
 
     @field_validator("weight_quant")
     @classmethod

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -30,11 +30,18 @@ if TYPE_CHECKING:
     from olmlx.engine.prompt_cache.store import PromptCacheStore
 
 try:
-    from mlx_lm.models.cache import make_prompt_cache, trim_prompt_cache
+    from mlx_lm.models.cache import (
+        KVCache,
+        RotatingKVCache,
+        make_prompt_cache,
+        trim_prompt_cache,
+    )
     from mlx_lm.utils import common_prefix_len as _find_common_prefix
 except ImportError:  # pragma: no cover
     make_prompt_cache = None  # type: ignore[assignment]
     trim_prompt_cache = None  # type: ignore[assignment]
+    KVCache = None  # type: ignore[assignment]
+    RotatingKVCache = None  # type: ignore[assignment]
     _find_common_prefix = None  # type: ignore[assignment]
     logging.getLogger(__name__).warning(
         "mlx-lm prompt cache imports unavailable — prompt caching disabled"
@@ -1362,6 +1369,43 @@ def _parse_kv_cache_quant(spec: str) -> tuple[str, int]:
     return method, int(bits_str)
 
 
+def _parse_kv_eviction(spec: str) -> tuple[int, int]:
+    """Split an ``OLMLX_KV_EVICTION`` value like ``"4:512"`` into
+    ``(sink, window)``. Format is validated at config load time (#505)."""
+    sink_str, window_str = spec.split(":")
+    return int(sink_str), int(window_str)
+
+
+def _make_eviction_prompt_cache(model: Any, sink: int, window: int) -> list:
+    """Build a StreamingLLM sink+window eviction cache for *model* (#505).
+
+    ``RotatingKVCache(max_size=sink+window, keep=sink)`` keeps the first
+    ``sink`` (attention-sink) tokens plus a rotating recent ``window`` and
+    drops the middle — bounding KV count for long contexts. mlx-lm's
+    ``create_attention_mask`` delegates to ``RotatingKVCache.make_mask``, so a
+    full-attention model attends correctly to the retained keys with no custom
+    mask/rope work.
+
+    Eviction is applied **only to pure full-attention models** — those whose
+    default cache is all plain ``KVCache``. Hybrid/SWA/GDN models (any
+    ``RotatingKVCache`` already present, or ``ArraysCache`` recurrent state)
+    are left untouched: a single per-forward mask is built from ``cache[0]``,
+    so a mixed list would mis-mask, and recurrent layers can't be windowed.
+    """
+    default = make_prompt_cache(model)
+    if RotatingKVCache is None or KVCache is None:
+        return default
+    if not default or not all(type(layer) is KVCache for layer in default):
+        logger.warning(
+            "kv_eviction requested but model is not pure full-attention "
+            "(cache layers: %s); eviction skipped for this model.",
+            sorted({type(layer).__name__ for layer in default}),
+        )
+        return default
+    max_size = sink + window
+    return [RotatingKVCache(max_size=max_size, keep=sink) for _ in default]
+
+
 def _make_prompt_cache_for_lm(lm: LoadedModel) -> list:
     """Create a fresh prompt cache for `lm` using the configured factory
     (plain mlx-lm, TurboQuant, or SpectralQuant).  Single source of truth
@@ -1378,6 +1422,9 @@ def _make_prompt_cache_for_lm(lm: LoadedModel) -> list:
             )
         return _make_turboquant_prompt_cache(lm.model, bits, is_vlm=lm.is_vlm)
     cache_model = _get_model_for_cache(lm.model, lm.is_vlm)
+    if lm.kv_eviction is not None:
+        sink, window = _parse_kv_eviction(lm.kv_eviction)
+        return _make_eviction_prompt_cache(cache_model, sink, window)
     return make_prompt_cache(cache_model)
 
 

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -756,6 +756,8 @@ class LoadedModel:
     # image-prefix KV reuse. Only populated for VLMs (None otherwise). #429.
     vlm_prompt_cache_store: Any = None
     kv_cache_quant: str | None = None
+    #: StreamingLLM sink+window KV eviction "<sink>:<window>" (#505), or None.
+    kv_eviction: str | None = None
     #: Weight quantization string (e.g. "hqq:4") applied at load time.
     #: ``None`` means no weight quantization was applied.
     weight_quant: str | None = None
@@ -1591,12 +1593,18 @@ class ModelManager(SpeculativeLoaderMixin):
                 # ``model_exp``.
                 flash_config = model_config.resolved_flash()
                 kv_cache_quant = model_config.resolved_kv_cache_quant()
+                kv_eviction = model_config.resolved_kv_eviction()
                 weight_quant_str = model_config.resolved_weight_quant()
                 # Whisper models (issue #366) have no LLM KV cache — never
                 # apply KV-cache quantization / spectral calibration to them.
                 _model_kind = self._detect_model_kind(hf_path)
                 if _model_kind in ("whisper", "tts", "reranker"):
                     kv_cache_quant = None
+                    kv_eviction = None
+                # KV quant and eviction are mutually exclusive (quant bounds
+                # bytes-per-token, eviction bounds token count); quant wins.
+                if kv_cache_quant is not None:
+                    kv_eviction = None
                 flash_moe_config = model_config.resolved_flash_moe()
 
                 # Pop LRU evictees under the lock; close them outside the lock
@@ -1963,6 +1971,7 @@ class ModelManager(SpeculativeLoaderMixin):
                         expires_at=expires,
                         size_bytes=_model_size,
                         kv_cache_quant=kv_cache_quant,
+                        kv_eviction=kv_eviction,
                         weight_quant=weight_quant_str,
                         spectral_calibration_dir=_spectral_dir,
                         shard_calibration_dir=_shard_dir,

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -1167,6 +1167,7 @@ class ModelConfig:
             and self.speculative_pld_lookup_window is None
             and self.speculative_layers_skip is None
             and self.kv_cache_quant is None
+            and self.kv_eviction is None
             and self.weight_quant is None
             and self.flash is None
             and self.flash_sparsity_threshold is None
@@ -1223,6 +1224,8 @@ class ModelConfig:
             result["speculative_layers_skip"] = self.speculative_layers_skip
         if self.kv_cache_quant is not None:
             result["kv_cache_quant"] = self.kv_cache_quant
+        if self.kv_eviction is not None:
+            result["kv_eviction"] = self.kv_eviction
         if self.weight_quant is not None:
             result["weight_quant"] = self.weight_quant
         if self.flash is not None:

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -94,6 +94,7 @@ PROMOTED_EXPERIMENTAL_KEYS: dict[str, str] = {
     "speculative_draft_model": "speculative_draft_model",
     "speculative_tokens": "speculative_tokens",
     "kv_cache_quant": "kv_cache_quant",
+    "kv_eviction": "kv_eviction",
     # Flash primary knobs promoted to top-level in Settings/ModelConfig.
     "flash": "flash",
     "flash_sparsity_threshold": "flash_sparsity_threshold",
@@ -401,6 +402,9 @@ class ModelConfig:
     #: KV cache quantization method and bits (e.g. "turboquant:4").
     #: ``None`` means inherit the global ``Settings.kv_cache_quant`` value.
     kv_cache_quant: str | None = None
+    #: StreamingLLM sink+window KV eviction, "<sink>:<window>" (e.g. "4:512").
+    #: ``None`` means inherit the global ``Settings.kv_eviction`` value (#505).
+    kv_eviction: str | None = None
     #: Weight quantization method, bits, and optional group size
     #: (e.g. "hqq:4", "hqq:8:128").
     #: ``None`` means inherit the global ``Settings.weight_quant`` value.
@@ -813,6 +817,12 @@ class ModelConfig:
             return self.kv_cache_quant
         return settings.kv_cache_quant
 
+    def resolved_kv_eviction(self) -> str | None:
+        """Resolve KV eviction config: per-model overrides global settings (#505)."""
+        if self.kv_eviction is not None:
+            return self.kv_eviction
+        return settings.kv_eviction
+
     def resolved_weight_quant(self) -> str | None:
         """Resolve weight quant config: per-model overrides global settings."""
         if self.weight_quant is not None:
@@ -1063,6 +1073,21 @@ class ModelConfig:
 
                 kv_cache_quant_raw = validate_kv_cache_quant_format(kv_cache_quant_raw)
 
+            kv_eviction_raw = entry.get("kv_eviction")
+            if kv_eviction_raw is not None:
+                if not isinstance(kv_eviction_raw, str):
+                    raise ValueError(
+                        f"'kv_eviction' must be a string, got {kv_eviction_raw!r}"
+                    )
+                if not kv_eviction_raw.strip():
+                    raise ValueError(
+                        "'kv_eviction' must be a non-empty string; "
+                        "use ``null`` to inherit from the global setting."
+                    )
+                from olmlx.config import validate_kv_eviction_format
+
+                kv_eviction_raw = validate_kv_eviction_format(kv_eviction_raw)
+
             weight_quant_raw = entry.get("weight_quant")
             if weight_quant_raw is not None:
                 if not isinstance(weight_quant_raw, str):
@@ -1096,6 +1121,7 @@ class ModelConfig:
                 speculative_pld_lookup_window=speculative_pld_lookup_window,
                 speculative_layers_skip=speculative_layers_skip,
                 kv_cache_quant=kv_cache_quant_raw,
+                kv_eviction=kv_eviction_raw,
                 weight_quant=weight_quant_raw,
                 flash=flash,
                 flash_sparsity_threshold=flash_sparsity_threshold,

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -4470,6 +4470,7 @@ class TestSetupPromptCache:
         lm = MagicMock()
         lm.is_vlm = False
         lm.kv_cache_quant = None
+        lm.kv_eviction = None
         lm.model = MagicMock()
         lm.prompt_cache_store = MagicMock()
         lm.prompt_cache_store.async_get = AsyncMock(return_value=None)
@@ -4628,6 +4629,7 @@ class TestKvCachePreflightCheckHelper:
         lm = MagicMock()
         lm.is_vlm = False
         lm.kv_cache_quant = None
+        lm.kv_eviction = None
         lm.model = MagicMock()
         lm.text_tokenizer = MagicMock()
         lm.prompt_cache_store = MagicMock()

--- a/tests/test_kv_eviction.py
+++ b/tests/test_kv_eviction.py
@@ -1,0 +1,180 @@
+"""Tests for StreamingLLM sink+window KV eviction (#505).
+
+The feature is an opt-in KV layout: for pure full-attention models, each layer's
+cache becomes ``RotatingKVCache(max_size=sink+window, keep=sink)`` — mlx-lm's
+own windowed cache, which keeps the first ``sink`` (attention-sink) tokens plus
+a rotating recent ``window`` and drops the middle. Correctness of the masking /
+rope is mlx-lm's; these tests cover olmlx's config plumbing, the cache-selection
+logic (only pure full-attention models are converted), and the eviction policy
+at the cache level (no-eviction exactness vs a plain KVCache + size bounding).
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+
+class TestKvEvictionConfigValidation:
+    def test_valid_values(self):
+        from olmlx.config import validate_kv_eviction_format
+
+        assert validate_kv_eviction_format(None) is None
+        assert validate_kv_eviction_format("4:512") == "4:512"
+        assert validate_kv_eviction_format("0:64") == "0:64"
+
+    @pytest.mark.parametrize(
+        "bad", ["512", "4:0", "-1:64", "a:b", "4:512:9", "4:", ":512"]
+    )
+    def test_invalid_values_rejected(self, bad):
+        from olmlx.config import validate_kv_eviction_format
+
+        with pytest.raises(ValueError, match="kv_eviction"):
+            validate_kv_eviction_format(bad)
+
+    def test_settings_env(self, monkeypatch):
+        from olmlx.config import Settings
+
+        monkeypatch.setenv("OLMLX_KV_EVICTION", "8:256")
+        assert Settings().kv_eviction == "8:256"
+
+    def test_settings_rejects_bad(self):
+        from pydantic import ValidationError
+
+        from olmlx.config import Settings
+
+        with pytest.raises(ValidationError):
+            Settings(kv_eviction="nope", _env_file=None)
+
+
+class TestResolvedKvEviction:
+    def test_per_model_overrides_global(self, monkeypatch):
+        from olmlx.engine.registry import ModelConfig
+
+        monkeypatch.setattr("olmlx.config.settings.kv_eviction", "4:512")
+        mc = ModelConfig(hf_path="org/m", kv_eviction="0:64")
+        assert mc.resolved_kv_eviction() == "0:64"
+
+    def test_falls_back_to_global(self, monkeypatch):
+        from olmlx.engine.registry import ModelConfig
+
+        monkeypatch.setattr("olmlx.config.settings.kv_eviction", "4:512")
+        assert ModelConfig(hf_path="org/m").resolved_kv_eviction() == "4:512"
+
+    def test_none_when_unset(self, monkeypatch):
+        from olmlx.engine.registry import ModelConfig
+
+        monkeypatch.setattr("olmlx.config.settings.kv_eviction", None)
+        assert ModelConfig(hf_path="org/m").resolved_kv_eviction() is None
+
+    def test_from_entry_validates(self):
+        from olmlx.engine.registry import ModelConfig
+
+        mc = ModelConfig.from_entry({"hf_path": "org/m", "kv_eviction": "4:512"})
+        assert mc.kv_eviction == "4:512"
+        with pytest.raises(ValueError, match="kv_eviction"):
+            ModelConfig.from_entry({"hf_path": "org/m", "kv_eviction": "bad"})
+
+
+class TestParse:
+    def test_parse(self):
+        from olmlx.engine.inference import _parse_kv_eviction
+
+        assert _parse_kv_eviction("4:512") == (4, 512)
+
+
+class TestEvictionCacheBuilder:
+    def test_pure_full_attention_converted(self, monkeypatch):
+        from olmlx.engine import inference
+
+        monkeypatch.setattr(
+            inference, "make_prompt_cache", lambda model: [KVCache(), KVCache()]
+        )
+        cache = inference._make_eviction_prompt_cache(object(), sink=4, window=64)
+        assert len(cache) == 2
+        assert all(isinstance(c, RotatingKVCache) for c in cache)
+        assert all(c.max_size == 68 and c.keep == 4 for c in cache)
+
+    def test_hybrid_model_left_untouched(self, monkeypatch):
+        """A model whose default cache mixes RotatingKVCache (SWA) must not be
+        converted — one per-forward mask is built from cache[0]."""
+        from olmlx.engine import inference
+
+        default = [KVCache(), RotatingKVCache(max_size=128, keep=0)]
+        monkeypatch.setattr(inference, "make_prompt_cache", lambda model: default)
+        cache = inference._make_eviction_prompt_cache(object(), sink=4, window=64)
+        assert cache is default  # unchanged
+
+    def test_selected_when_kv_eviction_set(self, monkeypatch):
+        """_make_prompt_cache_for_lm routes through the eviction builder."""
+        from types import SimpleNamespace
+
+        from olmlx.engine import inference
+
+        monkeypatch.setattr(inference, "make_prompt_cache", lambda model: [KVCache()])
+        monkeypatch.setattr(inference, "_get_model_for_cache", lambda m, v: m)
+        lm = SimpleNamespace(
+            model=object(), is_vlm=False, kv_cache_quant=None, kv_eviction="4:64"
+        )
+        cache = inference._make_prompt_cache_for_lm(lm)
+        assert isinstance(cache[0], RotatingKVCache)
+
+    def test_quant_takes_precedence_over_eviction(self, monkeypatch):
+        """When both are set on the LoadedModel, the quant branch wins."""
+        from types import SimpleNamespace
+
+        from olmlx.engine import inference
+
+        sentinel = ["quant-cache"]
+        monkeypatch.setattr(
+            inference, "_make_turboquant_prompt_cache", lambda *a, **k: sentinel
+        )
+        lm = SimpleNamespace(
+            model=object(),
+            is_vlm=False,
+            kv_cache_quant="turboquant:4",
+            kv_eviction="4:64",
+        )
+        assert inference._make_prompt_cache_for_lm(lm) is sentinel
+
+
+class TestEvictionPolicyAtCacheLevel:
+    """The sink+window behavior is mlx-lm's RotatingKVCache; pin the two
+    properties olmlx relies on."""
+
+    @staticmethod
+    def _kv(n, d=4, h=2):
+        k = mx.random.normal((1, h, n, d)).astype(mx.float16)
+        v = mx.random.normal((1, h, n, d)).astype(mx.float16)
+        return k, v
+
+    def test_no_eviction_matches_plain_cache(self):
+        """max_size >= total tokens → identical retained K/V to a plain KVCache,
+        so model output is unchanged when nothing is evicted."""
+        mx.random.seed(0)
+        plain, rot = KVCache(), RotatingKVCache(max_size=10_000, keep=4)
+        # prefill chunk + a few decode steps
+        for n in (6, 1, 1, 1):
+            k, v = self._kv(n)
+            pk, pv = plain.update_and_fetch(k, v)
+            rk, rv = rot.update_and_fetch(k, v)
+            assert mx.array_equal(pk, rk)
+            assert mx.array_equal(pv, rv)
+        assert plain.offset == rot.offset == 9
+
+    def test_eviction_bounds_kv_count(self):
+        mx.random.seed(1)
+        sink, window = 4, 8
+        rot = RotatingKVCache(max_size=sink + window, keep=sink)
+        # Prefill past capacity, then decode many steps.
+        k, v = self._kv(20)
+        rot.update_and_fetch(k, v)
+        for _ in range(30):
+            k, v = self._kv(1)
+            rk, _ = rot.update_and_fetch(k, v)
+            assert rk.shape[2] <= sink + window
+        # offset tracks the true token count even though KV is bounded.
+        assert rot.offset == 50
+        assert rot.size() == sink + window

--- a/tests/test_kv_eviction.py
+++ b/tests/test_kv_eviction.py
@@ -77,6 +77,22 @@ class TestResolvedKvEviction:
         with pytest.raises(ValueError, match="kv_eviction"):
             ModelConfig.from_entry({"hf_path": "org/m", "kv_eviction": "bad"})
 
+    def test_to_entry_round_trips(self):
+        """kv_eviction must survive serialization (no silent data loss on
+        models.json re-save)."""
+        from olmlx.engine.registry import ModelConfig
+
+        entry = ModelConfig(hf_path="org/m", kv_eviction="4:512").to_entry()
+        assert isinstance(entry, dict)
+        assert entry["kv_eviction"] == "4:512"
+        assert ModelConfig.from_entry(entry).kv_eviction == "4:512"
+
+    def test_to_entry_bare_string_when_only_hf_path(self):
+        """An entry with no overrides still collapses to a bare hf_path string."""
+        from olmlx.engine.registry import ModelConfig
+
+        assert ModelConfig(hf_path="org/m").to_entry() == "org/m"
+
 
 class TestParse:
     def test_parse(self):

--- a/tests/test_prompt_cache_radix.py
+++ b/tests/test_prompt_cache_radix.py
@@ -280,6 +280,7 @@ def _make_lm_for_radix(store: PromptCacheStore) -> MagicMock:
     lm.supports_cache_trim = True
     lm.is_vlm = False
     lm.kv_cache_quant = None
+    lm.kv_eviction = None
     lm.is_distributed = False
     return lm
 


### PR DESCRIPTION
Closes #505.

## What

An opt-in KV layout that bounds KV **count** (per-step attention compute + memory) for long contexts — a different lever than the three KV-quant schemes, which bound *bytes-per-token* but keep every token. Useful for long-context chat where decode slows as the cache grows.

## The key realization

mlx-lm's `RotatingKVCache(max_size=sink+window, keep=sink)` **is** exactly a StreamingLLM sink+window cache: it retains the first `sink` (attention-sink) tokens plus a rotating recent `window` and drops the middle, and `create_attention_mask` already delegates to its `make_mask`. So applying it to a full-attention model as a runtime policy needs **no custom rope/mask work** — it reuses mlx-lm's tested implementation. (Verified: `qwen3.py` etc. build the per-forward mask via `create_attention_mask(h, cache[0])`, which dispatches to `RotatingKVCache.make_mask`.)

## How

- `OLMLX_KV_EVICTION="<sink>:<window>"` (e.g. `"4:512"`) — global + per-model override (`resolved_kv_eviction`), mirroring `kv_cache_quant` end-to-end (validator, `Settings`, `ModelConfig`, `from_entry`, `LoadedModel`).
- Applied in `_make_prompt_cache_for_lm` **only to pure full-attention models** (default cache is all plain `KVCache`). Hybrid / SWA / GDN models are left untouched and logged: one per-forward mask is built from `cache[0]`, so a mixed list would mis-mask, and recurrent (`ArraysCache`) layers can't be windowed.
- **Mutually exclusive with `kv_cache_quant`** (quant bounds bytes, eviction bounds count) — quant wins, enforced both at load and in the cache builder.
- Lossy and opt-in: exact prefix reuse degrades once eviction starts (`RotatingKVCache.is_trimmable` → `False`), which the existing prompt-cache reuse path already handles.

## Tests — `tests/test_kv_eviction.py`

- Config validation + resolution precedence + `from_entry`.
- Cache selection: pure full-attention converted to `RotatingKVCache(max_size, keep)`; hybrid left untouched; quant takes precedence.
- Eviction policy at the cache level: **no-eviction exactness** — `RotatingKVCache(max_size ≥ total)` returns byte-identical K/V to a plain `KVCache` (so model output is unchanged until eviction kicks in) — and KV-count bounding under sustained decode.

Verified locally on Apple Silicon: 21/21 new + config/registry/model_manager/prompt_cache suites green (350 passed). Ruff + pyright clean.

## Scope / verification note

Correctness of the masking/rope is mlx-lm's `RotatingKVCache` (battle-tested for SWA models); this PR is the opt-in plumbing to apply it as a runtime policy on full-attention models. The no-eviction path is exactness-tested. The lossy long-context **quality** (the point of the feature) is inherent to dropping the middle and is best evaluated with a long-context eval on a real model — not asserted here, since it's an approximation, not a correctness property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)