### PR TITLE
feat(tool_parser): support GLM-4.5/4.6 native tool-call format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ olmlx/
 │   ├── proxy_tuning.py # Decode-time logit arithmetic (base + α·(expert−antiexpert))
 │   ├── grammar.py      # xgrammar JSON-mode / JSON-Schema logits processor
 │   ├── chat_templating.py
-│   ├── tool_parser.py  # Qwen/Mistral/Llama/DeepSeek/MiniMax/bare-JSON
+│   ├── tool_parser.py  # Qwen/GLM/Mistral/Llama/DeepSeek/MiniMax/bare-JSON
 │   ├── template_caps.py
 │   ├── prompt_cache/   # cache_id LRU + radix prefix index + disk spill
 │   ├── turboquant*.py / spectralquant*.py / shardquant*.py

--- a/olmlx/engine/tool_parser.py
+++ b/olmlx/engine/tool_parser.py
@@ -50,6 +50,10 @@ _GPT_OSS_DETECT = "<|channel|>"
 _GEMMA4_TOOL_CALL_RE = re.compile(r"<\|tool_call>(.*?)<tool_call\|>", re.DOTALL)
 _TOOL_CALL_RE = re.compile(r"<tool_call>\s*(.*?)\s*</tool_call>", re.DOTALL)
 _FUNC_TAG_RE = re.compile(r"<function=([^>]+)>(.*?)</function>", re.DOTALL)
+# GLM-4.5/4.6 arg pairs inside <tool_call>: <arg_key>k</arg_key><arg_value>v</arg_value>
+_GLM_ARG_RE = re.compile(
+    r"<arg_key>\s*(.*?)\s*</arg_key>\s*<arg_value>(.*?)</arg_value>", re.DOTALL
+)
 _PARAM_TAG_RE = re.compile(r"<parameter=([^>]+)>(.*?)</parameter>", re.DOTALL)
 
 # Mistral: [TOOL_CALLS] followed by a JSON array
@@ -139,8 +143,33 @@ def _parse_func_tag(func_match: re.Match) -> dict | None:
     }
 
 
+def _parse_glm_tool_call(inner: str) -> dict | None:
+    """Parse a GLM-4.5/4.6 tool call body.
+
+    Format: ``name\\n<arg_key>k</arg_key>\\n<arg_value>v</arg_value>...``.
+    Values follow the GLM chat template (strings raw, non-strings
+    ``tojson``-encoded), so ``_extract_params`` (JSON-with-raw-fallback) parses
+    them the same way it does for the Mistral/MiniMax paths. Returns None if no
+    function name precedes the arg pairs.
+    """
+    arg_start = inner.find("<arg_key>")
+    name = (inner[:arg_start] if arg_start != -1 else inner).strip()
+    if not name:
+        return None
+    return {
+        "type": "tool_use",
+        "id": _make_tool_use_id(),
+        "name": name,
+        "input": _extract_params(inner, _GLM_ARG_RE),
+    }
+
+
 def _try_qwen(text: str) -> tuple[list[dict], str]:
-    """Parse Qwen-style <tool_call>...</tool_call> blocks."""
+    """Parse Qwen-style <tool_call>...</tool_call> blocks.
+
+    Also handles the GLM-4.5/4.6 body inside the same wrapper:
+    ``name\\n<arg_key>k</arg_key><arg_value>v</arg_value>...``.
+    """
     tool_uses = []
     for match in _TOOL_CALL_RE.finditer(text):
         span = (match.start(), match.end())
@@ -167,6 +196,20 @@ def _try_qwen(text: str) -> tuple[list[dict], str]:
                     logger.warning(
                         "Skipping <function> tag with empty name inside <tool_call>"
                     )
+        elif "<arg_key>" in inner and "<arg_value>" in inner:
+            # GLM-4.5/4.6 style: name\n<arg_key>k</arg_key><arg_value>v</arg_value>.
+            # Require both tag types so a stray "</arg_value>" in prose can't
+            # hijack the block. A bare-identifier body (no arg tags) is left to
+            # the existing "unparseable block" path — indistinguishable from
+            # garbage.
+            result = _parse_glm_tool_call(inner)
+            if result:
+                result["_span"] = span
+                tool_uses.append(result)
+            else:
+                logger.warning(
+                    "Failed to parse GLM <tool_call> block (no name): %r", inner[:500]
+                )
         else:
             logger.warning("Failed to parse <tool_call> block: %r", inner[:500])
 

--- a/tests/test_tool_parser.py
+++ b/tests/test_tool_parser.py
@@ -383,6 +383,83 @@ class TestTryMinimax:
         assert "<minimax:tool_call>" not in visible
 
 
