### PR TITLE
fix: Anthropic streaming input_tokens (#610) + registry untagged-key normalization (#619)

### DIFF
--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -1529,13 +1529,16 @@ class ModelRegistry:
                         self._panels[normalized] = PanelConfig.from_entry(normalized, v)
                     except (ValueError, TypeError) as exc:
                         logger.warning("Skipping invalid panel entry %r: %s", k, exc)
-                        self._raw_unrecognized[k] = v
+                        self._raw_unrecognized[normalized] = v
                     continue
                 try:
-                    self._mappings[k] = ModelConfig.from_entry(v)
+                    # Store under the normalized (`:latest`-tagged) key so the
+                    # mutators — which all normalize (remove/add_mapping) —
+                    # can find hand-edited untagged entries (issue #619).
+                    self._mappings[normalized] = ModelConfig.from_entry(v)
                 except (ValueError, TypeError) as exc:
                     logger.warning("Skipping invalid models.json entry %r: %s", k, exc)
-                    self._raw_unrecognized[k] = v
+                    self._raw_unrecognized[normalized] = v
             self._validate_panels()
         if self._aliases_path.exists():
             try:
@@ -1842,7 +1845,15 @@ class ModelRegistry:
                     f"existing file is not a JSON object (got "
                     f"{type(loaded).__name__})."
                 )
-            disk_data = loaded
+            # Normalize on-disk keys so removal/overlay (which key by the
+            # normalized `:latest` form) match hand-edited untagged entries,
+            # instead of leaving a dangling entry or writing a duplicate
+            # (issue #619). "adapters" is a reserved section keyed by its
+            # colon-named children, not a model — leave it untouched.
+            disk_data = {
+                dk if dk == "adapters" else self.normalize_name(dk): dv
+                for dk, dv in loaded.items()
+            }
             disk_read_ok = True
 
         if not disk_read_ok and self._mappings:

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -1522,6 +1522,10 @@ class ModelRegistry:
                         "Ignoring 'adapters' section: expected an object, got %s",
                         type(adapters_raw).__name__,
                     )
+            # Keys claimed by an explicit `:latest` form. If a file holds both
+            # a bare name and its tagged twin, the tagged entry wins regardless
+            # of order — matching resolve() and the on-disk _normalize_disk_keys.
+            tagged_mappings: set[str] = set()
             for k, v in raw.items():
                 normalized = self.normalize_name(k)
                 if isinstance(v, dict) and v.get("type") == "panel":
@@ -1531,11 +1535,17 @@ class ModelRegistry:
                         logger.warning("Skipping invalid panel entry %r: %s", k, exc)
                         self._raw_unrecognized[normalized] = v
                     continue
+                if k != normalized and normalized in tagged_mappings:
+                    # Bare form colliding with an explicit `:latest` twin that
+                    # already won — drop the bare one (issue #619 review).
+                    continue
                 try:
                     # Store under the normalized (`:latest`-tagged) key so the
                     # mutators — which all normalize (remove/add_mapping) —
                     # can find hand-edited untagged entries (issue #619).
                     self._mappings[normalized] = ModelConfig.from_entry(v)
+                    if k == normalized:
+                        tagged_mappings.add(normalized)
                 except (ValueError, TypeError) as exc:
                     logger.warning("Skipping invalid models.json entry %r: %s", k, exc)
                     self._raw_unrecognized[normalized] = v
@@ -1790,11 +1800,26 @@ class ModelRegistry:
         Shared by both disk read-modify-write paths (``_save_mappings_locked``
         and ``_save_adapters`` via ``_read_models_config_for_update``) so they
         agree on the on-disk key form.
+
+        If a file holds both a bare name and its explicit ``:latest`` twin
+        (e.g. ``"foo"`` and ``"foo:latest"``), the two collapse to one key.
+        The tagged entry wins regardless of file order — matching ``resolve``,
+        which normalizes and so already returns the ``:latest`` entry — instead
+        of letting dict-iteration order silently pick a winner.
         """
-        return {
-            dk if dk == "adapters" else self.normalize_name(dk): dv
-            for dk, dv in loaded.items()
-        }
+        out: dict[str, Any] = {}
+        tagged: set[str] = set()  # keys claimed by an explicit `:latest` form
+        for dk, dv in loaded.items():
+            if dk == "adapters":
+                out[dk] = dv
+                continue
+            nk = self.normalize_name(dk)
+            if dk == nk:  # already tagged — always wins
+                out[nk] = dv
+                tagged.add(nk)
+            elif nk not in tagged:  # bare form — only if no tagged twin present
+                out[nk] = dv
+        return out
 
     def _read_models_config_for_update(self) -> dict[str, Any]:
         """Read models.json as a dict for a read-modify-write, or {} if absent.

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -1780,6 +1780,22 @@ class ModelRegistry:
                 disk_data.pop("adapters", None)
             _atomic_write_json(disk_data, settings.models_config)
 
