### PR TITLE
fix(engine): stop sequences ignore matches inside <think> blocks (#588)

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -1633,6 +1633,7 @@ async def generate_completion(
                 keep_alive=keep_alive,
                 grammar_active=grammar_active,
                 adopt_pin=True,
+                thinking_expected=thinking_expected,
             )
             # Ownership of the pin transfers to the wrapper; its finally
             # releases on any generator exit. Mark the flag for the outer
@@ -1664,6 +1665,7 @@ async def generate_completion(
                         keep_alive=keep_alive,
                         grammar_active=grammar_active,
                         adopt_pin=True,
+                        thinking_expected=thinking_expected,
                     )
                 result["thinking_expected"] = thinking_expected
                 return result
@@ -2983,6 +2985,7 @@ async def _stream_completion_batched(
     prompt_tokens: list[int] | None = None,
     use_prompt_cache: bool = False,
     cache_id: str = "",
+    thinking_expected: bool = False,
 ) -> AsyncGenerator[dict, None]:
     """Batched counterpart of ``_stream_completion`` (plan §2/§4).
 
@@ -3036,7 +3039,7 @@ async def _stream_completion_batched(
         else settings.inference_timeout
     )
 
-    stop_scanner = StopScanner(stop_sequences)
+    stop_scanner = StopScanner(stop_sequences, thinking_aware=thinking_expected)
     stop_hit = False
     timed_out = False
     lagged = False
@@ -3257,6 +3260,7 @@ async def _stream_completion(
     messages: list[dict] | None = None,
     tokenizer: Any = None,
     template_kwargs: dict | None = None,
+    thinking_expected: bool = False,
 ) -> AsyncGenerator[dict, None]:
     # Continuous batching (docs/batching-plan.md): eligible requests join
     # the per-model batch instead of serializing on the inference lock.
@@ -3277,6 +3281,7 @@ async def _stream_completion(
             prompt_tokens=prompt_tokens,
             use_prompt_cache=use_prompt_cache,
             cache_id=cache_id,
+            thinking_expected=thinking_expected,
         ):
             yield chunk
         return
@@ -3512,7 +3517,9 @@ async def _stream_completion(
             with Timer() as eval_timer:
                 inf_start = time.monotonic()
                 token = None
-                stop_scanner = StopScanner(stop_sequences)
+                stop_scanner = StopScanner(
+                    stop_sequences, thinking_aware=thinking_expected
+                )
                 async for token in stream:
                     # Always accumulate for prompt cache (raw stream, not filtered)
                     stats.eval_count = token.generation_tokens
@@ -3730,6 +3737,7 @@ async def _full_completion_batched(
     prompt_tokens: list[int] | None = None,
     cache_id: str = "",
     keep_alive: str | None = None,
+    thinking_expected: bool = False,
 ) -> dict:
     """Non-streaming batched completion (plan §4 item 6).
 
@@ -3752,6 +3760,7 @@ async def _full_completion_batched(
         prompt_tokens=prompt_tokens,
         use_prompt_cache=use_prompt_cache,
         cache_id=cache_id,
+        thinking_expected=thinking_expected,
     ):
         if chunk.get("cache_info"):
             result["cache_read_tokens"] = chunk.get("cache_read_tokens", 0)
@@ -3789,6 +3798,7 @@ async def _full_completion(
     messages: list[dict] | None = None,
     tokenizer: Any = None,
     template_kwargs: dict | None = None,
+    thinking_expected: bool = False,
 ) -> dict:
     # Continuous batching (plan §4 item 6): eligible non-streaming
     # requests internally consume the batched stream and aggregate —
@@ -3810,6 +3820,7 @@ async def _full_completion(
             prompt_tokens=prompt_tokens,
             cache_id=cache_id,
             keep_alive=keep_alive,
+            thinking_expected=thinking_expected,
         )
 
     # inference_timeout is not enforced for non-streaming: the GPU thread
@@ -3951,7 +3962,11 @@ async def _full_completion(
                                 exc_info=True,
                             )
     if stop_sequences and result_dict:
-        text, hit = truncate_at_stop(result_dict.get("text", ""), stop_sequences)
+        text, hit = truncate_at_stop(
+            result_dict.get("text", ""),
+            stop_sequences,
+            thinking_aware=thinking_expected,
+        )
         if hit:
             result_dict["finish_reason"] = "stop"
             # The stop sequence is applied post-hoc, so mlx-lm may have run on to
@@ -4564,6 +4579,7 @@ async def generate_chat(
                 messages=messages,
                 tokenizer=lm.tokenizer,
                 template_kwargs=chat_template_kwargs,
+                thinking_expected=thinking_expected,
             )
             # Ownership of the pin transfers to the wrapper; its finally
             # releases on any generator exit. Mark the flag for the outer
@@ -4603,6 +4619,7 @@ async def generate_chat(
                         messages=messages,
                         tokenizer=lm.tokenizer,
                         template_kwargs=chat_template_kwargs,
+                        thinking_expected=thinking_expected,
                     )
                 # Mirror the streaming meta chunk so non-streaming routers
                 # can gate orphan `</think>` handling on the same signal

--- a/olmlx/engine/stop_sequences.py
+++ b/olmlx/engine/stop_sequences.py
@@ -5,9 +5,49 @@ Three call sites previously carried their own copy of this logic
 ``StopScanner`` is the one incremental implementation and
 ``truncate_at_stop`` the whole-text variant (batching plan Phase 2,
 PR #507 review follow-up).
+
+``thinking_aware=True`` makes both variants ignore stop sequences that
+fall inside a ``<think>...</think>`` block, so a stop string that appears
+only in the model's reasoning does not halt generation before any visible
+text is produced (issue #588).
 """
 
 from __future__ import annotations
+
+# Open/close tag pairs that delimit a hidden "thinking" region. Must stay in
+# sync with ``_THINKING_PAIRS`` in ``routers/thinking_split.py`` — adding a new
+# thinking format there without mirroring it here would let stop sequences fire
+# inside that format's thinking block. Cannot import from thinking_split.py:
+# it imports INIT_ORPHAN_DETECT_LIMIT from inference.py, which imports this
+# module — a circular import.
+_THINKING_PAIRS: tuple[tuple[str, str], ...] = (
+    ("<think>", "</think>"),
+    ("<|channel>thought\n", "<channel|>"),
+)
+
+
+def _find_think_span(text: str) -> tuple[int, int]:
+    """Span ``[open_start, visible_resume)`` of the first thinking block.
+
+    ``visible_resume`` is the offset where visible text resumes after the close
+    tag (leading newlines skipped, mirroring ``thinking_split``). Returns
+    ``(open_start, len(text))`` for an unterminated block (everything after the
+    open tag is still hidden) and ``(-1, -1)`` when no open tag is present.
+    """
+    best_idx, best_open, best_close = -1, "", ""
+    for open_tag, close_tag in _THINKING_PAIRS:
+        i = text.find(open_tag)
+        if i != -1 and (best_idx == -1 or i < best_idx):
+            best_idx, best_open, best_close = i, open_tag, close_tag
+    if best_idx == -1:
+        return -1, -1
+    j = text.find(best_close, best_idx + len(best_open))
+    if j == -1:
+        return best_idx, len(text)
+    resume = j + len(best_close)
+    while resume < len(text) and text[resume] == "\n":
+        resume += 1
+    return best_idx, resume
 
 
 class StopScanner:
@@ -18,12 +58,23 @@ class StopScanner:
     stop matched. Matches may span piece boundaries (text accumulates
     internally), but the search start is bounded so each call scans
     O(len(piece)) — not O(generation length).
+
+    When ``thinking_aware=True`` a stop match is honoured only if it lies in
+    visible text (before a ``<think>`` open tag or after its ``</think>``
+    close); matches inside the thinking block are skipped (issue #588).
     """
 
-    def __init__(self, stop_sequences: list[str] | None):
+    def __init__(self, stop_sequences: list[str] | None, thinking_aware: bool = False):
         self._stops = [s for s in (stop_sequences or []) if s]
         self._text = ""
         self.stop_hit = False
+        self._thinking_aware = thinking_aware
+        # Thinking-phase state (only used when thinking_aware).
+        self._phase = "detect"  # "detect" | "in_think" | "passthrough"
+        self._expected_close = ""
+        self._open_start = -1  # offset of the open tag, or -1 if none seen
+        self._open_end = 0  # offset just past the open tag
+        self._visible_resume = -1  # offset where visible text resumes, or -1
 
     def feed(self, piece: str) -> tuple[str, bool]:
         """Append *piece*; return (emittable_text, stop_hit).
@@ -35,12 +86,19 @@ class StopScanner:
             return piece, False
         prev_len = len(self._text)
         self._text += piece
+        if self._thinking_aware:
+            self._advance_thinking_state(prev_len)
         stop_idx = -1
         for stop_seq in self._stops:
             # A match ending in the new piece must start within
             # len(stop_seq)-1 of the boundary; anything earlier was
             # caught (and truncated at) by a previous call.
-            idx = self._text.find(stop_seq, max(0, prev_len - len(stop_seq) + 1))
+            start = max(0, prev_len - len(stop_seq) + 1)
+            idx = self._text.find(stop_seq, start)
+            if self._thinking_aware:
+                # Skip matches that fall inside the thinking block.
+                while idx != -1 and not self._is_visible(idx):
+                    idx = self._text.find(stop_seq, idx + 1)
             if idx != -1 and (stop_idx == -1 or idx < stop_idx):
                 stop_idx = idx
         if stop_idx == -1:
@@ -48,17 +106,70 @@ class StopScanner:
         self.stop_hit = True
         return (self._text[prev_len:stop_idx] if prev_len < stop_idx else ""), True
 
+    def _is_visible(self, idx: int) -> bool:
+        """Whether a match starting at *idx* lies in visible (non-thinking) text."""
+        if self._open_start == -1:
+            return True  # no thinking block seen → all visible
+        if idx < self._open_start:
+            return True  # before the thinking block
+        if self._visible_resume != -1 and idx >= self._visible_resume:
+            return True  # after the thinking block closed
+        return False  # inside the (open) thinking block
 
-def truncate_at_stop(text: str, stop_sequences: list[str] | None) -> tuple[str, bool]:
+    def _advance_thinking_state(self, prev_len: int) -> None:
+        """Advance detect→in_think→passthrough over newly-appended text.
+
+        Bounded to the boundary window so each call is O(len(piece)): an open or
+        close tag that completes in the new piece must start within
+        ``len(tag)-1`` of ``prev_len``; one entirely in a prior piece was
+        resolved on an earlier call.
+        """
+        if self._phase == "passthrough":
+            return
+        if self._phase == "detect":
+            best_idx, best_open, best_close = -1, "", ""
+            for open_tag, close_tag in _THINKING_PAIRS:
+                start = max(0, prev_len - len(open_tag) + 1)
+                i = self._text.find(open_tag, start)
+                if i != -1 and (best_idx == -1 or i < best_idx):
+                    best_idx, best_open, best_close = i, open_tag, close_tag
+            if best_idx == -1:
+                return
+            self._open_start = best_idx
+            self._open_end = best_idx + len(best_open)
+            self._expected_close = best_close
+            self._phase = "in_think"
+            # Fall through: the close tag may be in the same piece.
+        if self._phase == "in_think":
+            start = max(self._open_end, prev_len - len(self._expected_close) + 1)
+            j = self._text.find(self._expected_close, start)
+            if j != -1:
+                resume = j + len(self._expected_close)
+                while resume < len(self._text) and self._text[resume] == "\n":
+                    resume += 1
+                self._visible_resume = resume
+                self._phase = "passthrough"
+
+
+def truncate_at_stop(
+    text: str, stop_sequences: list[str] | None, thinking_aware: bool = False
+) -> tuple[str, bool]:
     """Whole-text variant for the non-streaming path.
 
-    Returns (text truncated at the earliest match, whether one matched).
+    Returns (text truncated at the earliest match, whether one matched). When
+    ``thinking_aware=True``, matches inside the first ``<think>...</think>``
+    block are ignored (issue #588).
     """
+    skip_start, skip_end = (-1, -1)
+    if thinking_aware:
+        skip_start, skip_end = _find_think_span(text)
     earliest = -1
     for stop_seq in stop_sequences or []:
         if not stop_seq:
             continue
         idx = text.find(stop_seq)
+        while idx != -1 and skip_start != -1 and skip_start <= idx < skip_end:
+            idx = text.find(stop_seq, idx + 1)
         if idx != -1 and (earliest == -1 or idx < earliest):
             earliest = idx
     if earliest == -1:

--- a/olmlx/engine/stop_sequences.py
+++ b/olmlx/engine/stop_sequences.py
@@ -9,7 +9,9 @@ PR #507 review follow-up).
 ``thinking_aware=True`` makes both variants ignore stop sequences that
 fall inside a ``<think>...</think>`` block, so a stop string that appears
 only in the model's reasoning does not halt generation before any visible
-text is produced (issue #588).
+text is produced (issue #588). Every thinking block in the output is
+skipped — matching ``thinking_split.py``, which re-enters the thinking
+state on each open tag — not just the first.
 """
 
 from __future__ import annotations
@@ -25,29 +27,37 @@ _THINKING_PAIRS: tuple[tuple[str, str], ...] = (
     ("<|channel>thought\n", "<channel|>"),
 )
 
+_MAX_OPEN_TAG_LEN = max(len(open_tag) for open_tag, _ in _THINKING_PAIRS)
 
-def _find_think_span(text: str) -> tuple[int, int]:
-    """Span ``[open_start, visible_resume)`` of the first thinking block.
 
-    ``visible_resume`` is the offset where visible text resumes after the close
-    tag (leading newlines skipped, mirroring ``thinking_split``). Returns
-    ``(open_start, len(text))`` for an unterminated block (everything after the
-    open tag is still hidden) and ``(-1, -1)`` when no open tag is present.
+def _find_think_spans(text: str) -> list[tuple[int, int]]:
+    """Every hidden thinking span ``[open_start, visible_resume)`` in *text*.
+
+    Mirrors ``thinking_split.py``: each ``<think>...</think>`` pair is hidden,
+    and ``visible_resume`` skips leading newlines after the close tag. An
+    unterminated final block hides everything to the end of *text*.
     """
-    best_idx, best_open, best_close = -1, "", ""
-    for open_tag, close_tag in _THINKING_PAIRS:
-        i = text.find(open_tag)
-        if i != -1 and (best_idx == -1 or i < best_idx):
-            best_idx, best_open, best_close = i, open_tag, close_tag
-    if best_idx == -1:
-        return -1, -1
-    j = text.find(best_close, best_idx + len(best_open))
-    if j == -1:
-        return best_idx, len(text)
-    resume = j + len(best_close)
-    while resume < len(text) and text[resume] == "\n":
-        resume += 1
-    return best_idx, resume
+    spans: list[tuple[int, int]] = []
+    pos = 0
+    n = len(text)
+    while pos < n:
+        best_idx, best_open, best_close = -1, "", ""
+        for open_tag, close_tag in _THINKING_PAIRS:
+            i = text.find(open_tag, pos)
+            if i != -1 and (best_idx == -1 or i < best_idx):
+                best_idx, best_open, best_close = i, open_tag, close_tag
+        if best_idx == -1:
+            break
+        j = text.find(best_close, best_idx + len(best_open))
+        if j == -1:
+            spans.append((best_idx, n))
+            break
+        resume = j + len(best_close)
+        while resume < n and text[resume] == "\n":
+            resume += 1
+        spans.append((best_idx, resume))
+        pos = resume
+    return spans
 
 
 class StopScanner:
@@ -60,8 +70,8 @@ class StopScanner:
     O(len(piece)) — not O(generation length).
 
     When ``thinking_aware=True`` a stop match is honoured only if it lies in
-    visible text (before a ``<think>`` open tag or after its ``</think>``
-    close); matches inside the thinking block are skipped (issue #588).
+    visible text (outside every ``<think>...</think>`` block); matches inside a
+    thinking block are skipped (issue #588).
     """
 
     def __init__(self, stop_sequences: list[str] | None, thinking_aware: bool = False):
@@ -69,12 +79,15 @@ class StopScanner:
         self._text = ""
         self.stop_hit = False
         self._thinking_aware = thinking_aware
-        # Thinking-phase state (only used when thinking_aware).
-        self._phase = "detect"  # "detect" | "in_think" | "passthrough"
+        # Thinking-phase state (only used when thinking_aware). The phase machine
+        # cycles detect → in_think → detect so every block is tracked, not just
+        # the first.
+        self._phase = "detect"  # "detect" | "in_think"
         self._expected_close = ""
-        self._open_start = -1  # offset of the open tag, or -1 if none seen
-        self._open_end = 0  # offset just past the open tag
-        self._visible_resume = -1  # offset where visible text resumes, or -1
+        self._cur_open = -1  # start of the currently-open block, or -1
+        self._cur_open_end = 0  # offset just past the current open tag
+        self._spans: list[tuple[int, int]] = []  # closed (start, visible_resume)
+        self._detect_from = 0  # lower bound for the next open-tag search
 
     def feed(self, piece: str) -> tuple[str, bool]:
         """Append *piece*; return (emittable_text, stop_hit).
@@ -96,7 +109,7 @@ class StopScanner:
             start = max(0, prev_len - len(stop_seq) + 1)
             idx = self._text.find(stop_seq, start)
             if self._thinking_aware:
-                # Skip matches that fall inside the thinking block.
+                # Skip matches that fall inside a thinking block.
                 while idx != -1 and not self._is_visible(idx):
                     idx = self._text.find(stop_seq, idx + 1)
             if idx != -1 and (stop_idx == -1 or idx < stop_idx):
@@ -108,47 +121,56 @@ class StopScanner:
 
     def _is_visible(self, idx: int) -> bool:
         """Whether a match starting at *idx* lies in visible (non-thinking) text."""
-        if self._open_start == -1:
-            return True  # no thinking block seen → all visible
-        if idx < self._open_start:
-            return True  # before the thinking block
-        if self._visible_resume != -1 and idx >= self._visible_resume:
-            return True  # after the thinking block closed
-        return False  # inside the (open) thinking block
+        for start, resume in self._spans:
+            if start <= idx < resume:
+                return False  # inside a closed thinking block
+        if self._cur_open != -1 and idx >= self._cur_open:
+            return False  # inside the currently-open thinking block
+        return True
 
     def _advance_thinking_state(self, prev_len: int) -> None:
-        """Advance detect→in_think→passthrough over newly-appended text.
+        """Advance the detect↔in_think phase machine over newly-appended text.
 
-        Bounded to the boundary window so each call is O(len(piece)): an open or
-        close tag that completes in the new piece must start within
-        ``len(tag)-1`` of ``prev_len``; one entirely in a prior piece was
-        resolved on an earlier call.
+        Bounded to the boundary window so each call is O(len(piece)): a tag that
+        completes in the new piece must start within ``len(tag)-1`` of the
+        boundary; one entirely in a prior piece was resolved on an earlier call.
+        Loops so multiple blocks opening/closing within one piece are all seen.
         """
-        if self._phase == "passthrough":
-            return
-        if self._phase == "detect":
-            best_idx, best_open, best_close = -1, "", ""
-            for open_tag, close_tag in _THINKING_PAIRS:
-                start = max(0, prev_len - len(open_tag) + 1)
-                i = self._text.find(open_tag, start)
-                if i != -1 and (best_idx == -1 or i < best_idx):
-                    best_idx, best_open, best_close = i, open_tag, close_tag
-            if best_idx == -1:
-                return
-            self._open_start = best_idx
-            self._open_end = best_idx + len(best_open)
-            self._expected_close = best_close
-            self._phase = "in_think"
-            # Fall through: the close tag may be in the same piece.
-        if self._phase == "in_think":
-            start = max(self._open_end, prev_len - len(self._expected_close) + 1)
-            j = self._text.find(self._expected_close, start)
-            if j != -1:
+        while True:
+            if self._phase == "detect":
+                start = max(self._detect_from, prev_len - _MAX_OPEN_TAG_LEN + 1, 0)
+                best_idx, best_open, best_close = -1, "", ""
+                for open_tag, close_tag in _THINKING_PAIRS:
+                    i = self._text.find(open_tag, start)
+                    if i != -1 and (best_idx == -1 or i < best_idx):
+                        best_idx, best_open, best_close = i, open_tag, close_tag
+                if best_idx == -1:
+                    # No open tag in range; remember how far we scanned so the
+                    # next call doesn't rescan from the start.
+                    self._detect_from = max(
+                        self._detect_from, len(self._text) - _MAX_OPEN_TAG_LEN + 1
+                    )
+                    return
+                self._cur_open = best_idx
+                self._cur_open_end = best_idx + len(best_open)
+                self._expected_close = best_close
+                self._phase = "in_think"
+                # Loop: the close tag may be in the same piece.
+            else:  # in_think
+                start = max(
+                    self._cur_open_end, prev_len - len(self._expected_close) + 1
+                )
+                j = self._text.find(self._expected_close, start)
+                if j == -1:
+                    return
                 resume = j + len(self._expected_close)
                 while resume < len(self._text) and self._text[resume] == "\n":
                     resume += 1
-                self._visible_resume = resume
-                self._phase = "passthrough"
+                self._spans.append((self._cur_open, resume))
+                self._cur_open = -1
+                self._phase = "detect"
+                self._detect_from = resume
+                # Loop: a further thinking block may follow.
 
 
 def truncate_at_stop(
@@ -157,18 +179,20 @@ def truncate_at_stop(
     """Whole-text variant for the non-streaming path.
 
     Returns (text truncated at the earliest match, whether one matched). When
-    ``thinking_aware=True``, matches inside the first ``<think>...</think>``
-    block are ignored (issue #588).
+    ``thinking_aware=True``, matches inside any ``<think>...</think>`` block are
+    ignored (issue #588).
     """
-    skip_start, skip_end = (-1, -1)
-    if thinking_aware:
-        skip_start, skip_end = _find_think_span(text)
+    spans = _find_think_spans(text) if thinking_aware else []
+
+    def _hidden(idx: int) -> bool:
+        return any(start <= idx < resume for start, resume in spans)
+
     earliest = -1
     for stop_seq in stop_sequences or []:
         if not stop_seq:
             continue
         idx = text.find(stop_seq)
-        while idx != -1 and skip_start != -1 and skip_start <= idx < skip_end:
+        while idx != -1 and _hidden(idx):
             idx = text.find(stop_seq, idx + 1)
         if idx != -1 and (earliest == -1 or idx < earliest):
             earliest = idx

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -714,6 +714,59 @@ class TestStopSequenceHandling:
     @patch("olmlx.engine.inference._inference_locked")
     @patch("olmlx.engine.inference._inference_ref")
     @patch("olmlx.engine.inference._full_completion_inner")
+    async def test_thinking_aware_stop_inside_think_not_truncated(
+        self, mock_inner, mock_ref, mock_locked
+    ):
+        """Issue #588: with thinking_expected, a stop string inside <think> must
+        not truncate — generation is reported as not stopped."""
+        gen_kwargs = {"stop": ["three"]}
+        stats = MagicMock()
+        lm = MagicMock()
+        lm.inference_queue_timeout = 30.0
+        lm.sync_mode = None
+
+        mock_locked.return_value.__aenter__.return_value = None
+        mock_ref.return_value.__enter__.return_value = None
+        raw = "<think>one two three four</think>\nThe visible answer"
+        mock_inner.return_value = {"text": raw, "done": True, "stats": stats}
+
+        result = await _full_completion(
+            lm, "prompt", 50, gen_kwargs, stats, thinking_expected=True
+        )
+        assert result["text"] == raw
+        assert "finish_reason" not in result
+
+    @patch("olmlx.engine.inference._inference_locked")
+    @patch("olmlx.engine.inference._inference_ref")
+    @patch("olmlx.engine.inference._full_completion_inner")
+    async def test_thinking_aware_stop_in_visible_still_fires(
+        self, mock_inner, mock_ref, mock_locked
+    ):
+        """Issue #588: a stop string in the visible region (after </think>) must
+        still truncate when thinking_expected is set."""
+        gen_kwargs = {"stop": ["three"]}
+        stats = MagicMock()
+        lm = MagicMock()
+        lm.inference_queue_timeout = 30.0
+        lm.sync_mode = None
+
+        mock_locked.return_value.__aenter__.return_value = None
+        mock_ref.return_value.__enter__.return_value = None
+        mock_inner.return_value = {
+            "text": "<think>reasoning</think>\nThe answer is three!",
+            "done": True,
+            "stats": stats,
+        }
+
+        result = await _full_completion(
+            lm, "prompt", 50, gen_kwargs, stats, thinking_expected=True
+        )
+        assert result["text"] == "<think>reasoning</think>\nThe answer is "
+        assert result["finish_reason"] == "stop"
+
+    @patch("olmlx.engine.inference._inference_locked")
+    @patch("olmlx.engine.inference._inference_ref")
+    @patch("olmlx.engine.inference._full_completion_inner")
     async def test_stop_not_in_kwargs_no_effect(
         self, mock_inner, mock_ref, mock_locked
     ):

--- a/tests/test_stop_sequences.py
+++ b/tests/test_stop_sequences.py
@@ -156,3 +156,31 @@ def test_thinking_pairs_in_sync_with_thinking_split():
     from olmlx.routers.thinking_split import _THINKING_PAIRS as SPLIT_PAIRS
 
     assert STOP_PAIRS == SPLIT_PAIRS
+
+
+class TestThinkingAwareMultipleBlocks:
+    """Issue #588 review: every thinking block is skipped, not just the first."""
+
+    def test_scanner_stop_in_second_think_block_skipped(self):
+        s = StopScanner(["three"], thinking_aware=True)
+        s.feed("<think>a</think>\nout1 <think>one two three</think>\n")
+        piece, hit = s.feed("out2 three end")
+        assert hit and piece == "out2 "
+
+    def test_scanner_no_stop_when_only_in_think_blocks(self):
+        s = StopScanner(["three"], thinking_aware=True)
+        s.feed("<think>three</think>\nout1 ")
+        piece, hit = s.feed("<think>three again</think>\nout2")
+        assert not hit and not s.stop_hit
+
+    def test_truncate_stop_in_second_think_block_skipped(self):
+        text = "<think>a</think>\nout1 <think>one two three</think>\nout2"
+        result, hit = truncate_at_stop(text, ["three"], thinking_aware=True)
+        assert not hit and result == text
+
+    def test_truncate_stop_after_second_think_fires(self):
+        text = "<think>a</think>\nout1 <think>b</think>\nthe answer is three!"
+        result, hit = truncate_at_stop(text, ["three"], thinking_aware=True)
+        assert (
+            hit and result == "<think>a</think>\nout1 <think>b</think>\nthe answer is "
+        )

--- a/tests/test_stop_sequences.py
+++ b/tests/test_stop_sequences.py
@@ -76,3 +76,83 @@ class TestTruncateAtStop:
 
     def test_empty_stop_ignored(self):
         assert truncate_at_stop("abc", [""]) == ("abc", False)
+
+
+class TestStopScannerThinkingAware:
+    """Issue #588: stop sequences must not fire inside a <think> block."""
+
+    def test_stop_inside_think_does_not_fire(self):
+        s = StopScanner(["three"], thinking_aware=True)
+        assert s.feed("<think>") == ("<think>", False)
+        assert s.feed("one two three four") == ("one two three four", False)
+        assert not s.stop_hit
+
+    def test_stop_in_visible_content_fires_after_think(self):
+        s = StopScanner(["three"], thinking_aware=True)
+        s.feed("<think>one two three</think>\n")
+        piece, hit = s.feed("one two three four five")
+        assert hit and piece == "one two "
+
+    def test_stop_before_think_fires_normally(self):
+        s = StopScanner(["stop"], thinking_aware=True)
+        piece, hit = s.feed("prestop<think>thinking</think>\ncontent")
+        assert hit and piece == "pre"
+
+    def test_no_think_block_identical_to_non_aware(self):
+        s = StopScanner(["STOP"], thinking_aware=True)
+        assert s.feed("abc") == ("abc", False)
+        piece, hit = s.feed("STOPdef")
+        assert hit and piece == ""
+
+    def test_stop_spanning_piece_boundary_after_think(self):
+        s = StopScanner(["STOP"], thinking_aware=True)
+        s.feed("<think>thinking</think>\nprefix")
+        assert s.feed("ST") == ("ST", False)
+        piece, hit = s.feed("OP")
+        assert hit and piece == ""
+
+    def test_gemma_channel_close_tag_respected(self):
+        s = StopScanner(["three"], thinking_aware=True)
+        s.feed("<|channel>thought\none two three<channel|>")
+        piece, hit = s.feed("one two three four")
+        assert hit and piece == "one two "
+
+    def test_think_open_and_close_in_one_piece(self):
+        s = StopScanner(["three"], thinking_aware=True)
+        # Open and close tag in the same fed piece, stop only inside think.
+        piece, hit = s.feed("<think>one two three</think>\nvisible")
+        assert not hit and piece == "<think>one two three</think>\nvisible"
+        piece, hit = s.feed("a three b")
+        assert hit and piece == "a "
+
+
+class TestTruncateAtStopThinkingAware:
+    """Issue #588: whole-text variant must skip the thinking block."""
+
+    def test_stop_inside_think_not_matched(self):
+        text = "<think>one two three four</think>\nvisible"
+        result, hit = truncate_at_stop(text, ["three"], thinking_aware=True)
+        assert not hit and result == text
+
+    def test_stop_in_visible_part_fires(self):
+        text = "<think>thinking</think>\none two three four"
+        result, hit = truncate_at_stop(text, ["three"], thinking_aware=True)
+        assert hit and result == "<think>thinking</think>\none two "
+
+    def test_thinking_aware_no_think_block_normal(self):
+        result, hit = truncate_at_stop("one two three", ["three"], thinking_aware=True)
+        assert hit and result == "one two "
+
+    def test_gemma_channel_thinking_skipped(self):
+        text = "<|channel>thought\none two three<channel|>one two three four"
+        result, hit = truncate_at_stop(text, ["three"], thinking_aware=True)
+        assert hit and result == "<|channel>thought\none two three<channel|>one two "
+
+
+def test_thinking_pairs_in_sync_with_thinking_split():
+    """Guard against drift: the stop-scanner's thinking tag pairs must match the
+    canonical set in routers/thinking_split.py (issue #588 risk note)."""
+    from olmlx.engine.stop_sequences import _THINKING_PAIRS as STOP_PAIRS
+    from olmlx.routers.thinking_split import _THINKING_PAIRS as SPLIT_PAIRS
+
+    assert STOP_PAIRS == SPLIT_PAIRS


### PR DESCRIPTION
Fixes #588.

## Problem

Stop sequences were matched against the **entire** raw model output, including `<think>...</think>` content. When the stop string appeared inside the reasoning block (e.g. `stop=["three"]` with a prompt that makes the model count in its thinking), generation halted before producing any visible text — yielding `content: null` (OpenAI) / `content: ""` (Ollama) with `finish_reason: stop`, on every API surface, for any thinking model.

## Fix

Make both stop helpers in `engine/stop_sequences.py` thinking-aware (opt-in via `thinking_aware=True`):

- **`StopScanner`** tracks the `detect → in_think → passthrough` phase incrementally (bounded to the boundary window, still O(piece)) and honours a stop match only when it lies in visible text — before a `<think>` open tag or after its `</think>` close. Matches inside the thinking block are skipped.
- **`truncate_at_stop`** finds the first `<think>` span and ignores matches within it.

`engine/inference.py` threads a `thinking_expected` flag (already computed by `_resolve_thinking_active`) from `generate_completion`/`generate_chat` through the streaming, batched-streaming, batched non-streaming, and exclusive non-streaming paths to the three scanner/truncator construction sites. `thinking_aware` defaults `False`, so non-thinking callers and existing tests are unchanged.

`_THINKING_PAIRS` is duplicated from `routers/thinking_split.py` (importing it would create a circular import via `inference.py`); a guard test asserts the two constants stay in sync.

## Tests (TDD)

- New `TestStopScannerThinkingAware` / `TestTruncateAtStopThinkingAware` in `tests/test_stop_sequences.py` — cover stop-inside-think (skipped), stop-in-visible (fires), pre-think, no-think (identical to non-aware), piece-boundary spans, the Gemma `<|channel>` format, and open+close in one piece.
- New `_full_completion` integration tests in `tests/test_inference.py::TestStopSequenceHandling` — stop inside think isn't truncated; stop in visible text still fires.
- `_THINKING_PAIRS` cross-module sync guard.
- Broader sweep (stop_sequences, inference, finish_reason, openai/chat/generate/anthropic routers, batching): 679 pass.

## Invariants

No CLAUDE.md invariants touched — pure Python string scanning; no Metal/GPU, prefill, grammar, or speculative code. The new threading is keyword-only with a `False` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)