### PR TITLE
fix(openai): announce assistant role when thinking exhausts budget (#551)

### DIFF
--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -97,6 +97,7 @@ async def _stream_openai_sse(
         return {k: v for k, v in choice.items() if v is not None}
 
     think_state: dict = {}
+    content_emitted = False
     try:
         async for chunk in result:
             if chunk.get("cache_info"):
@@ -124,6 +125,23 @@ async def _stream_openai_sse(
                             "choices": [_compact_choice(format_content(flushed))],
                         }
                         yield f"data: {json.dumps(data)}\n\n"
+                        content_emitted = True
+                # Issue #551: if thinking consumed the whole token budget, no
+                # content chunk ever fired and the client never saw a role
+                # announcement — the stream looks like an instant empty success.
+                # Emit a role/empty-content chunk so the assistant turn is
+                # detectable. Scoped to the chat path (format_content carries a
+                # role); the completions path uses a text-shaped formatter.
+                if strip_thinking and not content_emitted:
+                    data = {
+                        "id": response_id,
+                        "object": object_type,
+                        "created": created,
+                        "model": model,
+                        "choices": [_compact_choice(format_content(""))],
+                    }
+                    yield f"data: {json.dumps(data)}\n\n"
+                    content_emitted = True
                 done_reason = chunk.get("done_reason")
                 finish_reason = (
                     "length"
@@ -155,6 +173,7 @@ async def _stream_openai_sse(
                     "choices": [_compact_choice(format_content(text))],
                 }
                 yield f"data: {json.dumps(data)}\n\n"
+                content_emitted = True
     except Exception as exc:
         logger.error("Error during OpenAI streaming: %s", exc, exc_info=True)
         error_payload = json.dumps(

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -1692,7 +1692,11 @@ class TestToolCallParsing:
         contents = "".join(
             e["choices"][0]["delta"].get("content", "") or "" for e in events
         )
+        # Neither the <think> marker nor the thinking text itself may leak into
+        # visible content — the whole budget was reasoning.
         assert "<think>" not in contents
+        assert "Okay, 2+2 is" not in contents
+        assert contents.strip() == ""
         done_events = [e for e in events if e["choices"][0].get("finish_reason")]
         assert done_events[-1]["choices"][0]["finish_reason"] == "length"
 

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -1648,6 +1648,87 @@ class TestToolCallParsing:
         assert "The answer is 42." in full_content
 
     @pytest.mark.asyncio
+    async def test_streaming_thinking_exhausts_max_tokens_emits_role_chunk(
+        self, app_client
+    ):
+        """Issue #551: when thinking consumes the entire max_tokens budget, no
+        content chunk fires, so the stream must still announce the assistant
+        role (otherwise it is indistinguishable from an instant empty success)
+        and report finish_reason 'length'."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"thinking_expected": True}
+                yield {"text": "<think>", "done": False}
+                yield {"text": "Okay, 2+2 is...", "done": False}
+                yield {
+                    "text": "",
+                    "done": True,
+                    "done_reason": "length",
+                    "stats": TimingStats(),
+                }
+
+            return gen()
+
+        with patch("olmlx.routers.openai.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "2+2?"}],
+                    "stream": True,
+                    "max_tokens": 30,
+                },
+            )
+
+        assert resp.status_code == 200
+        events = [
+            json.loads(line[6:])
+            for line in resp.text.strip().split("\n")
+            if line.startswith("data: ") and line.strip() != "data: [DONE]"
+        ]
+        roles = [e["choices"][0]["delta"].get("role") for e in events]
+        assert "assistant" in roles, "no role announcement in all-thinking stream"
+        contents = "".join(
+            e["choices"][0]["delta"].get("content", "") or "" for e in events
+        )
+        assert "<think>" not in contents
+        done_events = [e for e in events if e["choices"][0].get("finish_reason")]
+        assert done_events[-1]["choices"][0]["finish_reason"] == "length"
+
+    @pytest.mark.asyncio
+    async def test_streaming_normal_response_role_announced_once(self, app_client):
+        """Regression guard for #551: a normal response must not gain an extra
+        empty role chunk — the role rides the (single) content chunk."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": "Hello!", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.openai.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "any",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                },
+            )
+
+        events = [
+            json.loads(line[6:])
+            for line in resp.text.strip().split("\n")
+            if line.startswith("data: ") and line.strip() != "data: [DONE]"
+        ]
+        role_chunks = [
+            e for e in events if e["choices"][0]["delta"].get("role") == "assistant"
+        ]
+        assert len(role_chunks) == 1
+
+    @pytest.mark.asyncio
     async def test_streaming_qwen35_long_orphaned_thinking(self, app_client):
         """Issue #307: Qwen3.5/3.6 stream their thinking without ``<think>``
         opener; the orphan ``</think>`` arrives only after several hundred


### PR DESCRIPTION
Fixes #551.

## Problem

On the **streaming** `/v1/chat/completions` path, when a thinking model (Qwen3) consumes its entire `max_tokens` budget inside `<think>`, no visible text is produced. Because `format_content` (which bundles `delta.role = "assistant"`) only fires for content chunks, the stream emitted a single empty `delta: {}` done chunk with no role announcement — indistinguishable from an instant empty success.

The `finish_reason: "length"` half of the issue was already resolved by merged #565 (engine now propagates `done_reason="length"`, which the router maps to `"length"`).

## Fix

Track whether any content chunk was emitted. In the `done` branch, if none was (chat path only — `strip_thinking=True`), emit a role/empty-content chunk (`{"role": "assistant", "content": ""}`) before the done chunk so the assistant turn is detectable. The `/v1/completions` path uses a text-shaped formatter with `strip_thinking=False` and is unaffected.

## Tests (TDD)

- New `test_streaming_thinking_exhausts_max_tokens_emits_role_chunk` — all-thinking stream; asserts a role announcement appears, no `<think>` leaks, and `finish_reason == "length"`. Failed before the fix (`roles == [None]`).
- New `test_streaming_normal_response_role_announced_once` — regression guard that a normal response gains no extra empty role chunk.
- Full `tests/test_routers_openai.py` suite passes (84 tests).

## Invariants

No CLAUDE.md invariants touched — post-generation SSE emission only; no inference, stream selection, speculative, or cache plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)