### PR TITLE
perf(flash): overhaul MoE expert prefetch; default it off

### DIFF
--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -2787,7 +2787,10 @@ def cmd_flash_train_moe_lookahead(args):
     from olmlx.engine.flash.moe_lookahead_train import train_moe_lookahead
 
     print(f"Training MoE expert lookahead for {args.model}...")
-    print(f"  Rank: {args.rank}  Epochs: {args.epochs}  Samples: {args.samples}")
+    print(
+        f"  Rank: {args.rank}  Epochs: {args.epochs}  Samples: {args.samples}"
+        f"  Max positions/layer: {args.max_positions}"
+    )
     print()
 
     out_dir = train_moe_lookahead(
@@ -2797,13 +2800,15 @@ def cmd_flash_train_moe_lookahead(args):
         epochs=args.epochs,
         num_samples=args.samples,
         calibration_dataset=args.calibration_dataset,
+        max_positions_per_layer=args.max_positions,
+        self_generate=args.self_generate,
         progress_callback=_flash_progress,
     )
 
     print("\nMoE lookahead training complete!")
     print(f"  Output: {out_dir}")
-    print("\nExpert prefetch activates automatically on the next model load")
-    print("(disable with OLMLX_FLASH_MOE_PREFETCH=false).")
+    print("\nExpert prefetch is off by default (it benchmarked slower than")
+    print("plain LRU caching); enable with OLMLX_FLASH_MOE_PREFETCH=true.")
 
 
 def cmd_dflash_precompute(args):
@@ -3494,6 +3499,25 @@ def build_parser() -> argparse.ArgumentParser:
         type=str,
         default=None,
         help="Calibration dataset: 'c4' (default) or 'synthetic'",
+    )
+    tml_p.add_argument(
+        "--max-positions",
+        type=int,
+        default=4096,
+        help="Max trace positions per MoE layer (default: 4096). This caps "
+        "the per-pair training-set size, so raising it (with enough "
+        "--samples to fill it) is the main recall lever. RAM cost is "
+        "~hidden_size*4 bytes per position per layer.",
+    )
+    tml_p.add_argument(
+        "--self-generate",
+        action="store_true",
+        help="Trace the model's own decode steps over chat prompts instead "
+        "of teacher-forced prefill over calibration text (same recipe as "
+        "dflash --self-generate). Serve-time predictions run on decode "
+        "states, and prefill-trained heads lose ~2/3 of their recall "
+        "there. --samples counts prompts; --calibration-dataset is "
+        "ignored. Slower: one forward per generated token.",
     )
 
     # DFlash draft training

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -434,10 +434,21 @@ class Settings(BaseSettings):
 
     # MoE expert prefetch (requires a trained lookahead bank —
     # ``olmlx flash train-moe-lookahead``; silently off without one).
-    flash_moe_prefetch: bool = True
+    # Default OFF: benchmarked 2026-07-10 on Qwen3.5-35B-A3B (32 GB M-series,
+    # cache budget 128/layer), every prefetch configuration lost 30-45% decode
+    # throughput to plain LRU (best ~14.5 vs 20.4 tok/s) — speculative expert
+    # reads cost more SSD bandwidth than their hits save, and raising real
+    # decode-state recall 0.11→0.28 (via --self-generate retraining) did not
+    # change that: predicted-and-routed experts are mostly already cached.
+    flash_moe_prefetch: bool = False
     flash_moe_lookahead_margin: Annotated[float, Field(ge=1.0)] = 1.5
     flash_moe_prefetch_max_positions: Annotated[int, Field(gt=0)] = 8
     flash_moe_scored_eviction: bool = True
+    # Only prefetch from lookahead pairs whose trained holdout recall@m is at
+    # least this value — a low-recall head mostly reads wrong experts (pure
+    # wasted SSD bandwidth). 0.0 = no gating. Banks trained before recall
+    # persistence have no per-pair recall recorded and are never gated.
+    flash_moe_prefetch_min_recall: Annotated[float, Field(ge=0.0, le=1.0)] = 0.0
 
     # Flash prefetch — promoted toggle. Advanced prefetch tuning
     # (confidence_threshold, min/max_neurons, io_threads) stays on
@@ -851,7 +862,8 @@ class FlashMoeConfig:
     cache_budget_experts: int
     io_threads: int
     # Prefetch knobs are global-only (no per-model registry override).
-    prefetch: bool = True
+    prefetch: bool = False
     lookahead_margin: float = 1.5
     prefetch_max_positions: int = 8
     scored_eviction: bool = True
+    prefetch_min_recall: float = 0.0

--- a/olmlx/engine/flash/flash_moe.py
+++ b/olmlx/engine/flash/flash_moe.py
@@ -77,12 +77,11 @@ class FlashMoE(nn.Module):
         Returns:
             Output hidden states, shape (B, L, hidden_size).
         """
-        # Wait for any pending prefetch targeting THIS layer (submitted by
-        # the previous MoE layer) BEFORE the mx.eval below — the prediction
-        # thread owns the only background mx.eval, and it must have finished
-        # before the main thread evaluates.
-        if self.prefetcher is not None:
-            self.prefetcher.wait(self.layer_idx)
+        # Prefetch is non-blocking: any prefetch I/O targeting THIS layer
+        # (submitted by the previous MoE layer) races the load_experts call
+        # below. Landed predictions are cache hits; still-in-flight ones are
+        # re-read by load_experts (occasional duplicate read — cheaper than
+        # blocking every layer on mostly-speculative I/O).
 
         # Collect unique expert indices for the SSD read list (Python-side, one eval per layer).
         # Invariant: ``unique_experts`` must contain every value in ``inds`` so the remap LUT
@@ -93,10 +92,11 @@ class FlashMoE(nn.Module):
         unique_experts = sorted(set(flat_inds))
 
         # Kick off prediction + SSD I/O for the NEXT MoE layer before this
-        # layer's blocking load, so they overlap with the load, the expert
-        # matmuls, and the intervening dense/attention work. Must come AFTER
-        # the mx.eval above (concurrent mx.eval is unsafe) and the main
-        # thread must not eval again until the next wait().
+        # layer's blocking load, so the I/O overlaps with the load, the
+        # expert matmuls, and the intervening dense/attention work.
+        # Prediction runs inline (NumPy) on this thread; keep the call AFTER
+        # the mx.eval above so x is already materialized and submit()'s
+        # NumPy conversion is a cast, not a graph drive.
         if self.prefetcher is not None:
             self.prefetcher.submit(self.layer_idx, x)
 

--- a/olmlx/engine/flash/flash_moe_model.py
+++ b/olmlx/engine/flash/flash_moe_model.py
@@ -274,13 +274,17 @@ def _maybe_create_prefetcher(
     margin: float,
     max_positions: int,
     scored_eviction: bool,
+    min_recall: float = 0.0,
 ) -> MoePrefetcher | None:
     """Load the trained lookahead bank and build a prefetcher, or None.
 
     Never raises: a missing/corrupt/stale ``moe_lookahead/`` directory is an
     optional accelerator, not a load failure. A sidecar that disagrees with
     the bundle (re-bundled model, wrong architecture) is rejected — serving a
