### PR TITLE
responses.py: dedupe tools-mode buffering and post-parse triple

### DIFF
--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -39,7 +39,10 @@ def _build_tool_calls(
     because that handling runs above the ``has_tools`` gate.
     """
     thinking, visible_text, tool_uses = parse_model_output_post(
-        raw_text, has_tools=bool(tools), declared_tools=tools, thinking_expected=thinking_expected
+        raw_text,
+        has_tools=bool(tools),
+        declared_tools=tools,
+        thinking_expected=thinking_expected,
     )
     if not tool_uses:
         return thinking, visible_text, None

--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -10,13 +10,8 @@ from olmlx.config import settings
 from olmlx.engine.grammar import parse_response_format
 from olmlx.engine.inference import generate_chat
 from olmlx.engine.panel import panel_generate_chat
-from olmlx.engine.tool_parser import (
-    fill_missing_required_args,
-    parse_model_output,
-    resolve_tool_names,
-)
 from olmlx.routers.common import format_error, resolve_think_flag
-from olmlx.routers.streaming_common import collect_stream
+from olmlx.routers.streaming_common import collect_stream, parse_model_output_post
 from olmlx.routers.thinking_split import (
     flush_split_thinking,
     split_thinking_streaming,
@@ -43,11 +38,9 @@ def _build_tool_calls(
     and the Gemma 4 channel format) are still stripped unconditionally
     because that handling runs above the ``has_tools`` gate.
     """
-    thinking, visible_text, tool_uses = parse_model_output(
-        raw_text, has_tools=bool(tools), thinking_expected=thinking_expected
+    thinking, visible_text, tool_uses = parse_model_output_post(
+        raw_text, has_tools=bool(tools), declared_tools=tools, thinking_expected=thinking_expected
     )
-    resolve_tool_names(tool_uses, tools)
-    fill_missing_required_args(tool_uses, tools)
     if not tool_uses:
         return thinking, visible_text, None
     # ``fill_missing_required_args`` normalizes ``tu["input"]`` to a dict

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -23,7 +23,12 @@ from olmlx.routers.common import (
     collect_content_parts,
     resolve_openai_think,
 )
-from olmlx.routers.streaming_common import collect_stream, parse_buffered_output, parse_model_output_post, sse_error_event
+from olmlx.routers.streaming_common import (
+    collect_stream,
+    parse_buffered_output,
+    parse_model_output_post,
+    sse_error_event,
+)
 from olmlx.routers.thinking_split import (
     flush_thinking_buffer,
     strip_thinking_streaming,
@@ -427,7 +432,7 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
             cache_id=cache_id,
             enable_thinking=enable_thinking,
             grammar_spec=grammar_spec,
-)
+        )
         text = result.get("text", "")
         # Use raw_text for tool parsing (preserves gpt-oss channel tokens);
         # ``or text`` (not ``.get(key, text)``) so an empty-string ``raw_text``

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -28,7 +28,7 @@ from olmlx.routers.common import (
     collect_content_parts,
     resolve_openai_think,
 )
-from olmlx.routers.streaming_common import collect_stream, parse_buffered_output
+from olmlx.routers.streaming_common import collect_stream, parse_buffered_output, parse_model_output_post, sse_error_event
 from olmlx.routers.thinking_split import (
     flush_thinking_buffer,
     strip_thinking_streaming,
@@ -176,16 +176,7 @@ async def _stream_openai_sse(
                 content_emitted = True
     except Exception as exc:
         logger.error("Error during OpenAI streaming: %s", exc, exc_info=True)
-        error_payload = json.dumps(
-            {
-                "error": {
-                    "message": "An internal server error occurred during streaming.",
-                    "type": "server_error",
-                    "code": "internal_error",
-                }
-            }
-        )
-        yield f"data: {error_payload}\n\n"
+        yield sse_error_event()
         yield "data: [DONE]\n\n"
     finally:
         await result.aclose()
@@ -272,16 +263,7 @@ async def _stream_openai_sse_with_tools(
         yield "data: [DONE]\n\n"
     except Exception as exc:
         logger.error("Error during OpenAI streaming: %s", exc, exc_info=True)
-        error_payload = json.dumps(
-            {
-                "error": {
-                    "message": "An internal server error occurred during streaming.",
-                    "type": "server_error",
-                    "code": "internal_error",
-                }
-            }
-        )
-        yield f"data: {error_payload}\n\n"
+        yield sse_error_event()
         yield "data: [DONE]\n\n"
     finally:
         await result.aclose()
@@ -450,7 +432,7 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
             cache_id=cache_id,
             enable_thinking=enable_thinking,
             grammar_spec=grammar_spec,
-        )
+)
         text = result.get("text", "")
         # Use raw_text for tool parsing (preserves gpt-oss channel tokens);
         # ``or text`` (not ``.get(key, text)``) so an empty-string ``raw_text``
@@ -463,17 +445,12 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
         usage = OpenAIUsage.from_stats(result.get("stats"))
 
         has_tools = bool(req.tools)
-        # Pass `thinking_expected` so the orphan-`</think>` heuristic only
-        # fires when the engine actually requested thinking (issue #307
-        # review): a non-thinking model that mentions the literal token
-        # would otherwise have its prefix silently dropped from content.
-        _thinking, visible_text, tool_uses = parse_model_output(
+        _thinking, visible_text, tool_uses = parse_model_output_post(
             parse_text,
             has_tools,
+            req.tools,
             thinking_expected=bool(result.get("thinking_expected")),
         )
-        resolve_tool_names(tool_uses, req.tools)
-        fill_missing_required_args(tool_uses, req.tools)
 
         tool_calls = _to_openai_tool_calls(tool_uses) if tool_uses else None
         done_reason = result.get("done_reason")

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -18,11 +18,6 @@ from olmlx.engine.inference import (
     generate_embeddings,
 )
 from olmlx.engine.panel import panel_generate_chat
-from olmlx.engine.tool_parser import (
-    fill_missing_required_args,
-    parse_model_output,
-    resolve_tool_names,
-)
 from olmlx.routers.common import (
     build_inference_options,
     collect_content_parts,

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -376,7 +376,7 @@ async def _stream_response(
         out: BufferedModelOutput = await collect_stream(result)
 
         thinking, visible_text, tool_uses = parse_buffered_output(
-            out, tools, fill_missing_args=True
+            out, tools, has_tools=True, fill_missing_args=True
         )
         output_items = _build_output_items(thinking, visible_text, tool_uses)
         done_reason = out.done_reason
@@ -798,7 +798,7 @@ async def create_response(req: ResponsesRequest, request: Request):
         thinking_expected=bool(result.get("thinking_expected")),
     )
     thinking, visible_text, tool_uses = parse_buffered_output(
-        out, tools, fill_missing_args=True
+        out, tools, has_tools=bool(tools), fill_missing_args=True
     )
 
     output_items = _build_output_items(thinking, visible_text, tool_uses)

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -10,10 +10,10 @@ from olmlx.config import settings
 from olmlx.engine.grammar import GrammarSpec, parse_response_format
 from olmlx.engine.inference import generate_chat
 from olmlx.engine.responses_state import get_store
-from olmlx.engine.tool_parser import (
-    fill_missing_required_args,
-    parse_model_output,
-    resolve_tool_names,
+from olmlx.routers.streaming_common import (
+    BufferedModelOutput,
+    collect_stream,
+    parse_buffered_output,
 )
 from olmlx.routers.common import build_inference_options, resolve_openai_think
 from olmlx.routers.thinking_split import flush_split_thinking, split_thinking_parts
@@ -373,33 +373,14 @@ async def _stream_response(
 
     async def _stream_tools_response():
         """Buffer the engine output, parse once, replay full semantic events."""
-        full_text = ""
-        raw_text = ""
-        done_reason = None
-        thinking_expected = False
-        stats = None
-        async for chunk in result:
-            if chunk.get("cache_info"):
-                continue
-            # `done` is checked before `thinking_expected` so a terminal chunk
-            # that also carries the meta key can't have its stats dropped.
-            if chunk.get("done"):
-                raw_text = chunk.get("raw_text", raw_text)
-                done_reason = chunk.get("done_reason")
-                stats = chunk.get("stats")
-                break
-            if "thinking_expected" in chunk:
-                thinking_expected = bool(chunk["thinking_expected"])
-                continue
-            full_text += chunk.get("text", "")
+        out: BufferedModelOutput = await collect_stream(result)
 
-        parse_text = raw_text or full_text
-        thinking, visible_text, tool_uses = parse_model_output(
-            parse_text, bool(tools), thinking_expected=thinking_expected
+        thinking, visible_text, tool_uses = parse_buffered_output(
+            out, tools, fill_missing_args=True
         )
-        resolve_tool_names(tool_uses, tools)
-        fill_missing_required_args(tool_uses, tools)
         output_items = _build_output_items(thinking, visible_text, tool_uses)
+        done_reason = out.done_reason
+        stats = out.stats
 
         in_progress_resp = base_response("in_progress", [], None, None)
         yield ev("response.created", {"response": in_progress_resp})
@@ -808,14 +789,17 @@ async def create_response(req: ResponsesRequest, request: Request):
         grammar_spec=grammar_spec,
     )
 
-    parse_text = result.get("raw_text") or result.get("text", "")
-    thinking, visible_text, tool_uses = parse_model_output(
-        parse_text,
-        bool(tools),
+    # Wrap non-streaming result in BufferedModelOutput for shared parse path
+    out = BufferedModelOutput(
+        full_text=result.get("text", ""),
+        raw_text=result.get("raw_text", ""),
+        done_reason=result.get("done_reason"),
+        stats=result.get("stats"),
         thinking_expected=bool(result.get("thinking_expected")),
     )
-    resolve_tool_names(tool_uses, tools)
-    fill_missing_required_args(tool_uses, tools)
+    thinking, visible_text, tool_uses = parse_buffered_output(
+        out, tools, fill_missing_args=True
+    )
 
     output_items = _build_output_items(thinking, visible_text, tool_uses)
     response = _build_response_object(

--- a/olmlx/routers/streaming_common.py
+++ b/olmlx/routers/streaming_common.py
@@ -115,11 +115,6 @@ async def buffer_stream(
         if chunk.get("cache_info"):
             yield chunk
             continue
-        if "thinking_expected" in chunk:
-            # Engine meta chunk, emitted before any text: gates the orphan
-            # `</think>` heuristic in `parse_model_output` (issue #307).
-            out.thinking_expected = bool(chunk["thinking_expected"])
-            continue
         if chunk.get("done"):
             # gpt-oss models put the unfiltered channel output here so tool
             # calls survive the visible-text filter.
@@ -127,6 +122,11 @@ async def buffer_stream(
             out.done_reason = chunk.get("done_reason")
             out.stats = chunk.get("stats")
             break
+        if "thinking_expected" in chunk:
+            # Engine meta chunk, emitted before any text: gates the orphan
+            # `</think>` heuristic in `parse_model_output` (issue #307).
+            out.thinking_expected = bool(chunk["thinking_expected"])
+            continue
         parts.append(chunk.get("text", ""))
     out.full_text = "".join(parts)
     yield out

--- a/olmlx/routers/streaming_common.py
+++ b/olmlx/routers/streaming_common.py
@@ -9,6 +9,7 @@ router.
 """
 
 import asyncio
+import json
 import logging
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -155,12 +156,49 @@ def parse_buffered_output(
     omissions visible to the client) injects empty strings for required
     string args the model omitted.
     """
-    thinking, visible_text, tool_uses = parse_model_output(
+    return parse_model_output_post(
         out.parse_text,
         has_tools,
+        declared_tools,
         thinking_expected=out.thinking_expected,
+        fill_missing_args=fill_missing_args,
+    )
+
+
+def parse_model_output_post(
+    text: str,
+    has_tools: bool,
+    declared_tools: list[dict[str, Any]] | None,
+    *,
+    thinking_expected: bool = False,
+    fill_missing_args: bool = True,
+) -> tuple[str, str, list[dict[str, Any]]]:
+    """Run the post-parse triple: parse_model_output -> resolve_tool_names -> fill_missing_required_args.
+
+    Centralized so all routers (OpenAI, Responses, Ollama) share the exact
+    same logic.  The Anthropic surface sets ``fill_missing_args=False`` to
+    leave model omissions visible to the client.
+    """
+    thinking, visible_text, tool_uses = parse_model_output(
+        text,
+        has_tools,
+        thinking_expected=thinking_expected,
     )
     resolve_tool_names(tool_uses, declared_tools)
     if fill_missing_args:
         fill_missing_required_args(tool_uses, declared_tools)
     return thinking, visible_text, tool_uses
+
+
+def sse_error_event(error_message: str = "An internal server error occurred during streaming.") -> str:
+    """Shared SSE error event payload used by OpenAI and Responses streaming."""
+    error_payload = json.dumps(
+        {
+            "error": {
+                "message": error_message,
+                "type": "server_error",
+                "code": "internal_error",
+            }
+        }
+    )
+    return f"data: {error_payload}\n\n"

--- a/olmlx/routers/streaming_common.py
+++ b/olmlx/routers/streaming_common.py
@@ -190,7 +190,9 @@ def parse_model_output_post(
     return thinking, visible_text, tool_uses
 
 
-def sse_error_event(error_message: str = "An internal server error occurred during streaming.") -> str:
+def sse_error_event(
+    error_message: str = "An internal server error occurred during streaming.",
+) -> str:
     """Shared SSE error event payload used by OpenAI and Responses streaming."""
     error_payload = json.dumps(
         {


### PR DESCRIPTION
Fix #631

- `streaming_common.py`: add `parse_model_output_post()` for the shared post-parse triple (`parse_model_output` → `resolve_tool_names` → `fill_missing_required_args`) and `sse_error_event()` for the shared SSE error payload
- `responses.py`: route `_stream_tools_response` through `collect_stream()`/`parse_buffered_output()` instead of reimplementing the drain/aggregate loop; wrap non-streaming result in `BufferedModelOutput` for same parse path; fixes a bug where `done_reason` was undefined
- `openai.py`: use `parse_model_output_post()` in non-streaming path; both streaming functions use `sse_error_event()` instead of duplicated inline error payloads
- `chat.py`: `_build_tool_calls()` uses `parse_model_output_post()`

Closes #631