### PR TITLE
fix(openai): always serialize content key (null) in tool-call responses (#576)

### DIFF
--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -7,7 +7,7 @@ import time
 import uuid
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from olmlx.config import settings
 from olmlx.engine.grammar import parse_response_format
@@ -468,7 +468,7 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
         if not content:
             content = None
 
-        return OpenAIChatResponse(
+        resp = OpenAIChatResponse(
             id=chat_id,
             created=created,
             model=req.model,
@@ -485,6 +485,15 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
             ],
             usage=usage,
         )
+        resp_dict = resp.model_dump(mode="json", exclude_none=True)
+        # OpenAI spec: assistant messages must always carry a content key
+        # (null if absent). FastAPI's response_model_exclude_none would strip
+        # it, so we serialize ourselves and return a JSONResponse.
+        for ch in resp_dict.get("choices", []):
+            msg = ch.get("message")
+            if msg and msg.get("role") == "assistant" and "content" not in msg:
+                msg["content"] = None
+        return JSONResponse(content=resp_dict)
 
 
 @router.post(

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -1283,8 +1283,46 @@ class TestToolCallParsing:
         assert tool_calls[0]["function"]["name"] == "get_weather"
         args = json.loads(tool_calls[0]["function"]["arguments"])
         assert args == {"city": "London"}
-        # Tool call text should be stripped from content
-        assert not choice["message"].get("content")
+        # Tool call text should be stripped from content, but the key must be
+        # present with value null (OpenAI spec) — not omitted.
+        assert "content" in choice["message"]
+        assert choice["message"]["content"] is None
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_tool_call_content_key_present(self, app_client):
+        """OpenAI spec: content key must be present (as null) even for tool-only responses."""
+        mock_result = {
+            "text": self.QWEN_TOOL_CALL,
+            "done": True,
+            "stats": TimingStats(prompt_eval_count=10, eval_count=20),
+        }
+
+        with patch(
+            "olmlx.routers.openai.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "weather?"}],
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "parameters": {"type": "object"},
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert resp.status_code == 200
+        msg = resp.json()["choices"][0]["message"]
+        assert "content" in msg  # key must be present ...
+        assert msg["content"] is None  # ... with value null
+        assert msg["tool_calls"] is not None
 
     @pytest.mark.asyncio
     async def test_non_streaming_text_and_tool_call(self, app_client):


### PR DESCRIPTION
Fixes #576.

## Problem

Non-streaming `/v1/chat/completions` omitted the `content` key entirely from `choices[0].message` when the assistant returned only tool calls. The OpenAI spec requires `content: null` to always be present on assistant messages so SDK clients can access `message.content` without a `KeyError`/`AttributeError`.

Root cause: the route is decorated with `response_model_exclude_none=True`, which strips any `None`-valued field — including `content`.

## Fix

Serialize the response ourselves via `model_dump(mode="json", exclude_none=True)`, then re-insert `content: null` for any assistant message missing the key, and return a `JSONResponse` (FastAPI passes `Response` subclasses through without re-applying `exclude_none`). The `response_model` decorator stays for OpenAPI docs.

This incidentally also fixes the related omission in #558 (thinking-exhausts-budget, no visible text).

## Tests (TDD)

- New `test_non_streaming_tool_call_content_key_present` — asserts the key is present and null. Failed before the fix.
- Strengthened `test_non_streaming_tool_call` to require `content` present and `None` (was a falsy `.get()` check).
- Full `tests/test_routers_openai.py` suite passes (82 tests).

## Invariants

No CLAUDE.md invariants touched — change is entirely in the HTTP response-serialization layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)