-    wrong-shaped predictor would prefetch garbage every token.
+    wrong-shaped predictor would prefetch garbage every token. Pairs whose
+    trained holdout recall is below *min_recall* are gated off (their
+    predictions are mostly wasted SSD reads); if that gates every pair, no
+    prefetcher is built at all.
     """
     from olmlx.engine.flash.moe_predictor import MoeLookaheadBank
     from olmlx.engine.flash.moe_prefetch import MoePrefetcher
@@ -320,12 +324,29 @@ def _maybe_create_prefetcher(
         )
         return None
 
+    gated = bank.apply_recall_gate(min_recall)
+    if gated:
+        logger.info(
+            "Recall gate (min_recall=%.2f): disabled %d of %d lookahead pairs",
+            min_recall,
+            gated,
+            len(bank.heads),
+        )
+    if not bank.trained_pairs:
+        logger.info(
+            "All lookahead pairs gated below min_recall=%.2f — prefetch disabled",
+            min_recall,
+        )
+        return None
+
     logger.info(
         "MoE expert prefetch enabled (margin=%.2f, max_positions=%d, "
-        "scored_eviction=%s)",
+        "scored_eviction=%s, active_pairs=%d/%d)",
         margin,
         max_positions,
         scored_eviction,
+        len(bank.trained_pairs),
+        len(bank.heads),
     )
     return MoePrefetcher(
         bank,
@@ -346,6 +367,7 @@ def wrap_flash_moe(
     lookahead_margin: float = 1.5,
     prefetch_max_positions: int = 8,
     scored_eviction: bool = True,
+    prefetch_min_recall: float = 0.0,
 ) -> tuple[Any, Any]:
     """Wrap a lazily-loaded MoE model with SSD-streamed experts.
 
