### PR TITLE
Fix two API-surface bugs: embed prompt_eval_count (#643) + non-dict tool params crash (#644)

### DIFF
--- a/olmlx/routers/chat.py
+++ b/olmlx/routers/chat.py
@@ -11,7 +11,11 @@ from olmlx.engine.grammar import parse_response_format
 from olmlx.engine.inference import generate_chat
 from olmlx.engine.panel import panel_generate_chat
 from olmlx.routers.common import format_error, resolve_think_flag
-from olmlx.routers.streaming_common import collect_stream, parse_model_output_post
+from olmlx.routers.streaming_common import (
+    collect_stream,
+    parse_model_output_post,
+    validate_declared_tools,
+)
 from olmlx.routers.thinking_split import (
     flush_split_thinking,
     split_thinking_streaming,
@@ -163,6 +167,10 @@ async def chat(req: ChatRequest, request: Request):
     options = req.options.model_dump(exclude_none=True) if req.options else {}
     messages = [m.model_dump(exclude_none=True) for m in req.messages]
     tools = [t.model_dump(exclude_none=True) for t in req.tools] if req.tools else None
+    # Reject malformed tool schemas before generation (a non-dict
+    # ``parameters`` would otherwise crash post-parse — see #644). Raises
+    # ValueError → 400 via the app's ValueError handler.
+    validate_declared_tools(tools)
     max_tokens = options.pop("num_predict", settings.default_max_tokens)
     cache_id = request.headers.get("x-cache-id", "")[:256]
     enable_thinking = resolve_think_flag(req.think)

--- a/olmlx/routers/embed.py
+++ b/olmlx/routers/embed.py
@@ -18,7 +18,7 @@ async def embed(req: EmbedRequest, request: Request):
     texts = req.input if isinstance(req.input, list) else [req.input]
 
     with Timer() as t:
-        embeddings, _ = await generate_embeddings(
+        embeddings, total_tokens = await generate_embeddings(
             manager, req.model, texts, keep_alive=req.keep_alive
         )
 
@@ -26,6 +26,7 @@ async def embed(req: EmbedRequest, request: Request):
         model=req.model,
         embeddings=embeddings,
         total_duration=t.duration_ns,
+        prompt_eval_count=total_tokens,
     )
 
 

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -28,6 +28,7 @@ from olmlx.routers.streaming_common import (
     parse_buffered_output,
     parse_model_output_post,
     sse_error_event,
+    validate_declared_tools,
 )
 from olmlx.routers.thinking_split import (
     flush_thinking_buffer,
@@ -320,6 +321,10 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
         req.max_completion_tokens,
     )
     manager = request.app.state.model_manager
+    # Reject malformed tool schemas before generation (a non-dict
+    # ``parameters`` would otherwise crash post-parse — see #644). Raises
+    # ValueError → 400 via the app's ValueError handler.
+    validate_declared_tools(req.tools)
     messages = [m.model_dump(exclude_none=True) for m in req.messages]
     # A malformed image content part (e.g. image_url with no url) is a client
     # error — surface as 422 rather than an uncaught 500.

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -14,6 +14,7 @@ from olmlx.routers.streaming_common import (
     BufferedModelOutput,
     collect_stream,
     parse_buffered_output,
+    validate_declared_tools,
 )
 from olmlx.routers.common import build_inference_options, resolve_openai_think
 from olmlx.routers.thinking_split import flush_split_thinking, split_thinking_parts
@@ -731,6 +732,12 @@ async def create_response(req: ResponsesRequest, request: Request):
         grammar_spec = _grammar_from_text_format(req.text)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
+
+    # Reject malformed tool schemas before generation (a non-dict
+    # ``parameters`` would otherwise crash post-parse — see #644). Validates
+    # the converted (engine-nested) tools; raises ValueError → 400 via the
+    # app's ValueError handler, matching the OpenAI/Ollama chat surfaces.
+    validate_declared_tools(tools)
 
     if req.previous_response_id:
         conversation = _history_messages_from_store(req.previous_response_id)

--- a/olmlx/routers/streaming_common.py
+++ b/olmlx/routers/streaming_common.py
@@ -165,6 +165,39 @@ def parse_buffered_output(
     )
 
 
+def validate_declared_tools(tools: list[dict[str, Any]] | None) -> None:
+    """Reject malformed tool definitions at the router boundary (issue #644).
+
+    ``Tool.function`` and its ``parameters`` are typed as free-shape
+    ``dict[str, Any]`` (project convention for JSON-passthrough fields), so
+    Pydantic does not validate their shape.  A client can therefore send a
+    tool whose ``parameters`` is not an object; left unchecked it crashes
+    ``fill_missing_required_args`` with an ``AttributeError`` deep in
+    post-parse — a 500 that lands *after* generation has already run (and,
+    for streaming, after the 200 has been sent).
+
+    Validate up front instead so the request fails fast with a clean 400,
+    mirroring the Anthropic surface (whose typed ``input_schema`` already
+    rejects a non-dict).  Raises ``ValueError``; the app's ``ValueError``
+    handler turns it into a 400 with the per-surface error envelope.
+    """
+    if not tools:
+        return
+    for i, tool in enumerate(tools):
+        if not isinstance(tool, dict):
+            raise ValueError(f"tools[{i}] must be an object")
+        func = tool.get("function")
+        # ``function`` is optional here (some callers pass bare-shaped tools);
+        # only a *present, non-dict* value is malformed.
+        if func is None:
+            continue
+        if not isinstance(func, dict):
+            raise ValueError(f"tools[{i}].function must be an object")
+        params = func.get("parameters")
+        if params is not None and not isinstance(params, dict):
+            raise ValueError(f"tools[{i}].function.parameters must be an object")
+
+
 def parse_model_output_post(
     text: str,
     has_tools: bool,

--- a/olmlx/routers/streaming_common.py
+++ b/olmlx/routers/streaming_common.py
@@ -180,22 +180,59 @@ def validate_declared_tools(tools: list[dict[str, Any]] | None) -> None:
     mirroring the Anthropic surface (whose typed ``input_schema`` already
     rejects a non-dict).  Raises ``ValueError``; the app's ``ValueError``
     handler turns it into a 400 with the per-surface error envelope.
+
+    The validated shape is exactly what ``fill_missing_required_args``
+    consumes downstream: ``function.parameters`` **and** its ``required``
+    (walked with ``set(...)``) and ``properties`` (walked with
+    ``.items()``, and ``.get(...)`` on each required property's definition).
+    A non-dict / non-list at *any* of those levels crashes the same way, so
+    all of them are checked here rather than only the top ``parameters``
+    object.
     """
     if not tools:
         return
     for i, tool in enumerate(tools):
+        where = f"tools[{i}]"
         if not isinstance(tool, dict):
-            raise ValueError(f"tools[{i}] must be an object")
+            raise ValueError(f"{where} must be an object")
         func = tool.get("function")
         # ``function`` is optional here (some callers pass bare-shaped tools);
         # only a *present, non-dict* value is malformed.
         if func is None:
             continue
         if not isinstance(func, dict):
-            raise ValueError(f"tools[{i}].function must be an object")
+            raise ValueError(f"{where}.function must be an object")
         params = func.get("parameters")
-        if params is not None and not isinstance(params, dict):
-            raise ValueError(f"tools[{i}].function.parameters must be an object")
+        if params is None:
+            continue
+        if not isinstance(params, dict):
+            raise ValueError(f"{where}.function.parameters must be an object")
+        # ``required`` is walked with ``set(...)`` — a non-list (or a list
+        # with an unhashable element) would crash it; JSON Schema requires an
+        # array of property-name strings.
+        required = params.get("required", [])
+        if not isinstance(required, list) or not all(
+            isinstance(r, str) for r in required
+        ):
+            raise ValueError(
+                f"{where}.function.parameters.required must be an array of strings"
+            )
+        properties = params.get("properties")
+        if properties is None:
+            continue
+        if not isinstance(properties, dict):
+            raise ValueError(
+                f"{where}.function.parameters.properties must be an object"
+            )
+        # Only *required* property definitions are dereferenced downstream
+        # (``v.get("type")``), so only those must be objects — this avoids
+        # over-rejecting an unusual-but-harmless non-required property value.
+        for pname in required:
+            pdef = properties.get(pname)
+            if pdef is not None and not isinstance(pdef, dict):
+                raise ValueError(
+                    f"{where}.function.parameters.properties[{pname!r}] must be an object"
+                )
 
 
 def parse_model_output_post(

--- a/tests/test_routers_chat.py
+++ b/tests/test_routers_chat.py
@@ -1199,3 +1199,40 @@ def test_chat_message_accepts_audio_field_and_dumps_it():
     m = Message(role="user", content="hi", audio=["a.wav"])
     dumped = m.model_dump(exclude_none=True)
     assert dumped["audio"] == ["a.wav"]
+
+
+class TestChatMalformedToolSchemaRejected:
+    """/api/chat must reject a non-dict ``function.parameters`` with a clean
+    400 at the boundary — before generation — instead of crashing post-parse
+    (issue #644). No ``generate_chat`` mock: the request must fail before
+    dispatch."""
+
+    BAD_TOOLS = [{"type": "function", "function": {"name": "foo", "parameters": "x"}}]
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_returns_400(self, app_client):
+        resp = await app_client.post(
+            "/api/chat",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": self.BAD_TOOLS,
+                "stream": False,
+            },
+        )
+        assert resp.status_code == 400
+        # Ollama-shaped error envelope: {"error": "<msg>"}.
+        assert "parameters" in resp.json()["error"]
+
+    @pytest.mark.asyncio
+    async def test_streaming_returns_400(self, app_client):
+        resp = await app_client.post(
+            "/api/chat",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": self.BAD_TOOLS,
+                "stream": True,
+            },
+        )
+        assert resp.status_code == 400

--- a/tests/test_routers_embed.py
+++ b/tests/test_routers_embed.py
@@ -25,6 +25,9 @@ class TestEmbedRouter:
         assert data["model"] == "qwen3"
         assert data["embeddings"] == [[0.1, 0.2, 0.3]]
         assert "total_duration" in data
+        # ``generate_embeddings`` returns the real summed token count; the route
+        # must surface it as ``prompt_eval_count`` rather than discarding it.
+        assert data["prompt_eval_count"] == 1
 
     @pytest.mark.asyncio
     async def test_embed_list(self, app_client):
@@ -43,6 +46,7 @@ class TestEmbedRouter:
         assert resp.status_code == 200
         data = resp.json()
         assert len(data["embeddings"]) == 2
+        assert data["prompt_eval_count"] == 2
 
     @pytest.mark.asyncio
     async def test_embeddings_legacy(self, app_client):

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -2072,3 +2072,44 @@ def test_normalize_splits_input_audio_into_audio_list():
     out = _normalize_multimodal_messages(messages)
     assert out[0]["content"] == "what is said?"
     assert out[0]["audio"] == ["data:audio/wav;base64,QQ=="]
+
+
+class TestMalformedToolSchemaRejected:
+    """A non-dict ``function.parameters`` must be rejected with a clean 400
+    at the boundary — before generation — instead of crashing post-parse
+    (issue #644). No ``generate_chat`` mock: the request must fail before
+    dispatch, so any call to the model would be a bug."""
+
+    BAD_TOOLS = [{"type": "function", "function": {"name": "foo", "parameters": "x"}}]
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_returns_400(self, app_client):
+        resp = await app_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": self.BAD_TOOLS,
+            },
+        )
+        assert resp.status_code == 400
+        body = resp.json()
+        # OpenAI-shaped error envelope.
+        assert "parameters" in body["error"]["message"]
+        assert body["error"]["type"] == "invalid_request_error"
+
+    @pytest.mark.asyncio
+    async def test_streaming_returns_400_before_any_bytes(self, app_client):
+        # The crash previously surfaced as an SSE error *after* a 200 was
+        # sent; boundary validation must reject before the stream opens.
+        resp = await app_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": self.BAD_TOOLS,
+                "stream": True,
+            },
+        )
+        assert resp.status_code == 400
+        assert "text/event-stream" not in resp.headers.get("content-type", "")

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -940,3 +940,43 @@ class TestSDKShapeRegression:
             e for e in events if e["event"] == "response.function_call_arguments.done"
         )
         assert done["data"]["name"] == "f"
+
+
+class TestResponsesMalformedToolSchemaRejected:
+    """/v1/responses shares the fill_missing_required_args path (via
+    _convert_tools) and must reject a non-dict ``parameters`` with a clean
+    400 at the boundary — before generation — instead of crashing post-parse
+    (issue #644). No ``generate_chat`` mock: the request must fail before
+    dispatch."""
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_returns_400(self, app_client):
+        resp = await app_client.post(
+            "/v1/responses",
+            json={
+                "model": "qwen3",
+                "input": "hi",
+                "tools": [
+                    {"type": "function", "name": "foo", "parameters": "not-an-object"}
+                ],
+            },
+        )
+        assert resp.status_code == 400
+        # OpenAI-shaped error envelope (Responses is under /v1/).
+        assert "parameters" in resp.json()["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_streaming_returns_400(self, app_client):
+        resp = await app_client.post(
+            "/v1/responses",
+            json={
+                "model": "qwen3",
+                "input": "hi",
+                "stream": True,
+                "tools": [
+                    {"type": "function", "name": "foo", "parameters": "not-an-object"}
+                ],
+            },
+        )
+        assert resp.status_code == 400
+        assert "text/event-stream" not in resp.headers.get("content-type", "")

--- a/tests/test_streaming_common.py
+++ b/tests/test_streaming_common.py
@@ -13,11 +13,60 @@ from olmlx.routers.streaming_common import (
     buffer_stream,
     collect_stream,
     parse_buffered_output,
+    validate_declared_tools,
     with_keepalive_pings,
 )
 from olmlx.utils.timing import TimingStats
 
 PING = "event: ping\ndata: {}\n\n"
+
+
+class TestValidateDeclaredTools:
+    """Boundary validation of declared tool schemas (issue #644)."""
+
+    def test_none_and_empty_are_noops(self):
+        validate_declared_tools(None)
+        validate_declared_tools([])
+
+    def test_well_formed_tools_pass(self):
+        validate_declared_tools(
+            [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "foo",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+        )
+
+    def test_missing_parameters_is_allowed(self):
+        # ``parameters`` is optional; absence is not malformed.
+        validate_declared_tools([{"type": "function", "function": {"name": "foo"}}])
+
+    def test_non_dict_parameters_raises(self):
+        with pytest.raises(ValueError, match=r"tools\[0\]\.function\.parameters"):
+            validate_declared_tools(
+                [{"type": "function", "function": {"name": "foo", "parameters": "x"}}]
+            )
+
+    def test_non_dict_function_raises(self):
+        with pytest.raises(ValueError, match=r"tools\[0\]\.function"):
+            validate_declared_tools([{"type": "function", "function": "x"}])
+
+    def test_non_dict_tool_raises(self):
+        with pytest.raises(ValueError, match=r"tools\[0\]"):
+            validate_declared_tools(["not-an-object"])  # type: ignore[list-item]
+
+    def test_index_is_reported(self):
+        with pytest.raises(ValueError, match=r"tools\[1\]"):
+            validate_declared_tools(
+                [
+                    {"type": "function", "function": {"name": "ok"}},
+                    {"type": "function", "function": {"name": "bad", "parameters": 3}},
+                ]
+            )
 
 
 async def _agen(chunks):

--- a/tests/test_streaming_common.py
+++ b/tests/test_streaming_common.py
@@ -68,6 +68,43 @@ class TestValidateDeclaredTools:
                 ]
             )
 
+    def _tool(self, params):
+        return [{"type": "function", "function": {"name": "foo", "parameters": params}}]
+
+    def test_non_dict_properties_raises(self):
+        # Would otherwise crash fill_missing_required_args at ``.items()``.
+        with pytest.raises(ValueError, match=r"parameters\.properties"):
+            validate_declared_tools(self._tool({"required": ["a"], "properties": "x"}))
+
+    def test_non_list_required_raises(self):
+        # Would otherwise crash at ``set(required)`` for a non-iterable.
+        with pytest.raises(ValueError, match=r"parameters\.required"):
+            validate_declared_tools(self._tool({"required": 3}))
+
+    def test_required_with_non_string_element_raises(self):
+        # An unhashable element would crash ``set(required)``.
+        with pytest.raises(ValueError, match=r"parameters\.required"):
+            validate_declared_tools(self._tool({"required": [{"nested": 1}]}))
+
+    def test_non_dict_required_property_value_raises(self):
+        # Would otherwise crash at ``v.get("type")`` for the required prop.
+        with pytest.raises(ValueError, match=r"properties\['a'\]"):
+            validate_declared_tools(
+                self._tool({"required": ["a"], "properties": {"a": "not-an-object"}})
+            )
+
+    def test_non_dict_value_on_non_required_property_is_allowed(self):
+        # Only *required* property definitions are dereferenced downstream, so
+        # a weird value on a non-required property must not be over-rejected.
+        validate_declared_tools(
+            self._tool({"required": ["a"], "properties": {"a": {}, "b": "whatever"}})
+        )
+
+    def test_missing_properties_with_required_is_allowed(self):
+        # fill_missing_required_args coalesces a missing ``properties`` to {},
+        # yielding no injection — not a crash, so not rejected.
+        validate_declared_tools(self._tool({"required": ["a"]}))
+
 
 async def _agen(chunks):
     for chunk in chunks:


### PR DESCRIPTION
Fixes two independent, self-contained API-correctness bugs surfaced by the explorer review.

## #643 — `/api/embed` always returns `prompt_eval_count: null`
`generate_embeddings()` already computes and returns the summed input token count, but the `/api/embed` route discarded it via `_`, so `prompt_eval_count` was always `null`. This diverged from real Ollama and from olmlx's own `/v1/embeddings` surface, which reports the identical count as `usage.prompt_tokens`.

**Fix:** capture the token count and pass it through as `prompt_eval_count`.

## #644 — malformed `tool.function.parameters` (non-dict) crashes with 500
`Tool.function` (and its `parameters`) is deliberately typed as free-shape `dict[str, Any]` at the request boundary, so a client can send a tool whose `parameters` is a string. `fill_missing_required_args` then called `.get()` on it unconditionally, raising `AttributeError: 'str' object has no attribute 'get'` deep inside `parse_model_output_post` — a **500** on `/v1/chat/completions` (streaming and non-streaming) and `/api/chat`. Because it ran *after* generation, the crash also wasted the completed inference; in streaming mode it surfaced as an SSE error *after* the 200 had already been sent.

**Fix:** reject the malformed request at the router boundary with a clean **400**, before generation, mirroring the Anthropic surface (whose typed `input_schema` already rejects a non-dict `input_schema`). A shared `validate_declared_tools()` helper (in `streaming_common.py`) is called at the top of the OpenAI and Ollama chat handlers; it raises `ValueError` on a present-but-non-dict `function` or `function.parameters`, which the app's existing `ValueError` handler renders as a 400 with the correct per-surface error envelope. Failing fast also stops wasting inference and closes the streaming case (rejects before the stream opens). Anthropic needs no change — its typed schema already 400s.

## Tests
- `tests/test_routers_embed.py`: assert `prompt_eval_count` is surfaced for both string and list inputs.
- `tests/test_streaming_common.py::TestValidateDeclaredTools`: unit-level — well-formed/absent params pass; non-dict tool/`function`/`parameters` raise `ValueError` with the offending index in the message.
- `tests/test_routers_openai.py::TestMalformedToolSchemaRejected` and `tests/test_routers_chat.py::TestChatMalformedToolSchemaRejected`: end-to-end 400 on both non-streaming and streaming, with no `generate_chat` mock (the request must fail before dispatch — any model call would be a bug), asserting the per-dialect error envelope.

Written test-first (all failed before the fix). Affected suites — `test_routers_openai.py`, `test_routers_chat.py`, `test_streaming_common.py`, `test_fill_missing_args.py`, `test_routers_embed.py` — pass (164+); ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)