### PR TITLE
fix(api): require max_tokens on /v1/messages; provider-format validation errors (#578, #579)

### DIFF
--- a/olmlx/app.py
+++ b/olmlx/app.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -320,6 +321,41 @@ def create_app() -> FastAPI:
     # Added last → runs outermost, so the per-request root span wraps every
     # other middleware and all downstream engine spans nest under it.
     app.add_middleware(RootSpanMiddleware)
+
+    @app.exception_handler(RequestValidationError)
+    async def request_validation_error_handler(
+        request: Request, exc: RequestValidationError
+    ):
+        # FastAPI's default handler returns a raw 422 {"detail": [...]} body.
+        # Provider SDKs expect provider-shaped error envelopes, so translate the
+        # Pydantic errors into a single 400 message dispatched by request path.
+        parts: list[str] = []
+        for err in exc.errors():
+            loc = err.get("loc") or ()
+            field = str(loc[-1]) if loc else "body"
+            msg = str(err.get("msg", "invalid value"))
+            if err.get("type") == "missing":
+                parts.append(f"{field}: field required")
+            elif msg.startswith("Value error, "):
+                # A custom field-validator already produced a descriptive
+                # message; surface it verbatim without a redundant field prefix.
+                parts.append(msg[len("Value error, ") :])
+            elif len(loc) > 1:
+                # Generic constraint/type error (e.g. "Input should be ...") —
+                # prefix the field name so the client knows what was invalid.
+                parts.append(f"{field}: {msg}")
+            else:
+                parts.append(msg)
+        message = "; ".join(parts) if parts else "invalid request"
+        logger.warning("Request validation error on %s: %s", request.url.path, message)
+        return _make_error_response(
+            request.url.path,
+            400,
+            message,
+            "invalid_request_error",
+            "invalid_request_error",
+            "invalid_value",
+        )
 
     @app.exception_handler(ValueError)
     async def value_error_handler(request: Request, exc: ValueError):

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -30,6 +30,7 @@ from olmlx.engine.tool_parser import (
 )
 from olmlx.schemas.anthropic import (
     AnthropicContentBlock,
+    AnthropicCountTokensRequest,
     AnthropicMessagesRequest,
     AnthropicMessagesResponse,
     AnthropicTokenCountResponse,
@@ -626,7 +627,7 @@ async def _stream_thinking_state_machine(result):
     response_model=AnthropicTokenCountResponse,
     response_model_exclude_none=True,
 )
-async def anthropic_count_tokens(req: AnthropicMessagesRequest, request: Request):
+async def anthropic_count_tokens(req: AnthropicCountTokensRequest, request: Request):
     logger.info(
         "Anthropic count_tokens: model=%s messages=%d tools=%d",
         req.model,

--- a/olmlx/schemas/anthropic.py
+++ b/olmlx/schemas/anthropic.py
@@ -71,7 +71,10 @@ class AnthropicThinkingParam(BaseModel):
 class AnthropicMessagesRequest(BaseModel):
     model: ModelName
     messages: list[AnthropicMessage]
-    max_tokens: int = Field(4096, ge=1)
+    # Required per the Anthropic API spec — omitting it must yield a 400, not a
+    # silent default. count_tokens uses AnthropicCountTokensRequest, which makes
+    # this optional (the real count_tokens endpoint takes no max_tokens).
+    max_tokens: int = Field(..., ge=1)
     stream: bool = False
 
     @field_validator("max_tokens")
@@ -115,6 +118,18 @@ class AnthropicMessagesRequest(BaseModel):
     metadata: dict | None = None
 
     model_config = {"extra": "allow"}
+
+
+class AnthropicCountTokensRequest(AnthropicMessagesRequest):
+    """Request schema for /v1/messages/count_tokens.
+
+    The real Anthropic count_tokens endpoint takes no max_tokens field, so —
+    unlike /v1/messages — omitting it must not be an error. Re-declaring the
+    field with a default makes it optional while inheriting every other field
+    and validator from AnthropicMessagesRequest.
+    """
+
+    max_tokens: int = Field(1, ge=1)
 
 
 class AnthropicUsage(BaseModel):

--- a/tests/integration/test_edge_cases.py
+++ b/tests/integration/test_edge_cases.py
@@ -61,7 +61,7 @@ class TestZeroTokenGeneration:
                 "max_tokens": 0,
             },
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
 
     async def test_openai_zero_max_completion_tokens_rejected(self, integration_ctx):
         """POST /v1/chat/completions with max_completion_tokens: 0 is rejected."""
@@ -73,7 +73,7 @@ class TestZeroTokenGeneration:
                 "max_completion_tokens": 0,
             },
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -193,6 +193,34 @@ class TestErrorHandlers:
         assert data["error"]["type"] == "invalid_request_error"
 
     @pytest.mark.asyncio
