### PR TITLE
fix(tool_parser): parse GLM zero-argument tool calls

### DIFF
--- a/olmlx/engine/tool_parser.py
+++ b/olmlx/engine/tool_parser.py
@@ -58,6 +58,9 @@ _PARAM_TAG_RE = re.compile(r"<parameter=([^>]+)>(.*?)</parameter>", re.DOTALL)
 # GLM zero-argument call: the body is just the bare function name (no arg tags).
 # A strict single-identifier match distinguishes a real tool name from prose.
 _GLM_BARE_NAME_RE = re.compile(r"[A-Za-z_][\w.-]*")
+# JSON literals match the identifier pattern but are never tool names — a bare
+# "true"/"false"/"null" block is noise, not a zero-arg call.
+_JSON_LITERALS = frozenset({"true", "false", "null"})
 
 # Mistral: [TOOL_CALLS] followed by a JSON array
 _MISTRAL_TOOL_RE = re.compile(r"\[TOOL_CALLS\]\s*(\[.*?\])", re.DOTALL)
@@ -213,7 +216,10 @@ def _try_qwen(text: str) -> tuple[list[dict], str]:
                 logger.warning(
                     "Failed to parse GLM <tool_call> block (no name): %r", inner[:500]
                 )
-        elif _GLM_BARE_NAME_RE.fullmatch(inner.strip()):
+        elif (
+            _GLM_BARE_NAME_RE.fullmatch(inner.strip())
+            and inner.strip() not in _JSON_LITERALS
+        ):
             # GLM renders a no-argument call as just the bare function name
             # ("<tool_call>ls\n</tool_call>"). Require a strict single identifier
             # so prose (which contains spaces/punctuation) still falls through to

--- a/olmlx/engine/tool_parser.py
+++ b/olmlx/engine/tool_parser.py
@@ -55,6 +55,9 @@ _GLM_ARG_RE = re.compile(
     r"<arg_key>\s*(.*?)\s*</arg_key>\s*<arg_value>(.*?)</arg_value>", re.DOTALL
 )
 _PARAM_TAG_RE = re.compile(r"<parameter=([^>]+)>(.*?)</parameter>", re.DOTALL)
+# GLM zero-argument call: the body is just the bare function name (no arg tags).
+# A strict single-identifier match distinguishes a real tool name from prose.
+_GLM_BARE_NAME_RE = re.compile(r"[A-Za-z_][\w.-]*")
 
 # Mistral: [TOOL_CALLS] followed by a JSON array
 _MISTRAL_TOOL_RE = re.compile(r"\[TOOL_CALLS\]\s*(\[.*?\])", re.DOTALL)
@@ -210,6 +213,20 @@ def _try_qwen(text: str) -> tuple[list[dict], str]:
                 logger.warning(
                     "Failed to parse GLM <tool_call> block (no name): %r", inner[:500]
                 )
+        elif _GLM_BARE_NAME_RE.fullmatch(inner.strip()):
+            # GLM renders a no-argument call as just the bare function name
+            # ("<tool_call>ls\n</tool_call>"). Require a strict single identifier
+            # so prose (which contains spaces/punctuation) still falls through to
+            # the "unparseable block" path below.
+            tool_uses.append(
+                {
+                    "type": "tool_use",
+                    "id": _make_tool_use_id(),
+                    "name": inner.strip(),
+                    "input": {},
+                    "_span": span,
+                }
+            )
         else:
             logger.warning("Failed to parse <tool_call> block: %r", inner[:500])
 

--- a/tests/test_tool_parser.py
+++ b/tests/test_tool_parser.py
@@ -436,11 +436,30 @@ class TestGlmToolCall:
         tool_uses, _ = _try_qwen(text)
         assert tool_uses == []
 
-    def test_glm_bare_name_body_not_parsed(self):
-        # A bare-identifier body (no arg tags) is indistinguishable from an
-        # unparseable/garbage block, so it is intentionally NOT parsed as a
-        # tool (preserves the existing <tool_call>GARBAGE</tool_call> contract).
+    def test_glm_zero_arg_call(self):
+        # GLM renders a no-argument call as just the bare name, e.g.
+        # "<tool_call>ls\n</tool_call>". It must parse as a zero-arg tool call
+        # rather than being dropped.
+        text = "<tool_call>ls\n</tool_call>"
+        tool_uses, _ = _try_qwen(text)
+        assert len(tool_uses) == 1
+        assert tool_uses[0]["name"] == "ls"
+        assert tool_uses[0]["input"] == {}
+        assert "_span" in tool_uses[0]
+
+    def test_glm_bare_identifier_body_parsed(self):
+        # A bare single-identifier body is a valid GLM zero-arg call.
         text = "<tool_call>list_models</tool_call>"