@@ -378,6 +400,7 @@ def wrap_flash_moe(
             margin=lookahead_margin,
             max_positions=prefetch_max_positions,
             scored_eviction=scored_eviction,
+            min_recall=prefetch_min_recall,
         )
     try:
         wrapped = FlashMoeModelWrapper(

--- a/olmlx/engine/flash/moe_lookahead_train.py
+++ b/olmlx/engine/flash/moe_lookahead_train.py
@@ -158,7 +158,13 @@ def record_moe_router_traces_decode(
 
     ``prompt_source`` yields chat-templated prompt token lists;
     ``_generate_fn(model, tokenizer, prompt_ids, max_new_tokens)`` is a test
-    hook replacing the default ``mlx_lm.stream_generate`` drive.
+    hook replacing the default ``mlx_lm.stream_generate`` drive. The drive
+    MUST decode with batch size 1 — the recorder identifies decode steps as
+    single-position forwards, so a batched drive records nothing. The first
+    single-position forward of each prompt is dropped: mlx_lm always feeds
+    the last prompt token as its own forward (teacher-forced, not a decode
+    state), so per prompt exactly one boundary position would otherwise
+    contaminate the trace.
     """
     import mlx.nn as nn
 
@@ -184,13 +190,13 @@ def record_moe_router_traces_decode(
                 self._inds_sink.append(np.array(flat_inds))
             return self._inner(x)
 
-    if _generate_fn is None:
+    def _default_generate_fn(model, tokenizer, prompt_ids, max_new):
+        from mlx_lm import stream_generate
 
-        def _generate_fn(model, tokenizer, prompt_ids, max_new):
-            from mlx_lm import stream_generate
+        for _ in stream_generate(model, tokenizer, prompt_ids, max_tokens=max_new):
+            pass
 
-            for _ in stream_generate(model, tokenizer, prompt_ids, max_tokens=max_new):
-                pass
+    generate_fn = _generate_fn if _generate_fn is not None else _default_generate_fn
 
     if prompt_source is None:
         from olmlx.engine.dflash.selfgen import iter_dataset_prompts
@@ -220,14 +226,32 @@ def record_moe_router_traces_decode(
         originals[layer_idx] = (mod, attr)
         setattr(layer, attr, _DecodeRecorder(mod, hidden_sink, inds_sink))
 
-    first_sink = next(iter(sinks.values()), None)
+    if not sinks:
+        # No recorder installed (no _route-style MoE layers) — generating
+        # would burn max_prompts full decodes and record nothing.
+        logger.warning("No recordable MoE layers — skipping decode tracing")
+        return {}
+
+    first_sink = next(iter(sinks.values()))
     try:
         for prompt_num, prompt_ids in enumerate(prompt_source):
             if prompt_num >= max_prompts:
                 break
-            if first_sink is not None and len(first_sink[0]) >= max_positions_per_layer:
+            if len(first_sink[0]) >= max_positions_per_layer:
                 break  # every layer records the same decode steps
-            _generate_fn(model, tokenizer, prompt_ids, max_new_tokens)
+            before = len(first_sink[0])
+            generate_fn(model, tokenizer, prompt_ids, max_new_tokens)
+            # Drop each layer's first recorded position for this prompt:
+            # mlx_lm's generate_step always leaves exactly one prompt token
+            # for the first sampling forward, so the first single-position
+            # call per prompt carries the LAST PROMPT TOKEN (teacher-forced),
+            # not a decode state. Recording it would contaminate the
+            # decode-only distribution this tracer exists to guarantee —
+            # one off-distribution position per prompt, every prompt.
+            for hidden_sink, inds_sink in sinks.values():
+                if len(hidden_sink) > before:
+                    del hidden_sink[before]
+                    del inds_sink[before]
     finally:
         for layer_idx, (mod, attr) in originals.items():
             setattr(layers[layer_idx], attr, mod)
@@ -386,13 +410,6 @@ def train_moe_lookahead(
             f"Need at least 2 MoE layers for lookahead, got {moe_layer_indices}"
         )
 
-    if self_generate:
-        texts = []  # prompts stream from iter_dataset_prompts instead
-    elif calibration_dataset == "synthetic":
-        texts = _get_calibration_data(num_samples)
-    else:
-        texts = _get_c4_calibration_data(num_samples)
-
     if progress_callback:
         progress_callback("Loading model (Flash-MoE, lazy)", 0.0)
 
@@ -415,6 +432,12 @@ def train_moe_lookahead(
                 max_prompts=num_samples,
             )
         else:
+            # self-generate streams prompts from iter_dataset_prompts;
+            # only the prefill path consumes calibration texts.
+            if calibration_dataset == "synthetic":
+                texts = _get_calibration_data(num_samples)
+            else:
+                texts = _get_c4_calibration_data(num_samples)
             traces = record_moe_router_traces(
                 model,
                 tokenizer,
@@ -427,7 +450,8 @@ def train_moe_lookahead(
 
     if not traces:
         raise RuntimeError(
-            "No router traces recorded — model has no _route-style MoE layers"
+            "No router traces recorded — model has no _route-style MoE "
+            "layers, or (self_generate) generation produced no decode steps"
         )
 
     bank, recalls = train_from_traces(

--- a/olmlx/engine/flash/moe_lookahead_train.py
+++ b/olmlx/engine/flash/moe_lookahead_train.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import math
 from pathlib import Path
+from collections.abc import Iterator
 from typing import Any, Callable
 
 import mlx.core as mx
@@ -132,6 +133,117 @@ def record_moe_router_traces(
     return traces
 
 
+def record_moe_router_traces_decode(
+    model: Any,
+    tokenizer: Any,
+    moe_layer_indices: list[int],
+    *,
+    max_positions_per_layer: int = 4096,
+    max_new_tokens: int = 256,
+    max_prompts: int = 256,
+    prompt_source: Iterator[list[int]] | None = None,
+    _generate_fn: Callable[..., None] | None = None,
+) -> dict[int, tuple[np.ndarray, np.ndarray]]:
+    """Record per-MoE-layer (input hidden, router top-k) during DECODE.
+
+    Serve-time expert prediction runs on decode-token hidden states of the
+    model's own output, but :func:`record_moe_router_traces` records
+    teacher-forced prefill states — an off-distribution training set (the
+    DFlash ``--self-generate`` lesson). This variant chat-prompts the model
+    (ultrachat prompts via dflash's ``iter_dataset_prompts`` by default) and
+    records only single-position forwards, i.e. the greedy decode steps of
+    the model's own responses. Prefill calls (multi-position) are skipped,
+    so positions stay aligned across layers exactly as in the prefill
+    recorder.
+
+    ``prompt_source`` yields chat-templated prompt token lists;
+    ``_generate_fn(model, tokenizer, prompt_ids, max_new_tokens)`` is a test
+    hook replacing the default ``mlx_lm.stream_generate`` drive.
+    """
+    import mlx.nn as nn
+
+    from olmlx.engine.flash.flash_moe_model import _find_moe_module
+
+    class _DecodeRecorder(nn.Module):
+        def __init__(self, inner: Any, hidden_sink: list, inds_sink: list):
+            super().__init__()
+            object.__setattr__(self, "_inner", inner)
+            object.__setattr__(self, "_hidden_sink", hidden_sink)
+            object.__setattr__(self, "_inds_sink", inds_sink)
+
+        def __call__(self, x: mx.array) -> mx.array:
+            flat = x.reshape(-1, x.shape[-1])
+            # Decode steps are exactly one position; prefill (or chunked
+            # prefill) is many. Recording only the former keeps the trace
+            # on the serve-time prediction distribution.
+            if flat.shape[0] == 1 and len(self._hidden_sink) < max_positions_per_layer:
+                inds, _ = self._inner._route(x)
+                flat_inds = inds.reshape(-1, inds.shape[-1])
+                mx.eval(flat, flat_inds)
+                self._hidden_sink.append(np.array(flat.astype(mx.float32)))
+                self._inds_sink.append(np.array(flat_inds))
+            return self._inner(x)
+
+    if _generate_fn is None:
+
+        def _generate_fn(model, tokenizer, prompt_ids, max_new):
+            from mlx_lm import stream_generate
+
+            for _ in stream_generate(model, tokenizer, prompt_ids, max_tokens=max_new):
+                pass
+
+    if prompt_source is None:
+        from olmlx.engine.dflash.selfgen import iter_dataset_prompts
+
+        prompt_source = iter_dataset_prompts(tokenizer)
+
+    sinks: dict[int, tuple[list, list]] = {}
+    originals: dict[int, tuple[Any, str]] = {}
+    layers = model.layers
+
+    for layer_idx in sorted(moe_layer_indices):
+        layer = layers[layer_idx]
+        try:
+            attr, mod = _find_moe_module(layer)
+        except AttributeError:
+            attr, mod = None, None
+        if mod is None or not hasattr(mod, "_route"):
+            logger.warning(
+                "MoE layer %d has no _route-style module — skipping decode "
+                "trace recording",
+                layer_idx,
+            )
+            continue
+        hidden_sink: list = []
+        inds_sink: list = []
+        sinks[layer_idx] = (hidden_sink, inds_sink)
+        originals[layer_idx] = (mod, attr)
+        setattr(layer, attr, _DecodeRecorder(mod, hidden_sink, inds_sink))
+
+    first_sink = next(iter(sinks.values()), None)
+    try:
+        for prompt_num, prompt_ids in enumerate(prompt_source):
+            if prompt_num >= max_prompts:
+                break
+            if first_sink is not None and len(first_sink[0]) >= max_positions_per_layer:
+                break  # every layer records the same decode steps
+            _generate_fn(model, tokenizer, prompt_ids, max_new_tokens)
+    finally:
+        for layer_idx, (mod, attr) in originals.items():
+            setattr(layers[layer_idx], attr, mod)
+
+    traces: dict[int, tuple[np.ndarray, np.ndarray]] = {}
+    for layer_idx, (hidden_sink, inds_sink) in sinks.items():
+        if not hidden_sink:
+            logger.warning("No decode positions recorded for MoE layer %d", layer_idx)
+            continue
+        traces[layer_idx] = (
+            np.concatenate(hidden_sink, axis=0),
+            np.concatenate(inds_sink, axis=0).astype(np.int32),
+        )
+    return traces
+
+
 def train_from_traces(
     traces: dict[int, tuple[np.ndarray, np.ndarray]],
     moe_layer_indices: list[int],
@@ -208,9 +320,13 @@ def train_from_traces(
             scores = bank.heads[pair_idx](mx.array(hid[n_train:]))
             mx.eval(scores)
             m = min(num_experts, math.ceil(eval_margin * num_experts_per_tok))
-            recalls[f"{src}→{dst}"] = recall_at_m(
+            recall = recall_at_m(
                 np.array(scores, dtype=np.float32), next_inds[n_train:], m
             )
+            recalls[f"{src}→{dst}"] = recall
+            # Pair-indexed copy on the bank itself: save() persists it so
+            # serve-time recall gating (apply_recall_gate) can use it.
+            bank.pair_recalls[pair_idx] = recall
         else:
             logger.info("Pair %d→%d trained, not evaluated (n=%d ≤ 10)", src, dst, n)
 
@@ -230,12 +346,22 @@ def train_moe_lookahead(
     holdout_fraction: float = 0.1,
     io_threads: int = 16,
     cache_budget_experts: int = 48,
+    self_generate: bool = False,
+    selfgen_max_new: int = 256,
     progress_callback: Callable[[str, float], None] | None = None,
 ) -> Path:
     """End-to-end: record traces on the Flash-MoE model, train, save.
 
     Saves to ``<flash_moe_dir>/moe_lookahead`` and returns that path. Prints
     per-pair holdout recall via the logger; the CLI surfaces it to the user.
+
+    ``self_generate``: record traces from the model's OWN decode steps over
+    chat prompts (``record_moe_router_traces_decode``) instead of
+    teacher-forced prefill over calibration text. Serve-time predictions run
+    on decode states; prefill-trained heads measured 0.39 holdout recall but
+    only 0.14 on real decode states (measured 2026-07-10, Qwen3.5-35B-A3B).
+    ``num_samples`` then counts prompts and ``calibration_dataset`` is
+    ignored. Tracing is slower per position (one forward per token).
     """
     import json
 
@@ -260,7 +386,9 @@ def train_moe_lookahead(
             f"Need at least 2 MoE layers for lookahead, got {moe_layer_indices}"
         )
 
-    if calibration_dataset == "synthetic":
+    if self_generate:
+        texts = []  # prompts stream from iter_dataset_prompts instead
+    elif calibration_dataset == "synthetic":
         texts = _get_calibration_data(num_samples)
     else:
         texts = _get_c4_calibration_data(num_samples)
@@ -277,13 +405,23 @@ def train_moe_lookahead(
     try:
         if progress_callback:
             progress_callback("Recording router traces", 0.05)
-        traces = record_moe_router_traces(
-            model,
-            tokenizer,
-            texts,
-            moe_layer_indices,
-            max_positions_per_layer=max_positions_per_layer,
-        )
+        if self_generate:
+            traces = record_moe_router_traces_decode(
+                model,
+                tokenizer,
+                moe_layer_indices,
+                max_positions_per_layer=max_positions_per_layer,
+                max_new_tokens=selfgen_max_new,
+                max_prompts=num_samples,
+            )
+        else:
+            traces = record_moe_router_traces(
+                model,
+                tokenizer,
+                texts,
+                moe_layer_indices,
+                max_positions_per_layer=max_positions_per_layer,
+            )
     finally:
         store.close()
 
@@ -323,6 +461,7 @@ def train_moe_lookahead(
         "lr": lr,
         "num_samples": num_samples,
         "holdout_fraction": holdout_fraction,
+        "self_generate": self_generate,
     }
     sidecar_path.write_text(json.dumps(sidecar, indent=2))
 

--- a/olmlx/engine/flash/moe_predictor.py
+++ b/olmlx/engine/flash/moe_predictor.py
@@ -90,6 +90,15 @@ class MoeLookaheadBank:
         no prediction, no I/O). Pairs with no recorded recall (legacy banks)
         are kept: gating on absent data would silently disable prefetch
         wholesale. Returns the number of pairs gated.
+
+        DESTRUCTIVE: do not ``save()`` a gated bank — gated-but-trained
+        pairs would persist as untrained, indistinguishable from
+        never-trained. Serving only ever gates a fresh per-load instance
+        (``_maybe_create_prefetcher``), so relaxing ``min_recall`` takes
+        effect on the next model load. Note the recorded recall is measured
+        at the trainer's eval margin (1.5); if the serve-time
+        ``flash_moe_lookahead_margin`` differs, the gate compares against a
+        slightly different m than prefetch actually uses.
         """
         if min_recall <= 0.0:
             return 0

--- a/olmlx/engine/flash/moe_predictor.py
+++ b/olmlx/engine/flash/moe_predictor.py
@@ -72,6 +72,34 @@ class MoeLookaheadBank:
             if trained_pairs is None
             else set(trained_pairs)
         )
+        # NumPy copies of head weights for predict_next_np, built on first
+        # use (load() replaces the constructor weights, so building here
+        # would capture the wrong ones). ~rank*(hidden+experts) fp32 per
+        # head — small next to the expert bundle.
+        self._np_heads: list[tuple[np.ndarray, np.ndarray]] | None = None
+        # Holdout recall@m per pair, set by the trainer and persisted in the
+        # sidecar. Empty for banks trained before recall persistence.
+        self.pair_recalls: dict[int, float] = {}
+
+    def apply_recall_gate(self, min_recall: float) -> int:
+        """Disable pairs whose holdout recall@m is below *min_recall*.
+
+        A low-recall head mostly prefetches wrong experts — pure wasted SSD
+        bandwidth — so gated pairs are removed from ``trained_pairs`` and
+        behave exactly like untrained ones (``next_moe_layer`` returns None;
+        no prediction, no I/O). Pairs with no recorded recall (legacy banks)
+        are kept: gating on absent data would silently disable prefetch
+        wholesale. Returns the number of pairs gated.
+        """
+        if min_recall <= 0.0:
+            return 0
+        gated = {
+            pair_idx
+            for pair_idx, recall in self.pair_recalls.items()
+            if recall < min_recall and pair_idx in self.trained_pairs
+        }
+        self.trained_pairs -= gated
+        return len(gated)
 
     def next_moe_layer(self, layer_idx: int) -> int | None:
         """The MoE layer whose experts head(layer_idx) predicts, or None.
@@ -116,6 +144,58 @@ class MoeLookaheadBank:
         )
         return sorted(int(i) for i in top_m), scores_np
 
+    def ensure_np_heads(self) -> None:
+        """Materialize NumPy copies of every head's weights.
+
+        Must run on a thread that may evaluate the head arrays (the loading
+        thread, or the generation thread) — the ``astype`` below is a fresh
+        lazy op on the current thread's stream. Idempotent; call after
+        :meth:`load` and before handing the bank to a prefetcher.
+        """
+        if self._np_heads is not None:
+            return
+        self._np_heads = [
+            (
+                np.array(head.down.weight.astype(mx.float32)),
+                np.array(head.up.weight.astype(mx.float32)),
+            )
+            for head in self.heads
+        ]
+
+    def predict_next_np(
+        self,
+        layer_idx: int,
+        hidden_np: np.ndarray,
+        *,
+        margin: float = 1.5,
+    ) -> tuple[list[int], np.ndarray] | None:
+        """NumPy twin of :meth:`predict_next` — no mx ops, no mx.eval.
+
+        Takes an already-materialized float32 hidden state of shape
+        ``(positions, hidden_size)``. Safe to call from any thread (the
+        head weights are one-time NumPy copies), which is what lets the
+        prefetcher predict inline on the forward-pass thread without a
+        background-eval rendezvous. Same return contract as
+        :meth:`predict_next`.
+        """
+        if self.next_moe_layer(layer_idx) is None:
+            return None
+        if self._np_heads is None:
+            self.ensure_np_heads()
+        assert self._np_heads is not None
+        down_w, up_w = self._np_heads[self._pair_for_layer[layer_idx]]
+        # SparsityPredictor forward: sigmoid(up(relu(down(x)))), nn.Linear
+        # convention y = x @ W.T, averaged over positions.
+        pre = np.maximum(hidden_np @ down_w.T, 0.0) @ up_w.T
+        scores_np = (1.0 / (1.0 + np.exp(-pre))).mean(axis=0).astype(np.float32)
+        m = min(self.num_experts, math.ceil(margin * self.num_experts_per_tok))
+        top_m = (
+            np.argpartition(-scores_np, m - 1)[:m]
+            if m < len(scores_np)
+            else np.arange(len(scores_np))
+        )
+        return sorted(int(i) for i in top_m), scores_np
+
     def save(self, path: Path) -> None:
         """Save heads + sidecar to a directory."""
         path.mkdir(parents=True, exist_ok=True)
@@ -136,6 +216,10 @@ class MoeLookaheadBank:
                     "rank": self.rank,
                     "moe_layer_indices": self.moe_layer_indices,
                     "trained_pairs": sorted(self.trained_pairs),
+                    # JSON keys are strings; load() converts back to int.
+                    "pair_recalls": {
+                        str(k): v for k, v in sorted(self.pair_recalls.items())
+                    },
                 },
                 indent=2,
             )
@@ -168,6 +252,9 @@ class MoeLookaheadBank:
             num_experts_per_tok=meta["num_experts_per_tok"],
             trained_pairs=trained_pairs,
         )
+        bank.pair_recalls = {
+            int(k): float(v) for k, v in meta.get("pair_recalls", {}).items()
+        }
         for i, head in enumerate(bank.heads):
             weights = dict(mx.load(str(path / f"head_{i:02d}.npz")))  # pyright: ignore[reportCallIssue]
             head.down.weight = weights[f"pair_{i}.down.weight"]

--- a/olmlx/engine/flash/moe_prefetch.py
+++ b/olmlx/engine/flash/moe_prefetch.py
@@ -5,12 +5,22 @@ the NEXT MoE layer will route to and starts background SSD reads, so the next
 layer's ``load_experts`` finds them cached. The same prediction's score
 vector steers cache eviction (``ScoredLayerCache``) when enabled.
 
-Concurrency contract (identical to the dense ``Prefetcher`` in
-``prefetch.py``): ``mx.eval`` is not safe for concurrent calls, so the single
-prediction thread is the ONLY background thread that evaluates arrays; the
-calling thread materializes the hidden state before enqueueing, and must not
-call ``mx.eval`` between ``submit()`` and the next ``wait()``. Prediction can
-never affect correctness — a misprediction or failure only costs latency.
+Concurrency contract: prediction runs INLINE in ``submit()`` on the calling
+thread, in pure NumPy (``MoeLookaheadBank.predict_next_np``) — no thread
+other than the caller ever evaluates mx arrays, so there is no
+background-eval rendezvous. Prefetch I/O is fully non-blocking: the forward
+path never waits on it — ``load_experts`` races in-flight prefetch inserts
+(the store's cache and protect() are built for that) and reads whatever is
+still missing itself; a finished prefetch clears its own dedup slot. The
+earlier design ran prediction on a dedicated thread whose ``mx.eval`` had
+to be mutually excluded from the main thread's, and blocked each MoE layer
+on the previous prediction+I/O — together ~40% of decode throughput (see
+bench runs 20260710T*). Prediction can never affect correctness — a
+misprediction or failure only costs latency (or a duplicate SSD read).
+
+``submit()`` keeps its single-caller contract: it is only ever called from
+the single forward-pass thread, so the pending-check and registration need
+no atomicity across the two lock acquisitions.
 """
 
 from __future__ import annotations
@@ -20,6 +30,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 
 import mlx.core as mx
+import numpy as np
 
 from olmlx.engine.flash.moe_predictor import MoeLookaheadBank
 from olmlx.engine.flash.moe_weight_store import FlashMoeWeightStore
@@ -42,15 +53,16 @@ class MoePrefetcher:
         io_threads: int = 8,
     ):
         self._bank = bank
+        # Build the NumPy head copies here, on the constructing thread —
+        # the bank's mx weights were materialized on this thread by
+        # load(), and predict_next_np must never touch mx afterwards.
+        bank.ensure_np_heads()
         self._weight_store = weight_store
         self._margin = margin
         self._max_positions = max_positions
         self._scored_eviction = scored_eviction
         self._io_executor = ThreadPoolExecutor(
             max_workers=io_threads, thread_name_prefix="moe-prefetch-io"
-        )
-        self._predict_executor = ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="moe-prefetch-predict"
         )
         self._lock = threading.Lock()
         self._pending: dict[int, _LayerPrefetchState] = {}