+    async def test_validation_error_anthropic_format(self, app_client):
+        """A request-body validation failure on /v1/messages is mapped to a 400
+        Anthropic error envelope, not the raw Pydantic 422 detail."""
+        resp = await app_client.post(
+            "/v1/messages",
+            json={"model": "qwen3", "messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert resp.status_code == 400
+        data = resp.json()
+        assert data["type"] == "error"
+        assert data["error"]["type"] == "invalid_request_error"
+        assert "max_tokens" in data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_validation_error_openai_format(self, app_client):
+        """A request-body validation failure on /v1/chat/completions is mapped to
+        a 400 OpenAI error envelope, not the raw Pydantic 422 detail."""
+        resp = await app_client.post(
+            "/v1/chat/completions",
+            json={"model": "qwen3", "messages": []},
+        )
+        assert resp.status_code == 400
+        data = resp.json()
+        assert "detail" not in data
+        assert data["error"]["type"] == "invalid_request_error"
+        assert data["error"]["code"] == "invalid_value"
+
+    @pytest.mark.asyncio
     async def test_runtime_error_handler(self, app_client):
         from unittest.mock import AsyncMock
 

--- a/tests/test_chat_errors.py
+++ b/tests/test_chat_errors.py
@@ -375,10 +375,12 @@ class TestRouterErrorShapeConsistency:
             content="{}",
             headers={"Content-Type": "application/json"},
         )
-        # Returns validation error — fastapi sends 422 with {'detail': [...]}
-        assert resp.status_code == 422
+        # Body validation fails; the RequestValidationError handler maps it to a
+        # 400 in the Ollama error envelope ({"error": ...}), not the raw 422.
+        assert resp.status_code == 400
         body = resp.json()
-        assert "detail" in body
+        assert "detail" not in body
+        assert "error" in body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_routers_agent.py
+++ b/tests/test_routers_agent.py
@@ -99,15 +99,15 @@ class TestCreateRun:
         resp = await client.post("/v1/agent/runs", json={"goal": "x"})
         assert resp.json()["model"] == "qwen3:latest"
 
-    async def test_create_empty_goal_422(self, agent_client):
+    async def test_create_empty_goal_400(self, agent_client):
         client, service = agent_client
         resp = await client.post("/v1/agent/runs", json={"goal": "   "})
-        assert resp.status_code == 422
+        assert resp.status_code == 400
 
-    async def test_create_missing_goal_422(self, agent_client):
+    async def test_create_missing_goal_400(self, agent_client):
         client, service = agent_client
         resp = await client.post("/v1/agent/runs", json={})
-        assert resp.status_code == 422
+        assert resp.status_code == 400
 
 
 class TestGetAndList:

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -32,6 +32,7 @@ MAP_PATCH = "olmlx.routers.anthropic._anthropic_model_map"
 class TestConvertTools:
     def test_no_tools(self):
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
         )
@@ -39,6 +40,7 @@ class TestConvertTools:
 
     def test_with_tools(self):
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
             tools=[
@@ -138,6 +140,7 @@ class TestStripBillingHeaders:
 class TestConvertMessages:
     def test_simple_user_message(self):
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hello")],
         )
@@ -148,6 +151,7 @@ class TestConvertMessages:
 
     def test_system_string(self):
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
             system="Be helpful.",
