### PR TITLE
fix: address code-review findings on flash env cleanup + calibration loading

### DIFF
--- a/olmlx/bench/scenarios.py
+++ b/olmlx/bench/scenarios.py
@@ -85,17 +85,18 @@ def _requires_flash_moe(model_path: Path) -> str | None:
 def _requires_flash_and_speculative_draft(model_path: Path) -> str | None:
     """Skip flash+spec unless Flash is prepared AND a draft model is set.
 
-    Accepts any of: the promoted env var ``OLMLX_FLASH_SPECULATIVE_DRAFT_MODEL``,
-    the legacy ``OLMLX_EXPERIMENTAL_FLASH_SPECULATIVE_DRAFT_MODEL`` (honoured
-    during the deprecation window), or ``settings.flash_speculative_draft_model``
-    set via a per-model ``models.json`` entry.
+    Accepts the env var ``OLMLX_FLASH_SPECULATIVE_DRAFT_MODEL`` or
+    ``settings.flash_speculative_draft_model`` set via a per-model
+    ``models.json`` entry. The legacy ``OLMLX_EXPERIMENTAL_FLASH_*`` name is
+    deliberately NOT accepted: it is warn-only and never reaches settings, so
+    honoring it would un-skip a scenario whose worker then fails at model
+    load with an unset draft model.
     """
     reason = _requires_flash(model_path)
     if reason is not None:
         return reason
     if (
         os.environ.get("OLMLX_FLASH_SPECULATIVE_DRAFT_MODEL")
-        or os.environ.get("OLMLX_EXPERIMENTAL_FLASH_SPECULATIVE_DRAFT_MODEL")
         or settings.flash_speculative_draft_model
     ):
         return None

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -2705,7 +2705,7 @@ def _cmd_flash_moe_prepare(args, model_path):
     print("\nFlash-MoE preparation complete!")
     print(f"  Output: {output_dir}")
     print("\nTo use Flash-MoE inference:")
-    print("  OLMLX_EXPERIMENTAL_FLASH_MOE=true olmlx serve")
+    print("  OLMLX_FLASH_MOE=true olmlx serve")
 
 
 def _cmd_flash_dense_prepare(args, model_path):
@@ -3063,7 +3063,7 @@ def _show_flash_moe_info(model_name, flash_moe_dir):
         print(f"  Total size:         {total_bytes / (1024**2):.1f} MB")
 
     print("\nTo use Flash-MoE inference:")
-    print("  OLMLX_EXPERIMENTAL_FLASH_MOE=true olmlx serve")
+    print("  OLMLX_FLASH_MOE=true olmlx serve")
 
 
 def _show_flash_dense_info(model_name, flash_dir):

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -767,7 +767,7 @@ def warn_legacy_flash_env() -> None:
     Lives in ``olmlx.config`` so the distributed-worker entry point can reuse
     it without importing ``olmlx.cli`` (and its argparse/uvicorn baggage).
     """
-    dotenv_keys = _legacy_values_in_dotenv(tuple(PROMOTED_FLASH_ENV_RENAMES))
+    dotenv_keys = _legacy_names_in_dotenv(tuple(PROMOTED_FLASH_ENV_RENAMES))
     detected = sorted(
         old
         for old in PROMOTED_FLASH_ENV_RENAMES
@@ -787,41 +787,28 @@ def warn_legacy_flash_env() -> None:
     )
 
 
-def _legacy_values_in_dotenv(names: tuple[str, ...]) -> dict[str, str]:
-    """Return ``{name: value}`` for any *names* found in the project ``.env`` file."""
+def _legacy_names_in_dotenv(names: tuple[str, ...]) -> set[str]:
+    """Return the subset of *names* present as keys in the project ``.env``.
+
+    Key membership only — ``warn_legacy_flash_env`` warns on presence
+    regardless of value, so values are never parsed.
+    """
     dotenv_path = Path(".env")
     try:
         text = dotenv_path.read_text()
     except (FileNotFoundError, OSError):
-        return {}
-    found: dict[str, str] = {}
+        return set()
+    found: set[str] = set()
     legacy = set(names)
     for raw_line in text.splitlines():
         line = raw_line.strip()
-        if not line or line.startswith("#"):
+        if not line or line.startswith("#") or "=" not in line:
             continue
-        if "=" not in line:
-            continue
-        key, _, value = line.partition("=")
-        key = key.strip()
+        key = line.partition("=")[0].strip()
         if key.startswith("export "):
             key = key[len("export ") :].strip()
-        value = value.strip()
-        # Quoted values keep ``#`` literal; unquoted values strip trailing
-        # inline comments. Match opening and closing quote characters to
-        # avoid treating ``'foo"`` (mismatched) as quoted.
-        is_paired_quoted = len(value) >= 2 and (
-            (value.startswith('"') and value.endswith('"'))
-            or (value.startswith("'") and value.endswith("'"))
-        )
-        if not is_paired_quoted:
-            comment_idx = value.find("#")
-            if comment_idx != -1:
-                value = value[:comment_idx].rstrip()
-        if is_paired_quoted:
-            value = value[1:-1]
-        if key in legacy and key not in found:
-            found[key] = value
+        if key in legacy:
+            found.add(key)
     return found
 
 

--- a/olmlx/engine/flash/flash_moe_model.py
+++ b/olmlx/engine/flash/flash_moe_model.py
@@ -257,27 +257,28 @@ class FlashMoeModelWrapper(nn.Module):
         return self._model.args
 
 
-def load_flash_moe_model(
-    load_path: str,
+def wrap_flash_moe(
+    model: Any,
     flash_moe_dir: Path | str,
     *,
-    cache_budget_experts: int,
     io_threads: int,
-) -> tuple[Any, Any, Any]:
-    """Load a model in Flash-MoE mode for offline use (e.g. KV-quant calibration).
+    cache_budget_experts: int,
+) -> tuple[Any, Any]:
+    """Wrap a lazily-loaded MoE model with SSD-streamed experts.
 
-    Mirrors ``model_manager._load_flash_moe_model``: lazy-load so routed expert
-    weights are never materialized, wrap with ``FlashMoeModelWrapper`` (experts
-    streamed from the SSD bundle), and eval only the non-expert params. Returns
-    ``(wrapped_model, tokenizer, store)``; the caller owns the store and must
-    close it. Raises if the bundle is present but cannot be loaded.
+    The kernel shared by the serving loader
+    (``ModelManager._load_flash_moe_model``) and the offline calibration
+    loader (``load_flash_moe_model``): read the bundle config, open the
+    weight store, replace MoE layers with streaming replacements, and eval
+    only the non-expert params. Closes the store and re-raises if wrapping
+    fails. Returns ``(wrapped_model, store)``; the caller owns the store.
     """
     import json
 