@@ -61,8 +73,9 @@ class MoePrefetcher:
 
         No-op when *layer_idx* has no successor head, the position count
         exceeds the prefill guard, or a prefetch for the successor is already
-        pending. The hidden state is materialized on the calling thread
-        (``mx.eval`` is not safe for concurrent calls).
+        pending. Prediction runs inline in NumPy on the calling thread; the
+        hidden-state conversion below is the only (implicit) eval and it
+        happens on the caller — nothing here touches mx from another thread.
         """
         next_layer = self._bank.next_moe_layer(layer_idx)
         if next_layer is None:
@@ -71,48 +84,22 @@ class MoePrefetcher:
         if positions > self._max_positions:
             return  # prefill: most experts activate anyway, skip the work
 
-        # Check before mx.eval to avoid wasted materialization when the
-        # previous prediction is still in flight. The check and the
-        # registration below are two separate lock acquisitions, but there
-        # is no TOCTOU race: submit() is only ever called from the single
-        # forward-pass thread (same contract as the dense Prefetcher.submit).
+        # submit() is only ever called from the single forward-pass thread
+        # (single-caller contract), so check-then-register across the two
+        # lock acquisitions below has no TOCTOU race.
         with self._lock:
             if next_layer in self._pending:
                 return  # already in flight
 
-        mx.eval(hidden_state)
-
-        state = _LayerPrefetchState()
-        with self._lock:
-            self._pending[next_layer] = state
         try:
-            self._predict_executor.submit(
-                self._do_predict_and_io, layer_idx, next_layer, hidden_state, state
-            )
-        except RuntimeError:  # executor shut down
-            with self._lock:
-                self._pending.pop(next_layer, None)
-            state.done.set()
-
-    def wait(self, layer_idx: int) -> None:
-        """Block until any pending prefetch targeting *layer_idx* completes."""
-        with self._lock:
-            state = self._pending.pop(layer_idx, None)
-        if state is None:
-            return
-        state.done.wait()
-
-    def _do_predict_and_io(
-        self,
-        layer_idx: int,
-        next_layer: int,
-        hidden_state: mx.array,
-        state: _LayerPrefetchState,
-    ) -> None:
-        """Run on the prediction thread: predict, push scores, enqueue I/O."""
-        try:
-            result = self._bank.predict_next(
-                layer_idx, hidden_state, margin=self._margin
+            # float32 detour: numpy has no bfloat16. The np.array call is an
+            # implicit eval on the calling thread — by the FlashMoE call
+            # order (after ``mx.eval(inds)``) the hidden state is already
+            # materialized, so this is a cast + copy, not a graph drive.
+            flat = hidden_state.reshape(-1, hidden_state.shape[-1])
+            hidden_np = np.array(flat.astype(mx.float32))
+            result = self._bank.predict_next_np(
+                layer_idx, hidden_np, margin=self._margin
             )
         except Exception:
             logger.warning(
@@ -120,10 +107,9 @@ class MoePrefetcher:
             )
             with self._lock:
                 self.stats.failures += 1
-            result = None
+            return
 
         if result is None:
-            state.done.set()
             return
 
         indices, scores = result
@@ -143,7 +129,9 @@ class MoePrefetcher:
                 with self._lock:
                     self.stats.failures += 1
 
+        state = _LayerPrefetchState()
         with self._lock:
+            self._pending[next_layer] = state
             self.stats.submitted += 1
 
         def _do_prefetch() -> None:
@@ -163,22 +151,48 @@ class MoePrefetcher:
                 with self._lock:
                     self.stats.failures += 1
             finally:
+                # Set done BEFORE clearing pending: a wait() that already
+                # popped the state unblocks; one that arrives after the pop
+                # finds nothing and returns — correct either way, since the
+                # I/O is complete at both points.
                 state.done.set()
+                # Self-clear: nothing on the hot path calls wait() anymore,
+                # so a finished prefetch must release its dedup slot or every
+                # later submit for this layer would no-op against it. Guarded
+                # by identity so a racing wait()+resubmit's fresh state is
+                # never clobbered.
+                with self._lock:
+                    if self._pending.get(next_layer) is state:
+                        del self._pending[next_layer]
 
         try:
             self._io_executor.submit(_do_prefetch)
         except RuntimeError:  # executor shut down
-            state.done.set()
             with self._lock:
+                self._pending.pop(next_layer, None)
                 self.stats.submitted -= 1
+            state.done.set()
+
+    def wait(self, layer_idx: int) -> None:
+        """Block until any pending prefetch I/O targeting *layer_idx* completes.
+
+        NOT called on the forward path — prefetch is non-blocking there:
+        ``load_experts`` races in-flight prefetch I/O and reads whatever is
+        still missing itself (the store's cache tolerates the concurrent
+        inserts; the cost is an occasional duplicate SSD read). Kept for
+        tests and any caller that needs a completed prefetch as a barrier.
+        """
+        with self._lock:
+            state = self._pending.pop(layer_idx, None)
+        if state is None:
+            return
+        state.done.wait()
 
     def close(self) -> None:
-        """Drain the prediction pool, then the I/O pool; log a summary.
+        """Drain the I/O pool; log a summary.
 
-        Prediction executor first — it submits work into the I/O executor.
         Idempotent: ThreadPoolExecutor.shutdown tolerates repeated calls.
         """