+        tool_uses, _ = _try_qwen(text)
+        assert len(tool_uses) == 1
+        assert tool_uses[0]["name"] == "list_models"
+        assert tool_uses[0]["input"] == {}
+
+    def test_glm_prose_body_not_parsed(self):
+        # A non-identifier body (contains spaces) is prose, not a tool name, and
+        # must NOT be parsed — preserves the <tool_call>GARBAGE</tool_call>
+        # contract for anything that isn't a bare identifier.
+        text = "<tool_call>Let me check the files</tool_call>"
         tool_uses, _ = _try_qwen(text)
         assert tool_uses == []
 
@@ -557,12 +576,13 @@ class TestParseModelOutputXmlFunc:
         Verified via parse_model_output because parsers no longer strip text —
         they annotate spans for parse_model_output to handle.
         """
-        text = "<tool_call>GARBAGE</tool_call><function=my_tool><parameter=x>1</parameter></function>"
+        # Body has spaces, so it is not a bare identifier / zero-arg call.
+        text = "<tool_call>not a tool</tool_call><function=my_tool><parameter=x>1</parameter></function>"
         _, visible, tools = parse_model_output(text, has_tools=True)
         assert len(tools) == 1
         assert tools[0]["name"] == "my_tool"
         # The orphaned <tool_call> skeleton must remain in visible text
-        assert "<tool_call>GARBAGE</tool_call>" in visible
+        assert "<tool_call>not a tool</tool_call>" in visible
         # The <function> tag must be stripped
         assert "<function=" not in visible
 

--- a/tests/test_tool_parser.py
+++ b/tests/test_tool_parser.py
@@ -455,6 +455,14 @@ class TestGlmToolCall:
         assert tool_uses[0]["name"] == "list_models"
         assert tool_uses[0]["input"] == {}
 
+    def test_glm_json_literal_body_not_parsed(self):
+        # A JSON literal (true/false/null) matches the identifier pattern but is
+        # not a real tool name — it must not become a zero-arg call.
+        for literal in ("true", "false", "null"):
+            text = f"<tool_call>{literal}</tool_call>"
+            tool_uses, _ = _try_qwen(text)
+            assert tool_uses == [], literal
+
     def test_glm_prose_body_not_parsed(self):
         # A non-identifier body (contains spaces) is prose, not a tool name, and
         # must NOT be parsed — preserves the <tool_call>GARBAGE</tool_call>


### PR DESCRIPTION
## Problem

GLM-4.5/4.6 renders a no-argument tool call as just the bare function name inside the wrapper:

```
<tool_call>ls
</tool_call>
```

#597 deliberately left bare-identifier bodies unparsed (comment: "indistinguishable from garbage"), so these calls were silently dropped — observed live with GLM-4.5-Air, whose `ls` call was discarded and broke the agent's tool loop:

```
[68e457fe] Failed to parse <tool_call> block: 'ls'
```

## Fix

In `_try_qwen`, recognize a body that is a **strict single identifier** (`[A-Za-z_][\w.-]*`) as a zero-argument call (`input: {}`).

The identifier restriction preserves the original anti-hijack contract: prose (which contains spaces/punctuation) fails `fullmatch` and still falls through to the unparseable-block path. So `Status: </arg_value> done` and `Let me check the files` are still rejected, while `ls` / `pwd` / `list_models` now parse.

## Tests

- Replaced `test_glm_bare_name_body_not_parsed` (asserted the now-fixed wrong behavior) with `test_glm_zero_arg_call`, `test_glm_bare_identifier_body_parsed`, and `test_glm_prose_body_not_parsed`.
- Updated `test_does_not_corrupt_orphaned_tool_call_wrappers` — its `GARBAGE` placeholder was a valid identifier under the new rule, so it now uses genuine prose (`not a tool`) to preserve the test's intent.

All 99 tests in `tests/test_tool_parser.py` pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)