### PR TITLE
fix(api): accurate parameter_size estimate (#642) + KV-cache byte double-count (#615)

### DIFF
--- a/olmlx/engine/prompt_cache/store.py
+++ b/olmlx/engine/prompt_cache/store.py
@@ -112,47 +112,58 @@ def _estimate_state_bytes(state: CachedPromptState) -> int:
         if seen_attr:
             continue
         # Fallback path: walk every mlx array owned by the layer. Walking
-        # ``__dict__`` catches side buffers (e.g. TurboQuant's
-        # ``_key_dequant``) that aren't surfaced through ``.state``;
-        # walking ``.state`` covers layer types whose backing storage
-        # lives in a sub-container exposed only via the property
-        # (``ArraysCache``). Container types (tuple / list / dict) are
-        # traversed; ``id()`` dedup prevents double-counting the same
-        # underlying array when it appears in both views.
+        # ``__dict__`` catches both the packed KV buffers and side buffers
+        # (e.g. TurboQuant's ``_key_dequant``) — the full set of real
+        # allocations. Container types (tuple / list / dict) are traversed;
+        # ``id()`` dedup prevents double-counting the same underlying array
+        # when it appears more than once.
         seen_ids: set[int] = set()
-        stack: list[Any] = []
+
+        def _walk(roots: list[Any]) -> None:
+            nonlocal total
+            stack = list(roots)
+            while stack:
+                item = stack.pop()
+                if item is None:
+                    continue
+                if isinstance(item, (tuple, list)):
+                    stack.extend(item)
+                    continue
+                if isinstance(item, dict):
+                    stack.extend(item.values())
+                    continue
+                nbytes = getattr(item, "nbytes", None)
+                # Guard against non-array objects that happen to have an
+                # ``nbytes`` attribute by additionally requiring ``ndim``
+                # (which mx.array has, but ints / Dtype singletons / etc. do
+                # not).
+                ndim = getattr(item, "ndim", None)
+                if isinstance(nbytes, int) and ndim is not None:
+                    key = id(item)
+                    if key in seen_ids:
+                        continue
+                    seen_ids.add(key)
+                    total += nbytes
+
         if hasattr(layer, "__dict__"):
-            stack.extend(vars(layer).values())
+            _walk(list(vars(layer).values()))
         # ``_MISSING`` (not ``None``) so a present-but-empty ``.state``
         # still counts as a strategy match below. Note ``getattr`` with a
         # default also swallows a *property* that raises AttributeError —
         # e.g. a fresh KVCache, whose ``.state`` getter touches
         # ``self.keys.shape`` while ``keys`` is still None.
         state_attr = getattr(layer, "state", _MISSING)
-        if state_attr is not _MISSING:
-            stack.append(state_attr)
-        while stack:
-            item = stack.pop()
-            if item is None:
-                continue
-            if isinstance(item, (tuple, list)):
-                stack.extend(item)
-                continue
-            if isinstance(item, dict):
-                stack.extend(item.values())
-                continue
-            nbytes = getattr(item, "nbytes", None)
-            # Guard against non-array objects that happen to have an
-            # ``nbytes`` attribute by additionally requiring ``ndim``
-            # (which mx.array has, but ints / Dtype singletons / etc. do
-            # not).
-            ndim = getattr(item, "ndim", None)
-            if isinstance(nbytes, int) and ndim is not None:
-                key = id(item)
-                if key in seen_ids:
-                    continue
-                seen_ids.add(key)
-                total += nbytes
+        # ``.state`` is only consulted when the ``__dict__`` walk exposed no
+        # arrays — i.e. for layer types whose backing storage is reachable
+        # *only* via the property. For ``__dict__``-backed caches (the three
+        # quantized KV caches, stock ``QuantizedKVCache``, ``ArraysCache``)
+        # ``.state`` returns *views* over buffers already counted above; on
+        # the quant caches those views are fresh ``[..., :offset, :]`` slice
+        # objects with distinct ``id()``s, so counting them would
+        # double-count the packed footprint and fire the RAM-budget
+        # soft-eviction at ~half the configured budget (issue #615).
+        if not seen_ids and state_attr is not _MISSING:
+            _walk([state_attr])
         # No sizing strategy matched this layer's class: warn once per
         # class (issue #465). ``seen_ids`` non-empty means the __dict__ /
         # .state walk found at least one array, i.e. the layer was sized.

--- a/olmlx/models/store.py
+++ b/olmlx/models/store.py
@@ -40,6 +40,68 @@ def _strip_ollama_tag(hf_path: str) -> str:
     return hf_path
 
 
+def _estimate_param_count(cfg: dict) -> int | None:
+    """Estimate a model's total parameter count from its ``config.json``.
+
+    The previous heuristic (``hidden**2 * num_layers * 4``) omitted the
+    embedding/LM-head matrix (huge for ~152k-vocab tokenizers) and assumed a
+    fixed MLP width, undercounting real models by 4-6x (issue #642). This sums
+    the actual weight matrices instead:
+
+    * embeddings (``vocab * hidden``), counted twice when the LM head is untied,
+    * per-layer GQA attention (q/k/v/o projections, KV width scaled by the
+      key-value head ratio),
+    * per-layer MLP — the routed experts for MoE configs (which dominate the
+      total, e.g. Qwen3-235B-A22B), else a gated (SwiGLU) dense MLP.
+
+    Newer VLM/hybrid configs nest the LM dims under ``text_config``; values are
+    read from the top level first, then ``text_config``. Returns ``None`` when
+    the two load-bearing dims (``hidden_size``/``num_hidden_layers``) are
+    missing. The estimate targets the right order of magnitude (real Ollama
+    reports total params for GGUF), not exactness — GDN/linear-attention layers
+    and non-gated MLPs introduce small errors that experts/embeddings dwarf.
+    """
+    text_cfg = cfg.get("text_config")
+    text_cfg = text_cfg if isinstance(text_cfg, dict) else {}
+
+    def get(key, default=None):
+        val = cfg.get(key)
+        if val is None:
+            val = text_cfg.get(key)
+        return default if val is None else val
+
+    hidden = get("hidden_size", 0)
+    layers = get("num_hidden_layers", 0)
+    if not hidden or not layers:
+        return None
+
+    vocab = get("vocab_size", 0)
+    n_heads = get("num_attention_heads", 0) or 0
+    n_kv_heads = get("num_key_value_heads", n_heads) or n_heads
+    head_dim = get("head_dim") or (hidden // n_heads if n_heads else 0)
+
+    q_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+    attn = hidden * q_dim + 2 * hidden * kv_dim + q_dim * hidden
+
+    n_experts = get("num_experts") or get("n_routed_experts") or 0
+    moe_inter = get("moe_intermediate_size") or 0
+    if n_experts and moe_inter:
+        # Gated experts (gate + up + down) plus the router gate.
+        mlp = n_experts * 3 * hidden * moe_inter + hidden * n_experts
+        shared_inter = get("shared_expert_intermediate_size") or 0
+        if shared_inter:
+            n_shared = get("n_shared_experts") or 1
+            mlp += n_shared * 3 * hidden * shared_inter
+    else:
+        inter = get("intermediate_size", 0) or 0
+        mlp = 3 * hidden * inter  # gated (SwiGLU) dense MLP
+
+    tie = get("tie_word_embeddings", True)
+    embeddings = vocab * hidden * (1 if tie else 2)
+    return embeddings + layers * (attn + mlp)
+
+
 def _extract_metadata(model_dir: Path) -> dict:
     """Extract model metadata from config.json if available."""
     config_path = model_dir / "config.json"
@@ -50,13 +112,10 @@ def _extract_metadata(model_dir: Path) -> dict:
             with open(config_path) as f:
                 cfg = json.load(f)
             meta["family"] = cfg.get("model_type", "")
-            # Estimate parameter size from hidden_size and num_layers
-            hidden = cfg.get("hidden_size", 0)
-            layers = cfg.get("num_hidden_layers", 0)
-            if hidden and layers:
-                params = hidden * hidden * layers * 4  # rough estimate
-                if params > 1e9:
-                    meta["parameter_size"] = f"{params / 1e9:.0f}B"
+            params = _estimate_param_count(cfg)
+            if params:
+                if params >= 1e9:
+                    meta["parameter_size"] = f"{params / 1e9:.1f}B"
                 else:
                     meta["parameter_size"] = f"{params / 1e6:.0f}M"
         except Exception:

--- a/olmlx/models/store.py
+++ b/olmlx/models/store.py
@@ -91,7 +91,10 @@ def _estimate_param_count(cfg: dict) -> int | None:
         mlp = n_experts * 3 * hidden * moe_inter + hidden * n_experts
         shared_inter = get("shared_expert_intermediate_size") or 0
         if shared_inter:
-            n_shared = get("n_shared_experts") or 1
+            # ``get(..., 1)`` (not ``... or 1``) so an explicit
+            # ``n_shared_experts: 0`` is honored rather than treated as
+            # missing and forced to one shared expert.
+            n_shared = get("n_shared_experts", 1)
             mlp += n_shared * 3 * hidden * shared_inter
     else:
         inter = get("intermediate_size", 0) or 0

--- a/tests/test_prompt_cache_store_multi.py
+++ b/tests/test_prompt_cache_store_multi.py
@@ -256,3 +256,48 @@ def test_estimate_state_bytes_no_warning_for_empty_known_layouts(caplog):
     assert warnings == [], (
         f"empty known layouts must not warn, got: {[r.getMessage() for r in warnings]}"
     )
+
+
+def test_estimate_state_bytes_does_not_double_count_quant_state_slices():
+    """Issue #615: quantized KV caches (TurboQuant/Spectral/Shard, and stock
+    ``QuantizedKVCache``) return ``.state`` as *fresh slice objects*
+    (``self._key_indices[..., :offset, :]``) that view — but do not share
+    ``id()`` with — the full-capacity packed buffers already reachable from
+    ``__dict__``. The old ``id()``-dedup walk counted both the backing
+    buffer and its slice, inflating the estimate up to ~2x and firing the
+    ``ram_budget_bytes`` soft-eviction at roughly half the configured
+    budget. The estimator must count each real allocation once — i.e. the
+    full packed buffers, not the buffers *plus* their views."""
+    import mlx.core as mx
+    from olmlx.engine.prompt_cache.state import CachedPromptState
+    from olmlx.engine.prompt_cache.store import _estimate_state_bytes
+
+    class _QuantLike:
+        """Stand-in for a quant KV cache: full-capacity packed buffers in
+        __dict__, and a ``.state`` property that returns [:offset] slices
+        (distinct objects) — exactly the TurboQuant/Spectral/Shard shape."""
+
+        def __init__(self):
+            self.offset = 16
+            # Full-capacity packed buffers (what is actually allocated).
+            self._key_indices = mx.zeros((1, 4, 64, 4), dtype=mx.uint8)
+            self._value_indices = mx.zeros((1, 4, 64, 4), dtype=mx.uint8)
+
+        @property
+        def state(self):
+            # Fresh slice objects — distinct id() from the backing buffers.
+            return [
+                self._key_indices[..., : self.offset, :],
+                self._value_indices[..., : self.offset, :],
+            ]
+
+    layer = _QuantLike()
+    # Sanity: the slices really are distinct objects from the buffers.
+    assert id(layer.state[0]) != id(layer._key_indices)
+
+    state = CachedPromptState(tokens=[1], cache=[layer])
+    nbytes = _estimate_state_bytes(state)
+    expected = layer._key_indices.nbytes + layer._value_indices.nbytes
+    assert nbytes == expected, (
+        f"expected {expected} bytes (full packed buffers, counted once), got {nbytes}"
+    )

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -109,6 +109,10 @@ class TestExtractMetadata:
             "model_type": "qwen2",
             "hidden_size": 4096,
             "num_hidden_layers": 32,
+            "vocab_size": 151936,
+            "intermediate_size": 11008,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 32,
         }
         (tmp_path / "config.json").write_text(json.dumps(config))
         meta = _extract_metadata(tmp_path)
@@ -130,6 +134,81 @@ class TestExtractMetadata:
         meta = _extract_metadata(tmp_path)
         # quantize_config.json is checked first, then config.json quantization overrides
         assert "bit" in meta["quantization_level"]
+
+    @staticmethod
+    def _parse_params(size: str) -> float:
+        """Parse a "494M" / "4.0B" parameter_size string into a raw count."""
+        assert size, "parameter_size was empty"
+        unit = size[-1]
+        value = float(size[:-1])
+        return value * {"M": 1e6, "B": 1e9}[unit]
+
+    def test_parameter_size_qwen2_dense_ballpark(self, tmp_path):
+        """Issue #642: the estimate must include the embedding matrix and the
+        real (gated) MLP width, not just ``hidden**2 * layers * 4``. Qwen2.5
+        -0.5B-Instruct has ~494M real parameters; the old formula reported
+        ~77M (6.4x too low)."""
+        # Real Qwen2.5-0.5B-Instruct config values.
+        config = {
+            "model_type": "qwen2",
+            "hidden_size": 896,
+            "num_hidden_layers": 24,
+            "vocab_size": 151936,
+            "intermediate_size": 4864,
+            "num_attention_heads": 14,
+            "num_key_value_heads": 2,
+            "tie_word_embeddings": True,
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        params = self._parse_params(_extract_metadata(tmp_path)["parameter_size"])
+        assert 0.44e9 <= params <= 0.55e9, f"got {params:.3e}, want ~494M"
+
+    def test_parameter_size_qwen3_dense_gqa_ballpark(self, tmp_path):
+        """Qwen3-4B (GQA, head_dim != hidden/heads) has ~4.0B real params;
+        the old formula reported ~944M (4.3x too low)."""
+        config = {
+            "model_type": "qwen3",
+            "hidden_size": 2560,
+            "num_hidden_layers": 36,
+            "vocab_size": 151936,
+            "intermediate_size": 9728,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+            "head_dim": 128,
+            "tie_word_embeddings": True,
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        params = self._parse_params(_extract_metadata(tmp_path)["parameter_size"])
+        assert 3.5e9 <= params <= 4.5e9, f"got {params:.3e}, want ~4.0B"
+
+    def test_parameter_size_moe_reads_text_config(self, tmp_path):
+        """Newer MoE/hybrid configs nest the LM dims under ``text_config`` and
+        the total is dominated by the routed experts. Qwen3.6-35B-A3B
+        (256 experts) has ~35B total params; the estimator must read
+        ``text_config`` and sum all experts, not report the top-level nulls
+        as an empty size."""
+        text_config = {
+            "hidden_size": 2048,
+            "num_hidden_layers": 40,
+            "vocab_size": 248320,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 2,
+            "head_dim": 256,
+            "num_experts": 256,
+            "moe_intermediate_size": 512,
+            "shared_expert_intermediate_size": 512,
+            "tie_word_embeddings": False,
+        }
+        config = {"model_type": "qwen3_5_moe", "text_config": text_config}
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        params = self._parse_params(_extract_metadata(tmp_path)["parameter_size"])
+        assert 25e9 <= params <= 45e9, f"got {params:.3e}, want ~35B"
+
+    def test_parameter_size_missing_dims_stays_empty(self, tmp_path):
+        """A config with no usable dimensions yields an empty size rather than
+        a bogus number."""
+        (tmp_path / "config.json").write_text(json.dumps({"model_type": "mystery"}))
+        assert _extract_metadata(tmp_path)["parameter_size"] == ""
 
 
 class TestLocalPath:


### PR DESCRIPTION
Fixes two independent size/byte-accounting bugs, both unit-tested via TDD.

## #642 — `parameter_size` in `/api/show` and `/api/tags` is 4–6× too low

`_extract_metadata` estimated params with a crude `hidden**2 * num_layers * 4`
formula that omitted the embedding/LM-head matrix (huge for ~152k-vocab
tokenizers) and assumed a fixed MLP width. Observed vs real:

| model | old | real | new |
|---|---|---|---|
| Qwen2.5-0.5B-Instruct | 77M | ~494M | **494M** |
| Qwen3-4B | 944M | ~4.0B | **4.0B** |

New `_estimate_param_count` sums the actual weight matrices:
- embeddings (`vocab × hidden`, ×2 when the LM head is untied),
- per-layer GQA attention (q/k/v/o, KV width scaled by the KV-head ratio),
- per-layer MLP — routed experts for MoE configs (which dominate the total),
  else a gated (SwiGLU) dense MLP.

Reads dims from `text_config` for newer VLM/hybrid configs. Validated against
9 real local configs: dense/GQA/MoE land at ratio ~1.0 of advertised size
(494M, 4.0B, 8.2B, Qwen3.6-35B-A3B → 34.1B, gemma-4-26b → 24.6B). Where a
config lacks the load-bearing dims it returns an empty size rather than a
bogus number. This targets order-of-magnitude accuracy (matching how Ollama
reports total params for GGUF), not exactness.

## #615 — `_estimate_state_bytes` double-counts quantized KV caches (~2×)

The `id()`-dedup walk pushed both the full-capacity packed buffers (reached via
`__dict__`, e.g. `_key_indices`) and the fresh `[..., :offset, :]` slice
objects returned by `.state` — same backing memory, distinct `id()` — so
TurboQuant/Spectral/Shard (and stock `QuantizedKVCache`) entries were counted
at up to 2× their packed footprint. Consequently `prompt_cache_ram_budget_gb`
soft-eviction fired at ~half the configured budget.

Fix: consult `.state` only when the `__dict__` walk found no arrays. For
`__dict__`-backed caches `.state` is a redundant view over already-counted
buffers; a truly property-backed layer (arrays reachable only via `.state`)
still gets counted. The existing `_TurboLike` regression test didn't catch this
because it returned same-`id()` objects from `.state`; the new test returns
real `[:offset]` slices.

## Tests
- #615: new distinct-slice quant stand-in + the existing real-TurboQuant
  `test_store_insert_sheds_dequant_buffers`; all `_estimate_state_bytes`
  regression tests still green.
- #642: real dense/GQA/MoE (text_config) config shapes with ballpark
  assertions, plus a missing-dims → empty-size case.
- `349 passed` across store / prompt-cache / turboquant / spectral / shard /
  manifest suites; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)