+class TestGlmToolCall:
+    """GLM-4.5/4.6 native format: <tool_call>name\\n<arg_key>k</arg_key><arg_value>v</arg_value>."""
+
+    def test_glm_string_args_via_try_qwen(self):
+        text = (
+            "<tool_call>task\n"
+            "<arg_key>description</arg_key>\n"
+            "<arg_value>Explore repository structure</arg_value>\n"
+            "<arg_key>subagent_type</arg_key>\n"
+            "<arg_value>explore</arg_value>\n"
+            "</tool_call>"
+        )
+        tool_uses, _ = _try_qwen(text)
+        assert len(tool_uses) == 1
+        assert tool_uses[0]["name"] == "task"
+        assert tool_uses[0]["input"] == {
+            "description": "Explore repository structure",
+            "subagent_type": "explore",
+        }
+        assert "_span" in tool_uses[0]
+
+    def test_glm_non_string_values_json_coerced(self):
+        # Per GLM template: string values are raw, non-string values are tojson-encoded.
+        text = (
+            "<tool_call>search\n"
+            "<arg_key>query</arg_key>\n"
+            "<arg_value>find files</arg_value>\n"
+            "<arg_key>limit</arg_key>\n"
+            "<arg_value>10</arg_value>\n"
+            "<arg_key>recursive</arg_key>\n"
+            "<arg_value>true</arg_value>\n"
+            "<arg_key>tags</arg_key>\n"
+            '<arg_value>["a", "b"]</arg_value>\n'
+            "</tool_call>"
+        )
+        tool_uses, _ = _try_qwen(text)
+        assert len(tool_uses) == 1
+        assert tool_uses[0]["input"] == {
+            "query": "find files",
+            "limit": 10,
+            "recursive": True,
+            "tags": ["a", "b"],
+        }
+
+    def test_glm_stray_close_tag_not_hijacked(self):
+        # A block containing a stray "</arg_value>" but no real arg pairs must
+        # NOT be parsed as a GLM call (detection requires both tag types), so it
+        # falls through to the "unparseable block" path instead of producing a
+        # tool with a garbage name that halts the parser chain.
+        text = "<tool_call>Status: </arg_value> done</tool_call>"
+        tool_uses, _ = _try_qwen(text)
+        assert tool_uses == []
+
+    def test_glm_bare_name_body_not_parsed(self):
+        # A bare-identifier body (no arg tags) is indistinguishable from an
+        # unparseable/garbage block, so it is intentionally NOT parsed as a
+        # tool (preserves the existing <tool_call>GARBAGE</tool_call> contract).
+        text = "<tool_call>list_models</tool_call>"
+        tool_uses, _ = _try_qwen(text)
+        assert tool_uses == []
+
+    def test_glm_via_parse_model_output(self):
+        text = (
+            "I'll explore the repo.\n"
+            "<tool_call>task\n"
+            "<arg_key>description</arg_key>\n"
+            "<arg_value>Explore repo</arg_value>\n"
+            "</tool_call>"
+        )
+        _, visible, tools = parse_model_output(text, has_tools=True)
+        assert len(tools) == 1
+        assert tools[0]["name"] == "task"
+        assert tools[0]["input"] == {"description": "Explore repo"}
+        assert "<tool_call>" not in visible
+        assert "_span" not in tools[0]
+
+
 class TestTryXmlFunc:
     def test_single_tool_call(self):
         text = "<function=get_weather><parameter=city>NYC</parameter></function>"


### PR DESCRIPTION
## Problem
Tool calling was silently broken for GLM-4.5/4.6 models (e.g. GLM-4.5-Air in opencode). GLM emits tool calls in its native format:

```
<tool_call>task
<arg_key>description</arg_key>
<arg_value>Explore repository structure</arg_value>
<arg_key>subagent_type</arg_key>
<arg_value>explore</arg_value>
</tool_call>
```

`_try_qwen` only handled JSON or `<function=>` XML *inside* the `<tool_call>` wrapper. GLM's `<arg_key>/<arg_value>` structure matched neither, so the parser logged `Failed to parse <tool_call> block` and returned **zero** tool calls — clients (opencode) saw the call as plain assistant text.

## Fix
Add a GLM handler as a third fallback in `_try_qwen` (GLM reuses the same `<tool_call>` wrapper):
- `_parse_glm_tool_call` — function name is the text before the first `<arg_key>`, followed by `<arg_key>/<arg_value>` pairs.
- `_parse_glm_value` — follows the GLM chat template (line 77: strings emitted raw, non-strings `tojson`-encoded): try `json.loads`, fall back to the raw string. So `10`→int, `true`→bool, `["a","b"]`→list, prose→string.

A bare-identifier body with no arg tags (`<tool_call>list_models</tool_call>`) is intentionally left to the existing "unparseable block" path — it's indistinguishable from a garbage block, preserving that contract.

## Verification
- **Unit (TDD):** 5 new GLM tests written first (confirmed failing, then passing). Full `test_tool_parser.py`: 97 passed.
- **No regressions:** router/chat suites consuming `parse_model_output`: 225 passed.
- **Live end-to-end** against GLM-4.5-Air on the server:
  - Non-streaming → `finish_reason: tool_calls`, `get_weather({"city":"Paris"})`.
  - Streaming (opencode's path) → proper `tool_calls` deltas, multi-arg `bash({"command":"ls -la","description":"..."})`.
- `ruff check` + `format` clean; CLAUDE.md format list updated to include GLM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)