@@ -158,6 +162,7 @@ class TestConvertMessages:
 
     def test_system_blocks(self):
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
             system=[
@@ -182,6 +187,7 @@ class TestConvertMessages:
         every ``/v1/messages`` request.  Regression for that failure.
         """
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             system=[AnthropicContentBlock(type="text", text="Top-level system.")],
             messages=[
@@ -201,6 +207,7 @@ class TestConvertMessages:
         """A ``system``-role message in ``messages`` with no top-level system
         still becomes the single leading system message."""
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[
                 AnthropicMessage(role="system", content="Inline only."),
@@ -214,6 +221,7 @@ class TestConvertMessages:
 
     def test_assistant_with_tool_use(self):
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[
                 AnthropicMessage(
@@ -239,6 +247,7 @@ class TestConvertMessages:
 
     def test_user_with_tool_result(self):
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[
                 AnthropicMessage(
@@ -264,6 +273,7 @@ class TestConvertMessages:
 
     def test_tool_result_list_content(self):
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[
                 AnthropicMessage(
@@ -288,6 +298,7 @@ class TestConvertMessages:
 
     def test_thinking_blocks_skipped(self):
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[
                 AnthropicMessage(
@@ -306,6 +317,7 @@ class TestConvertMessages:
     def test_system_blocks_billing_header_stripped(self):
         """Billing header block in system is stripped during convert_messages."""
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
             system=[
@@ -324,6 +336,7 @@ class TestConvertMessages:
     def test_system_only_billing_header_no_system_message(self):
         """System with only billing header produces no system message."""
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
             system=[
@@ -340,6 +353,7 @@ class TestConvertMessages:
 class TestBuildOptions:
     def test_empty(self):
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
         )
@@ -348,6 +362,7 @@ class TestBuildOptions:
 
     def test_all_options(self):
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
             temperature=0.5,
@@ -400,6 +415,34 @@ class TestAnthropicEndpoint:
         assert data["content"][0]["text"] == "Hello from MLX!"
         assert data["usage"]["input_tokens"] == 10
         assert data["usage"]["output_tokens"] == 20
+
+    @pytest.mark.asyncio
+    async def test_missing_max_tokens_returns_400(self, app_client):
+        """max_tokens is required per the Anthropic spec; omitting it must yield
+        a 400 in the Anthropic error envelope, not a silent default 200."""
+        resp = await app_client.post(
+            "/v1/messages",
+            json={"model": "qwen3", "messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert resp.status_code == 400
+        data = resp.json()
+        assert data["type"] == "error"
+        assert data["error"]["type"] == "invalid_request_error"
+        assert "max_tokens" in data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_count_tokens_without_max_tokens_succeeds(
+        self, app_client, mock_loaded_model
+    ):
+        """The real Anthropic count_tokens endpoint takes no max_tokens field, so
+        omitting it must still succeed (unlike /v1/messages)."""
+        mock_loaded_model.tokenizer.apply_chat_template.return_value = [1, 2, 3]
+        resp = await app_client.post(
+            "/v1/messages/count_tokens",
+            json={"model": "qwen3", "messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["input_tokens"] == 3
 
     @pytest.mark.asyncio
     async def test_non_streaming_literal_close_think_preserved_when_not_thinking(
@@ -1525,10 +1568,13 @@ class TestEmptyMessagesRejected:
             "/v1/messages",
             json={"model": "qwen3", "messages": [], "max_tokens": 100},
         )
-        assert resp.status_code == 422
-        body = resp.text.lower()
-        assert "messages" in body
-        assert "empty" in body
+        # The RequestValidationError handler maps Pydantic validation failures to
+        # a 400 in the provider error envelope (Anthropic format here).
+        assert resp.status_code == 400
+        data = resp.json()
+        assert data["type"] == "error"
+        assert data["error"]["type"] == "invalid_request_error"
+        assert "messages cannot be empty" in data["error"]["message"]
 
 
 class TestCountTokens:
@@ -2082,6 +2128,7 @@ class TestXCacheIDHeader:
 class TestThinkingParamSchema:
     def test_thinking_enabled(self):
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
             thinking=AnthropicThinkingParam(type="enabled", budget_tokens=10000),
@@ -2092,6 +2139,7 @@ class TestThinkingParamSchema:
 
     def test_thinking_disabled(self):
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
             thinking=AnthropicThinkingParam(type="disabled"),
@@ -2102,6 +2150,7 @@ class TestThinkingParamSchema:
 
     def test_thinking_missing(self):
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
         )
@@ -2110,6 +2159,7 @@ class TestThinkingParamSchema:
     def test_thinking_from_dict(self):
         """Schema parses thinking from raw dict (as JSON would arrive)."""
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
             thinking={"type": "enabled", "budget_tokens": 5000},
@@ -2120,6 +2170,7 @@ class TestThinkingParamSchema:
     def test_thinking_adaptive(self):
         """Schema accepts 'adaptive' type (used by Claude Code)."""
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
             thinking={"type": "adaptive"},
@@ -2129,6 +2180,7 @@ class TestThinkingParamSchema:
     def test_thinking_unknown_type_accepted(self):
         """Schema accepts unknown types for forward compatibility."""
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
             thinking={"type": "some_future_type"},
@@ -2138,6 +2190,7 @@ class TestThinkingParamSchema:
     def test_thinking_extra_fields_accepted(self):
         """Unknown fields in thinking param are accepted for forward compatibility."""
         req = AnthropicMessagesRequest(
+            max_tokens=100,
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
             thinking={"type": "enabled", "budget_tokens": 5000, "new_field": "value"},

--- a/tests/test_routers_chat.py
+++ b/tests/test_routers_chat.py
@@ -1140,7 +1140,7 @@ class TestEmptyMessagesRejected:
             "/api/chat",
             json={"model": "qwen3", "messages": []},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
         body = resp.text.lower()
         assert "messages" in body
         assert "empty" in body

--- a/tests/test_routers_embed.py
+++ b/tests/test_routers_embed.py
@@ -68,7 +68,7 @@ class TestEmbedRouter:
             "/api/embed",
             json={"model": "qwen3", "input": ""},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
         assert "input" in resp.text.lower()
         assert "empty" in resp.text.lower()
 
@@ -78,7 +78,7 @@ class TestEmbedRouter:
             "/api/embed",
             json={"model": "qwen3", "input": []},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
         assert "input" in resp.text.lower()
         assert "empty" in resp.text.lower()
 
@@ -88,6 +88,6 @@ class TestEmbedRouter:
             "/api/embeddings",
             json={"model": "qwen3", "prompt": ""},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
         assert "prompt" in resp.text.lower()
         assert "empty" in resp.text.lower()

--- a/tests/test_routers_generate.py
+++ b/tests/test_routers_generate.py
@@ -352,7 +352,7 @@ class TestEmptyPromptRejected:
             "/api/generate",
             json={"model": "qwen3", "prompt": ""},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
         body = resp.text.lower()
         assert "prompt" in body
         assert "empty" in body
@@ -363,6 +363,6 @@ class TestEmptyPromptRejected:
             "/api/generate",
             json={"model": "qwen3"},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
         body = resp.text.lower()
         assert "prompt" in body

--- a/tests/test_routers_models.py
+++ b/tests/test_routers_models.py
@@ -58,4 +58,4 @@ class TestModelsRouter:
     async def test_show_rejects_empty_body(self, app_client):
         # neither name nor model gives 422
         resp = await app_client.post("/api/show", json={})
-        assert resp.status_code == 422
+        assert resp.status_code == 400

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -533,7 +533,7 @@ class TestOpenAIRouter:
                 "encoding_format": "bogus",
             },
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
 
     @pytest.mark.asyncio
     async def test_completions_streaming(self, app_client):
@@ -755,7 +755,7 @@ class TestEmptyInputRejected:
             "/v1/chat/completions",
             json={"model": "qwen3", "messages": []},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
         body = resp.text.lower()
         assert "messages" in body
         assert "empty" in body
@@ -766,7 +766,7 @@ class TestEmptyInputRejected:
             "/v1/embeddings",
             json={"model": "qwen3", "input": ""},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
         body = resp.text.lower()
         assert "input" in body
         assert "empty" in body
@@ -777,7 +777,7 @@ class TestEmptyInputRejected:
             "/v1/embeddings",
             json={"model": "qwen3", "input": []},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
         body = resp.text.lower()
         assert "input" in body
         assert "empty" in body
@@ -788,7 +788,7 @@ class TestEmptyInputRejected:
             "/v1/completions",
             json={"model": "qwen3", "prompt": ""},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
         body = resp.text.lower()
         assert "prompt" in body
         assert "empty" in body
@@ -799,13 +799,13 @@ class TestEmptyInputRejected:
             "/v1/completions",
             json={"model": "qwen3", "prompt": []},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
         body = resp.text.lower()
         assert "prompt" in body
         assert "empty" in body
 
     @pytest.mark.asyncio
-    async def test_user_null_content_returns_422(self, app_client):
+    async def test_user_null_content_returns_400(self, app_client):
         resp = await app_client.post(
             "/v1/chat/completions",
             json={
@@ -813,7 +813,7 @@ class TestEmptyInputRejected:
                 "messages": [{"role": "user", "content": None}],
             },
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
         body = resp.text.lower()
         assert "content" in body
 
@@ -998,7 +998,7 @@ class TestResponseFormat:
                 "response_format": {"type": "json_schema"},
             },
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
 
     @pytest.mark.asyncio
     async def test_json_schema_requires_name(self, app_client):
@@ -1013,7 +1013,7 @@ class TestResponseFormat:
                 },
             },
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
 
     @pytest.mark.asyncio
     async def test_json_schema_requires_schema_field(self, app_client):
@@ -1028,7 +1028,7 @@ class TestResponseFormat:
                 },
             },
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
 
     @pytest.mark.asyncio
     async def test_json_schema_passes_grammar_spec_and_injects_system_message(
@@ -1205,7 +1205,7 @@ class TestResponseFormat:
                 },
             },
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
 
     @pytest.mark.asyncio
     async def test_json_schema_sanitizes_name(self, app_client):

--- a/tests/test_routers_rerank.py
+++ b/tests/test_routers_rerank.py
@@ -70,7 +70,7 @@ class TestRerankRouter:
             "/v1/rerank",
             json={"model": "m", "query": "q", "documents": []},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 400
 
     @pytest.mark.asyncio
     async def test_rerank_non_reranker_model_returns_400(self, app_client):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from olmlx.schemas.anthropic import (
     AnthropicContentBlock,
+    AnthropicCountTokensRequest,
     AnthropicMessage,
     AnthropicMessagesRequest,
     AnthropicMessagesResponse,
@@ -692,16 +693,34 @@ class TestAnthropicSchemas:
         req = AnthropicMessagesRequest(
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
+            max_tokens=100,
         )
-        assert req.max_tokens == 4096
         assert req.stream is False
         assert req.tools is None
         assert req.system is None
+
+    def test_messages_request_max_tokens_required(self):
+        """max_tokens has no default — omitting it is a validation error."""
+        with pytest.raises(ValidationError, match="max_tokens"):
+            AnthropicMessagesRequest(
+                model="test",
+                messages=[AnthropicMessage(role="user", content="hi")],
+            )
+
+    def test_count_tokens_request_max_tokens_optional(self):
+        """count_tokens accepts requests without max_tokens (real Anthropic API
+        takes no such field there)."""
+        req = AnthropicCountTokensRequest(
+            model="test",
+            messages=[AnthropicMessage(role="user", content="hi")],
+        )
+        assert req.max_tokens == 1
 
     def test_messages_request_with_system(self):
         req = AnthropicMessagesRequest(
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
+            max_tokens=100,
             system="You are helpful.",
         )
         assert req.system == "You are helpful."
@@ -741,6 +760,7 @@ class TestAnthropicSchemas:
         req = AnthropicMessagesRequest(
             model="test",
             messages=[AnthropicMessage(role="user", content="hi")],
+            max_tokens=100,
             temperature=1.0,
         )
         assert req.temperature == 1.0
@@ -750,6 +770,7 @@ class TestAnthropicSchemas:
             AnthropicMessagesRequest(
                 model="test",
                 messages=[AnthropicMessage(role="user", content="hi")],
+                max_tokens=100,
                 temperature=1.1,
             )
 
@@ -758,6 +779,7 @@ class TestAnthropicSchemas:
             AnthropicMessagesRequest(
                 model="test",
                 messages=[AnthropicMessage(role="user", content="hi")],
+                max_tokens=100,
                 temperature=-0.1,
             )
 
@@ -766,6 +788,7 @@ class TestAnthropicSchemas:
             AnthropicMessagesRequest(
                 model="test",
                 messages=[AnthropicMessage(role="user", content="hi")],
+                max_tokens=100,
                 top_p=1.1,
             )
 
@@ -774,6 +797,7 @@ class TestAnthropicSchemas:
             AnthropicMessagesRequest(
                 model="test",
                 messages=[AnthropicMessage(role="user", content="hi")],
+                max_tokens=100,
                 top_k=0,
             )
 
@@ -787,7 +811,7 @@ class TestAnthropicSchemas:
 
     def test_messages_request_rejects_empty_messages(self):
         with pytest.raises(ValidationError, match="messages"):
-            AnthropicMessagesRequest(model="test", messages=[])
+            AnthropicMessagesRequest(model="test", messages=[], max_tokens=100)
 
     def test_usage(self):
         u = AnthropicUsage()


### PR DESCRIPTION
Fixes #578. Fixes #579.

These two issues share a single root fix — a `RequestValidationError` handler — so they're resolved together rather than artificially split.

## #578 — Anthropic `/v1/messages` must require `max_tokens`

`max_tokens` carried a default of `4096`, so omitting it silently succeeded (200) instead of returning a 400 like the real Anthropic API. Changed to `Field(..., ge=1)` (required).

The real Anthropic `count_tokens` endpoint takes **no** `max_tokens` field, so making it required everywhere would make olmlx *less* faithful there. Instead, `/v1/messages/count_tokens` now uses a dedicated `AnthropicCountTokensRequest` subclass that keeps `max_tokens` optional while inheriting all other fields/validators.

## #579 — validation errors must use the provider error envelope

Request-body Pydantic failures returned FastAPI's raw `422 {"detail": [...]}` body, which OpenAI/Anthropic SDK clients can't parse (`error.message` → KeyError). Added a `RequestValidationError` handler in `app.py` that:
- flattens the Pydantic errors into one message (`max_tokens: field required`, `messages cannot be empty`, etc.),
- returns **400** in the provider envelope dispatched by request path via the existing `_make_error_response` helper (Anthropic `{"type":"error","error":{...}}`, OpenAI `{"error":{...}}`, Ollama `{"error": ...}`).

In-handler `HTTPException(422)` paths (e.g. an unrecognized `format` value) are deliberately unaffected — only Pydantic body-validation is reshaped.

## Tests (TDD)

- New: `test_missing_max_tokens_returns_400`, `test_count_tokens_without_max_tokens_succeeds`, schema `test_messages_request_max_tokens_required` / `test_count_tokens_request_max_tokens_optional`, app-level `test_validation_error_anthropic_format` / `test_validation_error_openai_format`.
- Updated existing 422-expecting tests to 400 + provider envelope across OpenAI, Ollama (chat/generate/embed/models), agent, rerank, and edge-case surfaces.
- Full `pytest -m "not real_model"` suite: the only remaining failures are pre-existing, environment-specific Metal-kernel (`test_shardquant_*`) and a TTS handler test — all confirmed to fail identically on a clean tree without this diff.

## Invariants

No CLAUDE.md Metal-stream / prefill / speculative / distributed invariants touched — entirely in the HTTP request-validation layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)