### PR TITLE
mlx-vlm 0.6.4 bump + gemma4 audio-tower sanitize workaround

### DIFF
--- a/olmlx/engine/flash/flash_moe_model.py
+++ b/olmlx/engine/flash/flash_moe_model.py
@@ -328,6 +328,9 @@ def load_flash_moe_model(
         # without it here, bundle-bearing VLMs could not be calibrated.
         import mlx_vlm
 
+        from olmlx.engine.gemma4_sanitize_fix import ensure_gemma4_sanitize_patch
+
+        ensure_gemma4_sanitize_patch()
         model, processor = mlx_vlm.load(load_path, lazy=True)
         tokenizer = (
             processor.tokenizer if hasattr(processor, "tokenizer") else processor

--- a/olmlx/engine/flash/flash_moe_model.py
+++ b/olmlx/engine/flash/flash_moe_model.py
@@ -326,12 +326,9 @@ def load_flash_moe_model(
         # VLM-shaped architectures mlx-lm rejects (Gemma4-class, Kimi-K2.5)
         # are served via the same fallback in the manager's Flash-MoE loader;
         # without it here, bundle-bearing VLMs could not be calibrated.
-        import mlx_vlm
+        from olmlx.engine.vlm_load import load_vlm
 
-        from olmlx.engine.gemma4_sanitize_fix import ensure_gemma4_sanitize_patch
-
-        ensure_gemma4_sanitize_patch()
-        model, processor = mlx_vlm.load(load_path, lazy=True)
+        model, processor = load_vlm(load_path, lazy=True)
         tokenizer = (
             processor.tokenizer if hasattr(processor, "tokenizer") else processor
         )

--- a/olmlx/engine/flash/prepare.py
+++ b/olmlx/engine/flash/prepare.py
@@ -378,12 +378,9 @@ def _stream_record_activations(
     except ValueError:
         # mlx_lm doesn't support this model type (e.g. gemma4 VLM) —
         # fall back to mlx_vlm and extract the language model.
-        import mlx_vlm
+        from olmlx.engine.vlm_load import load_vlm
 
-        from olmlx.engine.gemma4_sanitize_fix import ensure_gemma4_sanitize_patch
-
-        ensure_gemma4_sanitize_patch()
-        vlm_model, processor = mlx_vlm.load(model_path, lazy=True)
+        vlm_model, processor = load_vlm(model_path, lazy=True)
         model = vlm_model.language_model
         tokenizer = (
             processor.tokenizer if hasattr(processor, "tokenizer") else processor

--- a/olmlx/engine/flash/prepare.py
+++ b/olmlx/engine/flash/prepare.py
@@ -380,6 +380,9 @@ def _stream_record_activations(
         # fall back to mlx_vlm and extract the language model.
         import mlx_vlm
 
+        from olmlx.engine.gemma4_sanitize_fix import ensure_gemma4_sanitize_patch
+
+        ensure_gemma4_sanitize_patch()
         vlm_model, processor = mlx_vlm.load(model_path, lazy=True)
         model = vlm_model.language_model
         tokenizer = (

--- a/olmlx/engine/gemma4_sanitize_fix.py
+++ b/olmlx/engine/gemma4_sanitize_fix.py
@@ -1,0 +1,113 @@
+"""Workaround for mlx-vlm 0.6.x scrambling gemma4 audio conv weights on
+pre-converted MLX checkpoints.
+
+mlx-vlm 0.5.0's ``load_model`` skipped ``sanitize_weights`` entirely for
+checkpoints whose safetensors carry the ``format: mlx`` metadata (the
+``is_mlx_format`` guard). mlx-vlm 0.6.0 removed that guard, so gemma4's
+``Model.sanitize`` conv transposes — PyTorch ``[out, in, kH, kW]`` ->
+MLX ``[out, kH, kW, in]`` — now also run on mlx-community checkpoints whose
+audio-tower conv weights are ALREADY in MLX layout, scrambling them:
+
+    Expected shape (128, 3, 3, 1) but received shape (128, 3, 1, 3) for
+    parameter audio_tower.subsample_conv_projection.layer0.conv.weight
+
+This breaks loading every gemma4 checkpoint that ships an audio tower
+(e2b/e4b/12B/26B/31b families). Upstream main has since added shape-based
+guards to the transposes (``expected_in``), but that fix is unreleased as
+of 0.6.4.
+
+The patch wraps ``Model.sanitize``: conv weights that are already in MLX
+layout (detected with upstream main's exact discriminant — last dim equals
+the layer's input channels) are pre-inverted to PyTorch layout so the
+wrapped sanitize's transpose restores them. This stays correct if the
+installed sanitize is the fixed (guarded) upstream version too: the
+pre-inverted PyTorch-layout weight fails the guard's already-MLX check and
+gets transposed back, so the patch never double-applies.
+
+Call ``ensure_gemma4_sanitize_patch()`` after ``import mlx_vlm`` and before
+``mlx_vlm.load(...)``.
+
+Remove once the pinned mlx-vlm release carries the upstream guard —
+``tests/test_gemma4_sanitize_fix.py::test_removal_gate_upstream_still_broken``
+fails loudly when that time comes.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+logger = logging.getLogger("olmlx.engine.gemma4_sanitize_fix")
+
+_PATCH_ATTR = "_olmlx_gemma4_sanitize_patch"
+_original: Callable[..., dict[str, Any]] | None = None
+
+
+def _pre_invert_mlx_layout(model_self: Any, weights: dict[str, Any]) -> dict[str, Any]:
+    """Return ``weights`` with already-MLX-layout audio conv weights
+    transposed to PyTorch layout, so the following unconditional sanitize
+    transpose lands them back in MLX layout."""
+    fixed: dict[str, Any] = {}
+    for k, v in weights.items():
+        if (
+            "subsample_conv_projection" in k
+            and "conv.weight" in k
+            and getattr(v, "ndim", 0) == 4
+        ):
+            # Upstream main's discriminant: MLX layout iff the last dim is
+            # the layer's input-channel count (1 for layer0, the previous
+            # layer's out-channels for layer1). kH/kW are small odd kernel
+            # sizes, so they can't collide with 128-ish channel counts.
+            expected_in = None
+            audio_config = getattr(model_self.config, "audio_config", None)
+            if audio_config is not None:
+                if ".layer0." in k:
+                    expected_in = 1
+                elif ".layer1." in k:
+                    expected_in = audio_config.subsampling_conv_channels[0]
+            if expected_in is not None and v.shape[-1] == expected_in:
+                # Inverse of sanitize's transpose(0, 2, 3, 1).
+                v = v.transpose(0, 3, 1, 2)
+        elif "depthwise_conv1d.weight" in k and getattr(v, "ndim", 0) == 3:
+            if v.shape[-1] == 1:
+                # Depthwise conv1d has in=1: MLX layout is [out, kW, 1].
+                # transpose(0, 2, 1) is its own inverse.
+                v = v.transpose(0, 2, 1)
+        fixed[k] = v
+    return fixed
+
+
+def ensure_gemma4_sanitize_patch() -> None:
+    """Idempotently patch ``mlx_vlm.models.gemma4.gemma4.Model.sanitize``.
+
+    Safe to call unconditionally before any ``mlx_vlm.load``; a no-op if
+    already applied or if the module layout has changed (the removal-gate
+    test catches the day this stops being needed).
+    """
+    global _original
+    try:
+        from mlx_vlm.models.gemma4.gemma4 import Model
+    except ImportError:  # pragma: no cover - future mlx-vlm restructure
+        logger.debug("mlx_vlm gemma4 module not found; sanitize patch skipped")
+        return
+
+    current = Model.sanitize
+    if getattr(current, _PATCH_ATTR, False):
+        return
+    _original = current
+
+    def sanitize(self: Any, weights: dict[str, Any]) -> dict[str, Any]:
+        return current(self, _pre_invert_mlx_layout(self, weights))
+
+    setattr(sanitize, _PATCH_ATTR, True)
+    Model.sanitize = sanitize
+    logger.debug("Patched mlx_vlm gemma4 Model.sanitize (MLX-layout conv guard)")
+
+
+def _original_sanitize() -> Callable[..., dict[str, Any]]:
+    """The unpatched upstream sanitize (for the removal-gate test)."""
+    if _original is not None:
+        return _original
+    from mlx_vlm.models.gemma4.gemma4 import Model
+
+    return Model.sanitize

--- a/olmlx/engine/gemma4_sanitize_fix.py
+++ b/olmlx/engine/gemma4_sanitize_fix.py
@@ -1,9 +1,9 @@
-"""Workaround for mlx-vlm 0.6.x scrambling gemma4 audio conv weights on
+"""Workaround for mlx-vlm 0.6.4 scrambling gemma4 audio conv weights on
 pre-converted MLX checkpoints.
 
-mlx-vlm 0.5.0's ``load_model`` skipped ``sanitize_weights`` entirely for
-checkpoints whose safetensors carry the ``format: mlx`` metadata (the
-``is_mlx_format`` guard). mlx-vlm 0.6.0 removed that guard, so gemma4's
+Through 0.6.3, mlx-vlm's ``load_model`` skipped ``sanitize_weights`` entirely
+for checkpoints whose safetensors carry the ``format: mlx`` metadata (the
+``is_mlx_format`` guard). mlx-vlm 0.6.4 removed that guard, so gemma4's
 ``Model.sanitize`` conv transposes — PyTorch ``[out, in, kH, kW]`` ->
 MLX ``[out, kH, kW, in]`` — now also run on mlx-community checkpoints whose
 audio-tower conv weights are ALREADY in MLX layout, scrambling them:
@@ -13,8 +13,20 @@ audio-tower conv weights are ALREADY in MLX layout, scrambling them:
 
 This breaks loading every gemma4 checkpoint that ships an audio tower
 (e2b/e4b/12B/26B/31b families). Upstream main has since added shape-based
-guards to the transposes (``expected_in``), but that fix is unreleased as
-of 0.6.4.
+guards to the gemma4 transposes (``expected_in``), but that fix is unreleased
+as of 0.6.4. Pinning ``<0.6.4`` would avoid the monkeypatch entirely; 0.6.4
+is taken anyway for its server/TTS/STT endpoints, gemma4_unified module, and
+prefill performance work, so this shim carries the difference.
+
+Scope: **gemma4 only** — the removed guard was global, and other families
+also ship unguarded layout-changing sanitizes in 0.6.4 (``qwen3_omni_moe``
+audio conv transposes, ``phi4mm`` every-4-dim-weight transposes,
+``falcon_perception``'s shape-preserving ``.w13.`` interleave,
+rfdetr/rt_detr_v2/sam3 conv transposes). Pre-converted MLX checkpoints of
+those families will fail (or silently corrupt) the same way. They are left
+unpatched because no olmlx deployment loads them today and each needs its own
+family-specific discriminant; extend this module on the same pattern if one
+shows up.
 
 The patch wraps ``Model.sanitize``: conv weights that are already in MLX
 layout (detected with upstream main's exact discriminant — last dim equals
@@ -24,8 +36,8 @@ installed sanitize is the fixed (guarded) upstream version too: the
 pre-inverted PyTorch-layout weight fails the guard's already-MLX check and
 gets transposed back, so the patch never double-applies.
 
-Call ``ensure_gemma4_sanitize_patch()`` after ``import mlx_vlm`` and before
-``mlx_vlm.load(...)``.
+Applied via :func:`olmlx.engine.vlm_load.load_vlm`, the single chokepoint
+every ``mlx_vlm.load`` call site uses.
 
 Remove once the pinned mlx-vlm release carries the upstream guard —
 ``tests/test_gemma4_sanitize_fix.py::test_removal_gate_upstream_still_broken``
@@ -39,8 +51,10 @@ from typing import Any, Callable
 
 logger = logging.getLogger("olmlx.engine.gemma4_sanitize_fix")
 
-_PATCH_ATTR = "_olmlx_gemma4_sanitize_patch"
-_original: Callable[..., dict[str, Any]] | None = None
+# Set on the wrapper function; carries the wrapped (original) sanitize so the
+# original is always recoverable from ``Model.sanitize`` itself — module
+# reloads can't strand it in a stale global.
+_PATCH_ATTR = "_olmlx_gemma4_sanitize_original"
 
 
 def _pre_invert_mlx_layout(model_self: Any, weights: dict[str, Any]) -> dict[str, Any]:
@@ -80,34 +94,43 @@ def _pre_invert_mlx_layout(model_self: Any, weights: dict[str, Any]) -> dict[str
 def ensure_gemma4_sanitize_patch() -> None:
     """Idempotently patch ``mlx_vlm.models.gemma4.gemma4.Model.sanitize``.
 
-    Safe to call unconditionally before any ``mlx_vlm.load``; a no-op if
-    already applied or if the module layout has changed (the removal-gate
-    test catches the day this stops being needed).
+    Safe to call unconditionally before any ``mlx_vlm.load``. Degrades to a
+    no-op (WARNING log) if the gemma4 module import or attribute lookup
+    fails — a broken gemma4 import must not take down loads of unrelated
+    VLM families, and the removal-gate test catches the day this module
+    stops being needed.
     """
-    global _original
     try:
         from mlx_vlm.models.gemma4.gemma4 import Model
-    except ImportError:  # pragma: no cover - future mlx-vlm restructure
-        logger.debug("mlx_vlm gemma4 module not found; sanitize patch skipped")
+
+        current = Model.sanitize
+    except Exception:
+        logger.warning(
+            "gemma4 sanitize workaround could not be applied "
+            "(mlx_vlm.models.gemma4.gemma4 import or attribute lookup "
+            "failed); pre-converted gemma4 audio checkpoints may fail to "
+            "load — see engine/gemma4_sanitize_fix.py",
+            exc_info=True,
+        )
         return
 
-    current = Model.sanitize
-    if getattr(current, _PATCH_ATTR, False):
+    if getattr(current, _PATCH_ATTR, None) is not None:
         return
-    _original = current
 
     def sanitize(self: Any, weights: dict[str, Any]) -> dict[str, Any]:
         return current(self, _pre_invert_mlx_layout(self, weights))
 
-    setattr(sanitize, _PATCH_ATTR, True)
+    setattr(sanitize, _PATCH_ATTR, current)
     Model.sanitize = sanitize
     logger.debug("Patched mlx_vlm gemma4 Model.sanitize (MLX-layout conv guard)")
 
 
 def _original_sanitize() -> Callable[..., dict[str, Any]]:
-    """The unpatched upstream sanitize (for the removal-gate test)."""
-    if _original is not None:
-        return _original
+    """The unpatched upstream sanitize (for the removal-gate test).
+
+    Read off the wrapper itself rather than module state, so it stays
+    correct across module reloads."""
     from mlx_vlm.models.gemma4.gemma4 import Model
 
-    return Model.sanitize
+    current = Model.sanitize
+    return getattr(current, _PATCH_ATTR, None) or current

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2590,13 +2590,10 @@ class ModelManager(SpeculativeLoaderMixin):
             return model, tokenizer, False, caps
         except _FALLBACK_EXCEPTIONS as exc:
             logger.warning("mlx-lm failed for %s (%s), trying mlx-vlm", label, exc)
-            import mlx_vlm
+            from olmlx.engine.vlm_load import load_vlm
 
-            from olmlx.engine.gemma4_sanitize_fix import ensure_gemma4_sanitize_patch
-
-            ensure_gemma4_sanitize_patch()
             try:
-                model, processor = mlx_vlm.load(load_path)
+                model, processor = load_vlm(load_path)
             except FileNotFoundError as vlm_exc:
                 raise ValueError(
                     f"Model '{label}' not found at '{load_path}'. "
@@ -2616,13 +2613,10 @@ class ModelManager(SpeculativeLoaderMixin):
 
         Returns (language_model, tokenizer, vlm_model).
         """
-        import mlx_vlm
-
-        from olmlx.engine.gemma4_sanitize_fix import ensure_gemma4_sanitize_patch
+        from olmlx.engine.vlm_load import load_vlm
 
         logger.info("mlx-lm failed for %s, falling back to mlx-vlm", hf_path)
-        ensure_gemma4_sanitize_patch()
-        vlm_model, processor = mlx_vlm.load(load_path, lazy=lazy)
+        vlm_model, processor = load_vlm(load_path, lazy=lazy)
         model = vlm_model.language_model
         tokenizer = (
             processor.tokenizer if hasattr(processor, "tokenizer") else processor
@@ -3559,14 +3553,9 @@ class ModelManager(SpeculativeLoaderMixin):
         if kind == "vlm":
             # VLM detected — load with mlx-vlm directly
             try:
-                import mlx_vlm
+                from olmlx.engine.vlm_load import load_vlm
 
-                from olmlx.engine.gemma4_sanitize_fix import (
-                    ensure_gemma4_sanitize_patch,
-                )
-
-                ensure_gemma4_sanitize_patch()
-                model, processor = mlx_vlm.load(load_path)
+                model, processor = load_vlm(load_path)
                 tok = (
                     processor.tokenizer
                     if hasattr(processor, "tokenizer")

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -2592,6 +2592,9 @@ class ModelManager(SpeculativeLoaderMixin):
             logger.warning("mlx-lm failed for %s (%s), trying mlx-vlm", label, exc)
             import mlx_vlm
 
+            from olmlx.engine.gemma4_sanitize_fix import ensure_gemma4_sanitize_patch
+
+            ensure_gemma4_sanitize_patch()
             try:
                 model, processor = mlx_vlm.load(load_path)
             except FileNotFoundError as vlm_exc:
@@ -2615,7 +2618,10 @@ class ModelManager(SpeculativeLoaderMixin):
         """
         import mlx_vlm
 
+        from olmlx.engine.gemma4_sanitize_fix import ensure_gemma4_sanitize_patch
+
         logger.info("mlx-lm failed for %s, falling back to mlx-vlm", hf_path)
+        ensure_gemma4_sanitize_patch()
         vlm_model, processor = mlx_vlm.load(load_path, lazy=lazy)
         model = vlm_model.language_model
         tokenizer = (
@@ -3555,6 +3561,11 @@ class ModelManager(SpeculativeLoaderMixin):
             try:
                 import mlx_vlm
 
+                from olmlx.engine.gemma4_sanitize_fix import (
+                    ensure_gemma4_sanitize_patch,
+                )
+
+                ensure_gemma4_sanitize_patch()
                 model, processor = mlx_vlm.load(load_path)
                 tok = (
                     processor.tokenizer

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -373,6 +373,9 @@ def _load_calibration_model(model_path: str):
         except ValueError:
             import mlx_vlm
 
+            from olmlx.engine.gemma4_sanitize_fix import ensure_gemma4_sanitize_patch
+
+            ensure_gemma4_sanitize_patch()
             model, processor = mlx_vlm.load(model_path, lazy=False)
             tokenizer = (
                 processor.tokenizer if hasattr(processor, "tokenizer") else processor

--- a/olmlx/engine/spectralquant_calibrate.py
+++ b/olmlx/engine/spectralquant_calibrate.py
@@ -371,12 +371,9 @@ def _load_calibration_model(model_path: str):
         try:
             model, tokenizer = load_model_with_strict_fallback(model_path, lazy=False)
         except ValueError:
-            import mlx_vlm
+            from olmlx.engine.vlm_load import load_vlm
 
-            from olmlx.engine.gemma4_sanitize_fix import ensure_gemma4_sanitize_patch
-
-            ensure_gemma4_sanitize_patch()
-            model, processor = mlx_vlm.load(model_path, lazy=False)
+            model, processor = load_vlm(model_path, lazy=False)
             tokenizer = (
                 processor.tokenizer if hasattr(processor, "tokenizer") else processor
             )

--- a/olmlx/engine/vlm_load.py
+++ b/olmlx/engine/vlm_load.py
@@ -1,0 +1,24 @@
+"""Single chokepoint for loading models through mlx-vlm.
+
+Every ``mlx_vlm.load`` call in olmlx goes through :func:`load_vlm` so that
+load-time workarounds for upstream regressions are applied exactly once and
+structurally — a new call site cannot forget them.
+``tests/test_vlm_load.py`` enforces the invariant with a source grep.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def load_vlm(path: str, **kwargs: Any) -> tuple[Any, Any]:
+    """``mlx_vlm.load`` with olmlx's load-time workarounds applied.
+
+    Returns ``(model, processor)`` exactly like ``mlx_vlm.load``.
+    """
+    import mlx_vlm
+
+    from olmlx.engine.gemma4_sanitize_fix import ensure_gemma4_sanitize_patch
+
+    ensure_gemma4_sanitize_patch()
+    return mlx_vlm.load(path, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,11 @@ dependencies = [
     "jinja2>=3.0",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
-    "mlx-vlm>=0.5.0,<0.6",
+    # mlx-vlm 0.6.x dropped the is_mlx_format guard around sanitize_weights,
+    # which scrambles gemma4 audio-tower conv weights on pre-converted MLX
+    # checkpoints; engine/gemma4_sanitize_fix.py carries the workaround until
+    # the upstream shape-guard fix (on main, unreleased as of 0.6.4) ships.
+    "mlx-vlm>=0.6.4,<0.7",
     "transformers>=5.5.0",
     # torch is NOT declared here on purpose (#469): xgrammar and mlx-whisper
     # both require it transitively, so it is always installed — but olmlx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,14 @@ dependencies = [
     "jinja2>=3.0",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
-    # mlx-vlm 0.6.x dropped the is_mlx_format guard around sanitize_weights,
-    # which scrambles gemma4 audio-tower conv weights on pre-converted MLX
-    # checkpoints; engine/gemma4_sanitize_fix.py carries the workaround until
-    # the upstream shape-guard fix (on main, unreleased as of 0.6.4) ships.
+    # mlx-vlm 0.6.4 (specifically — the guard is present through 0.6.3)
+    # dropped the is_mlx_format guard around sanitize_weights, which
+    # scrambles gemma4 audio-tower conv weights on pre-converted MLX
+    # checkpoints; engine/gemma4_sanitize_fix.py carries a gemma4-scoped
+    # workaround until the upstream shape-guard fix (on main, unreleased as
+    # of 0.6.4) ships. 0.6.4 is taken despite the patch-free <0.6.4
+    # alternative for its server/TTS/STT endpoints, gemma4_unified module,
+    # and prefill performance work.
     "mlx-vlm>=0.6.4,<0.7",
     "transformers>=5.5.0",
     # torch is NOT declared here on purpose (#469): xgrammar and mlx-whisper

--- a/tests/test_gemma4_sanitize_fix.py
+++ b/tests/test_gemma4_sanitize_fix.py
@@ -1,19 +1,20 @@
-"""Tests for the mlx-vlm 0.6.x gemma4 audio-tower sanitize workaround.
+"""Tests for the mlx-vlm 0.6.4 gemma4 audio-tower sanitize workaround.
 
-mlx-vlm 0.6.0 removed the ``is_mlx_format`` guard around ``sanitize_weights``
-in ``load_model``, so the gemma4 ``Model.sanitize`` conv transposes
-(PyTorch [out, in, kH, kW] -> MLX [out, kH, kW, in]) now also run on
-pre-converted mlx-community checkpoints whose conv weights are ALREADY in
-MLX layout — scrambling them and failing the load with e.g.::
+mlx-vlm 0.6.4 removed the ``is_mlx_format`` guard around ``sanitize_weights``
+in ``load_model`` (present through 0.6.3), so the gemma4 ``Model.sanitize``
+conv transposes (PyTorch [out, in, kH, kW] -> MLX [out, kH, kW, in]) now also
+run on pre-converted mlx-community checkpoints whose conv weights are ALREADY
+in MLX layout — scrambling them and failing the load with e.g.::
 
     Expected shape (128, 3, 3, 1) but received shape (128, 3, 1, 3) for
     parameter audio_tower.subsample_conv_projection.layer0.conv.weight
 
 Upstream main has since added shape-based guards (``expected_in``) to the
-transposes, but the fix is not in any released version (<= 0.6.4).
+gemma4 transposes, but the fix is not in any released version (<= 0.6.4).
 ``olmlx/engine/gemma4_sanitize_fix.py`` carries the workaround until then.
 """
 
+import importlib
 from types import SimpleNamespace
 
 import mlx.core as mx
@@ -21,6 +22,7 @@ import pytest
 
 mlx_vlm_gemma4 = pytest.importorskip("mlx_vlm.models.gemma4.gemma4")
 
+import olmlx.engine.gemma4_sanitize_fix as gemma4_sanitize_fix  # noqa: E402
 from olmlx.engine.gemma4_sanitize_fix import (  # noqa: E402
     _original_sanitize,
     ensure_gemma4_sanitize_patch,
@@ -33,6 +35,18 @@ DW_KEY = "audio_tower.conformer.0.lconv1d.depthwise_conv1d.weight"
 # gemma-4-e4b: layer0 in=1 out=128 k=3x3, layer1 in=128 out=32 k=3x3,
 # depthwise conv1d out=1536 kW=5 in=1 (values don't matter, shapes do).
 SUBSAMPLING_CONV_CHANNELS = [128, 32]
+
+MLX_SHAPES = {
+    L0_KEY: (128, 3, 3, 1),
+    L1_KEY: (32, 3, 3, 128),
+    DW_KEY: (1536, 5, 1),
+}
+
+PYTORCH_SHAPES = {
+    L0_KEY: (128, 1, 3, 3),
+    L1_KEY: (32, 128, 3, 3),
+    DW_KEY: (1536, 1, 5),
+}
 
 
 def _fake_model_self() -> SimpleNamespace:
@@ -49,40 +63,20 @@ def _fake_model_self() -> SimpleNamespace:
     )
 
 
-def _mlx_layout_weights() -> dict[str, mx.array]:
-    return {
-        L0_KEY: mx.zeros((128, 3, 3, 1)),
-        L1_KEY: mx.zeros((32, 3, 3, 128)),
-        DW_KEY: mx.zeros((1536, 5, 1)),
-    }
-
-
-def _pytorch_layout_weights() -> dict[str, mx.array]:
-    return {
-        L0_KEY: mx.zeros((128, 1, 3, 3)),
-        L1_KEY: mx.zeros((32, 128, 3, 3)),
-        DW_KEY: mx.zeros((1536, 1, 5)),
-    }
-
-
-def test_patched_sanitize_preserves_mlx_layout():
+@pytest.mark.parametrize(
+    "shapes",
+    [MLX_SHAPES, PYTORCH_SHAPES],
+    ids=["already-mlx-layout-preserved", "pytorch-layout-converted"],
+)
+def test_patched_sanitize_lands_in_mlx_layout(shapes):
     # The workaround: already-MLX-layout conv weights must come out of
-    # sanitize with their shapes intact.
+    # sanitize with their shapes intact, while unconverted (PyTorch-layout)
+    # weights must still be transposed to MLX layout as upstream does.
     ensure_gemma4_sanitize_patch()
-    out = mlx_vlm_gemma4.Model.sanitize(_fake_model_self(), _mlx_layout_weights())
-    assert out[L0_KEY].shape == (128, 3, 3, 1)
-    assert out[L1_KEY].shape == (32, 3, 3, 128)
-    assert out[DW_KEY].shape == (1536, 5, 1)
-
-
-def test_patched_sanitize_still_converts_pytorch_layout():
-    # Unconverted (PyTorch-layout) weights must still be transposed to MLX
-    # layout, exactly as upstream sanitize does.
-    ensure_gemma4_sanitize_patch()
-    out = mlx_vlm_gemma4.Model.sanitize(_fake_model_self(), _pytorch_layout_weights())
-    assert out[L0_KEY].shape == (128, 3, 3, 1)
-    assert out[L1_KEY].shape == (32, 3, 3, 128)
-    assert out[DW_KEY].shape == (1536, 5, 1)
+    weights = {k: mx.zeros(shape) for k, shape in shapes.items()}
+    out = mlx_vlm_gemma4.Model.sanitize(_fake_model_self(), weights)
+    for k, expected in MLX_SHAPES.items():
+        assert out[k].shape == expected
 
 
 def test_patch_is_idempotent():
@@ -92,16 +86,35 @@ def test_patch_is_idempotent():
     assert mlx_vlm_gemma4.Model.sanitize is first
 
 
+def test_original_sanitize_survives_module_reload():
+    # The original must be recoverable from the wrapper itself, not module
+    # state: after a reload of the fix module (fresh globals) with the patch
+    # already applied, _original_sanitize() must still return the unpatched
+    # upstream function — otherwise the removal gate below fires spuriously.
+    ensure_gemma4_sanitize_patch()
+    reloaded = importlib.reload(gemma4_sanitize_fix)
+    reloaded.ensure_gemma4_sanitize_patch()
+    raw = reloaded._original_sanitize()
+    assert getattr(raw, reloaded._PATCH_ATTR, None) is None
+
+
 def test_removal_gate_upstream_still_broken():
     # REMOVAL GATE: when the installed mlx-vlm's own sanitize stops
     # scrambling already-MLX-layout conv weights (upstream main's
-    # ``expected_in`` guards, unreleased as of 0.6.4), this test fails —
-    # delete olmlx/engine/gemma4_sanitize_fix.py, its call sites, and this
-    # test file, and drop the pyproject comment referencing it.
+    # ``expected_in`` guards, unreleased as of 0.6.4), this test fails.
+    # Then: delete olmlx/engine/gemma4_sanitize_fix.py, the ensure call in
+    # olmlx/engine/vlm_load.py, this test file, and the pyproject comment
+    # referencing the workaround. NOTE before assuming all is well: the
+    # 0.6.4 regression (removed is_mlx_format guard) also affects other
+    # families (qwen3_omni_moe, phi4mm, falcon_perception, rfdetr,
+    # rt_detr_v2, sam3) — check whether the release that fixes gemma4 also
+    # guards those before loading their pre-converted checkpoints.
     ensure_gemma4_sanitize_patch()
     raw = _original_sanitize()
-    out = raw(_fake_model_self(), _mlx_layout_weights())
-    assert out[L0_KEY].shape != (128, 3, 3, 1), (
+    weights = {k: mx.zeros(shape) for k, shape in MLX_SHAPES.items()}
+    out = raw(_fake_model_self(), weights)
+    assert out[L0_KEY].shape != MLX_SHAPES[L0_KEY], (
         "mlx-vlm's gemma4 sanitize is now layout-aware: the workaround in "
-        "olmlx/engine/gemma4_sanitize_fix.py is obsolete — remove it."
+        "olmlx/engine/gemma4_sanitize_fix.py is obsolete — remove it (see "
+        "this test's comment for the checklist)."
     )

--- a/tests/test_gemma4_sanitize_fix.py
+++ b/tests/test_gemma4_sanitize_fix.py
@@ -1,0 +1,107 @@
+"""Tests for the mlx-vlm 0.6.x gemma4 audio-tower sanitize workaround.
+
+mlx-vlm 0.6.0 removed the ``is_mlx_format`` guard around ``sanitize_weights``
+in ``load_model``, so the gemma4 ``Model.sanitize`` conv transposes
+(PyTorch [out, in, kH, kW] -> MLX [out, kH, kW, in]) now also run on
+pre-converted mlx-community checkpoints whose conv weights are ALREADY in
+MLX layout — scrambling them and failing the load with e.g.::
+
+    Expected shape (128, 3, 3, 1) but received shape (128, 3, 1, 3) for
+    parameter audio_tower.subsample_conv_projection.layer0.conv.weight
+
+Upstream main has since added shape-based guards (``expected_in``) to the
+transposes, but the fix is not in any released version (<= 0.6.4).
+``olmlx/engine/gemma4_sanitize_fix.py`` carries the workaround until then.
+"""
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+mlx_vlm_gemma4 = pytest.importorskip("mlx_vlm.models.gemma4.gemma4")
+
+from olmlx.engine.gemma4_sanitize_fix import (  # noqa: E402
+    _original_sanitize,
+    ensure_gemma4_sanitize_patch,
+)
+
+L0_KEY = "audio_tower.subsample_conv_projection.layer0.conv.weight"
+L1_KEY = "audio_tower.subsample_conv_projection.layer1.conv.weight"
+DW_KEY = "audio_tower.conformer.0.lconv1d.depthwise_conv1d.weight"
+
+# gemma-4-e4b: layer0 in=1 out=128 k=3x3, layer1 in=128 out=32 k=3x3,
+# depthwise conv1d out=1536 kW=5 in=1 (values don't matter, shapes do).
+SUBSAMPLING_CONV_CHANNELS = [128, 32]
+
+
+def _fake_model_self() -> SimpleNamespace:
+    """Minimal stand-in for a gemma4 Model: sanitize only touches
+    ``self.config`` and ``self.audio_tower``."""
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            vision_config=SimpleNamespace(use_clipped_linears=False),
+            audio_config=SimpleNamespace(
+                subsampling_conv_channels=SUBSAMPLING_CONV_CHANNELS
+            ),
+        ),
+        audio_tower=object(),
+    )
+
+
+def _mlx_layout_weights() -> dict[str, mx.array]:
+    return {
+        L0_KEY: mx.zeros((128, 3, 3, 1)),
+        L1_KEY: mx.zeros((32, 3, 3, 128)),
+        DW_KEY: mx.zeros((1536, 5, 1)),
+    }
+
+
+def _pytorch_layout_weights() -> dict[str, mx.array]:
+    return {
+        L0_KEY: mx.zeros((128, 1, 3, 3)),
+        L1_KEY: mx.zeros((32, 128, 3, 3)),
+        DW_KEY: mx.zeros((1536, 1, 5)),
+    }
+
+
+def test_patched_sanitize_preserves_mlx_layout():
+    # The workaround: already-MLX-layout conv weights must come out of
+    # sanitize with their shapes intact.
+    ensure_gemma4_sanitize_patch()
+    out = mlx_vlm_gemma4.Model.sanitize(_fake_model_self(), _mlx_layout_weights())
+    assert out[L0_KEY].shape == (128, 3, 3, 1)
+    assert out[L1_KEY].shape == (32, 3, 3, 128)
+    assert out[DW_KEY].shape == (1536, 5, 1)
+
+
+def test_patched_sanitize_still_converts_pytorch_layout():
+    # Unconverted (PyTorch-layout) weights must still be transposed to MLX
+    # layout, exactly as upstream sanitize does.
+    ensure_gemma4_sanitize_patch()
+    out = mlx_vlm_gemma4.Model.sanitize(_fake_model_self(), _pytorch_layout_weights())
+    assert out[L0_KEY].shape == (128, 3, 3, 1)
+    assert out[L1_KEY].shape == (32, 3, 3, 128)
+    assert out[DW_KEY].shape == (1536, 5, 1)
+
+
+def test_patch_is_idempotent():
+    ensure_gemma4_sanitize_patch()
+    first = mlx_vlm_gemma4.Model.sanitize
+    ensure_gemma4_sanitize_patch()
+    assert mlx_vlm_gemma4.Model.sanitize is first
+
+
+def test_removal_gate_upstream_still_broken():
+    # REMOVAL GATE: when the installed mlx-vlm's own sanitize stops
+    # scrambling already-MLX-layout conv weights (upstream main's
+    # ``expected_in`` guards, unreleased as of 0.6.4), this test fails —
+    # delete olmlx/engine/gemma4_sanitize_fix.py, its call sites, and this
+    # test file, and drop the pyproject comment referencing it.
+    ensure_gemma4_sanitize_patch()
+    raw = _original_sanitize()
+    out = raw(_fake_model_self(), _mlx_layout_weights())
+    assert out[L0_KEY].shape != (128, 3, 3, 1), (
+        "mlx-vlm's gemma4 sanitize is now layout-aware: the workaround in "
+        "olmlx/engine/gemma4_sanitize_fix.py is obsolete — remove it."
+    )

--- a/tests/test_vlm_load.py
+++ b/tests/test_vlm_load.py
@@ -1,0 +1,27 @@
+"""Conformance test for the mlx-vlm load chokepoint.
+
+All ``mlx_vlm.load`` calls must go through ``olmlx.engine.vlm_load.load_vlm``
+so load-time workarounds (engine/gemma4_sanitize_fix.py) are applied
+structurally — a call site that bypasses the chokepoint silently loses them.
+"""
+
+import re
+from pathlib import Path
+
+OLMLX_ROOT = Path(__file__).resolve().parents[1] / "olmlx"
+
+
+def test_no_direct_mlx_vlm_load_call_sites():
+    offenders = []
+    for path in OLMLX_ROOT.rglob("*.py"):
+        if path.name == "vlm_load.py":
+            continue
+        text = path.read_text()
+        for i, line in enumerate(text.splitlines(), start=1):
+            if re.search(r"\bmlx_vlm\s*\.\s*load\s*\(", line):
+                offenders.append(f"{path.relative_to(OLMLX_ROOT.parent)}:{i}")
+    assert not offenders, (
+        "Direct mlx_vlm.load call sites found — route them through "
+        "olmlx.engine.vlm_load.load_vlm so load-time workarounds apply: "
+        + ", ".join(offenders)
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2255,7 +2255,7 @@ wheels = [
 
 [[package]]
 name = "mlx-vlm"
-version = "0.5.0"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datasets" },
@@ -2268,14 +2268,16 @@ dependencies = [
     { name = "numpy" },
     { name = "opencv-python" },
     { name = "pillow" },
+    { name = "python-multipart" },
     { name = "requests" },
+    { name = "starlette" },
     { name = "tqdm" },
     { name = "transformers" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/a3/70dce014f6a72efd2cecc07b6a68fc11c0694fbe54ea553b2e00499c7b36/mlx_vlm-0.5.0.tar.gz", hash = "sha256:24563cd1b3a399fd941b2359100628306e2754db1b48780516d1283138258793", size = 1033154, upload-time = "2026-05-06T21:09:33.594Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/03810d375be44e04a0889a7709aa72d8f187ec94a5172dea3d91051032e4/mlx_vlm-0.6.4.tar.gz", hash = "sha256:2a911692aedc3861ae26f4057b1c05dcb9abfb954d50123df3ef63eab0c58e29", size = 1453442, upload-time = "2026-07-06T21:11:12.567Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/66/fb955ccc442aa556e5e9d8836fb9041a7aadff5a88fa80c285e53dc19bf5/mlx_vlm-0.5.0-py3-none-any.whl", hash = "sha256:3351d6ccf609cbf57a4c8cd8308e9a1ce469883d8679d9968c6c6f77af016419", size = 1218132, upload-time = "2026-05-06T21:09:32.071Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4d/45bc2462366fcec5fe7ffc1803d21c3042e9f4d55fdcf7c617a5b4af3c61/mlx_vlm-0.6.4-py3-none-any.whl", hash = "sha256:23810d8aa7b8610d6a5e9b3e24a0f81e768e131efdcb224e570b08147d763aa7", size = 1735033, upload-time = "2026-07-06T21:11:10.809Z" },
 ]
 
 [[package]]
@@ -2870,7 +2872,7 @@ requires-dist = [
     { name = "mlx", specifier = ">=0.32.0,<0.33" },
     { name = "mlx-audio", marker = "extra == 'audio'", specifier = ">=0.4.4" },
     { name = "mlx-lm", specifier = ">=0.31.3,<0.32" },
-    { name = "mlx-vlm", specifier = ">=0.5.0,<0.6" },
+    { name = "mlx-vlm", specifier = ">=0.6.4,<0.7" },
     { name = "mlx-whisper", specifier = ">=0.4.3" },
     { name = "olmlx", extras = ["audio"], marker = "extra == 'voice'" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.27" },


### PR DESCRIPTION
## Summary

Bumps mlx-vlm 0.5.0 → 0.6.4 and carries a workaround for a 0.6.x load regression that breaks every gemma-4 checkpoint with an audio tower.

### Bump

- `mlx-vlm>=0.6.4,<0.7`; resolves cleanly against the existing `mlx 0.32` / `mlx-lm 0.31.3` pins, and the locked transformers 5.11.0 fits mlx-vlm's new `<5.13` cap. Lock delta is mlx-vlm itself plus two small transitive deps (python-multipart, starlette).
- Audited the full `mlx_vlm` API surface olmlx uses — `load`, `stream_generate` (incl. `prompt_cache_state` / `logits_processors` kwargs), `apply_chat_template`, `generate.PromptCacheState`, `generate.generation_stream`, `utils.MODEL_REMAPPING`, the `models.<type>` package layout — all unchanged through 0.6.0's AR/diffusion-engine restructure. `stream_generate` still does not accept `prompt_progress_callback`, so streaming.py's VLM exclusion remains required.

### Regression workaround: `engine/gemma4_sanitize_fix.py`

mlx-vlm 0.6.0 removed the `is_mlx_format` guard around `sanitize_weights`, so gemma4's unconditional PyTorch→MLX conv transposes now also run on pre-converted mlx-community checkpoints — scrambling the audio-tower conv weights and failing the load:

```
Expected shape (128, 3, 3, 1) but received shape (128, 3, 1, 3) for
parameter audio_tower.subsample_conv_projection.layer0.conv.weight
```

A/B-verified: the same checkpoint loads fine under 0.5.0. Upstream main already guards the transposes by shape (`expected_in`), but that fix is unreleased as of 0.6.4.

The shim wraps `gemma4.Model.sanitize` to pre-invert already-MLX-layout conv weights (using upstream main's exact discriminant) so the following transpose restores them — correct under both the broken 0.6.4 sanitize and the fixed upstream one. Applied idempotently at every `mlx_vlm.load` site. `tests/test_gemma4_sanitize_fix.py::test_removal_gate_upstream_still_broken` fails loudly once a fixed mlx-vlm release lands, prompting removal (ropefix convention).

## Verification

- Full suite: 5501 passed, 40 skipped. (Two failures pre-exist on main and are unrelated — A/B-confirmed under 0.5.0: `test_self_attention_fused_sdpa_matches_reference` (borderline 1e-4 tolerance) and `test_speech_non_tts_model_400` (500 vs 400).)
- End-to-end on a live server with gemma-4-e4b-it-4bit: image chat answers correctly, streamed multi-turn works, VLM prompt-cache prefix reuse observed in logs.
- `tests/live/test_gemma4_unified_text.py` (real 12B model) passes — gemma4_unified keeps its pinned text-tower routing.

## Follow-ups (not in this PR)

- Report the sanitize regression upstream (Blaizzy/mlx-vlm) so the guard makes 0.6.5.
- mlx-vlm now ships a `gemma4_unified` module, so the text-only pin for those checkpoints could be relaxed to gain vision — needs separate verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)