+    def _normalize_disk_keys(self, loaded: dict[str, Any]) -> dict[str, Any]:
+        """Normalize model keys of a loaded models.json to their ``:latest``
+        form so removal/overlay (which key by the normalized form) match
+        hand-edited untagged entries, instead of leaving a dangling entry or
+        writing a duplicate (issue #619). ``adapters`` is a reserved section
+        keyed by its colon-named children, not a model — leave it untouched.
+
+        Shared by both disk read-modify-write paths (``_save_mappings_locked``
+        and ``_save_adapters`` via ``_read_models_config_for_update``) so they
+        agree on the on-disk key form.
+        """
+        return {
+            dk if dk == "adapters" else self.normalize_name(dk): dv
+            for dk, dv in loaded.items()
+        }
+
     def _read_models_config_for_update(self) -> dict[str, Any]:
         """Read models.json as a dict for a read-modify-write, or {} if absent.
 
@@ -1802,7 +1818,7 @@ class ModelRegistry:
                 f"Refusing to overwrite {settings.models_config}: existing "
                 f"file is not a JSON object (got {type(loaded).__name__})."
             )
-        return loaded
+        return self._normalize_disk_keys(loaded)
 
     def _save_mappings(self):
         with self._save_lock:
@@ -1845,15 +1861,9 @@ class ModelRegistry:
                     f"existing file is not a JSON object (got "
                     f"{type(loaded).__name__})."
                 )
-            # Normalize on-disk keys so removal/overlay (which key by the
-            # normalized `:latest` form) match hand-edited untagged entries,
-            # instead of leaving a dangling entry or writing a duplicate
-            # (issue #619). "adapters" is a reserved section keyed by its
-            # colon-named children, not a model — leave it untouched.
-            disk_data = {
-                dk if dk == "adapters" else self.normalize_name(dk): dv
-                for dk, dv in loaded.items()
-            }
+            # Normalize on-disk keys (issue #619) — shared with the adapter
+            # save path so both agree on the `:latest`-tagged form.
+            disk_data = self._normalize_disk_keys(loaded)
             disk_read_ok = True
 
         if not disk_read_ok and self._mappings:

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -509,6 +509,7 @@ async def _stream_thinking_state_machine(result):
     """
     block_idx = 0
     output_tokens = 0
+    input_tokens = 0
     done_reason = None
     split_state: dict = {}
     current: str | None = None  # open block type: None | "thinking" | "text"
@@ -599,6 +600,10 @@ async def _stream_thinking_state_machine(result):
             stats = chunk.get("stats")
             if stats:
                 output_tokens = stats.eval_count
+                # Issue #610: report the real prompt token count so streaming
+                # clients get non-zero input_tokens (via message_delta.usage),
+                # matching the non-streaming and buffered-tools paths.
+                input_tokens = stats.prompt_eval_count or 0
             done_reason = chunk.get("done_reason")
             break
 
@@ -637,6 +642,7 @@ async def _stream_thinking_state_machine(result):
         if done_reason in ("timeout", "length")
         else "end_turn",
         "output_tokens": output_tokens,
+        "input_tokens": input_tokens,
     }
 
 

--- a/tests/test_adapter_registry.py
+++ b/tests/test_adapter_registry.py
@@ -124,8 +124,11 @@ class TestAdapterPersistence:
             "base": "qwen3-8b",
             "hf_path": "acme/new-lora",
         }
