### PR TITLE
fix(spectral): allocate_bits only emits packable widths {2,4}

### DIFF
--- a/olmlx/engine/spectralquant.py
+++ b/olmlx/engine/spectralquant.py
@@ -98,11 +98,20 @@ class SpectralRotation:
         return x @ self.V
 
 
+#: Bit-widths the spectral KV cache can actually pack/unpack — these are the
+#: only cases ``turboquant.pack_indices`` / ``unpack_indices`` implement. A
+#: width outside this set (e.g. 5 or 1, which ``allocate_bits`` used to emit for
+#: low-``d_eff`` heads) crashes decode with ``ValueError: Unsupported bits=N``.
+_PACKABLE_BITS: tuple[int, ...] = (2, 4)
+
+
 def allocate_bits(d_eff: int, head_dim: int, avg_bits: int) -> tuple[int, int]:
     """Find (b_high, b_low) minimizing budget slack.
 
     Solves: d_eff * b_high + (head_dim - d_eff) * b_low ≈ head_dim * avg_bits
-    Subject to: b_high >= b_low >= 1, both in [1, 8].
+    Subject to: b_high >= b_low, both drawn from ``_PACKABLE_BITS`` ({2, 4}) —
+    the only widths the spectral KV cache can pack. Mixed widths outside this
+    set would otherwise crash at decode.
 
     Returns:
         (b_high, b_low): bits for semantic and tail regimes.
@@ -110,11 +119,11 @@ def allocate_bits(d_eff: int, head_dim: int, avg_bits: int) -> tuple[int, int]:
     budget = head_dim * avg_bits
     d_tail = head_dim - d_eff
 
-    best_pair = (avg_bits, avg_bits)  # fallback: uniform
+    best_pair = (avg_bits, avg_bits)  # fallback: uniform (avg_bits ∈ {2, 4})
     best_slack = float("inf")
 
-    for b_high in range(8, 0, -1):
-        for b_low in range(min(b_high, 8), 0, -1):
+    for b_high in sorted(_PACKABLE_BITS, reverse=True):
+        for b_low in sorted((b for b in _PACKABLE_BITS if b <= b_high), reverse=True):
             total = d_eff * b_high + d_tail * b_low
             slack = abs(total - budget)
             if slack < best_slack:

--- a/tests/test_spectralquant.py
+++ b/tests/test_spectralquant.py
@@ -148,6 +148,24 @@ class TestBitAllocation:
         # With most dimensions being semantic, difference should be small
         assert b_high - b_low <= 2
 
+    def test_only_emits_packable_bit_widths(self):
+        """allocate_bits must only return widths the cache can pack ({2, 4}).
+
+        Regression: d_eff=32 / avg_bits=2 used to return (5, 1); the spectral
+        KV cache packs indices via turboquant.pack_indices, which implements
+        only bits 2 and 4, so any other width crashes decode with
+        'Unsupported bits=N'. Sweep d_eff across the full range for both
+        supported avg_bits.
+        """
+        from olmlx.engine.spectralquant import allocate_bits
+
+        for avg_bits in (2, 4):
+            for d_eff in range(1, 128):
+                b_high, b_low = allocate_bits(d_eff, head_dim=128, avg_bits=avg_bits)
+                assert b_high in (2, 4), (avg_bits, d_eff, b_high, b_low)
+                assert b_low in (2, 4), (avg_bits, d_eff, b_high, b_low)
+                assert b_high >= b_low
+
 
 # ---------------------------------------------------------------------------
 # Lloyd-Max codebook fitting tests


### PR DESCRIPTION
## Problem

`spectral:N` KV-quant inference can crash with `ValueError: Unsupported bits=5`.

`allocate_bits()` searches bit-widths over the full range **[1, 8]** to best match the average-bits budget, so a head with low effective rank gets a high allocation for its few semantic dims and a low one for the tail. On a real model, `spectral:2` assigned `bits_high=5, bits_low=1` to some heads (e.g. `d_eff=32, head_dim=128`).

But the spectral KV cache packs indices via `turboquant.pack_indices` / `unpack_indices`, which implement **only bits 2 and 4**. Any other width (5, 1, 3, …) raises `Unsupported bits=N` at decode — so those heads crash the first time the model generates. This bites any spectral calibration that produces a low-`d_eff` head.

Reproduced on `Qwen3-235B-A22B-4bit` (`spectral:2`): 2 of 188 heads got `bits_high=5`, every request then failed mid-stream.

## Fix

Constrain `allocate_bits` to choose `b_high`/`b_low` only from the packable set `{2, 4}` (`b_high ≥ b_low`), via a new `_PACKABLE_BITS` constant documenting the coupling to the packer. Effect:

- `spectral:2` → uniform 2-bit. Still better than `turboquant:2`: spectral adds the per-head eigenvector rotation + data-calibrated Lloyd-Max codebooks. It loses per-head *mixed*-precision — which the packer can't represent anyway.
- `spectral:4` → uniform 4-bit.

## Test

TDD: a regression test sweeps `d_eff` across `1..127` for both `avg_bits ∈ {2, 4}` and asserts `b_high, b_low ∈ {2, 4}` with `b_high ≥ b_low`. It fails before the fix (`d_eff=32 → (5,1)`) and passes after. Existing `TestBitAllocation` tests still pass (the `≥1` and `≤2`-spread invariants hold under `{2,4}`). 164 passing across `test_spectralquant.py` + `test_spectralquant_calibrate_coverage.py`; ruff + pyright clean.

## Note

Calibration artifacts produced *before* this fix may already contain unpackable widths and must be regenerated (`olmlx spectral prepare <model> --avg-bits N`) to be usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)