-        self._predict_executor.shutdown(wait=True)
         self._io_executor.shutdown(wait=True)
         logger.info(
             "MoE prefetch stats: submitted=%d prefetched=%d already_cached=%d "

--- a/olmlx/engine/flash/moe_prefetch.py
+++ b/olmlx/engine/flash/moe_prefetch.py
@@ -76,6 +76,13 @@ class MoePrefetcher:
         pending. Prediction runs inline in NumPy on the calling thread; the
         hidden-state conversion below is the only (implicit) eval and it
         happens on the caller — nothing here touches mx from another thread.
+
+        Known limitation: the pending dedup returns before the score push,
+        so when a prefetch outlasts one decode step the next token pushes no
+        fresh eviction scores and that layer's eviction falls back to LRU
+        for the token (scores are consume-once). Latency-only; pushing
+        scores before the dedup check would cost a wasted prediction per
+        deduped submit instead.
         """
         next_layer = self._bank.next_moe_layer(layer_idx)
         if next_layer is None:
@@ -119,8 +126,11 @@ class MoePrefetcher:
             # forward consumes them. A failed push must not cancel the
             # prefetch itself — scores only steer eviction.
             try:
+                # dict(enumerate(tolist())) converts at C level — the
+                # per-element float(scores[i]) form boxes num_experts numpy
+                # scalars per MoE layer per token on the decode hot path.
                 self._weight_store.set_layer_scores(
-                    next_layer, {i: float(scores[i]) for i in range(len(scores))}
+                    next_layer, dict(enumerate(scores.tolist()))
                 )
             except Exception:
                 logger.warning(

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -621,13 +621,13 @@ def _effective_flash_moe_config(
     """Force MoE expert prefetch off under ``self_speculative``.
 
     ``SelfSpeculativeDecoder`` drafts by running the target's early layers
-    directly and calling ``mx.eval`` per draft token. With prefetch active,
-    the last MoE layer inside the draft window can call
-    ``MoePrefetcher.submit`` targeting a successor layer the draft loop never
-    reaches — so no ``wait()`` ever consumes it, and the decoder's
-    per-token ``mx.eval`` races the prediction thread's ``mx.eval``
-    (``MoeLookaheadBank.predict_next``). Concurrent ``mx.eval`` is the
-    documented Metal-deadlock hazard (see CLAUDE.md). Classic and PLD
+    directly. With prefetch active, the last MoE layer inside the draft
+    window can call ``MoePrefetcher.submit`` targeting a successor layer the
+    draft loop never reaches — no ``wait()`` ever consumes it, so every
+    draft token pays prediction + prefetch I/O for experts that are never
+    used. (Prediction is now inline NumPy on the calling thread, so the
+    former concurrent-``mx.eval`` hazard this guard was added for is gone —
+    the guard stays as a pure waste-avoidance measure.) Classic and PLD
     strategies were verified safe and are left untouched.
     """
     if (
@@ -3297,6 +3297,7 @@ class ModelManager(SpeculativeLoaderMixin):
             lookahead_margin=flash_moe_config.lookahead_margin,
             prefetch_max_positions=flash_moe_config.prefetch_max_positions,
             scored_eviction=flash_moe_config.scored_eviction,
+            prefetch_min_recall=flash_moe_config.prefetch_min_recall,
         )
 
         return wrapped, tokenizer, is_vlm, caps

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -920,6 +920,7 @@ class ModelConfig:
             lookahead_margin=settings.flash_moe_lookahead_margin,
             prefetch_max_positions=settings.flash_moe_prefetch_max_positions,
             scored_eviction=settings.flash_moe_scored_eviction,
+            prefetch_min_recall=settings.flash_moe_prefetch_min_recall,
         )
 
     @classmethod

--- a/tests/test_flash_moe_model.py
+++ b/tests/test_flash_moe_model.py
@@ -1311,8 +1311,12 @@ class TestMoePrefetchIntegration:
             np.array(baseline), np.array(with_prefetch), rtol=1e-5
         )
 
-    def test_flash_moe_submits_after_eval_and_waits_first(self, tmp_path):
-        """FlashMoE calls wait(layer) before eval and submit(layer) before load."""
+    def test_flash_moe_submits_without_waiting(self, tmp_path):
+        """FlashMoE calls submit(layer) before load — and never wait().
+
+        Non-blocking prefetch: the forward path must not block on in-flight
+        prefetch I/O; load_experts races it and fetches whatever is missing.
+        """
         import mlx.core as mx
 
         from olmlx.engine.flash.flash_moe import FlashMoE
@@ -1345,7 +1349,7 @@ class TestMoePrefetchIntegration:
         finally:
             store.close()
 
-        assert calls == [("wait", 1), ("submit", 1)]
+        assert calls == [("submit", 1)]
 
     def test_maybe_create_prefetcher_missing_dir_returns_none(self, tmp_path):
         from olmlx.engine.flash.flash_moe_model import _maybe_create_prefetcher

--- a/tests/test_moe_lookahead_predictor.py
+++ b/tests/test_moe_lookahead_predictor.py
@@ -79,6 +79,102 @@ class TestMoeLookaheadBank:
         assert orig is not None and rt is not None
         np.testing.assert_allclose(orig[1], rt[1], rtol=1e-5)
 
+    def test_predict_next_np_matches_mlx_path(self):
+        bank = MoeLookaheadBank(
+            [0, 1], hidden_size=16, num_experts=8, rank=4, num_experts_per_tok=2
+        )
+        hidden = mx.random.normal((1, 3, 16))
+        hidden_np = np.array(hidden.reshape(-1, 16).astype(mx.float32))
+        mlx_result = bank.predict_next(0, hidden, margin=1.5)
+        np_result = bank.predict_next_np(0, hidden_np, margin=1.5)
+        assert mlx_result is not None and np_result is not None
+        assert np_result[0] == mlx_result[0]
+        # fp32 Metal vs CPU-BLAS accumulation order — indices above are the
+        # exact contract; scores only need to agree to backend noise.
+        np.testing.assert_allclose(np_result[1], mlx_result[1], rtol=2e-3, atol=1e-4)
+        assert np_result[1].dtype == np.float32
+
+    def test_predict_next_np_returns_none_for_last_layer(self):
+        bank = MoeLookaheadBank(
+            [0, 1], hidden_size=16, num_experts=8, rank=4, num_experts_per_tok=2
+        )
+        hidden_np = np.zeros((1, 16), dtype=np.float32)
+        assert bank.predict_next_np(1, hidden_np) is None
+
+    def test_predict_next_np_after_load_uses_loaded_weights(self, tmp_path):
+        bank = MoeLookaheadBank(
+            [1, 2], hidden_size=16, num_experts=8, rank=4, num_experts_per_tok=2
+        )
+        out = tmp_path / "moe_lookahead"
+        bank.save(out)
+        loaded = MoeLookaheadBank.load(out)
+        hidden = mx.random.normal((1, 1, 16))
+        hidden_np = np.array(hidden.reshape(-1, 16).astype(mx.float32))
+        orig = bank.predict_next_np(1, hidden_np)
+        rt = loaded.predict_next_np(1, hidden_np)
+        assert orig is not None and rt is not None
+        assert orig[0] == rt[0]
+        np.testing.assert_allclose(orig[1], rt[1], rtol=1e-5)
+
+    def test_pair_recalls_save_load_roundtrip(self, tmp_path):
+        bank = MoeLookaheadBank(
+            [1, 2, 4], hidden_size=16, num_experts=8, rank=4, num_experts_per_tok=2
+        )
+        bank.pair_recalls = {0: 0.2, 1: 0.5}
+        out = tmp_path / "moe_lookahead"
+        bank.save(out)
+        loaded = MoeLookaheadBank.load(out)
+        assert loaded.pair_recalls == {0: 0.2, 1: 0.5}
+
+    def test_load_without_pair_recalls_is_empty(self, tmp_path):
+        """Sidecars written before recall persistence load with no recalls
+        (and the gate below is then a no-op for those pairs)."""
+        bank = MoeLookaheadBank(
+            [1, 2], hidden_size=16, num_experts=8, rank=4, num_experts_per_tok=2
+        )
+        out = tmp_path / "moe_lookahead"
+        bank.save(out)
+        sidecar = json.loads((out / SIDECAR_NAME).read_text())
+        sidecar.pop("pair_recalls", None)
+        (out / SIDECAR_NAME).write_text(json.dumps(sidecar))
+        loaded = MoeLookaheadBank.load(out)
+        assert loaded.pair_recalls == {}
+
+    def test_apply_recall_gate_disables_low_recall_pairs(self):
+        bank = MoeLookaheadBank(
+            [1, 2, 4, 5],
+            hidden_size=16,
+            num_experts=8,
+            rank=4,
+            num_experts_per_tok=2,
+        )
+        bank.pair_recalls = {0: 0.15, 1: 0.40, 2: 0.55}
+        gated = bank.apply_recall_gate(0.35)
+        assert gated == 1
+        assert bank.next_moe_layer(1) is None  # pair 0 gated
+        assert bank.next_moe_layer(2) == 4  # pair 1 kept
+        assert bank.next_moe_layer(4) == 5  # pair 2 kept
+
+    def test_apply_recall_gate_keeps_pairs_without_recall(self):
+        """A pair with no recorded recall must survive the gate — gating on
+        absent data would silently disable prefetch for legacy banks."""
+        bank = MoeLookaheadBank(
+            [1, 2, 4], hidden_size=16, num_experts=8, rank=4, num_experts_per_tok=2
+        )
+        bank.pair_recalls = {0: 0.1}  # pair 1 has no recall recorded
+        gated = bank.apply_recall_gate(0.35)
+        assert gated == 1
+        assert bank.next_moe_layer(1) is None
+        assert bank.next_moe_layer(2) == 4
+
+    def test_apply_recall_gate_zero_threshold_is_noop(self):
+        bank = MoeLookaheadBank(
+            [1, 2], hidden_size=16, num_experts=8, rank=4, num_experts_per_tok=2
+        )
+        bank.pair_recalls = {0: 0.05}
+        assert bank.apply_recall_gate(0.0) == 0
+        assert bank.next_moe_layer(1) == 2
+
     def test_load_missing_dir_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             MoeLookaheadBank.load(tmp_path / "nonexistent")

--- a/tests/test_moe_lookahead_train.py
+++ b/tests/test_moe_lookahead_train.py
@@ -248,16 +248,34 @@ class TestDecodeTraceRecording:
             model,
             _FakeTokenizer(),
             [1, 2],
-            max_new_tokens=4,
+            max_new_tokens=5,
             max_prompts=1,
             prompt_source=iter([[1, 2, 3, 4, 5]]),
-            _generate_fn=self._gen_fn(prefill_len=5, decode_steps=4),
+            _generate_fn=self._gen_fn(prefill_len=5, decode_steps=5),
         )
         assert set(traces.keys()) == {1, 2}
-        # Only the 4 decode steps recorded — the 5-position prefill skipped.
+        # 5 single-position calls: the first carries the last PROMPT token
+        # (mlx_lm feeds it as its own forward — teacher-forced) and is
+        # dropped; the 5-position prefill call is skipped. 4 remain.
         assert traces[1][0].shape[0] == 4
         assert traces[2][1].shape == (4, 2)
         assert traces[1][0].shape[0] == traces[2][0].shape[0]
+
+    def test_prompt_boundary_position_dropped_per_prompt(self):
+        """Exactly one position per prompt (the prompt-final token's
+        forward) is excluded, keeping the trace decode-pure."""
+        model = _FakeModel(hidden=8, num_experts=4, k=2)
+        traces = record_moe_router_traces_decode(
+            model,
+            _FakeTokenizer(),
+            [1, 2],
+            max_new_tokens=3,
+            max_prompts=2,
+            prompt_source=iter([[1, 2], [3, 4]]),
+            _generate_fn=self._gen_fn(prefill_len=2, decode_steps=3),
+        )
+        # 2 prompts x (3 single-position calls - 1 boundary) = 4
+        assert traces[1][0].shape[0] == 4
 
     def test_decode_position_cap(self):
         model = _FakeModel(hidden=8, num_experts=4, k=2)
@@ -271,7 +289,9 @@ class TestDecodeTraceRecording:
             prompt_source=iter([[1, 2, 3]] * 5),
             _generate_fn=self._gen_fn(prefill_len=3, decode_steps=10),
         )
-        assert traces[1][0].shape[0] == 3
+        # Cap is respected; the per-prompt boundary drop may leave the
+        # final count one under the cap.
+        assert 0 < traces[1][0].shape[0] <= 3
 
     def test_originals_restored(self):
         model = _FakeModel(hidden=8, num_experts=4, k=2)

--- a/tests/test_moe_lookahead_train.py
+++ b/tests/test_moe_lookahead_train.py
@@ -11,6 +11,7 @@ from olmlx.engine.flash.moe_lookahead_train import (
     build_multi_hot,
     recall_at_m,
     record_moe_router_traces,
+    record_moe_router_traces_decode,
     train_from_traces,
     train_moe_lookahead,
 )
@@ -66,6 +67,9 @@ class TestTrainFromTraces:
         assert "1→2" in recalls
         assert recalls["1→2"] > 0.9  # trivially learnable rule
         assert bank.trained_pairs == {0}
+        # Recall must also land on the bank itself (pair-indexed) so save()
+        # persists it and serve-time recall gating can use it.
+        assert bank.pair_recalls == {0: recalls["1→2"]}
 
     def test_missing_layer_trace_skipped(self):
         hid = np.zeros((10, 16), dtype=np.float32)
@@ -223,6 +227,67 @@ class TestRecordTraces:
         assert 2 not in traces
 
 
+class TestDecodeTraceRecording:
+    """Decode-state tracing (--self-generate): record hidden/routing during
+    the model's own greedy generation, not teacher-forced prefill — the
+    serve-time prediction runs on decode states, and prefill-trained heads
+    are off-distribution there (same lesson as DFlash --self-generate)."""
+
+    @staticmethod
+    def _gen_fn(prefill_len: int, decode_steps: int):
+        def _gen(model, tokenizer, prompt_ids, max_new):
+            model(mx.array([prompt_ids[:prefill_len]]))  # prefill: skipped
+            for _ in range(min(decode_steps, max_new)):
+                model(mx.array([[1]]))  # decode steps: recorded
+
+        return _gen
+
+    def test_records_only_decode_positions(self):
+        model = _FakeModel(hidden=8, num_experts=4, k=2)
+        traces = record_moe_router_traces_decode(
+            model,
+            _FakeTokenizer(),
+            [1, 2],
+            max_new_tokens=4,
+            max_prompts=1,
+            prompt_source=iter([[1, 2, 3, 4, 5]]),
+            _generate_fn=self._gen_fn(prefill_len=5, decode_steps=4),
+        )
+        assert set(traces.keys()) == {1, 2}
+        # Only the 4 decode steps recorded — the 5-position prefill skipped.
+        assert traces[1][0].shape[0] == 4
+        assert traces[2][1].shape == (4, 2)
+        assert traces[1][0].shape[0] == traces[2][0].shape[0]
+
+    def test_decode_position_cap(self):
+        model = _FakeModel(hidden=8, num_experts=4, k=2)
+        traces = record_moe_router_traces_decode(
+            model,
+            _FakeTokenizer(),
+            [1, 2],
+            max_positions_per_layer=3,
+            max_new_tokens=10,
+            max_prompts=5,
+            prompt_source=iter([[1, 2, 3]] * 5),
+            _generate_fn=self._gen_fn(prefill_len=3, decode_steps=10),
+        )
+        assert traces[1][0].shape[0] == 3
+
+    def test_originals_restored(self):
+        model = _FakeModel(hidden=8, num_experts=4, k=2)
+        original_1 = model.layers[1].mlp
+        record_moe_router_traces_decode(
+            model,
+            _FakeTokenizer(),
+            [1, 2],
+            max_new_tokens=2,
+            max_prompts=1,
+            prompt_source=iter([[1, 2]]),
+            _generate_fn=self._gen_fn(prefill_len=2, decode_steps=2),
+        )
+        assert model.layers[1].mlp is original_1
+
+
 class TestTrainMoeLookaheadCalibrationDatasetValidation:
     """Finding 3: an unrecognized ``calibration_dataset`` string used to
     silently fall back to c4 (only "synthetic" was special-cased). Must be
@@ -320,6 +385,7 @@ class TestTrainMoeLookaheadSidecarProvenance:
             "lr": 5e-4,
             "num_samples": 7,
             "holdout_fraction": 0.2,
+            "self_generate": False,
         }
         # load() must ignore the unknown key rather than choking on it.
         from olmlx.engine.flash.moe_predictor import MoeLookaheadBank

