### PR TITLE
fix(api): honor tool_choice none/reject forced (#620) + keepalive pings on buffered tool streaming (#616)

### DIFF
--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -15,8 +15,13 @@ from olmlx.engine.inference import (
     count_chat_tokens,
     generate_chat,
 )
-from olmlx.routers.common import build_inference_options, collect_content_parts
+from olmlx.routers.common import (
+    build_inference_options,
+    collect_content_parts,
+    resolve_tool_choice,
+)
 from olmlx.routers.streaming_common import (
+    KEEPALIVE_PING_INTERVAL,
     BufferedModelOutput,
     buffer_stream,
     parse_buffered_output,
@@ -87,7 +92,6 @@ def _resolve_anthropic_model(model: str) -> str:
 
 THINKING_CHUNK_SIZE = 1000
 TEXT_CHUNK_SIZE = 100
-KEEPALIVE_PING_INTERVAL = 5.0
 
 
 def _make_msg_id() -> str:
@@ -716,6 +720,12 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
     options = _build_options(req)
     tools = _convert_tools(req)
     has_tools = bool(tools)
+    # Honor tool_choice (issue #620): {"type":"none"} suppresses tools
+    # (guaranteed text answer); {"type":"any"} or a forced {"type":"tool"}
+    # selection raises ValueError → 400 rather than being silently ignored.
+    if not resolve_tool_choice(req.tool_choice):
+        tools = []
+        has_tools = False
     msg_id = _make_msg_id()
     logger.debug("Converted %d messages, %d tools", len(messages), len(tools or []))
 

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -723,8 +723,10 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
     # Honor tool_choice (issue #620): {"type":"none"} suppresses tools
     # (guaranteed text answer); {"type":"any"} or a forced {"type":"tool"}
     # selection raises ValueError → 400 rather than being silently ignored.
+    # ``None`` (not ``[]``) matches _convert_tools' own no-tools value, so a
+    # suppressed request reaches the engine identically to one with no tools.
     if not resolve_tool_choice(req.tool_choice):
-        tools = []
+        tools = None
         has_tools = False
     msg_id = _make_msg_id()
     logger.debug("Converted %d messages, %d tools", len(messages), len(tools or []))

--- a/olmlx/routers/common.py
+++ b/olmlx/routers/common.py
@@ -71,6 +71,43 @@ def resolve_openai_think(
     return None
 
 
+def resolve_tool_choice(tool_choice: str | dict[str, Any] | None) -> bool:
+    """Map a request ``tool_choice`` to whether tools are honored (issue #620).
+
+    Collapses the OpenAI/Responses form (a string ``"auto"``/``"none"``/…, or a
+    ``{"type": "function", …}`` forced selection) and the Anthropic form (a
+    ``{"type": "auto"|"none"|"any"|"tool"}`` object) into a single boolean:
+
+    - ``None`` / ``"auto"`` / ``{"type": "auto"}`` → ``True``: the model may
+      call tools and they are parsed out of the output (the prior, default
+      behavior).
+    - ``"none"`` / ``{"type": "none"}`` → ``False``: suppress tools — the
+      request runs as if none were declared, guaranteeing a text answer (the
+      standard way to force prose mid tool-loop).
+
+    Any other value — ``"required"``, Anthropic ``"any"``, or a forced
+    ``{"type": "function"|"tool", …}`` selection — cannot be honored (there is
+    no forced-tool decoding), so it raises :class:`ValueError` (→ 400 via the
+    app's handler) instead of being silently ignored, which is exactly the
+    divergence issue #620 reports.
+    """
+    if tool_choice is None:
+        return True
+    if isinstance(tool_choice, str):
+        value = tool_choice.strip().lower()
+    elif isinstance(tool_choice, dict):
+        value = tool_choice.get("type")
+    else:
+        raise ValueError("tool_choice must be a string or an object")
+    if value == "auto":
+        return True
+    if value == "none":
+        return False
+    raise ValueError(
+        f"tool_choice {value!r} is not supported; only 'auto' and 'none' are honored"
+    )
+
+
 def collect_content_parts(
     parts: Iterable[Any],
 ) -> tuple[list[str], list[str], list[str]]:

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -22,9 +22,12 @@ from olmlx.routers.common import (
     build_inference_options,
     collect_content_parts,
     resolve_openai_think,
+    resolve_tool_choice,
 )
 from olmlx.routers.streaming_common import (
-    collect_stream,
+    KEEPALIVE_PING_INTERVAL,
+    BufferedModelOutput,
+    buffer_stream,
     parse_buffered_output,
     parse_model_output_post,
     sse_error_event,
@@ -199,7 +202,24 @@ async def _stream_openai_sse_with_tools(
     4. Done:  delta={}, finish_reason="tool_calls"
     """
     try:
-        out = await collect_stream(result)
+        # Buffer the full output, but forward keepalive pings while it drains
+        # (issue #616). With tools declared, a thinking model can generate for
+        # minutes before the first real SSE byte; SSE comment lines (": ...")
+        # are the protocol-legal keepalive that keeps SDK/proxy idle-read
+        # timeouts from aborting the request mid-generation.
+        out = BufferedModelOutput()
+        async for item in buffer_stream(
+            result,
+            keepalive_interval=KEEPALIVE_PING_INTERVAL,
+            ping=": ping\n\n",
+        ):
+            if isinstance(item, BufferedModelOutput):
+                out = item
+            elif isinstance(item, str):
+                # Keepalive ping SSE comment. (cache_info dicts, also yielded
+                # by buffer_stream, carry no OpenAI-SSE payload and are dropped
+                # here just as collect_stream discarded them.)
+                yield item
         done_reason = out.done_reason
         _thinking, visible_text, tool_uses = parse_buffered_output(out, declared_tools)
         logger.debug(
@@ -325,6 +345,11 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
     # ``parameters`` would otherwise crash post-parse — see #644). Raises
     # ValueError → 400 via the app's ValueError handler.
     validate_declared_tools(req.tools)
+    # Honor tool_choice (issue #620): "none" suppresses tools (guaranteed text
+    # answer), "auto"/absent keeps them; anything forced ("required", a
+    # {"type":"function"} selection) raises ValueError → 400 rather than being
+    # silently ignored. ``effective_tools`` gates every downstream tools path.
+    effective_tools = req.tools if resolve_tool_choice(req.tool_choice) else None
     messages = [m.model_dump(exclude_none=True) for m in req.messages]
     # A malformed image content part (e.g. image_url with no url) is a client
     # error — surface as 422 rather than an uncaught 500.
@@ -388,7 +413,7 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
             req.model,
             messages,
             options,
-            tools=req.tools,
+            tools=effective_tools,
             stream=True,
             max_tokens=max_tokens,
             cache_id=cache_id,
@@ -396,14 +421,14 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
             grammar_spec=grammar_spec,
         )
 
-        if req.tools:
+        if effective_tools:
             return StreamingResponse(
                 _stream_openai_sse_with_tools(
                     result,
                     chat_id,
                     req.model,
                     created,
-                    declared_tools=req.tools,
+                    declared_tools=effective_tools,
                 ),
                 media_type="text/event-stream",
             )
@@ -431,7 +456,7 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
             req.model,
             messages,
             options,
-            tools=req.tools,
+            tools=effective_tools,
             stream=False,
             max_tokens=max_tokens,
             cache_id=cache_id,
@@ -449,11 +474,11 @@ async def openai_chat(req: OpenAIChatRequest, request: Request):
         )
         usage = OpenAIUsage.from_stats(result.get("stats"))
 
-        has_tools = bool(req.tools)
+        has_tools = bool(effective_tools)
         _thinking, visible_text, tool_uses = parse_model_output_post(
             parse_text,
             has_tools,
-            req.tools,
+            effective_tools,
             thinking_expected=bool(result.get("thinking_expected")),
         )
 

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -762,10 +762,11 @@ async def create_response(req: ResponsesRequest, request: Request):
 
     # Honor tool_choice (issue #620): "none" suppresses tools (guaranteed text
     # answer); anything forced ("required", a {"type":"function"} selection)
-    # raises ValueError → 400 rather than being silently ignored. Dropping the
-    # tools here routes the request through the plain text path everywhere.
+    # raises ValueError → 400 rather than being silently ignored. ``None`` (not
+    # ``[]``) matches _convert_tools' own no-tools value, so a suppressed
+    # request reaches the engine identically to one with no tools.
     if not resolve_tool_choice(req.tool_choice):
-        tools = []
+        tools = None
 
     if req.previous_response_id:
         conversation = _history_messages_from_store(req.previous_response_id)

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -379,6 +379,14 @@ async def _stream_response(
 
     async def _stream_tools_response():
         """Buffer the engine output, parse once, replay full semantic events."""
+        # Emit response.created / response.in_progress up front — they carry no
+        # generation output — so the client sees the stream open immediately and
+        # any keepalive pings arrive *after* the mandatory first events, not
+        # before (mirrors the Anthropic surface's early message_start).
+        in_progress_resp = base_response("in_progress", [], None, None)
+        yield ev("response.created", {"response": in_progress_resp})
+        yield ev("response.in_progress", {"response": in_progress_resp})
+
         # Forward keepalive pings while the output buffers (issue #616): with
         # tools declared a thinking model can generate for minutes before the
         # first real event, and SSE comment lines (": ...") keep SDK/proxy
@@ -403,10 +411,6 @@ async def _stream_response(
         output_items = _build_output_items(thinking, visible_text, tool_uses)
         done_reason = out.done_reason
         stats = out.stats
-
-        in_progress_resp = base_response("in_progress", [], None, None)
-        yield ev("response.created", {"response": in_progress_resp})
-        yield ev("response.in_progress", {"response": in_progress_resp})
 
         for out_index, item in enumerate(output_items):
             yield ev(

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -11,12 +11,17 @@ from olmlx.engine.grammar import GrammarSpec, parse_response_format
 from olmlx.engine.inference import generate_chat
 from olmlx.engine.responses_state import get_store
 from olmlx.routers.streaming_common import (
+    KEEPALIVE_PING_INTERVAL,
     BufferedModelOutput,
-    collect_stream,
+    buffer_stream,
     parse_buffered_output,
     validate_declared_tools,
 )
-from olmlx.routers.common import build_inference_options, resolve_openai_think
+from olmlx.routers.common import (
+    build_inference_options,
+    resolve_openai_think,
+    resolve_tool_choice,
+)
 from olmlx.routers.thinking_split import flush_split_thinking, split_thinking_parts
 from olmlx.schemas.responses import ResponsesRequest, ResponsesResponse
 from olmlx.utils.images import normalize_image_block
@@ -374,7 +379,23 @@ async def _stream_response(
 
     async def _stream_tools_response():
         """Buffer the engine output, parse once, replay full semantic events."""
-        out: BufferedModelOutput = await collect_stream(result)
+        # Forward keepalive pings while the output buffers (issue #616): with
+        # tools declared a thinking model can generate for minutes before the
+        # first real event, and SSE comment lines (": ...") keep SDK/proxy
+        # idle-read timeouts from aborting the request mid-generation.
+        out = BufferedModelOutput()
+        async for item in buffer_stream(
+            result,
+            keepalive_interval=KEEPALIVE_PING_INTERVAL,
+            ping=": ping\n\n",
+        ):
+            if isinstance(item, BufferedModelOutput):
+                out = item
+            elif isinstance(item, str):
+                # Keepalive ping SSE comment. (cache_info dicts also yielded by
+                # buffer_stream carry no Responses-SSE payload and are dropped,
+                # as collect_stream discarded them.)
+                yield item
 
         thinking, visible_text, tool_uses = parse_buffered_output(
             out, tools, has_tools=True, fill_missing_args=True
@@ -738,6 +759,13 @@ async def create_response(req: ResponsesRequest, request: Request):
     # the converted (engine-nested) tools; raises ValueError → 400 via the
     # app's ValueError handler, matching the OpenAI/Ollama chat surfaces.
     validate_declared_tools(tools)
+
+    # Honor tool_choice (issue #620): "none" suppresses tools (guaranteed text
+    # answer); anything forced ("required", a {"type":"function"} selection)
+    # raises ValueError → 400 rather than being silently ignored. Dropping the
+    # tools here routes the request through the plain text path everywhere.
+    if not resolve_tool_choice(req.tool_choice):
+        tools = []
 
     if req.previous_response_id:
         conversation = _history_messages_from_store(req.previous_response_id)

--- a/olmlx/routers/streaming_common.py
+++ b/olmlx/routers/streaming_common.py
@@ -23,6 +23,13 @@ from olmlx.engine.tool_parser import (
 
 logger = logging.getLogger(__name__)
 
+# Interval between keepalive pings emitted during the tools-mode buffering
+# window (issue #616). Every buffered surface (Anthropic SSE, OpenAI SSE,
+# Responses SSE) can generate for minutes before the first real byte; without
+# pings, SDK/proxy idle-read timeouts abort the request while the GPU keeps
+# burning. Shared here so all three surfaces agree on the cadence.
+KEEPALIVE_PING_INTERVAL = 5.0
+
 
 @dataclass
 class BufferedModelOutput:

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -3237,7 +3237,7 @@ class TestToolChoiceHonored:
         blocks = resp.json()["content"]
         assert not any(b["type"] == "tool_use" for b in blocks)
         # Tools must not be forwarded to the engine when the client forced text.
-        assert mock_gen.call_args.kwargs["tools"] in (None, [])
+        assert mock_gen.call_args.kwargs["tools"] is None
 
     @pytest.mark.asyncio
     async def test_any_is_rejected_with_400(self, app_client):

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -3197,3 +3197,72 @@ def test_convert_messages_collects_audio_block():
     msgs = _convert_messages(req)
     user = [m for m in msgs if m["role"] == "user"][0]
     assert user["audio"] == ["data:audio/wav;base64,QQ=="]
+
+
+class TestToolChoiceHonored:
+    """Issue #620: on /v1/messages ``tool_choice`` was accepted and ignored.
+    ``{"type":"none"}`` must suppress tool calls; ``"any"``/forced ``"tool"``
+    must 400."""
+
+    TOOLS = [
+        {
+            "name": "search",
+            "description": "Search",
+            "input_schema": {
+                "type": "object",
+                "properties": {"q": {"type": "string"}},
+            },
+        }
+    ]
+    TOOL_OUTPUT = '<tool_call>{"name": "search", "arguments": {"q": "x"}}</tool_call>'
+
+    @pytest.mark.asyncio
+    async def test_none_suppresses_tool_use(self, app_client):
+        mock_result = {"text": self.TOOL_OUTPUT, "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.anthropic.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "search"}],
+                    "max_tokens": 100,
+                    "tools": self.TOOLS,
+                    "tool_choice": {"type": "none"},
+                },
+            )
+        assert resp.status_code == 200
+        blocks = resp.json()["content"]
+        assert not any(b["type"] == "tool_use" for b in blocks)
+        # Tools must not be forwarded to the engine when the client forced text.
+        assert mock_gen.call_args.kwargs["tools"] in (None, [])
+
+    @pytest.mark.asyncio
+    async def test_any_is_rejected_with_400(self, app_client):
+        resp = await app_client.post(
+            "/v1/messages",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+                "tools": self.TOOLS,
+                "tool_choice": {"type": "any"},
+            },
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_forced_tool_is_rejected_with_400(self, app_client):
+        resp = await app_client.post(
+            "/v1/messages",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+                "tools": self.TOOLS,
+                "tool_choice": {"type": "tool", "name": "search"},
+            },
+        )
+        assert resp.status_code == 400

--- a/tests/test_routers_common.py
+++ b/tests/test_routers_common.py
@@ -2,12 +2,58 @@
 
 import json
 
+import pytest
+
 from olmlx.routers.common import (
     build_inference_options,
     format_error,
     resolve_openai_think,
     resolve_think_flag,
+    resolve_tool_choice,
 )
+
+
+class TestResolveToolChoice:
+    """Issue #620: ``tool_choice`` must be honored (auto/none) or rejected,
+    never silently ignored."""
+
+    def test_none_value_defaults_to_auto(self):
+        # Absent tool_choice → tools honored (default auto behavior).
+        assert resolve_tool_choice(None) is True
+
+    def test_string_auto_honors_tools(self):
+        assert resolve_tool_choice("auto") is True
+
+    def test_string_none_suppresses_tools(self):
+        assert resolve_tool_choice("none") is False
+
+    def test_dict_auto_honors_tools(self):
+        # Anthropic-shaped ``{"type": "auto"}``.
+        assert resolve_tool_choice({"type": "auto"}) is True
+
+    def test_dict_none_suppresses_tools(self):
+        assert resolve_tool_choice({"type": "none"}) is False
+
+    def test_string_required_is_rejected(self):
+        with pytest.raises(ValueError, match="tool_choice"):
+            resolve_tool_choice("required")
+
+    def test_anthropic_any_is_rejected(self):
+        with pytest.raises(ValueError, match="tool_choice"):
+            resolve_tool_choice({"type": "any"})
+
+    def test_forced_function_is_rejected(self):
+        # OpenAI/Responses forced-function selection is not supported.
+        with pytest.raises(ValueError, match="tool_choice"):
+            resolve_tool_choice({"type": "function", "function": {"name": "f"}})
+
+    def test_anthropic_forced_tool_is_rejected(self):
+        with pytest.raises(ValueError, match="tool_choice"):
+            resolve_tool_choice({"type": "tool", "name": "f"})
+
+    def test_case_insensitive_string(self):
+        assert resolve_tool_choice("NONE") is False
+        assert resolve_tool_choice("Auto") is True
 
 
 class TestFormatError:

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -2238,7 +2238,7 @@ class TestToolChoice:
                 },
             )
         # The engine must not receive the tools when the client forced text.
-        assert mock_gen.call_args.kwargs["tools"] in (None, [])
+        assert mock_gen.call_args.kwargs["tools"] is None
 
     @pytest.mark.asyncio
     async def test_auto_still_parses_tool_calls(self, app_client):

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -2177,3 +2177,161 @@ class TestMalformedToolSchemaRejected:
         )
         assert resp.status_code == 400
         assert "text/event-stream" not in resp.headers.get("content-type", "")
+
+
+class TestToolChoice:
+    """Issue #620: ``tool_choice`` was accepted then silently ignored on
+    ``/v1/chat/completions``. ``"none"`` must suppress tool calls (guaranteed
+    text answer); unsupported forced values must 400 rather than be ignored."""
+
+    TOOLS = [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                },
+            },
+        }
+    ]
+    # Model output that WOULD parse into a tool call if tools were honored.
+    TOOL_OUTPUT = '<tool_call>{"name": "search", "arguments": {"q": "x"}}</tool_call>'
+
+    @pytest.mark.asyncio
+    async def test_none_suppresses_tool_calls_non_streaming(self, app_client):
+        mock_result = {"text": self.TOOL_OUTPUT, "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.openai.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "tools": self.TOOLS,
+                    "tool_choice": "none",
+                },
+            )
+        assert resp.status_code == 200
+        msg = resp.json()["choices"][0]["message"]
+        # tool_choice "none" → no tool_calls, the raw text is returned verbatim.
+        assert not msg.get("tool_calls")
+        assert resp.json()["choices"][0]["finish_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_none_does_not_pass_tools_to_engine(self, app_client):
+        mock_result = {"text": "ok", "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.openai.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            await app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "tools": self.TOOLS,
+                    "tool_choice": "none",
+                },
+            )
+        # The engine must not receive the tools when the client forced text.
+        assert mock_gen.call_args.kwargs["tools"] in (None, [])
+
+    @pytest.mark.asyncio
+    async def test_auto_still_parses_tool_calls(self, app_client):
+        mock_result = {"text": self.TOOL_OUTPUT, "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.openai.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "tools": self.TOOLS,
+                    "tool_choice": "auto",
+                },
+            )
+        assert resp.status_code == 200
+        assert resp.json()["choices"][0]["message"]["tool_calls"]
+
+    @pytest.mark.asyncio
+    async def test_required_is_rejected_with_400(self, app_client):
+        # No generate_chat mock: request must fail before dispatch.
+        resp = await app_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": self.TOOLS,
+                "tool_choice": "required",
+            },
+        )
+        assert resp.status_code == 400
+        assert resp.json()["error"]["type"] == "invalid_request_error"
+
+    @pytest.mark.asyncio
+    async def test_forced_function_is_rejected_with_400(self, app_client):
+        resp = await app_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": self.TOOLS,
+                "tool_choice": {"type": "function", "function": {"name": "search"}},
+            },
+        )
+        assert resp.status_code == 400
+
+
+class TestBufferedToolStreamKeepalive:
+    """Issue #616: the OpenAI tools-mode buffered stream must emit keepalive
+    pings during the (potentially minutes-long) generation window so idle-read
+    timeouts don't abort the request. Previously it sent zero bytes until the
+    whole generation finished."""
+
+    @pytest.mark.asyncio
+    async def test_pings_emitted_during_slow_generation(self):
+        import asyncio
+
+        from olmlx.routers.openai import _stream_openai_sse_with_tools
+
+        class SlowResult:
+            def __init__(self):
+                self._chunks = [
+                    {"text": "hello", "done": False},
+                    {"text": "", "done": True, "stats": TimingStats()},
+                ]
+                self._i = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self._i >= len(self._chunks):
+                    raise StopAsyncIteration
+                # Sleep longer than the (patched) ping interval so pings fire.
+                await asyncio.sleep(0.05)
+                chunk = self._chunks[self._i]
+                self._i += 1
+                return chunk
+
+            async def aclose(self):
+                pass
+
+        with patch("olmlx.routers.openai.KEEPALIVE_PING_INTERVAL", 0.01):
+            emitted = [
+                item
+                async for item in _stream_openai_sse_with_tools(
+                    SlowResult(), "id", "qwen3", 0, declared_tools=None
+                )
+            ]
+
+        # SSE comment lines (": ...") are the protocol-legal keepalive.
+        assert any(item.startswith(": ") for item in emitted), emitted
+        # And normal completion still happens.
+        assert any("[DONE]" in item for item in emitted)

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -940,7 +940,14 @@ class TestBufferedToolStreamKeepalive:
                 },
             )
         # SSE comment lines (": ...") are the protocol-legal keepalive.
-        assert any(line.startswith(": ") for line in resp.text.splitlines()), resp.text
+        lines = resp.text.splitlines()
+        ping_idx = next(i for i, ln in enumerate(lines) if ln.startswith(": "))
+        # response.created must be the first event; pings come *after* it, never
+        # before (a comment ahead of the mandatory first event trips strict SDKs).
+        created_idx = next(
+            i for i, ln in enumerate(lines) if ln == "event: response.created"
+        )
+        assert created_idx < ping_idx, resp.text
 
 
 class TestSDKShapeRegression:

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -890,7 +890,7 @@ class TestToolChoiceHonored:
         out = resp.json()["output"]
         assert not any(it["type"] == "function_call" for it in out)
         # Tools must not be forwarded to the engine when the client forced text.
-        assert mock_gen.call_args.kwargs["tools"] in (None, [])
+        assert mock_gen.call_args.kwargs["tools"] is None
 
     @pytest.mark.asyncio
     async def test_required_is_rejected_with_400(self, app_client):

--- a/tests/test_routers_responses.py
+++ b/tests/test_routers_responses.py
@@ -1,5 +1,6 @@
 """Tests for olmlx.routers.responses and its schemas."""
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, patch
 
@@ -860,6 +861,86 @@ class TestRetrieveDelete:
     async def test_delete_unknown_404(self, app_client):
         resp = await app_client.delete("/v1/responses/resp_unknown")
         assert resp.status_code == 404
+
+
+class TestToolChoiceHonored:
+    """Issue #620: on /v1/responses ``tool_choice`` was accepted and ignored.
+    ``"none"`` must suppress tool calls; forced values must 400."""
+
+    TOOLS = [{"type": "function", "name": "f", "parameters": {"type": "object"}}]
+    TOOL_OUTPUT = '<tool_call>{"name": "f", "arguments": {"x": 1}}</tool_call>'
+
+    @pytest.mark.asyncio
+    async def test_none_suppresses_function_call(self, app_client):
+        mock_result = {"text": self.TOOL_OUTPUT, "done": True, "stats": TimingStats()}
+        with patch(
+            "olmlx.routers.responses.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = mock_result
+            resp = await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": "go",
+                    "tools": self.TOOLS,
+                    "tool_choice": "none",
+                },
+            )
+        assert resp.status_code == 200
+        out = resp.json()["output"]
+        assert not any(it["type"] == "function_call" for it in out)
+        # Tools must not be forwarded to the engine when the client forced text.
+        assert mock_gen.call_args.kwargs["tools"] in (None, [])
+
+    @pytest.mark.asyncio
+    async def test_required_is_rejected_with_400(self, app_client):
+        resp = await app_client.post(
+            "/v1/responses",
+            json={
+                "model": "qwen3",
+                "input": "go",
+                "tools": self.TOOLS,
+                "tool_choice": "required",
+            },
+        )
+        assert resp.status_code == 400
+
+
+class TestBufferedToolStreamKeepalive:
+    """Issue #616: the Responses tools-mode buffered stream must emit keepalive
+    pings during generation instead of zero bytes until it finishes."""
+
+    @pytest.mark.asyncio
+    async def test_pings_emitted_during_slow_generation(self, app_client):
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                await asyncio.sleep(0.05)
+                yield {"text": "hi", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with (
+            patch("olmlx.routers.responses.generate_chat", side_effect=mock_stream),
+            patch("olmlx.routers.responses.KEEPALIVE_PING_INTERVAL", 0.01),
+        ):
+            resp = await app_client.post(
+                "/v1/responses",
+                json={
+                    "model": "qwen3",
+                    "input": "go",
+                    "stream": True,
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "f",
+                            "parameters": {"type": "object"},
+                        }
+                    ],
+                },
+            )
+        # SSE comment lines (": ...") are the protocol-legal keepalive.
+        assert any(line.startswith(": ") for line in resp.text.splitlines()), resp.text
 
 
 class TestSDKShapeRegression:


### PR DESCRIPTION
Fixes two independent, router-layer API-correctness bugs from the whole-repo review.

## #620 — `tool_choice` accepted then silently ignored

`tool_choice` was accepted in the request schema on all three dialects (OpenAI, Anthropic, Responses) and then never read: a client sending `tool_choice: "none"` still got tool calls parsed, and a forced function was never forced.

- New shared helper `resolve_tool_choice` (`routers/common.py`) collapses the OpenAI/Responses (string or `{"type": …}`) and Anthropic (`{"type": …}`) forms into a single decision:
  - `None` / `"auto"` / `{"type":"auto"}` → tools honored (unchanged default).
  - `"none"` / `{"type":"none"}` → tools **suppressed**: the request runs as if none were declared, guaranteeing a text answer (the standard way to force prose mid tool-loop). Tools are also not forwarded to the engine.
  - `"required"`, Anthropic `"any"`, a forced `{"type":"function"|"tool", …}` → **400** (there is no forced-tool decoding), rather than silently ignored — matching the repo's reject-what-we-can't-honor culture (#644, #645).
- Wired into all three handlers so every accepted value is now honored.

## #616 — buffered tool streaming sent zero keepalive bytes

On the OpenAI and Responses surfaces, tools-mode buffered streaming sent **zero bytes for the entire generation**, so SDK/proxy idle-read timeouts aborted long thinking generations while the GPU kept burning. The Anthropic surface already pinged every 5s during the same window.

- Both surfaces now forward keepalive pings (SSE comment lines, `: ping`) during the buffering window via the existing `with_keepalive_pings`, mirroring Anthropic.
- `KEEPALIVE_PING_INTERVAL` moves to `streaming_common.py` so all three surfaces share one cadence.

## Tests (TDD)

- `resolve_tool_choice` unit tests (`test_routers_common.py`).
- Per-dialect integration tests: `"none"` suppresses tool calls and doesn't forward tools to the engine; `"auto"` still parses; forced values return 400 (`test_routers_openai.py`, `test_routers_responses.py`, `test_routers_anthropic.py`).
- Keepalive-ping tests for the OpenAI and Responses buffered streams under a slow generator.

All 397 tests across the affected suites pass; `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)