### PR TITLE
fix(engine): correct completion_tokens when stop sequence truncates (#577)

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -3959,6 +3959,13 @@ async def _full_completion(
             # the visible generation ended at the stop, so "stop" wins — drop the
             # length marker that routers key on.
             result_dict.pop("done_reason", None)
+            # mlx-lm generated (and counted) tokens past the stop sequence; the
+            # client only sees the truncated text, so report its token count as
+            # eval_count instead of the full max_tokens run. add_special_tokens
+            # avoids inflating the count with a BOS that was never generated.
+            stats.eval_count = len(
+                lm.text_tokenizer.encode(text, add_special_tokens=False)
+            )
         result_dict["text"] = text
     return result_dict
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -654,6 +654,66 @@ class TestStopSequenceHandling:
     @patch("olmlx.engine.inference._inference_locked")
     @patch("olmlx.engine.inference._inference_ref")
     @patch("olmlx.engine.inference._full_completion_inner")
+    async def test_stop_sequence_updates_eval_count(
+        self, mock_inner, mock_ref, mock_locked
+    ):
+        """eval_count must be updated to the truncated token count, not max_tokens."""
+        from olmlx.utils.timing import TimingStats
+
+        gen_kwargs = {"stop": ["STOP"]}
+        stats = TimingStats()
+        stats.eval_count = 200  # mlx-lm generated full max_tokens
+        lm = MagicMock()
+        lm.inference_queue_timeout = 30.0
+        lm.sync_mode = None
+        lm.text_tokenizer.encode.return_value = [10, 20, 30]  # 3 tokens
+
+        mock_locked.return_value.__aenter__.return_value = None
+        mock_ref.return_value.__enter__.return_value = None
+        mock_inner.return_value = {
+            "text": "foo STOP bar",
+            "done": True,
+            "stats": stats,
+        }
+
+        result = await _full_completion(lm, "prompt", 200, gen_kwargs, stats)
+        assert result["text"] == "foo "
+        assert result["finish_reason"] == "stop"
+        assert stats.eval_count == 3
+        lm.text_tokenizer.encode.assert_called_once_with(
+            "foo ", add_special_tokens=False
+        )
+
+    @patch("olmlx.engine.inference._inference_locked")
+    @patch("olmlx.engine.inference._inference_ref")
+    @patch("olmlx.engine.inference._full_completion_inner")
+    async def test_no_stop_match_eval_count_unchanged(
+        self, mock_inner, mock_ref, mock_locked
+    ):
+        """eval_count is unchanged when no stop sequence fires."""
+        from olmlx.utils.timing import TimingStats
+
+        gen_kwargs = {"stop": ["STOP"]}
+        stats = TimingStats()
+        stats.eval_count = 50
+        lm = MagicMock()
+        lm.inference_queue_timeout = 30.0
+        lm.sync_mode = None
+
+        mock_locked.return_value.__aenter__.return_value = None
+        mock_ref.return_value.__enter__.return_value = None
+        mock_inner.return_value = {
+            "text": "hello world",
+            "done": True,
+            "stats": stats,
+        }
+
+        await _full_completion(lm, "prompt", 200, gen_kwargs, stats)
+        assert stats.eval_count == 50
+
+    @patch("olmlx.engine.inference._inference_locked")
+    @patch("olmlx.engine.inference._inference_ref")
+    @patch("olmlx.engine.inference._full_completion_inner")
     async def test_stop_not_in_kwargs_no_effect(
         self, mock_inner, mock_ref, mock_locked
     ):


### PR DESCRIPTION
Fixes #577.

## Problem

On the non-streaming exclusive path, `usage.completion_tokens` reported the full `max_tokens` budget even when a stop sequence fired early. Stop sequences are popped from `gen_kwargs` before mlx-lm runs (mlx-lm has no native support), so mlx-lm generates up to `max_tokens` and sets `stats.eval_count` to the full count. `_full_completion` then truncates the returned *text* at the stop sequence via `truncate_at_stop`, but never updated `eval_count` — so every non-streaming, non-batched caller over-reported completion tokens.

## Fix

On a stop hit in `_full_completion`, re-tokenize the truncated text (`add_special_tokens=False`, to avoid a phantom BOS) and overwrite `stats.eval_count` so usage reflects the text actually returned to the client.

- The prompt-cache store runs earlier (before truncation) and still records the full generation — correct, since the cache holds every generated token.
- The batched path (`StopScanner` inline) increments `eval_count` only for pre-stop tokens and is unaffected.

## Tests (TDD)

- New `test_stop_sequence_updates_eval_count` — asserts `eval_count` becomes the truncated count and `encode` is called with `add_special_tokens=False`. Failed before the fix.
- New `test_no_stop_match_eval_count_unchanged` — `eval_count` untouched when no stop fires.
- Full `tests/test_inference.py` passes (279 tests).

## Invariants

No CLAUDE.md invariants touched — pure CPU post-processing after the GPU generation thread returns; Metal-stream / speculative / batched paths untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)