### PR TITLE
fix(api): empty content as "" not null (#660) + reject invalid JSON-Schema with 4xx (#645)

### DIFF
--- a/olmlx/engine/grammar.py
+++ b/olmlx/engine/grammar.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 import threading
 import weakref
 from dataclasses import dataclass
@@ -341,6 +342,36 @@ def make_processor(
     return GrammarLogitsProcessor(compiled, vocab_size)
 
 
+def _sanitize_xgrammar_error(msg: str) -> str:
+    """Strip xgrammar's ``[HH:MM:SS] /abs/path/file.cc:NNN:`` prefix so the
+    internal C++ build path/line is never forwarded to the client."""
+    cleaned = re.sub(r"^\s*\[[^\]]*\]\s*\S+:\d+:\s*", "", msg.strip())
+    return cleaned.strip() or msg.strip()
+
+
+def _reject_invalid_json_schema(schema: Any) -> None:
+    """Validate *schema* eagerly so a malformed JSON Schema surfaces as a
+    clean client error at request-parse time instead of crashing xgrammar's
+    compiler mid-generation with a leaked-C++-path 500 (issue #645).
+
+    ``Grammar.from_json_schema`` runs the exact same schema→grammar
+    conversion the compiler does (``json_schema_converter``) but needs no
+    tokenizer, so it is a cheap, faithful pre-check. Skipped when xgrammar is
+    unavailable — grammar decoding is already inert in that case.
+    """
+    if xgr is None:
+        return
+    try:
+        xgr.Grammar.from_json_schema(schema)
+    except RuntimeError as exc:
+        # xgrammar raises RuntimeError (incl. InvalidJSONError subclasses)
+        # for unsupported types / malformed schemas — all client errors.
+        raise ValueError(
+            "invalid JSON schema in response_format: "
+            + _sanitize_xgrammar_error(str(exc))
+        ) from exc
+
+
 def parse_response_format(value: Any) -> GrammarSpec | None:
     """Normalize router-level input into a ``GrammarSpec`` or ``None``.
 
@@ -382,14 +413,17 @@ def parse_response_format(value: Any) -> GrammarSpec | None:
             schema = js.get("schema")
             if schema is None:
                 raise ValueError("response_format.json_schema.schema is required")
+            _reject_invalid_json_schema(schema)
             return GrammarSpec(kind="json_schema", schema=schema)
         # Ollama shape: ``format`` is itself a JSON Schema dict. Accept
         # only schemas with explicit JSON-Schema markers OR a ``type``
         # field whose value is a real JSON-Schema type (so an OpenAI-style
         # ``{"type": "image_url"}`` doesn't sneak through here).
         if any(k in value for k in ("properties", "$schema", "anyOf", "oneOf")):
+            _reject_invalid_json_schema(value)
             return GrammarSpec(kind="json_schema", schema=value)
         if value.get("type") in _JSON_SCHEMA_TYPES:
+            _reject_invalid_json_schema(value)
             return GrammarSpec(kind="json_schema", schema=value)
         raise ValueError(
             "unrecognized grammar format dict (need OpenAI response_format shape "

--- a/olmlx/engine/grammar.py
+++ b/olmlx/engine/grammar.py
@@ -342,11 +342,26 @@ def make_processor(
     return GrammarLogitsProcessor(compiled, vocab_size)
 
 
+_XGRAMMAR_TIMESTAMP_RE = re.compile(r"^\s*\[[^\]]*\]\s*")
+# An absolute source-file location (``/a/b/file.cc:123``, optional trailing
+# ``:``) anywhere in the message. Kept independent of the leading-timestamp
+# strip so a change to xgrammar's message layout can't leak a build path.
+_XGRAMMAR_SRC_LOCATION_RE = re.compile(r"/\S+\.(?:cc|cpp|cxx|hpp|h|c|py):\d+:?\s*")
+
+
 def _sanitize_xgrammar_error(msg: str) -> str:
-    """Strip xgrammar's ``[HH:MM:SS] /abs/path/file.cc:NNN:`` prefix so the
-    internal C++ build path/line is never forwarded to the client."""
-    cleaned = re.sub(r"^\s*\[[^\]]*\]\s*\S+:\d+:\s*", "", msg.strip())
-    return cleaned.strip() or msg.strip()
+    """Reduce an xgrammar error to its actionable tail without leaking the
+    internal C++ build path/line to the client.
+
+    xgrammar's canonical layout is ``[HH:MM:SS] /abs/path/file.cc:NNN: <detail>``,
+    but rather than depend on that exact shape we strip the leading timestamp
+    bracket *and* any absolute source-file location wherever it appears. If
+    nothing meaningful survives, fall back to a generic string — never the raw
+    message, which could itself be a bare path.
+    """
+    cleaned = _XGRAMMAR_TIMESTAMP_RE.sub("", msg.strip())
+    cleaned = _XGRAMMAR_SRC_LOCATION_RE.sub("", cleaned).strip()
+    return cleaned or "schema compilation failed"
 
 
 def _reject_invalid_json_schema(schema: Any) -> None:

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -465,9 +465,14 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
             finish_reason = "length"
         else:
             finish_reason = "stop"
-        content = visible_text
+        # OpenAI spec: ``content`` is ``null`` ONLY when ``tool_calls`` is
+        # present; otherwise it is a (possibly empty) string. An empty
+        # ``visible_text`` with no tool call is legitimate — e.g. a thinking
+        # model whose reasoning consumed the whole ``max_tokens`` budget — and
+        # must serialize as ``""`` to match the streaming path (issue #660).
+        content: str | None = visible_text
         if not content:
-            content = None
+            content = None if tool_uses else ""
 
         resp = OpenAIChatResponse(
             id=chat_id,

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -113,6 +113,48 @@ class TestParseResponseFormat:
         with pytest.raises(ValueError, match="unsupported grammar format type"):
             parse_response_format(42)
 
+    def test_invalid_nested_json_schema_type_raises_clean_error(self):
+        """Issue #645: a schema whose (nested) ``type`` is not a real
+        JSON-Schema type is a client error — it must be rejected at parse
+        time with a clean ValueError, not crash the xgrammar compiler later
+        with a 500. The message must not leak xgrammar's internal C++ source
+        path/line."""
+        with pytest.raises(ValueError, match="invalid JSON schema") as exc_info:
+            parse_response_format(
+                {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "x",
+                        "schema": {"type": "not-a-real-type"},
+                    },
+                }
+            )
+        msg = str(exc_info.value)
+        assert ".cc:" not in msg  # no leaked C++ source location
+        assert "runner/work" not in msg  # no leaked build path
+        assert "not-a-real-type" in msg  # the actionable detail is preserved
+
+    def test_invalid_bare_ollama_schema_rejected_at_parse_time(self):
+        """The Ollama ``format`` path (a bare JSON Schema with
+        ``properties``) is validated too, not just the OpenAI shape."""
+        with pytest.raises(ValueError, match="invalid JSON schema"):
+            parse_response_format(
+                {"type": "object", "properties": {"x": {"type": "bogus"}}}
+            )
+
+    def test_valid_nested_schema_passes_new_validation(self):
+        """A well-formed nested schema must NOT be rejected by the added
+        validation (guard against false positives)."""
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+            "required": ["name"],
+        }
+        spec = parse_response_format(schema)
+        assert spec is not None
+        assert spec.kind == "json_schema"
+        assert spec.schema == schema
+
 
 class TestGrammarSpec:
     def test_not_hashable(self):

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -15,6 +15,7 @@ import mlx.core as mx
 
 from olmlx.engine.grammar import (
     GrammarSpec,
+    _sanitize_xgrammar_error,
     clear_caches,
     compile_for_tokenizer,
     drop_for_tokenizer,
@@ -141,6 +142,35 @@ class TestParseResponseFormat:
             parse_response_format(
                 {"type": "object", "properties": {"x": {"type": "bogus"}}}
             )
+
+    def test_sanitize_strips_leading_timestamp_and_path(self):
+        """The canonical xgrammar error layout is reduced to its actionable
+        tail with no timestamp and no source path."""
+        raw = (
+            "[09:48:54] /Users/runner/work/xgrammar/xgrammar/cpp/"
+            'json_schema_converter.cc:3109: Unsupported type "not-a-real-type"\n'
+        )
+        out = _sanitize_xgrammar_error(raw)
+        assert out == 'Unsupported type "not-a-real-type"'
+
+    def test_sanitize_strips_embedded_path_in_any_layout(self):
+        """Defense-in-depth: an absolute source path is stripped even when
+        it isn't behind the ``[HH:MM:SS]`` prefix, so an xgrammar
+        message-format change can't leak build paths to the client."""
+        raw = "/opt/homebrew/Cellar/xgrammar/cpp/grammar_parser.cpp:42: bad thing"
+        out = _sanitize_xgrammar_error(raw)
+        assert "/opt/homebrew" not in out
+        assert ".cpp:" not in out
+        assert "bad thing" in out
+
+    def test_sanitize_never_returns_a_bare_path(self):
+        """If sanitisation would strip the message down to nothing, fall back
+        to a generic string rather than leaking the raw path."""
+        raw = "/Users/runner/work/xgrammar/internal.cc:1:"
+        out = _sanitize_xgrammar_error(raw)
+        assert "/Users/runner" not in out
+        assert ".cc:" not in out
+        assert out  # non-empty
 
     def test_valid_nested_schema_passes_new_validation(self):
         """A well-formed nested schema must NOT be rejected by the added

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -350,6 +350,46 @@ class TestOpenAIRouter:
         assert data["usage"]["completion_tokens"] == 20
 
     @pytest.mark.asyncio
+    async def test_non_streaming_empty_content_is_empty_string_not_null(
+        self, app_client
+    ):
+        """Issue #660: when a thinking model's reasoning consumes the whole
+        max_tokens budget before any visible text (and there are no tool
+        calls), ``message.content`` must be an empty string — matching the
+        streaming path and the OpenAI spec, which only sets ``content: null``
+        when ``tool_calls`` is present. A bare ``content: null`` with no
+        ``tool_calls`` is a state the real API never produces."""
+        stats = TimingStats(prompt_eval_count=15, eval_count=5)
+        mock_result = {
+            "text": "",
+            "done": True,
+            "done_reason": "length",
+            "stats": stats,
+            "thinking_expected": True,
+        }
+        with patch(
+            "olmlx.routers.openai.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 5,
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        msg = data["choices"][0]["message"]
+        assert "content" in msg
+        assert msg["content"] == ""
+        assert msg["content"] is not None
+        assert not msg.get("tool_calls")
+        assert data["choices"][0]["finish_reason"] == "length"
+
+    @pytest.mark.asyncio
     async def test_chat_completions_streaming(self, app_client):
         async def mock_stream(*args, **kwargs):
             async def gen():
@@ -884,6 +924,30 @@ class TestResponseFormat:
         assert resp.status_code == 200
         messages = mock_gen.call_args[0][2]
         assert messages[0] == {"role": "system", "content": JSON_MODE_SYSTEM_MSG}
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_schema_returns_4xx_not_500(self, app_client):
+        """Issue #645: an invalid JSON Schema in ``response_format`` must be
+        rejected before generation with a clean 4xx, not crash the xgrammar
+        compiler mid-request with a 500 that leaks the C++ source path."""
+        resp = await app_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "user", "content": "give me data"}],
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "x",
+                        "schema": {"type": "not-a-real-type"},
+                    },
+                },
+            },
+        )
+        assert resp.status_code == 422
+        body = resp.text
+        assert ".cc:" not in body  # internal C++ source location not leaked
+        assert "runner/work" not in body
 
     @pytest.mark.asyncio
     async def test_json_mode_streaming(self, app_client):


### PR DESCRIPTION
Fixes two OpenAI `/v1/chat/completions` correctness bugs.

## #660 — non-streaming returns `content: null` instead of `""`

When a thinking model's `<think>` reasoning consumes the whole `max_tokens` budget before any visible text (no tool calls), the non-streaming handler set `message.content` to `null` — a combination the real OpenAI API never produces (`content` is `null` only when `tool_calls` is present) and one that diverges from olmlx's own streaming path for the identical request (which returns `""`).

The blanket `if not content: content = None` coercion now scopes `None` to the tool-call path only:

```python
content: str | None = visible_text
if not content:
    content = None if tool_uses else ""
```

## #645 — invalid JSON-Schema crashes with 500 + leaked C++ path

An invalid schema in `response_format.json_schema.schema` was handed straight to the xgrammar compiler, which crashed mid-generation with a `RuntimeError` leaking an internal C++ source path (`.../json_schema_converter.cc:3109: Unsupported type "..."`), surfaced as a generic 500.

`parse_response_format` now eagerly validates every `json_schema` spec via `Grammar.from_json_schema` — the same schema→grammar converter the compiler uses, but tokenizer-free, so it's a cheap, faithful pre-check. On failure it raises a **sanitized** `ValueError` (C++ path stripped) → **422** at request-parse time. This covers all four routers (openai/chat/generate/responses), which already translate `ValueError → 422`.

## Tests
- `test_grammar.py`: nested invalid type rejected with clean message (no `.cc:`/build path leak), bare Ollama schema path validated, valid nested schema not falsely rejected.
- `test_routers_openai.py`: empty-content-is-`""` for the non-streaming thinking-exhausted case; invalid `response_format` schema returns 422 (not 500) with no leaked path through `/v1/chat/completions`.

TDD: each test was written first and watched fail before implementing. Full affected suites (grammar + all four routers) green (238 passed); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)