--- a/tests/test_moe_prefetch.py
+++ b/tests/test_moe_prefetch.py
@@ -88,13 +88,54 @@ class TestMoePrefetcher:
             pf.close()
 
     def test_duplicate_submit_is_noop(self, bank, store):
+        """A submit while the previous prefetch I/O is still in flight is a
+        no-op. The I/O is gated on an event so 'in flight' is deterministic —
+        with self-clearing pending entries, real I/O on tiny test experts can
+        finish between the two submits."""
+        import threading
+
         pf = _make_prefetcher(bank, store)
+        gate = threading.Event()
+        real_prefetch = store.prefetch_experts
+
+        def _gated(layer_idx, indices):
+            gate.wait(timeout=5.0)
+            return real_prefetch(layer_idx, indices)
+
+        store.prefetch_experts = _gated
         try:
             hidden = mx.random.normal((1, 1, HIDDEN))
             pf.submit(1, hidden)
             pf.submit(1, hidden)  # second submit while first pending: no-op
+            gate.set()
             pf.wait(2)
             assert pf.stats.submitted == 1  # never double-registers pending
+        finally:
+            gate.set()
+            pf.close()
+
+    def test_pending_self_clears_after_io(self, bank, store):
+        """Non-blocking prefetch: nothing calls wait() on the hot path, so a
+        completed prefetch must clear its own pending entry — otherwise every
+        later submit for the same layer dedups against the stale entry and
+        prefetch silently stops after one pass."""
+        import time
+
+        pf = _make_prefetcher(bank, store)
+        try:
+            hidden = mx.random.normal((1, 1, HIDDEN))
+            pf.submit(1, hidden)
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                with pf._lock:
+                    if 2 not in pf._pending:
+                        break
+                time.sleep(0.005)
+            else:
+                pytest.fail("pending entry for layer 2 never self-cleared")
+            pf.submit(1, hidden)  # must register again, not dedup
+            pf.wait(2)
+            assert pf.stats.submitted == 2
         finally:
             pf.close()
 
