### PR TITLE
fix(tests): disable thinking in responses SDK smoke text tests

### DIFF
--- a/tests/live/test_responses_sdk.py
+++ b/tests/live/test_responses_sdk.py
@@ -78,8 +78,14 @@ async def sdk_client(tmp_path, monkeypatch):
 
 
 async def test_text(sdk_client):
+    # Qwen3 is a thinking model; reasoning.effort="none" disables thinking so the
+    # 64-token budget produces visible prose rather than being spent entirely on an
+    # unclosed <think> block (which #555 correctly routes to reasoning, not content).
     resp = await sdk_client.responses.create(
-        model=MODEL, input="Say the single word: pong.", max_output_tokens=64
+        model=MODEL,
+        input="Say the single word: pong.",
+        max_output_tokens=64,
+        reasoning={"effort": "none"},
     )
     assert resp.status in ("completed", "incomplete")
     assert resp.output_text  # SDK convenience accessor concatenates output_text
@@ -88,7 +94,10 @@ async def test_text(sdk_client):
 async def test_streaming_text(sdk_client):
     chunks = []
     async with sdk_client.responses.stream(
-        model=MODEL, input="Count to three.", max_output_tokens=64
+        model=MODEL,
+        input="Count to three.",
+        max_output_tokens=64,
+        reasoning={"effort": "none"},
     ) as stream:
         async for event in stream:
             if event.type == "response.output_text.delta":


### PR DESCRIPTION
## Problem

The nightly **Real-model smoke** has failed since 2026-06-24 (last green: 06-23) on `tests/live/test_responses_sdk.py::test_text` and `::test_streaming_text`. Both assert `output_text` is non-empty, but the response came back `output_tokens=64` (== the `max_output_tokens=64` cap) with `output_text=''`.

## Root cause

Not a code regression — a stale test assertion exposed by an intended fix.

- `mlx-community/Qwen3-4B-4bit` is a **thinking** model. With reasoning on and only 64 tokens, it spends the whole budget inside a `<think>` block that never closes.
- Commit b96316a (#555), merged 06-23 23:07 — exactly between the last green run and the first failure — correctly reclassifies a truncated/unclosed `<think>` block as *reasoning* rather than visible content. Before it, that partial reasoning leaked into the content field, so `output_text` was (wrongly) non-empty and the assertion passed by accident. The new behavior is correct; the test was relying on the old bug.

## Fix

Pass `reasoning={"effort": "none"}` to both text smoke tests, which maps to `enable_thinking=False` via `resolve_openai_think` — so the 64-token budget yields visible prose. `test_tool_use` is untouched (it asserts on `function_call` shape, not prose).

## Verification

Triggered the smoke workflow via `workflow_dispatch` on this branch (self-hosted Mac runner, model cached): green — `tests/live/test_responses_sdk.py` **3 passed** (was 2 failed, 1 passed). Run: https://github.com/motsognirr/olmlx/actions/runs/28223639015

🤖 Generated with [Claude Code](https://claude.com/claude-code)