### PR TITLE
fix(rerank): use fused SDPA in cross-encoder attention (#625)

### DIFF
--- a/olmlx/engine/rerank/model.py
+++ b/olmlx/engine/rerank/model.py
@@ -99,10 +99,14 @@ class XLMRobertaSelfAttention(nn.Module):
             .reshape(b, s, self.num_heads, self.head_dim)
             .transpose(0, 2, 1, 3)
         )
-        scores = (q @ k.transpose(0, 1, 3, 2)) * self.scale
-        scores = scores + additive_mask  # [b, 1, 1, s] broadcast
-        weights = mx.softmax(scores, axis=-1)
-        out = weights @ v  # [b, heads, s, head_dim]
+        # Fused SDPA computes softmax(q @ kᵀ * scale + mask) @ v without ever
+        # materializing the [b, heads, s, s] float32 score tensor that OOMs Metal
+        # on long padded rerank batches (issue #625). The additive mask is
+        # [b, 1, 1, s] and broadcasts over heads and query positions, matching the
+        # unfused reference math exactly (bidirectional encoder — no causal mask).
+        out = mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=self.scale, mask=additive_mask
+        )
         return out.transpose(0, 2, 1, 3).reshape(b, s, -1)
 
 

--- a/tests/test_rerank_model.py
+++ b/tests/test_rerank_model.py
@@ -5,6 +5,7 @@ from olmlx.engine.rerank.config import RerankerConfig
 from olmlx.engine.rerank.model import (
     XLMRobertaCrossEncoder,
     XLMRobertaEmbeddings,
+    XLMRobertaSelfAttention,
     roberta_position_ids,
 )
 from olmlx.engine.rerank.weights import detect_layout, remap_flash, remap_standard
@@ -105,6 +106,46 @@ def test_cross_encoder_forward_shape():
     mx.eval(logits)
     assert logits.shape == (2, 1)
     assert not bool(mx.any(mx.isnan(logits)))  # masking must not produce NaN
+
+
+def test_self_attention_fused_sdpa_matches_reference():
+    # The attention must run through mx.fast.scaled_dot_product_attention (no
+    # materialized [b, heads, s, s] score tensor — issue #625) and match the
+    # unfused reference math on a random masked case.
+    cfg = _tiny_config()
+    attn = XLMRobertaSelfAttention(cfg)
+    mx.eval(attn.parameters())
+
+    calls: list[bool] = []
+    real_sdpa = mx.fast.scaled_dot_product_attention
+
+    def spy(*args, **kwargs):
+        calls.append(True)
+        return real_sdpa(*args, **kwargs)
+
+    b, s = 2, 6
+    x = mx.random.normal((b, s, cfg.hidden_size))
+    keep = mx.array([[1, 1, 1, 1, 1, 1], [1, 1, 1, 0, 0, 0]])
+    additive = (1.0 - keep.astype(mx.float32))[:, None, None, :] * -1.0e4
+
+    try:
+        mx.fast.scaled_dot_product_attention = spy
+        out = attn(x, additive)
+        mx.eval(out)
+    finally:
+        mx.fast.scaled_dot_product_attention = real_sdpa
+
+    assert calls, "attention must use mx.fast.scaled_dot_product_attention"
+
+    # Reference: the unfused attention math with the same projections.
+    q = attn.query(x).reshape(b, s, attn.num_heads, attn.head_dim).transpose(0, 2, 1, 3)
+    k = attn.key(x).reshape(b, s, attn.num_heads, attn.head_dim).transpose(0, 2, 1, 3)
+    v = attn.value(x).reshape(b, s, attn.num_heads, attn.head_dim).transpose(0, 2, 1, 3)
+    scores = (q @ k.transpose(0, 1, 3, 2)) * attn.scale + additive
+    ref = (mx.softmax(scores, axis=-1) @ v).transpose(0, 2, 1, 3).reshape(b, s, -1)
+    mx.eval(ref)
+    assert out.shape == ref.shape
+    assert float(mx.max(mx.abs(out - ref))) < 1e-4
 
 
 def test_cross_encoder_padding_invariance():


### PR DESCRIPTION
## Summary
The reranker's `XLMRobertaSelfAttention` materialized the full `[batch, heads, seq, seq]` float32 score tensor via an explicit `q @ kᵀ` + `softmax`. At default settings (`max_tokens_per_doc=4096`, pad-to-longest batch of 32 on bge-reranker-v2-m3) one layer's score tensor is ~34 GB, OOMing Metal — a single long document inflates the whole padded batch (issue #625).

## Fix
Route the attention through `mx.fast.scaled_dot_product_attention`, passing the existing `[b, 1, 1, s]` additive mask and the `head_dim**-0.5` scale. The fused kernel computes `softmax(q @ kᵀ * scale + mask) @ v` without ever materializing the score matrix, and matches the unfused reference math exactly (bidirectional encoder — no causal mask).

The mask is unchanged: `keep -> 0`, `pad -> -1e4`, broadcast over heads and query positions. Padding-invariance and no-NaN behavior are covered by existing tests.

## Test
`tests/test_rerank_model.py::test_self_attention_fused_sdpa_matches_reference` spies on `mx.fast.scaled_dot_product_attention` to assert the fused path is taken and checks the output against the unfused reference. The pre-written test referenced `XLMRobertaSelfAttention` without importing it (the class already existed in the module); the only test edit is adding that name to the import list — no assertion was changed.

Full file passes under the CI-equivalent CPU device mode (`OLMLX_TESTS_CPU_DEVICE=1`): 13 passed.

## Note on tolerance / device
The test's `1e-4` tolerance is met on the CPU backend the unit suite uses in CI (match to ~6e-8). The Metal fused SDPA kernel at this tiny `head_dim=8` config diverges ~3e-4 from a manual matmul, so the exactness assertion is a CPU-suite check — consistent with how this repo gates Metal-specific kernel tests behind `metal_default_device`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)