@@ -105,10 +146,40 @@ class TestMoePrefetcher:
             def _boom(*a, **k):
                 raise RuntimeError("synthetic predictor failure")
 
-            bank.predict_next = _boom
+            bank.predict_next_np = _boom
             pf.submit(1, mx.random.normal((1, 1, HIDDEN)))
             pf.wait(2)  # must not hang
             assert pf.stats.failures == 1
+        finally:
+            pf.close()
+
+    def test_prediction_failure_registers_no_pending(self, bank, store):
+        """Inline prediction: a failing predictor must leave no pending entry."""
+        pf = _make_prefetcher(bank, store)
+        try:
+
+            def _boom(*a, **k):
+                raise RuntimeError("synthetic predictor failure")
+
+            bank.predict_next_np = _boom
+            pf.submit(1, mx.random.normal((1, 1, HIDDEN)))
+            with pf._lock:
+                assert 2 not in pf._pending
+            assert pf.stats.submitted == 0
+        finally:
+            pf.close()
+
+    def test_prediction_is_inline_no_background_eval(self, bank, store):
+        """Prediction runs synchronously in submit() on the calling thread —
+        scores are pushed before submit() returns, and no thread other than
+        the caller ever touches mx (eval-avoidance contract)."""
+        pf = _make_prefetcher(bank, store, scored_eviction=True)
+        try:
+            pf.submit(1, mx.random.normal((1, 1, HIDDEN)))
+            # No wait(): scores must already be pushed by the inline prediction.
+            with store._cache._lock:
+                assert 2 in store._cache._scores
+            assert pf.stats.submitted == 1
         finally:
             pf.close()
 
