### PR TITLE
fix(tests): provision real-model smoke model once per session, not per test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,14 @@ jobs:
         # (exit 138). These tests are developer-run; CI covers the logic via
         # mocked unit tests. (The marker's intent was already documented in
         # tests/live/test_tts_speech.py.)
+        #
+        # OLMLX_TESTS_CPU_DEVICE moves MLX unit-test compute to the CPU
+        # backend (tests/__init__.py): the two runners share one Mac with
+        # real-inference jobs, and concurrent Metal pressure starved runner
+        # heartbeats ("runner lost communication" kills). Metal-kernel tests
+        # opt back into the GPU via the metal_default_device fixture.
+        env:
+          OLMLX_TESTS_CPU_DEVICE: "1"
         run: uv sync --no-editable && uv run pytest -m "not real_model" --cov=olmlx --cov-report=xml --cov-report=term
       - name: Upload coverage report
         if: always()

--- a/scripts/real_model_smoke.sh
+++ b/scripts/real_model_smoke.sh
@@ -33,16 +33,32 @@ fi
 # test, which the summary below (correctly) treats as a failed smoke run, not a
 # green one. Pre-pull them so the run exercises real coverage. Pull reuses the
 # HF blob cache, so this is cheap once the runner has downloaded them once
-# (test_real_model.py and test_mtp_loader.py self-provision and are omitted).
+# (test_mtp_loader.py self-provisions and is omitted). Qwen2.5-0.5B is pulled
+# for test_real_model.py: its session fixture prefers the operator store, so
+# with the pull done here the tests themselves run with zero network I/O.
 # Only for the default subset — explicit file args manage their own models.
 DEFAULT_MODELS=(
+  "mlx-community/Qwen2.5-0.5B-Instruct-4bit"
   "mlx-community/Qwen3-4B-4bit"
   "mlx-community/gemma-4-26B-A4B-it-4bit"
 )
+
+# Retry pulls: the runner's early-morning network drops connections often
+# enough that single-shot pulls were a recurring cause of red smoke runs.
+pull_with_retries() {
+  local m="$1" attempt
+  for attempt in 1 2 3; do
+    uv run olmlx models pull "$m" && return 0
+    echo "pull attempt ${attempt}/3 failed for ${m}"
+    [ "$attempt" -lt 3 ] && sleep $((attempt * 30))
+  done
+  return 1
+}
+
 if [ "$DEFAULT_RUN" -eq 1 ]; then
   for m in "${DEFAULT_MODELS[@]}"; do
     echo "::group::pull ${m}"
-    uv run olmlx models pull "$m" || echo "warning: pull failed for ${m} (its test will skip)"
+    pull_with_retries "$m" || echo "warning: pull failed for ${m} (its test will skip)"
     echo "::endgroup::"
   done
 fi

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,24 @@
+"""Test package init — runs before tests/conftest.py imports anything.
+
+OLMLX_TESTS_CPU_DEVICE=1 moves MLX's default device to the CPU backend for
+the unit suite. CI sets it because two self-hosted runners share one Mac
+with real-inference jobs: concurrent Metal pressure from the unit suite
+(64 test files do real mx.* compute) starved the runner heartbeat and got
+jobs killed with "runner lost communication" (#596).
+
+This must happen before ``mlx_lm``/``mlx_vlm`` are imported anywhere:
+their module-level ``generation_stream`` binds the default device at
+import time, and tests/conftest.py imports both. Package ``__init__`` is
+the one hook guaranteed to run first.
+
+Tests that exercise Metal kernels explicitly (shardquant kernel parity,
+the mlx rope-bug removal gate) opt back into the GPU via the
+``metal_default_device`` fixture in tests/conftest.py.
+"""
+
+import os
+
+if os.environ.get("OLMLX_TESTS_CPU_DEVICE") == "1":
+    import mlx.core as mx
+
+    mx.set_default_device(mx.cpu)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import huggingface_hub
+import mlx.core as mx
 import mlx_lm
 import mlx_vlm
 import pytest
@@ -95,6 +96,27 @@ def block_real_model_loads(request, monkeypatch):
         _offline("huggingface_hub.model_info"),
     )
     yield
+
+
+@pytest.fixture
+def metal_default_device():
+    """Run a test with the GPU as MLX's default device.
+
+    ``OLMLX_TESTS_CPU_DEVICE=1`` (see tests/__init__.py) moves the suite's
+    default device to the CPU so unit-test compute can't contend with real
+    inference on the shared CI Mac. Tests whose subject *is* the Metal
+    kernel path (shardquant kernel parity, the mlx rope-bug removal gate)
+    opt back in through this fixture; ``kernels_supported`` and the rope
+    corruption both key off the default device, so without it they would
+    silently exercise the reference/CPU path instead. Skips on machines
+    without Metal — same behavior the previous ``skipif`` gates had.
+    """
+    if not mx.metal.is_available():
+        pytest.skip("requires Metal")
+    prev = mx.default_device()
+    mx.set_default_device(mx.gpu)
+    yield
+    mx.set_default_device(prev)
 
 
 def make_error_stream(chunks, error_msg="GPU error"):

