### PR TITLE
fix(anthropic): no spurious thinking block for whitespace-only fragments (#557)

### DIFF
--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -532,13 +532,14 @@ async def _stream_thinking_state_machine(result):
         nonlocal current, text_block_emitted
         if not fragment:
             return []
-        # A whitespace-only fragment must not *open* a new block. With
-        # `/no_think`, Qwen3 emits leading whitespace before an orphan
+        # A whitespace-only *thinking* fragment must not open a thinking block.
+        # With `/no_think`, Qwen3 emits leading whitespace before an orphan
         # `</think>`, which the splitter classifies as a thinking fragment;
-        # opening a thinking block for it produces a spurious block the
-        # non-streaming path never emits (issue #557). Whitespace *inside* an
-        # already-open block is preserved.
-        if current is None and not fragment.strip():
+        # opening a block for it produces a spurious thinking block the
+        # non-streaming path never emits (issue #557). Scoped to the thinking
+        # channel so leading whitespace in plain-text streams is preserved, and
+        # to block-opening so whitespace inside an open thinking block survives.
+        if channel == "thinking" and current is None and not fragment.strip():
             return []
         block_type = "thinking" if channel == "thinking" else "text"
         events = []

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -420,7 +420,9 @@ async def _stream_buffered_with_tools(
 
     block_idx = 0
 
-    if thinking:
+    if thinking and thinking.strip():
+        # Mirror the incremental path (issue #557): a whitespace-only thinking
+        # span must not produce a thinking content block.
         for event in _emit_content_block(
             block_idx,
             "thinking",
@@ -529,6 +531,14 @@ async def _stream_thinking_state_machine(result):
         """
         nonlocal current, text_block_emitted
         if not fragment:
+            return []
+        # A whitespace-only fragment must not *open* a new block. With
+        # `/no_think`, Qwen3 emits leading whitespace before an orphan
+        # `</think>`, which the splitter classifies as a thinking fragment;
+        # opening a thinking block for it produces a spurious block the
+        # non-streaming path never emits (issue #557). Whitespace *inside* an
+        # already-open block is preserved.
+        if current is None and not fragment.strip():
             return []
         block_type = "thinking" if channel == "thinking" else "text"
         events = []

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -898,7 +898,9 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
 
         content_blocks = []
 
-        if thinking:
+        # Consistent with the streaming paths (issue #557): a whitespace-only
+        # thinking span must not produce a thinking content block.
+        if thinking and thinking.strip():
             content_blocks.append(
                 AnthropicContentBlock(type="thinking", thinking=thinking, signature="")
             )

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -1153,6 +1153,60 @@ class TestAnthropicEndpoint:
             )
 
     @pytest.mark.asyncio
+    async def test_streaming_no_think_whitespace_no_spurious_thinking_block(
+        self, app_client
+    ):
+        """Issue #557: with `/no_think`, Qwen3 emits leading whitespace (`\\n\\n`)
+        before an orphan `</think>`. The splitter classifies that whitespace as
+        thinking content; the streaming path must NOT surface it as a thinking
+        content block — the non-streaming path emits only a text block."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"thinking_expected": True}
+                yield {"text": "\n\n</think>", "done": False}
+                yield {"text": "Yes.", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.anthropic.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "Say: yes. /no_think"}],
+                    "max_tokens": 20,
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        block_types: list[str] = []
+        thinking_text = ""
+        text_text = ""
+        for line in resp.text.splitlines():
+            if not line.startswith("data: "):
+                continue
+            try:
+                payload = json.loads(line[6:])
+            except json.JSONDecodeError:
+                continue
+            if payload.get("type") == "content_block_start":
+                block_types.append(payload["content_block"]["type"])
+            elif payload.get("type") == "content_block_delta":
+                delta = payload.get("delta", {})
+                if delta.get("type") == "thinking_delta":
+                    thinking_text += delta.get("thinking", "")
+                elif delta.get("type") == "text_delta":
+                    text_text += delta.get("text", "")
+        assert "thinking" not in block_types, (
+            f"spurious thinking block emitted: {block_types}"
+        )
+        assert thinking_text == ""
+        assert text_text == "Yes."
+
+    @pytest.mark.asyncio
     async def test_streaming_overflow_when_close_think_never_arrives(self, app_client):
         """When `thinking_expected=True` but no `</think>` arrives before the
         buffer crosses `INIT_ORPHAN_DETECT_LIMIT`, the state machine must


### PR DESCRIPTION
Fixes #557.

## Problem

On the Anthropic `/v1/messages` **streaming** path, a request with `/no_think` emitted a spurious `thinking` content block. Qwen3 emits leading whitespace (`\n\n`) before an orphan `</think>`; the thinking splitter classifies that whitespace as a thinking fragment, and `_route` opened a thinking content block for it because `"\n\n"` is truthy. The **non-streaming** path correctly emits only a `text` block — so this was a streaming/non-streaming inconsistency.

## Fix

- `_route`: skip a whitespace-only fragment when it would **open** a new block (`current is None`). Whitespace *inside* an already-open block is preserved, so legitimate inter-token spacing in real thinking/text content is untouched. This is narrower (and safer) than the issue's suggested blanket `if not fragment.strip()`, which would have dropped inter-word whitespace in streamed text.
- Buffered tool path: mirror the guard — `if thinking` → `if thinking and thinking.strip()`.

## Tests (TDD)

- New `test_streaming_no_think_whitespace_no_spurious_thinking_block` — reproduces the `\n\n</think>Yes.` scenario; asserts no `thinking` content block, empty thinking text, and `text == "Yes."`. Failed before the fix (`['thinking', 'text']`), passes after.
- Full `tests/test_routers_anthropic.py` suite passes (128 tests).

## Invariants

No CLAUDE.md invariants touched — purely SSE block-emission logic; no inference, stream selection, or cache plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)