@@ -162,10 +233,11 @@ class TestPrefetchConfig:
         from olmlx.config import FlashMoeConfig
 
         cfg = FlashMoeConfig(enabled=True, cache_budget_experts=48, io_threads=32)
-        assert cfg.prefetch is True
+        assert cfg.prefetch is False
         assert cfg.lookahead_margin == 1.5
         assert cfg.prefetch_max_positions == 8
         assert cfg.scored_eviction is True
+        assert cfg.prefetch_min_recall == 0.0
 
     def test_settings_prefetch_defaults(self, monkeypatch):
         from olmlx.config import Settings
@@ -175,10 +247,12 @@ class TestPrefetchConfig:
             "OLMLX_FLASH_MOE_LOOKAHEAD_MARGIN",
             "OLMLX_FLASH_MOE_PREFETCH_MAX_POSITIONS",
             "OLMLX_FLASH_MOE_SCORED_EVICTION",
+            "OLMLX_FLASH_MOE_PREFETCH_MIN_RECALL",
         ):
             monkeypatch.delenv(var, raising=False)
         s = Settings(_env_file=None)
-        assert s.flash_moe_prefetch is True
+        assert s.flash_moe_prefetch is False
         assert s.flash_moe_lookahead_margin == 1.5
         assert s.flash_moe_prefetch_max_positions == 8
         assert s.flash_moe_scored_eviction is True
+        assert s.flash_moe_prefetch_min_recall == 0.0


### PR DESCRIPTION
## Summary

Benchmarked head-to-head on Qwen3.5-35B-A3B-4bit (32 GB M-series, cache budget 128 experts/layer), **every Flash-MoE expert-prefetch configuration lost 30–45% decode throughput to plain LRU caching** (best ~14.5 vs a reproducible 20.4 tok/s). This PR removes prefetch's structural overheads, fixes two real training bugs found during the investigation, adds the diagnostics that explain the result — and flips `flash_moe_prefetch` to **off by default**.

## Changes

- **Inline NumPy prediction** — `MoeLookaheadBank.predict_next_np` computes the lookahead head on the forward-pass thread in pure NumPy; the dedicated prediction thread and its background `mx.eval` are gone, eliminating a per-MoE-layer cross-thread rendezvous (measured ~2.5 tok/s).
- **Non-blocking prefetch** — `FlashMoE` no longer `wait()`s on prefetch I/O; `load_experts` races in-flight inserts (the store's `protect()` already supports this) and pending entries self-clear on completion (identity-guarded, so a racing resubmit's fresh state is never clobbered).
- **`--max-positions` on `flash train-moe-lookahead`** — the hidden 4096-position cap silently bounded every pair's training set regardless of `--samples`; raising it lifted holdout recall 0.17–0.54 → 0.30–0.53.
- **`--self-generate` decode tracing** — record traces from the model's own decode steps over chat prompts (ultrachat via dflash's `iter_dataset_prompts`) instead of teacher-forced prefill. Measured serve-time decode recall of the prefill-trained bank was **0.14 vs its 0.39 holdout** (~2.8× overstated); decode-trained banks reach 0.35 on real decode states. Same recipe and rationale as dflash `--self-generate`.
- **Per-pair recall persistence + serve-time gating** — `pair_recalls` in the sidecar, `apply_recall_gate`, `OLMLX_FLASH_MOE_PREFETCH_MIN_RECALL` (default 0.0 = off; legacy sidecars without recalls are never gated).
- **Default off** — even at 2.6× better real recall, throughput was unchanged (14.1 tok/s): predicted-and-routed experts are mostly already LRU-cached, so speculative reads cost more SSD bandwidth than their marginal hits save. Re-enable with `OLMLX_FLASH_MOE_PREFETCH=true`.

## Benchmark ledger (7-prompt throughput set, budget 128)

| Config | tok/s |
|---|---|
| LRU, no prefetch | **20.4, 20.4** (two runs) |
| Prefetch: original → inline-NumPy → non-blocking | 13.0 → 15.5 → 15.7 |
| Prefetch: retrained C4 bank (real decode recall 0.11@8) | 16.1 / 13.2 |
| Prefetch: recall-gated 0.40 / 0.45 | 13.6 / 15.4 |
| Prefetch: decode-trained bank (real recall 0.28@8) | 14.1 / 12.3 |

## Test plan

- 17 new/updated tests (NumPy/MLX prediction equivalence, inline-prediction contract, pending self-clear, recall roundtrip + gate semantics + legacy-bank safety, decode-tracer prefill-skip/cap/restore, sidecar provenance, config defaults).
- Full suite: only 2 failures, both reproduce on clean `main` (`test_rerank_model` SDPA, `test_routers_speech`) — pre-existing, unrelated.
- ruff lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)