--- a/tests/integration/test_real_model.py
+++ b/tests/integration/test_real_model.py
@@ -71,9 +71,12 @@ def _seed_model(models_dir: Path, src: Path) -> None:
 
     def link_weights(s: str, d: str) -> None:
         if s.endswith(".safetensors"):
-            os.link(s, d)
-        else:
-            shutil.copy2(s, d)
+            try:
+                os.link(s, d)
+                return
+            except OSError:
+                pass  # cross-filesystem tmp dir — fall through to a real copy
+        shutil.copy2(s, d)
 
     shutil.copytree(
         src,

--- a/tests/integration/test_real_model.py
+++ b/tests/integration/test_real_model.py
@@ -1,10 +1,21 @@
 """Real-model smoke tests — load an actual MLX model and run inference.
 
-These tests require a GPU and download ~300MB on first run.
+These tests require a GPU and download ~300MB once per machine (into the
+HF cache, unless the model is already in the operator's olmlx store).
 Skipped in CI via: pytest -m "not real_model"
+
+The model is provisioned ONCE per pytest session (`real_model_files`) and
+seeded into each test's isolated models_dir with hardlinks. Tests
+themselves never touch the network: the nightly smoke runs used to flake
+with `assert 500 == 200` whenever the per-test `snapshot_download` hit a
+connection reset mid-test.
 """
 
 import json
+import os
+import shutil
+import time
+from pathlib import Path
 
 import pytest
 
@@ -15,8 +26,65 @@ REAL_MODEL = "mlx-community/Qwen2.5-0.5B-Instruct-4bit"
 pytestmark = pytest.mark.real_model
 
 
+@pytest.fixture(scope="session")
+def real_model_files() -> Path:
+    """Provision REAL_MODEL once per session, outside any test body.
+
+    Prefers a copy already in the operator's store (the smoke runner
+    pre-pulls it via scripts/real_model_smoke.sh); otherwise downloads
+    into the shared HF cache with retries, so a transient network error
+    surfaces here — clearly labeled as provisioning — instead of as a
+    500 from an endpoint under test.
+    """
+    from olmlx.config import settings
+    from olmlx.models.store import _safe_dir_name
+
+    operator_copy = settings.models_dir / _safe_dir_name(REAL_MODEL)
+    if (operator_copy / "config.json").exists() and not (
+        operator_copy / ".downloading"
+    ).exists():
+        return operator_copy
+
+    from huggingface_hub import snapshot_download
+
+    last_err: Exception | None = None
+    for attempt in range(3):
+        if attempt:
+            time.sleep(5 * attempt)
+        try:
+            return Path(snapshot_download(repo_id=REAL_MODEL))
+        except Exception as exc:  # noqa: BLE001 — retry any transport error
+            last_err = exc
+    raise RuntimeError(
+        f"could not provision {REAL_MODEL} after 3 attempts"
+    ) from last_err
+
+
+def _seed_model(models_dir: Path, src: Path) -> None:
+    """Copy the provisioned model into a test's models_dir.
+
+    Weights are hardlinked (cheap, read-only usage); everything else is a
+    real copy so in-place writes (e.g. manifest.json) can't reach through
+    a shared inode into the HF cache or the operator's store.
+    """
+    from olmlx.models.store import _safe_dir_name
+
+    def link_weights(s: str, d: str) -> None:
+        if s.endswith(".safetensors"):
+            os.link(s, d)
+        else:
+            shutil.copy2(s, d)
+
+    shutil.copytree(
+        src,
+        models_dir / _safe_dir_name(REAL_MODEL),
+        copy_function=link_weights,
+        ignore=shutil.ignore_patterns(".cache", ".downloading*"),
+    )
+
+
 @pytest.fixture
-async def real_ctx(tmp_path, monkeypatch):
+async def real_ctx(tmp_path, monkeypatch, real_model_files):
     """Integration context with NO MLX mocks — uses a real model."""
     models_config = tmp_path / "models.json"
     models_config.write_text(json.dumps({}))
@@ -25,6 +93,7 @@ async def real_ctx(tmp_path, monkeypatch):
 
     models_dir = tmp_path / "models"
     models_dir.mkdir()
+    _seed_model(models_dir, real_model_files)
 
     monkeypatch.setattr("olmlx.config.settings.models_dir", models_dir)
     monkeypatch.setattr("olmlx.config.settings.models_config", models_config)

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -103,9 +103,10 @@ class TestRopefix:
                 raise RuntimeError("boom")
         assert mx.fast.rope is orig
 
-    @pytest.mark.skipif(
-        not mx.metal.is_available(), reason="Metal-kernel bug; CPU path is fine"
-    )
+    # metal_default_device skips without Metal and forces the GPU default
+    # device: the corruption is Metal-only, so under OLMLX_TESTS_CPU_DEVICE=1
+    # the unforced CPU kernel is correct and this gate would fail spuriously.
+    @pytest.mark.usefixtures("metal_default_device")
     def test_rope_bug_still_present_remove_patch_when_this_fails(self):
         """Removal gate for safe_rope_patch (#499).
 

--- a/tests/test_shardquant_fused.py
+++ b/tests/test_shardquant_fused.py
@@ -303,7 +303,7 @@ class TestConfig:
 
 class TestEndToEndDecodeParity:
     @pytest.mark.parametrize("backend", ["ref", "auto"])
-    def test_multi_step_decode_matches_tier1(self, backend):
+    def test_multi_step_decode_matches_tier1(self, backend, request):
         """Drive 24 decode steps on forked caches; fused output must track
         the Tier-1 materialized path at every step (middle grows each step,
         so capacity growth, rope positions, and handle reuse are all
@@ -311,8 +311,11 @@ class TestEndToEndDecodeParity:
         from olmlx.engine.shardquant_cache import ShardFusedKV
         from olmlx.engine.shardquant_fused import fused_sdpa_decode
 
-        if backend == "auto" and not mx.metal.is_available():
-            pytest.skip("auto backend needs Metal for the kernel path")
+        if backend == "auto":
+            # Forces the GPU default device (skips without Metal) so
+            # kernels_supported() actually takes the kernel path under
+            # OLMLX_TESTS_CPU_DEVICE=1 (tests/__init__.py).
+            request.getfixturevalue("metal_default_device")
 
         D, H, nq = 64, 2, 4
         scale = D**-0.5

--- a/tests/test_shardquant_kernels.py
+++ b/tests/test_shardquant_kernels.py
@@ -9,7 +9,10 @@ import pytest
 
 from tests.test_shardquant_cache import _feed, _make_cache
 
-pytestmark = pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+# metal_default_device skips when Metal is unavailable and forces the GPU
+# default device, so kernels_supported() takes the kernel path even when the
+# suite runs under OLMLX_TESTS_CPU_DEVICE=1 (tests/__init__.py).
+pytestmark = pytest.mark.usefixtures("metal_default_device")
 
 
 def _decode_step(cache, D, H, seed=11):


### PR DESCRIPTION
Fixes the two test-shaped causes of flaky CI found while investigating the nightly smoke failures. (The third and dominant cause — the runner losing its GitHub connection — is infra and tracked separately.)

## 1. Per-test model downloads in `test_real_model.py`

The nightly Real-model smoke runs flaked with `assert 500 == 200` on a different test each night. The tracebacks show `httpx.RemoteProtocolError` raised from `huggingface_hub.snapshot_download` — the fixture pointed `models_dir` at a fresh tmp dir per test, so **every test re-downloaded the 0.5B model from HF Hub**, and any network blip surfaced as a 500 from the endpoint under test.

- Session-scoped `real_model_files` fixture provisions the model once — preferring the operator's store (the smoke runner pre-pulls it), else downloading into the shared HF cache with 3 retries. Each test's isolated `models_dir` is seeded from it (`.safetensors` hardlinked with cross-filesystem copy fallback; small files really copied so an in-place `manifest.json` write can't reach a shared inode). Tests never touch the network.
- `real_model_smoke.sh`: pulls retry 3× with backoff; Qwen2.5-0.5B added to the pre-pull list.

## 2. GPU contention between the two runners on one Mac

64 unit-test files execute real `mx.*` compute on Metal. Both June Tests-job hangs (and their "runner lost communication" kills) correlate exactly with a concurrent babysit agent or second Tests job on the other runner slot — combined Metal + memory pressure starves the runner heartbeat, which GitHub documents as a lost-communication cause.

- `tests/__init__.py`: `OLMLX_TESTS_CPU_DEVICE=1` sets MLX's default device to CPU before `mlx_lm`/`mlx_vlm` import (their module-level `generation_stream` binds the default device at import time).
- `tests/conftest.py`: `metal_default_device` fixture — tests whose *subject* is the Metal kernel path opt back into the GPU (and skip without Metal, replacing their old `skipif` gates): shardquant kernel parity, the fused `auto`-backend parity test, and the mlx rope-bug removal gate (the corruption is Metal-only; on CPU that gate would fail spuriously).
- `ci.yml`: sets the env var on the Tests job.

## Verification

- `pytest tests/integration/test_real_model.py -m real_model` → 6 passed; with `HF_HUB_OFFLINE=1` → 6 passed in 2.5s (proves zero network at test time)
- Full suite with `OLMLX_TESTS_CPU_DEVICE=1` → **5421 passed in 3:37**; the 15 failures on the dev laptop are identical with/without the env var and on the unmodified tree (machine-local Metal numerics, pre-existing — CI on the runner is green on main)
- Kernel-parity modules still pass on GPU without the env var; `bash scripts/real_model_smoke.sh tests/integration/test_real_model.py` → PASS
- `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)