### PR TITLE
fix(anthropic): no spurious empty text block before tool_use in streaming (#589)

### DIFF
--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -435,11 +435,17 @@ async def _stream_buffered_with_tools(
             yield event
         block_idx += 1
 
-    for event in _emit_content_block(
-        block_idx, "text", "text_delta", "text", visible_text, TEXT_CHUNK_SIZE
-    ):
-        yield event
-    block_idx += 1
+    # Mirror the non-streaming guard (issue #589): emit the text block only when
+    # there is visible text, or — when there isn't — only as the sole fallback
+    # block (no tool calls and no thinking block). Without this, a tool call with
+    # no visible preamble emits a spurious empty text block at index 0.
+    has_thinking_block = bool(thinking and thinking.strip())
+    if visible_text or (not tool_uses and not has_thinking_block):
+        for event in _emit_content_block(
+            block_idx, "text", "text_delta", "text", visible_text, TEXT_CHUNK_SIZE
+        ):
+            yield event
+        block_idx += 1
 
     for tool_use in tool_uses:
         yield _sse(

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -29,6 +29,21 @@ from olmlx.utils.timing import TimingStats
 MAP_PATCH = "olmlx.routers.anthropic._anthropic_model_map"
 
 
+def _content_block_start_types(sse_text: str) -> list[str]:
+    """Ordered list of content_block types from `content_block_start` SSE events."""
+    types: list[str] = []
+    for line in sse_text.splitlines():
+        if not line.startswith("data:"):
+            continue
+        try:
+            payload = json.loads(line[5:])
+        except json.JSONDecodeError:
+            continue
+        if payload.get("type") == "content_block_start":
+            types.append(payload["content_block"]["type"])
+    return types
+
+
 class TestConvertTools:
     def test_no_tools(self):
         req = AnthropicMessagesRequest(
@@ -809,6 +824,128 @@ class TestAnthropicEndpoint:
         assert "tool_use" in text
         assert "input_json_delta" in text
         assert '"stop_reason": "tool_use"' in text
+        # Issue #589: no spurious empty text block before the tool block.
+        assert _content_block_start_types(text) == ["tool_use"]
+
+    @pytest.mark.asyncio
+    async def test_streaming_tool_only_no_spurious_text_block(self, app_client):
+        """Issue #589: a tool call with no visible text must not emit a leading
+        empty text content block — matching the non-streaming path."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {
+                    "text": '<tool_call>{"name": "weather", "arguments": {"city": "NYC"}}</tool_call>',
+                    "done": False,
+                }
+                yield {"text": "", "done": True, "stats": TimingStats(eval_count=10)}
+
+            return gen()
+
+        with patch("olmlx.routers.anthropic.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "Get weather NYC"}],
+                    "max_tokens": 300,
+                    "stream": True,
+                    "tools": [
+                        {
+                            "name": "weather",
+                            "description": "Get weather",
+                            "input_schema": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert resp.status_code == 200
+        assert _content_block_start_types(resp.text) == ["tool_use"]
+
+    @pytest.mark.asyncio
+    async def test_streaming_tool_with_text_preamble_has_two_blocks(self, app_client):
+        """A visible text preamble before the tool call still emits a text block
+        first (index 0), then the tool block (index 1)."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {
+                    "text": 'Here is the answer <tool_call>{"name": "weather", "arguments": {"city": "NYC"}}</tool_call>',
+                    "done": False,
+                }
+                yield {"text": "", "done": True, "stats": TimingStats(eval_count=10)}
+
+            return gen()
+
+        with patch("olmlx.routers.anthropic.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "Get weather NYC"}],
+                    "max_tokens": 300,
+                    "stream": True,
+                    "tools": [
+                        {
+                            "name": "weather",
+                            "description": "Get weather",
+                            "input_schema": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert resp.status_code == 200
+        assert _content_block_start_types(resp.text) == ["text", "tool_use"]
+        assert "input_json_delta" in resp.text
+
+    @pytest.mark.asyncio
+    async def test_streaming_thinking_tool_no_visible_text_no_text_block(
+        self, app_client
+    ):
+        """Thinking + tool call with no visible text: thinking then tool_use, no
+        spurious empty text block between them."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {
+                    "text": '<think>reasoning</think><tool_call>{"name": "weather", "arguments": {"city": "NYC"}}</tool_call>',
+                    "done": False,
+                }
+                yield {"text": "", "done": True, "stats": TimingStats(eval_count=10)}
+
+            return gen()
+
+        with patch("olmlx.routers.anthropic.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "Get weather NYC"}],
+                    "max_tokens": 300,
+                    "stream": True,
+                    "tools": [
+                        {
+                            "name": "weather",
+                            "description": "Get weather",
+                            "input_schema": {
+                                "type": "object",
+                                "properties": {"city": {"type": "string"}},
+                            },
+                        }
+                    ],
+                },
+            )
+
+        assert resp.status_code == 200
+        assert _content_block_start_types(resp.text) == ["thinking", "tool_use"]
 
     @pytest.mark.asyncio
     async def test_streaming_empty_output(self, app_client):


### PR DESCRIPTION
Fixes #589.

## Problem

On `/v1/messages` with `stream: true`, when the model produced a tool call with no visible text preamble, `_stream_buffered_with_tools` emitted a spurious empty `text` content block at index 0 before the `tool_use` block: `[text(""), tool_use]`. The non-streaming path correctly omits it (`[tool_use]`), so streaming and non-streaming diverged — shifting block indices and breaking clients that assume `content[0].type == "tool_use"`.

Root cause: `_emit_content_block` always emits the `content_block_start`/`stop` pair (the `if content:` guard inside only skips the deltas), and the buffered path called it unconditionally.

## Fix

Guard the text-block emission to mirror the non-streaming builder:

```python
has_thinking_block = bool(thinking and thinking.strip())
if visible_text or (not tool_uses and not has_thinking_block):
    ...emit text block...
```

- visible text present → emit (preamble case, unchanged)
- no visible text + tool calls (or a thinking block) present → skip
- absolutely no content → still emit the single empty text block as the fallback (matches the non-streaming `if not content_blocks:` guard)

The more complete condition (vs the issue's simpler `if visible_text or not tool_uses`) also fixes the `thinking + no visible text + no tools` case.

## Tests (TDD)

- New `test_streaming_tool_only_no_spurious_text_block` → `[tool_use]`.
- New `test_streaming_tool_with_text_preamble_has_two_blocks` → `[text, tool_use]`.
- New `test_streaming_thinking_tool_no_visible_text_no_text_block` → `[thinking, tool_use]`.
- Strengthened `test_streaming_with_tools_buffered` to assert `content_block_start` types == `["tool_use"]`.
- Added a `_content_block_start_types` SSE helper. Full `tests/test_routers_anthropic.py` suite passes (130).

## Invariants

No CLAUDE.md invariants touched — purely SSE block-emission; the incremental `_stream_thinking_state_machine` (with its own "always emit a text block" rule) and the empty-output fallback are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)