-    from olmlx.engine.flash.prepare import load_model_with_strict_fallback
+    # Call-time import so tests can patch the store on its home module.
+    from olmlx.engine.flash.moe_weight_store import FlashMoeWeightStore
 
     flash_moe_dir = Path(flash_moe_dir)
-    model, tokenizer = load_model_with_strict_fallback(load_path, lazy=True)
     moe_config = json.loads((flash_moe_dir / "flash_moe_config.json").read_text())
 
     store = FlashMoeWeightStore(
@@ -295,10 +296,48 @@ def load_flash_moe_model(
             num_experts=moe_config["num_experts"],
             num_experts_per_tok=moe_config["num_experts_per_tok"],
         )
+        # Materialize only non-expert weights.
         mx.eval(wrapped.parameters())
     except Exception:
         store.close()
         raise
+    return wrapped, store
+
+
+def load_flash_moe_model(
+    load_path: str,
+    flash_moe_dir: Path | str,
+    *,
+    cache_budget_experts: int,
+    io_threads: int,
+) -> tuple[Any, Any, Any]:
+    """Load a model in Flash-MoE mode for offline use (e.g. KV-quant calibration).
+
+    Lazy-load so routed expert weights are never materialized, then
+    ``wrap_flash_moe`` — the same kernel the serving loader uses. Returns
+    ``(wrapped_model, tokenizer, store)``; the caller owns the store and must
+    close it. Raises if the bundle is present but cannot be loaded.
+    """
+    from olmlx.engine.flash.prepare import load_model_with_strict_fallback
+
+    try:
+        model, tokenizer = load_model_with_strict_fallback(load_path, lazy=True)
+    except ValueError:
+        # VLM-shaped architectures mlx-lm rejects (Gemma4-class, Kimi-K2.5)
+        # are served via the same fallback in the manager's Flash-MoE loader;
+        # without it here, bundle-bearing VLMs could not be calibrated.
+        import mlx_vlm
+
+        model, processor = mlx_vlm.load(load_path, lazy=True)
+        tokenizer = (
+            processor.tokenizer if hasattr(processor, "tokenizer") else processor
+        )
+    wrapped, store = wrap_flash_moe(
+        model,
+        flash_moe_dir,
+        io_threads=io_threads,
+        cache_budget_experts=cache_budget_experts,
+    )
     return wrapped, tokenizer, store
 
 

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -3232,12 +3232,11 @@ class ModelManager(SpeculativeLoaderMixin):
         """Load a model in Flash-MoE mode.
 
         1. Load model with lazy=True to avoid materializing expert weights
-        2. Create FlashMoeWeightStore
-        3. Wrap model with FlashMoeModelWrapper (replaces SwitchGLU)
-        4. Eval only non-expert params
+        2. Wrap via the shared ``wrap_flash_moe`` kernel (weight store +
+           FlashMoeModelWrapper replacing SwitchGLU + eval of only the
+           non-expert params)
         """
-        from olmlx.engine.flash.flash_moe_model import FlashMoeModelWrapper
-        from olmlx.engine.flash.moe_weight_store import FlashMoeWeightStore
+        from olmlx.engine.flash.flash_moe_model import wrap_flash_moe
 
         import mlx_lm
 
@@ -3255,30 +3254,14 @@ class ModelManager(SpeculativeLoaderMixin):
             is_vlm = True
         caps = detect_caps(tokenizer)
 
-        # Read flash_moe_config for architecture info
-        moe_config = json.loads((flash_moe_dir / "flash_moe_config.json").read_text())
-
-        store = FlashMoeWeightStore(
+        # The store is not returned: unload recovers it from the wrapper's
+        # `_weight_store` attribute.
+        wrapped, _ = wrap_flash_moe(
+            model,
             flash_moe_dir,
-            num_io_threads=flash_moe_config.io_threads,
+            io_threads=flash_moe_config.io_threads,
             cache_budget_experts=flash_moe_config.cache_budget_experts,
         )
-
-        try:
-            wrapped = FlashMoeModelWrapper(
-                model,
-                store,
-                moe_layer_indices=moe_config["moe_layer_indices"],
-                hidden_size=moe_config["hidden_size"],
-                intermediate_size=moe_config["intermediate_size"],
-                num_experts=moe_config["num_experts"],
-                num_experts_per_tok=moe_config["num_experts_per_tok"],
-            )
-            # Materialize only non-expert weights
-            mx.eval(wrapped.parameters())
-        except Exception:
-            store.close()
-            raise
 
         return wrapped, tokenizer, is_vlm, caps
 

--- a/olmlx/engine/shardquant_calibrate.py
+++ b/olmlx/engine/shardquant_calibrate.py
@@ -36,8 +36,7 @@ from olmlx.engine.shardquant import (
 )
 from olmlx.engine.spectralquant import fit_codebook
 from olmlx.engine.spectralquant_calibrate import (
-    _load_calibration_model,
-    collect_kv_vectors,
+    _load_and_collect_kv,
     compute_covariance,
     eigendecompose,
 )
@@ -189,9 +188,6 @@ def calibrate_model_shard(
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    if progress_callback:
-        progress_callback("Loading model", 0.0)
-
     (
         model,
         tokenizer,
@@ -199,43 +195,14 @@ def calibrate_model_shard(
         head_dim,
         n_kv_heads,
         num_layers,
-        store,
-    ) = _load_calibration_model(model_path)
-
-    # Everything from here through KV collection runs under the store's
-    # lifetime — including the c4 download in _get_c4_calibration_data, which
-    # can raise on a network error — so the Flash-MoE store is always closed.
-    try:
-        if progress_callback:
-            progress_callback("Generating calibration data", 0.05)
-
-        from olmlx.engine.flash.prepare import (
-            _get_c4_calibration_data,
-            _get_calibration_data,
-        )
-
-        if calibration_dataset == "synthetic":
-            texts = _get_calibration_data(num_samples)
-        else:
-            texts = _get_c4_calibration_data(num_samples)
-
-        if progress_callback:
-            progress_callback("Collecting KV vectors", 0.1)
-
-        kv_collectors = collect_kv_vectors(
-            model,
-            tokenizer,
-            inner,
-            num_layers=num_layers,
-            n_kv_heads=n_kv_heads,
-            head_dim=head_dim,
-            texts=texts,
-            max_tokens_per_head=max_tokens_per_head,
-            progress_callback=progress_callback,
-        )
-    finally:
-        if store is not None:
-            store.close()
+        kv_collectors,
+    ) = _load_and_collect_kv(
+        model_path,
+        num_samples=num_samples,
+        calibration_dataset=calibration_dataset,
+        max_tokens_per_head=max_tokens_per_head,
+        progress_callback=progress_callback,
+    )
 
     if progress_callback:
         progress_callback("Analyzing", 0.5)

--- a/olmlx/engine/spectralquant.py
+++ b/olmlx/engine/spectralquant.py
@@ -98,20 +98,23 @@ class SpectralRotation:
         return x @ self.V
 
 
-#: Bit-widths the spectral KV cache can actually pack/unpack — these are the
-#: only cases ``turboquant.pack_indices`` / ``unpack_indices`` implement. A
-#: width outside this set (e.g. 5 or 1, which ``allocate_bits`` used to emit for
-#: low-``d_eff`` heads) crashes decode with ``ValueError: Unsupported bits=N``.
-_PACKABLE_BITS: tuple[int, ...] = (2, 4)
+#: Bit-widths the spectral KV cache can actually pack/unpack — the cases this
+#: module's own ``pack_indices`` / ``unpack_indices`` implement (turboquant's
+#: {2, 4} plus the 1- and 8-bit extensions above). A width outside this set
+#: (e.g. 5, which ``allocate_bits`` used to emit for low-``d_eff`` heads)
+#: crashes decode with ``ValueError: Unsupported bits=N``.
+_PACKABLE_BITS: tuple[int, ...] = (1, 2, 4, 8)
 
 
 def allocate_bits(d_eff: int, head_dim: int, avg_bits: int) -> tuple[int, int]:
     """Find (b_high, b_low) minimizing budget slack.
 
     Solves: d_eff * b_high + (head_dim - d_eff) * b_low ≈ head_dim * avg_bits
-    Subject to: b_high >= b_low, both drawn from ``_PACKABLE_BITS`` ({2, 4}) —
-    the only widths the spectral KV cache can pack. Mixed widths outside this
-    set would otherwise crash at decode.
+    Subject to: b_high >= b_low, both drawn from ``_PACKABLE_BITS``
+    ({1, 2, 4, 8}) — the only widths the spectral KV cache can pack. Widths
+    outside this set would crash at decode. Ties on slack go to the pair
+    found first, i.e. the largest ``b_high``, so a slack-0 non-uniform split
+    beats the always-slack-0 uniform pair when the budget allows it.
 
     Returns:
         (b_high, b_low): bits for semantic and tail regimes.

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -345,6 +345,17 @@ def _load_calibration_model(model_path: str):
     flash_moe_dir = Path(model_path) / "flash_moe"
     store = None
     if (flash_moe_dir / "flash_moe_layout.json").exists():
+        if not (flash_moe_dir / "flash_moe_config.json").exists():
+            # The bundler writes the layout as its last act and the config
+            # afterwards, so layout-without-config means an interrupted
+            # `olmlx flash prepare`. Committing to the flash path would die
+            # with a bare FileNotFoundError; a full load could OOM.
+            raise ValueError(
+                f"Incomplete Flash-MoE bundle at {flash_moe_dir}: "
+                "flash_moe_layout.json exists but flash_moe_config.json is "
+                "missing (interrupted preparation?). Re-run `olmlx flash "
+                "prepare` to rebuild the bundle."
+            )
         from olmlx.engine.flash.flash_moe_model import load_flash_moe_model
 
         # Bundle present: commit to the Flash-MoE path. Do NOT fall back to a
@@ -383,6 +394,74 @@ def _load_calibration_model(model_path: str):
             store.close()
         raise
     return model, tokenizer, inner, head_dim, n_kv_heads, num_layers, store
+
+
+def _load_and_collect_kv(
+    model_path: str,
+    *,
+    num_samples: int,
+    calibration_dataset: str | None,
+    max_tokens_per_head: int,
+    progress_callback: Any | None,
+) -> tuple[Any, Any, Any, int, int, int, dict]:
+    """Fetch calibration texts, load the model, and collect K/V vectors.
+
+    The shared front half of ``calibrate_model`` (spectral) and
+    ``calibrate_model_shard``. Texts are fetched BEFORE the model load: they
+    need nothing from the model, and fetching first means a failing or slow
+    dataset download never wastes a multi-GB load nor runs under an open
+    Flash-MoE store. The store (if any) is open only for the collection
+    forwards and is always closed.
+
+    Returns ``(model, tokenizer, inner, head_dim, n_kv_heads, num_layers,
+    kv_collectors)``.
+    """
+    if progress_callback:
+        progress_callback("Generating calibration data", 0.0)
+
+    from olmlx.engine.flash.prepare import (
+        _get_c4_calibration_data,
+        _get_calibration_data,
+    )
+
+    if calibration_dataset == "synthetic":
+        texts = _get_calibration_data(num_samples)
+    else:
+        texts = _get_c4_calibration_data(num_samples)
+
+    if progress_callback:
+        progress_callback("Loading model", 0.05)
+
+    (
+        model,
+        tokenizer,
+        inner,
+        head_dim,
+        n_kv_heads,
+        num_layers,
+        store,
+    ) = _load_calibration_model(model_path)
+
+    try:
+        if progress_callback:
+            progress_callback("Collecting KV vectors", 0.1)
+
+        kv_collectors = collect_kv_vectors(
+            model,
+            tokenizer,
+            inner,
+            num_layers=num_layers,
+            n_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+            texts=texts,
+            max_tokens_per_head=max_tokens_per_head,
+            progress_callback=progress_callback,
+        )
+    finally:
+        if store is not None:
+            store.close()
+
+    return model, tokenizer, inner, head_dim, n_kv_heads, num_layers, kv_collectors
 
 
 def collect_kv_vectors(
@@ -456,6 +535,7 @@ def collect_kv_vectors(
         mx.eval([c.state for c in prompt_cache if hasattr(c, "state")])
 
         # Extract K/V from each layer's cache
+        advanced = False
         for layer_idx in range(min(num_layers, len(prompt_cache))):
             cache_entry = prompt_cache[layer_idx]
             # Combined type + shape filter. Rejects SSM cache types (ArraysCache,
@@ -477,6 +557,7 @@ def collect_kv_vectors(
                     k_h = k_h[:remaining]
                     kv_collectors[layer_idx][h]["key"].append(k_h)
                     tokens_collected[(layer_idx, h, "key")] += k_h.shape[0]
+                    advanced = True
 
                 if tokens_collected[(layer_idx, h, "value")] < max_tokens_per_head:
                     v_h = cached_values[0, h, :, :]  # (seq, head_dim)
@@ -486,8 +567,20 @@ def collect_kv_vectors(
                     v_h = v_h[:remaining]
                     kv_collectors[layer_idx][h]["value"].append(v_h)
                     tokens_collected[(layer_idx, h, "value")] += v_h.shape[0]
+                    advanced = True
 
         del prompt_cache
+        if not advanced:
+            # Every collectable head is at max_tokens_per_head (heads on
+            # filtered layers never advance and never will), so further
+            # forwards contribute nothing. On the Flash-MoE path each one
+            # re-streams routed experts from SSD — stop here.
+            logger.info(
+                "KV collection saturated after %d/%d samples; stopping early",
+                sample_idx + 1,
+                len(texts),
+            )
+            break
         if progress_callback:
             frac = progress_lo + (sample_idx + 1) / len(texts) * (
                 progress_hi - progress_lo
@@ -535,9 +628,6 @@ def calibrate_model(
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    if progress_callback:
-        progress_callback("Loading model", 0.0)
-
     (
         model,
         tokenizer,
@@ -545,44 +635,14 @@ def calibrate_model(
         head_dim,
         n_kv_heads,
         num_layers,
-        store,
-    ) = _load_calibration_model(model_path)
-
-    # Everything from here through KV collection runs under the store's
-    # lifetime — including the c4 download in _get_c4_calibration_data, which
-    # can raise on a network error — so the Flash-MoE store is always closed.
-    try:
-        if progress_callback:
-            progress_callback("Generating calibration data", 0.05)
-
-        from olmlx.engine.flash.prepare import (
-            _get_c4_calibration_data,
-            _get_calibration_data,
-        )
-
-        # Generate calibration data
-        if calibration_dataset == "synthetic":
-            texts = _get_calibration_data(num_samples)
-        else:
-            texts = _get_c4_calibration_data(num_samples)
-
-        if progress_callback:
-            progress_callback("Collecting KV vectors", 0.1)
-
-        kv_collectors = collect_kv_vectors(
-            model,
-            tokenizer,
-            inner,
-            num_layers=num_layers,
-            n_kv_heads=n_kv_heads,
-            head_dim=head_dim,
-            texts=texts,
-            max_tokens_per_head=max_tokens_per_head,
-            progress_callback=progress_callback,
-        )
-    finally:
-        if store is not None:
-            store.close()
+        kv_collectors,
+    ) = _load_and_collect_kv(
+        model_path,
+        num_samples=num_samples,
+        calibration_dataset=calibration_dataset,
+        max_tokens_per_head=max_tokens_per_head,
+        progress_callback=progress_callback,
+    )
 
     if progress_callback:
         progress_callback("Running eigenspectral analysis", 0.5)

--- a/tests/test_bench_scenarios.py
+++ b/tests/test_bench_scenarios.py
@@ -187,6 +187,29 @@ class TestSkipChecks:
         assert reason is not None
         assert "OLMLX_FLASH_SPECULATIVE_DRAFT_MODEL" in reason
 
+    def test_flash_and_spec_skips_with_only_legacy_draft_env(
+        self, tmp_path, monkeypatch
+    ):
+        """Legacy OLMLX_EXPERIMENTAL_FLASH_SPECULATIVE_DRAFT_MODEL is dead
+        (warn-only, never forwarded into settings), so it must NOT satisfy
+        the gate — otherwise the scenario runs against an unconfigured
+        speculative pipeline and errors instead of skipping."""
+        from olmlx.config import settings
+
+        flash_dir = tmp_path / "flash"
+        flash_dir.mkdir()
+        (flash_dir / "flash_layout.json").write_text("{}")
+        monkeypatch.delenv("OLMLX_FLASH_SPECULATIVE_DRAFT_MODEL", raising=False)
+        monkeypatch.setenv(
+            "OLMLX_EXPERIMENTAL_FLASH_SPECULATIVE_DRAFT_MODEL", "some/draft-model"
+        )
+        monkeypatch.setattr(
+            settings, "flash_speculative_draft_model", None, raising=True
+        )
+        reason = _requires_flash_and_speculative_draft(tmp_path)
+        assert reason is not None
+        assert "OLMLX_FLASH_SPECULATIVE_DRAFT_MODEL" in reason
+
     def test_flash_and_spec_runs_with_layout_and_draft_model(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2633,3 +2633,55 @@ class TestPullWithDraft:
         mock_store.register_speculative_draft.assert_called_once_with(
             "org/Big-Model:q4", "org/Big-Model", entry
         )
+
+
+class TestFlashMoeActivationInstruction:
+    """The activation command printed by flash prepare / flash info must use
+    the honored env name.
+
+    Regression: after the legacy OLMLX_EXPERIMENTAL_FLASH* removal, both
+    sites still printed the dead OLMLX_EXPERIMENTAL_FLASH_MOE name —
+    following the printed command starts serve with flash_moe disabled and
+    full-loads the model.
+    """
+
+    def _write_bundle(self, tmp_path):
+        flash_moe_dir = tmp_path / "flash_moe"
+        flash_moe_dir.mkdir()
+        (flash_moe_dir / "flash_moe_config.json").write_text(
+            json.dumps(
+                {
+                    "hidden_size": 8,
+                    "intermediate_size": 16,
+                    "num_experts": 4,
+                    "num_experts_per_tok": 2,
+                    "num_moe_layers": 1,
+                    "prepared_at": "2026-01-01",
+                }
+            )
+        )
+        return flash_moe_dir
+
+    def test_flash_moe_info_prints_honored_env_name(self, tmp_path, capsys):
+        from olmlx.cli import _show_flash_moe_info
+
+        _show_flash_moe_info("some-model", self._write_bundle(tmp_path))
+
+        out = capsys.readouterr().out
+        assert "OLMLX_FLASH_MOE=true olmlx serve" in out
+        assert "OLMLX_EXPERIMENTAL_FLASH_MOE" not in out
+
+    def test_flash_moe_prepare_prints_honored_env_name(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        from olmlx.cli import _cmd_flash_moe_prepare
+
+        monkeypatch.setattr(
+            "olmlx.engine.flash.moe_prepare.prepare_moe_for_flash",
+            lambda model_path, progress_callback: tmp_path / "flash_moe",
+        )
+        _cmd_flash_moe_prepare(MagicMock(), str(tmp_path))
+
+        out = capsys.readouterr().out
+        assert "OLMLX_FLASH_MOE=true olmlx serve" in out
+        assert "OLMLX_EXPERIMENTAL_FLASH_MOE" not in out

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -708,3 +708,34 @@ class TestWarnLegacyFlashEnv:
             warn_legacy_flash_env()
 
         assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+
+
+class TestLegacyNamesInDotenv:
+    """_legacy_names_in_dotenv returns the set of legacy names present in
+    .env — key membership only. warn_legacy_flash_env never reads values
+    (it warns on presence regardless of value), so the helper does not
+    parse them."""
+
+    def test_returns_set_of_present_names(self, monkeypatch, tmp_path):
+        from olmlx.config import _legacy_names_in_dotenv
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text(
+            "# comment\n"
+            "\n"
+            "OLMLX_EXPERIMENTAL_FLASH=true\n"
+            "export OLMLX_EXPERIMENTAL_FLASH_MOE=false  # inline comment\n"
+            "not-an-assignment\n"
+            "OLMLX_FLASH_PREFETCH=true\n"
+        )
+
+        names = _legacy_names_in_dotenv(
+            ("OLMLX_EXPERIMENTAL_FLASH", "OLMLX_EXPERIMENTAL_FLASH_MOE")
+        )
+        assert names == {"OLMLX_EXPERIMENTAL_FLASH", "OLMLX_EXPERIMENTAL_FLASH_MOE"}
+
+    def test_empty_when_no_dotenv(self, monkeypatch, tmp_path):
+        from olmlx.config import _legacy_names_in_dotenv
+
+        monkeypatch.chdir(tmp_path)
+        assert _legacy_names_in_dotenv(("OLMLX_EXPERIMENTAL_FLASH",)) == set()

--- a/tests/test_flash_moe_model.py
+++ b/tests/test_flash_moe_model.py
@@ -1108,3 +1108,131 @@ def test_flash_moe_wrapper_forwards_cache_to_inner_model(tmp_path):
         assert spy.call_args.kwargs["cache"] is sentinel_cache
     finally:
         store.close()
+
+
+def test_load_flash_moe_model_falls_back_to_vlm_loader(tmp_path):
+    """VLM-shaped MoE architectures that mlx-lm rejects load via mlx_vlm on
+    the serving path (``ModelManager._load_flash_moe_model`` →
+    ``_vlm_fallback_load``); the calibration loader needs the same escape
+    hatch or bundle-bearing VLMs (Gemma4-class, Kimi-K2.5) cannot be
+    calibrated at all."""
+    import json
+    from unittest.mock import MagicMock, patch
+
+    from olmlx.engine.flash.moe_bundler import bundle_moe_experts
+    from olmlx.engine.flash.flash_moe_model import (
+        FlashMoeModelWrapper,
+        load_flash_moe_model,
+    )
+
+    hidden, inter, experts = 64, 32, 8
+    num_dense, num_moe, ntok = 1, 2, 2
+    model_dir = _make_synthetic_moe_weights(
+        hidden, inter, experts, num_moe, num_dense, tmp_path
+    )
+    flash_dir = tmp_path / "flash_moe"
+    bundle_moe_experts(model_dir, flash_dir)
+    (flash_dir / "flash_moe_config.json").write_text(
+        json.dumps(
+            {
+                "hidden_size": hidden,
+                "intermediate_size": inter,
+                "num_experts": experts,
+                "num_experts_per_tok": 2,
+                "moe_layer_indices": [1, 2],
+            }
+        )
+    )
+
+    synth = _MockModel(hidden, inter, experts, ntok, num_dense, num_moe)
+    tok = MagicMock()
+    processor = MagicMock()
+    processor.tokenizer = tok
+    fake_vlm = MagicMock()
+    fake_vlm.load.return_value = (synth, processor)
+
+    with (
+        patch(
+            "olmlx.engine.flash.prepare.load_model_with_strict_fallback",
+            side_effect=ValueError("Model type gemma4 not supported"),
+        ),
+        patch.dict("sys.modules", {"mlx_vlm": fake_vlm}),
+    ):
+        model, tokenizer, store = load_flash_moe_model(
+            str(model_dir), flash_dir, cache_budget_experts=4, io_threads=4
+        )
+    try:
+        fake_vlm.load.assert_called_once()
+        assert fake_vlm.load.call_args.kwargs["lazy"] is True
+        assert tokenizer is tok
+        assert isinstance(model, FlashMoeModelWrapper)
+    finally:
+        store.close()
+
+
+class TestWrapFlashMoe:
+    """wrap_flash_moe is the shared store/wrap/eval/close kernel used by both
+    the serving loader (ModelManager._load_flash_moe_model) and the offline
+    calibration loader (load_flash_moe_model)."""
+
+    def _bundle(self, tmp_path, hidden=64, inter=32, experts=8):
+        import json
+
+        from olmlx.engine.flash.moe_bundler import bundle_moe_experts
+
+        model_dir = _make_synthetic_moe_weights(hidden, inter, experts, 2, 1, tmp_path)
+        flash_dir = tmp_path / "flash_moe"
+        bundle_moe_experts(model_dir, flash_dir)
+        (flash_dir / "flash_moe_config.json").write_text(
+            json.dumps(
+                {
+                    "hidden_size": hidden,
+                    "intermediate_size": inter,
+                    "num_experts": experts,
+                    "num_experts_per_tok": 2,
+                    "moe_layer_indices": [1, 2],
+                }
+            )
+        )
+        return flash_dir
+
+    def test_wraps_model_and_returns_store(self, tmp_path):
+        from olmlx.engine.flash.flash_moe_model import (
+            FlashMoeModelWrapper,
+            _FlashMoEBase,
+            wrap_flash_moe,
+        )
+
+        flash_dir = self._bundle(tmp_path)
+        synth = _MockModel(64, 32, 8, 2, 1, 2)
+
+        wrapped, store = wrap_flash_moe(
+            synth, flash_dir, io_threads=4, cache_budget_experts=4
+        )
+        try:
+            assert isinstance(wrapped, FlashMoeModelWrapper)
+            for i in (1, 2):
+                assert isinstance(wrapped.layers[i].mlp, _FlashMoEBase)
+        finally:
+            store.close()
+
+    def test_closes_store_when_wrapping_fails(self, tmp_path):
+        from unittest.mock import MagicMock, patch
+
+        from olmlx.engine.flash import flash_moe_model as fmm
+
+        flash_dir = self._bundle(tmp_path)
+        spy_store = MagicMock()
+
+        with (
+            patch(
+                "olmlx.engine.flash.moe_weight_store.FlashMoeWeightStore",
+                return_value=spy_store,
+            ),
+            patch.object(fmm, "FlashMoeModelWrapper", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            fmm.wrap_flash_moe(
+                MagicMock(), flash_dir, io_threads=4, cache_budget_experts=4
+            )
+        spy_store.close.assert_called_once()

--- a/tests/test_spectralquant.py
+++ b/tests/test_spectralquant.py
@@ -149,22 +149,38 @@ class TestBitAllocation:
         assert b_high - b_low <= 2
 
     def test_only_emits_packable_bit_widths(self):
-        """allocate_bits must only return widths the cache can pack ({2, 4}).
+        """allocate_bits must only return widths the cache can pack.
 
-        Regression: d_eff=32 / avg_bits=2 used to return (5, 1); the spectral
-        KV cache packs indices via turboquant.pack_indices, which implements
-        only bits 2 and 4, so any other width crashes decode with
-        'Unsupported bits=N'. Sweep d_eff across the full range for both
-        supported avg_bits.
+        Regression (#593): d_eff=32 / avg_bits=2 used to return (5, 1); the
+        spectral KV cache packs indices via spectralquant's own
+        pack_indices/unpack_indices, which implement bits 1, 2, 4, and 8 —
+        any other width crashes decode with 'Unsupported bits=N'. Sweep
+        d_eff across the full range for both supported avg_bits and two
+        head_dims.
         """
         from olmlx.engine.spectralquant import allocate_bits
 
         for avg_bits in (2, 4):
-            for d_eff in range(1, 128):
-                b_high, b_low = allocate_bits(d_eff, head_dim=128, avg_bits=avg_bits)
-                assert b_high in (2, 4), (avg_bits, d_eff, b_high, b_low)
-                assert b_low in (2, 4), (avg_bits, d_eff, b_high, b_low)
-                assert b_high >= b_low
+            for head_dim in (128, 192):
+                for d_eff in range(1, head_dim):
+                    b_high, b_low = allocate_bits(d_eff, head_dim, avg_bits)
+                    assert b_high in (1, 2, 4, 8), (avg_bits, d_eff, b_high, b_low)
+                    assert b_low in (1, 2, 4, 8), (avg_bits, d_eff, b_high, b_low)
+                    assert b_high >= b_low
+
+    def test_nonuniform_allocation_when_budget_allows(self):
+        """Non-uniform allocation must survive the packable-width restriction.
+
+        Regression: clamping _PACKABLE_BITS to (2, 4) made the uniform pair
+        (slack 0) unbeatable for every reachable avg_bits, silently killing
+        the module's semantic/tail split. With widths {1, 2, 4, 8}, a
+        slack-0 non-uniform pair found earlier in the search must win:
+        d_eff=64, head_dim=192, avg_bits=4 -> 64*8 + 128*2 = 768 = 192*4,
+        giving the semantic regime double precision at the same budget.
+        """
+        from olmlx.engine.spectralquant import allocate_bits
+
+        assert allocate_bits(d_eff=64, head_dim=192, avg_bits=4) == (8, 2)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_spectralquant_calibrate_coverage.py
+++ b/tests/test_spectralquant_calibrate_coverage.py
@@ -497,6 +497,48 @@ def test_calibrate_model_end_to_end(tmp_path):
     assert progress[-1] == ("Done", 1.0)
 
 
+def test_collect_kv_vectors_stops_once_no_head_advances():
+    """Once every head hit max_tokens_per_head, further forwards append
+    nothing — on the Flash-MoE calibration path each one re-streams experts
+    from SSD, so the loop must stop instead of running all samples.
+
+    With 10-token texts and max_tokens_per_head=20, heads saturate after 2
+    samples; the 3rd forward advances no counter and the loop exits.
+    """
+    head_dim, num_layers, n_kv_heads = 8, 2, 2
+    backbone = _FakeBackbone(num_layers, n_kv_heads, head_dim)
+    model = _FakeModel(backbone, head_dim)
+    tokenizer = MagicMock()
+    texts = ["one two three four five six seven eight nine ten"] * 10
+
+    def cache_factory(_owner):
+        return [KVCache() for _ in range(num_layers)]
+
+    with (
+        patch(
+            "olmlx.engine.flash.prepare._encode_tokens",
+            side_effect=lambda tok, text: list(range(len(text.split()))),
+        ),
+        patch("mlx_lm.models.cache.make_prompt_cache", side_effect=cache_factory),
+    ):
+        collectors = sc.collect_kv_vectors(
+            model,
+            tokenizer,
+            backbone,
+            num_layers=num_layers,
+            n_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+            texts=texts,
+            max_tokens_per_head=20,
+        )
+
+    # 2 collecting forwards + 1 that observes saturation — not all 10.
+    assert model.calls == 3
+    # The cap was still honored exactly.
+    total = sum(chunk.shape[0] for chunk in collectors[0][0]["key"])
+    assert total == 20
+
+
 def test_calibrate_model_raises_when_nothing_collected(tmp_path):
     head_dim = 8
     num_layers = 1
@@ -757,6 +799,7 @@ def test_load_calibration_model_uses_flash_when_bundle_present(tmp_path):
     fdir = tmp_path / "flash_moe"
     fdir.mkdir()
     (fdir / "flash_moe_layout.json").write_text("{}")
+    (fdir / "flash_moe_config.json").write_text("{}")
 
     sentinel_model = MagicMock()
     sentinel_model._backbone = _FakeBackbone(2, 2, 8)
@@ -779,6 +822,20 @@ def test_load_calibration_model_uses_flash_when_bundle_present(tmp_path):
     load_flash.assert_called_once()
     assert result[0] is sentinel_model
     assert result[6] is sentinel_store
+
+
+def test_load_calibration_model_incomplete_bundle_raises_clear_error(tmp_path):
+    """layout.json without config.json is an interrupted `olmlx flash prepare`
+    (the bundler writes the layout last, the config afterwards). Committing to
+    the flash path would die with a bare FileNotFoundError inside
+    load_flash_moe_model; falling back to a full load could OOM. Raise an
+    actionable error instead."""
+    fdir = tmp_path / "flash_moe"
+    fdir.mkdir()
+    (fdir / "flash_moe_layout.json").write_text("{}")
+
+    with pytest.raises(ValueError, match="flash prepare"):
+        sc._load_calibration_model(str(tmp_path))
 
 
 def test_load_calibration_model_full_load_when_no_bundle(tmp_path):
@@ -845,29 +902,14 @@ def test_calibrate_model_closes_store(tmp_path):
     spy_store.close.assert_called_once()
 
 
-def test_calibrate_model_closes_store_when_data_generation_fails(tmp_path):
-    """The store must close even if the c4 download raises before KV collection."""
+def test_calibrate_model_skips_load_when_data_generation_fails(tmp_path):
+    """Texts are fetched BEFORE the model load: they need nothing from the
+    model, and fetching first means a failing c4 download can never waste a
+    multi-GB load (nor open a Flash-MoE store it then has to unwind)."""
     from unittest.mock import MagicMock, patch
 
-    head_dim, num_layers, n_kv_heads = 8, 2, 2
-    backbone = _FakeBackbone(num_layers, n_kv_heads, head_dim)
-    model = _FakeModel(backbone, head_dim)
-    spy_store = MagicMock()
-
     with (
-        patch.object(
-            sc,
-            "_load_calibration_model",
-            return_value=(
-                model,
-                MagicMock(),
-                backbone,
-                head_dim,
-                n_kv_heads,
-                num_layers,
-                spy_store,
-            ),
-        ),
+        patch.object(sc, "_load_calibration_model", MagicMock()) as loader,
         patch(
             "olmlx.engine.flash.prepare._get_c4_calibration_data",
             side_effect=RuntimeError("network down"),
@@ -878,7 +920,51 @@ def test_calibrate_model_closes_store_when_data_generation_fails(tmp_path):
                 "fake/model", output_dir=tmp_path / "spectral", num_samples=2
             )
 
-    spy_store.close.assert_called_once()
+    loader.assert_not_called()
+
+
+def test_calibrate_model_fetches_texts_before_loading_model(tmp_path):
+    """Ordering contract: dataset fetch (network-bound, model-independent)
+    precedes the expensive model/store load in both calibrators."""
+    from unittest.mock import MagicMock, patch
+
+    head_dim, num_layers, n_kv_heads = 8, 2, 2
+    backbone = _FakeBackbone(num_layers, n_kv_heads, head_dim)
+    model = _FakeModel(backbone, head_dim)
+    tokenizer = MagicMock()
+    texts = ["one two three four five six seven eight nine ten"] * 2
+    order = []
+
+    def cache_factory(_owner):
+        return [KVCache() for _ in range(num_layers)]
+
+    def fake_texts(num_samples):
+        order.append("texts")
+        return texts
+
+    def fake_load(model_path):
+        order.append("load")
+        return (model, tokenizer, backbone, head_dim, n_kv_heads, num_layers, None)
+
+    patches = _patch_helpers(model, tokenizer, head_dim, texts, cache_factory)
+    patches.append(
+        patch(
+            "olmlx.engine.flash.prepare._get_c4_calibration_data",
+            side_effect=fake_texts,
+        )
+    )
+    patches.append(patch.object(sc, "_load_calibration_model", side_effect=fake_load))
+    for p in patches:
+        p.start()
+    try:
+        sc.calibrate_model(
+            "fake/model", output_dir=tmp_path / "spectral", num_samples=2
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert order == ["texts", "load"]
 
 
 def test_calibrate_model_synthetic_dataset_branch(tmp_path):
@@ -928,6 +1014,7 @@ def test_load_calibration_model_closes_store_when_resolution_fails(tmp_path):
     fdir = tmp_path / "flash_moe"
     fdir.mkdir()
     (fdir / "flash_moe_layout.json").write_text("{}")
+    (fdir / "flash_moe_config.json").write_text("{}")
 
     spy_store = MagicMock()
     model = MagicMock()


### PR DESCRIPTION
Fixes all 10 findings from the code review of `refactor/config-legacy-flash-env-cleanup` (vs `main`), TDD throughout — every fix has a test that failed first.

## Correctness

- **Stale CLI activation instructions** — `flash prepare` and `flash info` still printed `OLMLX_EXPERIMENTAL_FLASH_MOE=true olmlx serve`, a name this branch made warn-only; following it full-loads the model. Both sites now print `OLMLX_FLASH_MOE=true` (`tests/test_cli.py::TestFlashMoeActivationInstruction`).
- **Bench skip-gate honored a dead env var** — `_requires_flash_and_speculative_draft` accepted the legacy `OLMLX_EXPERIMENTAL_FLASH_SPECULATIVE_DRAFT_MODEL`, un-skipping a scenario whose worker then fails at model load. The sibling `_requires_speculative_draft` gate is untouched: its legacy name (PR #270 window) is still forwarded by `_apply_serve_overrides`.
- **`allocate_bits` had degenerated to always-uniform** — clamping `_PACKABLE_BITS` to `(2, 4)` made the uniform pair unbeatable for every reachable `--avg-bits`, silently killing non-uniform semantic/tail allocation. The decode path uses spectralquant's own packers, which support `{1, 2, 4, 8}` — widened to that set, restoring e.g. `(8, 2)` at `d_eff=64/head_dim=192/avg_bits=4` while still excluding the crash widths from #593. Also fixed the comment that misattributed the constraint to turboquant.
- **Incomplete-bundle probe** — `flash_moe_layout.json` without `flash_moe_config.json` (interrupted `flash prepare`; the bundler writes layout last, config after) now raises an actionable "re-run `olmlx flash prepare`" error instead of a bare `FileNotFoundError` deep in the loader.
- **Calibration couldn't load VLM MoE bundles** — `load_flash_moe_model` gains the same `mlx_vlm` fallback the serving loader has, so bundle-bearing Gemma4-class/Kimi-K2.5 models can be calibrated.

## Efficiency

- **KV-collection early exit** — once a sample advances no head counter (all collectable heads at `max_tokens_per_head`), the loop stops. With defaults, heads saturate after ~16 of 256 samples; on the Flash-MoE path every wasted forward re-streamed experts from SSD.
- **Texts before load** — both calibrators fetch calibration texts (network-bound, model-independent) before the multi-GB model/store load, so a failing or slow dataset fetch never wastes a load nor runs under an open store.

## Cleanup

- **`wrap_flash_moe`** — the store/wrap/eval/close-on-error kernel previously duplicated byte-for-byte between `ModelManager._load_flash_moe_model` and the calibration loader is now one shared helper both delegate to.
- **`_load_and_collect_kv`** — dedupes the ~47-line load+collect+store-lifecycle block copied between `calibrate_model` and `calibrate_model_shard`.
- **`_legacy_names_in_dotenv`** — the dotenv helper's quote/inline-comment value parsing was dead (its only caller tests key membership); reduced to a key-only set scan.

## Verification

- `uv run pytest`: 5439 passed; the 17 failures (shardquant Metal-numerics kernels + `test_speech_non_tts_model_400`) fail identically on the base branch — pre-existing, unrelated to this diff.
- `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)