-        # Base model entry is preserved alongside the adapters section.
-        assert saved["qwen3-8b"] == "Qwen/Qwen3-8B-MLX"
+        # Base model entry is preserved alongside the adapters section. The
+        # adapter save shares the model-save path's key normalization (#619),
+        # so the untagged `qwen3-8b` key is written in its `:latest` form.
+        assert saved["qwen3-8b:latest"] == "Qwen/Qwen3-8B-MLX"
+        assert "qwen3-8b" not in saved
 
     def test_add_adapter_then_reload(self, tmp_path, monkeypatch):
         reg, config_path = _load_registry(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -73,6 +73,76 @@ class TestModelRegistry:
         registry.remove("removable")
         assert registry.resolve("removable") is None
 
+    def test_load_normalizes_untagged_mapping_key(self, tmp_path, monkeypatch):
+        """Issue #619: a hand-edited untagged models.json key is normalized
+        to `<name>:latest` in-memory so mutators (which normalize) can find it."""
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps({"foo": "org/foo-model"}))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+        assert "foo:latest" in reg._mappings
+        assert "foo" not in reg._mappings
+
+    def test_remove_untagged_mapping_deletes_from_disk(self, tmp_path, monkeypatch):
+        """Issue #619: removing a hand-edited untagged entry must drop it from
+        disk, not leave a dangling entry pointing at a deleted directory."""
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps({"foo": "org/foo-model"}))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+        reg._aliases_path = tmp_path / "aliases.json"
+
+        reg.remove("foo")
+
+        assert reg.resolve("foo") is None
+        # And it must be gone on disk, so it doesn't reload on restart.
+        saved = json.loads(config_path.read_text())
+        assert "foo" not in saved
+        assert "foo:latest" not in saved
+
+    def test_readd_untagged_mapping_no_duplicate(self, tmp_path, monkeypatch):
+        """Issue #619: re-adding an untagged entry must overwrite the disk key
+        rather than create a duplicate `foo` + `foo:latest` pair."""
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps({"foo": "org/foo-old"}))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+        reg._aliases_path = tmp_path / "aliases.json"
+
+        reg.add_mapping("foo", "org/foo-new")
+
+        saved = json.loads(config_path.read_text())
+        model_keys = [k for k in saved if k != "adapters"]
+        assert model_keys == ["foo:latest"]
+        assert saved["foo:latest"] == "org/foo-new"
+
+    def test_save_preserves_adapters_section(self, tmp_path, monkeypatch):
+        """Issue #619 guard: normalizing disk keys must not mangle the reserved
+        `adapters` section into `adapters:latest`."""
+        config_path = tmp_path / "models.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "foo": "org/foo-model",
+                    "adapters": {"base:adp": {"base": "foo", "adapter": "org/adp"}},
+                }
+            )
+        )
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+        reg._aliases_path = tmp_path / "aliases.json"
+
+        reg.add_mapping("bar", "org/bar-model")
+
+        saved = json.loads(config_path.read_text())
+        assert "adapters" in saved
+        assert "adapters:latest" not in saved
+        assert saved["adapters"] == {"base:adp": {"base": "foo", "adapter": "org/adp"}}
+
     def test_alias_priority_over_mapping(self, registry, tmp_path):
         registry._aliases_path = tmp_path / "aliases.json"
         registry._aliases["qwen3:latest"] = "custom/override"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -143,6 +143,26 @@ class TestModelRegistry:
         assert "adapters:latest" not in saved
         assert saved["adapters"] == {"base:adp": {"base": "foo", "adapter": "org/adp"}}
 
+    def test_adapter_save_also_normalizes_untagged_mapping_key(
+        self, tmp_path, monkeypatch
+    ):
+        """Issue #619: the adapter save path (_save_adapters) shares the same
+        disk-key normalization, so an untagged model key is not left raw on
+        disk depending on which save ran last."""
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps({"foo": "org/foo-model"}))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+
+        reg.add_adapter_mapping("myadp", base="foo", hf_path="org/adapter")
+
+        saved = json.loads(config_path.read_text())
+        assert "foo:latest" in saved
+        assert "foo" not in saved
+        assert "adapters" in saved
+        assert "adapters:latest" not in saved
+
     def test_alias_priority_over_mapping(self, registry, tmp_path):
         registry._aliases_path = tmp_path / "aliases.json"
         registry._aliases["qwen3:latest"] = "custom/override"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -163,6 +163,35 @@ class TestModelRegistry:
         assert "adapters" in saved
         assert "adapters:latest" not in saved
 
+    @pytest.mark.parametrize(
+        "entries",
+        [
+            {"foo": "org/foo-bare", "foo:latest": "org/foo-tagged"},
+            {"foo:latest": "org/foo-tagged", "foo": "org/foo-bare"},
+        ],
+    )
+    def test_duplicate_bare_and_tagged_key_tagged_wins(
+        self, tmp_path, monkeypatch, entries
+    ):
+        """Issue #619 review: a file holding both `foo` and `foo:latest`
+        collapses to one entry — the explicitly-tagged one wins regardless of
+        file order (matching resolve()), not whichever iterates last."""
+        config_path = tmp_path / "models.json"
+        config_path.write_text(json.dumps(entries))
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+        reg._aliases_path = tmp_path / "aliases.json"
+
+        # In-memory resolve is deterministic.
+        assert reg.resolve("foo").hf_path == "org/foo-tagged"
+
+        # And a save collapses the disk to the single tagged entry.
+        reg.add_mapping("other", "org/other")
+        saved = json.loads(config_path.read_text())
+        assert saved["foo:latest"] == "org/foo-tagged"
+        assert "foo" not in saved
+
     def test_alias_priority_over_mapping(self, registry, tmp_path):
         registry._aliases_path = tmp_path / "aliases.json"
         registry._aliases["qwen3:latest"] = "custom/override"

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -44,6 +44,20 @@ def _content_block_start_types(sse_text: str) -> list[str]:
     return types
 
 
+def _message_delta_usage(sse_text: str) -> dict:
+    """Usage dict from the `message_delta` SSE event (empty if none)."""
+    for line in sse_text.splitlines():
+        if not line.startswith("data:"):
+            continue
+        try:
+            payload = json.loads(line[5:])
+        except json.JSONDecodeError:
+            continue
+        if payload.get("type") == "message_delta":
+            return payload.get("usage", {})
+    return {}
+
+
 class TestConvertTools:
     def test_no_tools(self):
         req = AnthropicMessagesRequest(
@@ -755,6 +769,38 @@ class TestAnthropicEndpoint:
         assert "event: content_block_stop" in text
         assert "event: message_delta" in text
         assert "event: message_stop" in text
+
+    @pytest.mark.asyncio
+    async def test_streaming_reports_input_tokens(self, app_client):
+        """Issue #610: the non-tools streaming path must report the real
+        prompt token count in message_delta.usage, not a hardcoded 0."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": "Hello", "done": False}
+                yield {
+                    "text": "",
+                    "done": True,
+                    "stats": TimingStats(prompt_eval_count=17, eval_count=5),
+                }
+
+            return gen()
+
+        with patch("olmlx.routers.anthropic.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 100,
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        usage = _message_delta_usage(resp.text)
+        assert usage["input_tokens"] == 17
+        assert usage["output_tokens"] == 5
 
     @pytest.mark.asyncio
     async def test_streaming_with_thinking(self, app_client):


### PR DESCRIPTION
Fixes two independent, whole-repo-review bugs.

## #610 — Anthropic streaming always reports `input_tokens: 0`

The non-tools streaming path (`_stream_thinking_state_machine`) captured the done-chunk `stats` but only read `eval_count`, so `message_delta.usage` always emitted `input_tokens: 0`. This diverged from both the non-streaming path and the buffered-tools streaming path, which already report the real prompt count. Every streaming client (including Claude Code) saw zero input tokens for cost/context tracking.

**Fix:** capture `stats.prompt_eval_count` in the thinking state machine and put it in the meta dict — the existing `message_delta.usage` wiring (already used by the tools path) does the rest. One-line-per-path, matching the shipped tools-path pattern.

## #619 — Untagged models.json entries are un-removable

`Registry.load()` stored mapping keys **raw**, while every mutator normalizes (`:latest` appended). A hand-edited untagged entry (`{"foo": ...}`) became silently un-removable: `DELETE /api/delete` removes the weights dir and returns 200, but `registry.remove("foo")` pops `"foo:latest"`, finds nothing, and the entry persists — now pointing at a deleted directory.

**Fix (both sides):**
- `load()` stores under the **normalized** key (also for `_raw_unrecognized` and the panel fallback), so in-memory mutators find the entry.
- `_save_mappings()` normalizes **on-disk** keys when re-reading the file (skipping the reserved `adapters` section), so removal/overlay match the normalized key and re-adding overwrites rather than creating a duplicate `foo` + `foo:latest` pair. The issue's suggested one-liner (normalize at load) alone would leave the raw key on disk to reload on restart.

## Tests

- `test_streaming_reports_input_tokens` — non-tools stream reports real `input_tokens` in `message_delta.usage` (fails before fix).
- `test_load_normalizes_untagged_mapping_key`, `test_remove_untagged_mapping_deletes_from_disk`, `test_readd_untagged_mapping_no_duplicate` — the #619 in-memory + on-disk behavior (all fail before fix).
- `test_save_preserves_adapters_section` — guard that disk-key normalization doesn't mangle `adapters` → `adapters:latest`.

All written test-first (TDD). Full `test_registry.py`, `test_adapter_registry.py`, `test_registry_panel.py`, `test_routers_anthropic.py`, and `test_routers_manage.py` suites pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)