### PR TITLE
fix(inference): stop sequences honored mid-generation (#613 + #604)

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -4282,10 +4282,19 @@ async def _full_completion_inner(
                 # mlx-lm's wired_limit.__exit__ runs its generation-stream sync
                 # now, on this worker thread — mirrors CancellableStream._run.
                 # Guarded: mlx_lm.stream_generate returns a real generator, but
-                # tests may substitute a plain iterator with no close().
+                # tests may substitute a plain iterator with no close(). The
+                # close itself is wrapped like CancellableStream._run — GPU
+                # teardown (wired_limit sync) can raise, and an exception here
+                # would supersede a real in-flight error from the loop body.
                 _close = getattr(mlx_gen, "close", None)
                 if callable(_close):
-                    _close()
+                    try:
+                        _close()
+                    except Exception:
+                        logger.debug(
+                            "stream_generate close() failed during teardown",
+                            exc_info=True,
+                        )
             # Store full text on the result for downstream extraction
             if result is not None:
                 result = (result, "".join(text_parts))

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -3596,6 +3596,7 @@ async def _stream_completion(
         )
         timed_out = False
         stop_hit = False
+        stopped = False
 
         with (
             _tracing.span("decode") as _decode_span,
@@ -3639,6 +3640,13 @@ async def _stream_completion(
                                     yield {"text": token_part, "done": False}
                                 elif channel_filter.should_yield(token_part):
                                     yield {"text": token_part, "done": False}
+                            # Cancel the worker so it stops decoding past-stop
+                            # tokens into the shared prompt_cache — otherwise it
+                            # keeps mutating the very object we are about to
+                            # store by reference (#604). Mirrors the timeout
+                            # path's cancel below.
+                            stopped = True
+                            stream.cancel()
                             break
 
                     # Yield text only if the filter allows it (or no filter).
@@ -3711,15 +3719,26 @@ async def _stream_completion(
             )
             generation_complete = True
 
-            # Store cache state after successful generation
-            await _store_prompt_cache_after_generation(
-                lm,
-                gen_kwargs,
-                full_prompt_tokens,
-                generated_tokens,
-                stats.eval_count,
-                cache_id,
-            )
+            if stopped:
+                # Stop-sequence hit: the worker was cancelled mid-decode, so the
+                # live prompt_cache holds tokens past the stop that our
+                # generated_tokens metadata does not track. Storing it by
+                # reference would misalign the next cache hit (#604). Drop any
+                # entry for this cache_id (setup may have installed this same
+                # mutated object) and skip storage — mirrors the timeout path,
+                # which never stores. The prefix is re-prefilled next turn.
+                if full_prompt_tokens is not None:
+                    lm.prompt_cache_store.remove(cache_id)
+            else:
+                # Store cache state after successful generation
+                await _store_prompt_cache_after_generation(
+                    lm,
+                    gen_kwargs,
+                    full_prompt_tokens,
+                    generated_tokens,
+                    stats.eval_count,
+                    cache_id,
+                )
 
         # raw_text contains the complete unfiltered output (e.g. gpt-oss channel tokens).
         # It is only present in the done chunk when gpt-oss channel format was used,
@@ -3996,6 +4015,8 @@ async def _full_completion(
                     generated_tokens_out=generated_tokens if use_prompt_cache else None,
                     grammar_active=grammar_active,
                     deferred_prefill=deferred_prefill,
+                    stop_sequences=stop_sequences,
+                    thinking_expected=thinking_expected,
                 )
                 generation_complete = True
 
@@ -4089,6 +4110,8 @@ async def _full_completion_inner(
     generated_tokens_out: list[int] | None = None,
     grammar_active: bool = False,
     deferred_prefill: Callable[[threading.Event | None], None] | None = None,
+    stop_sequences: list[str] | None = None,
+    thinking_expected: bool = False,
 ) -> dict:
     audio_paths: list[str] = []
     _audio_temps: list[str] = []
@@ -4218,25 +4241,51 @@ async def _full_completion_inner(
             # can persist the produced token IDs alongside the prompt prefix.
             result = None
             text_parts = []
-            for response in mlx_lm.stream_generate(
+            # Feed a StopScanner so a stop-sequence match halts decoding at the
+            # earliest match instead of running on to max_tokens and truncating
+            # post-hoc — the latter wastes GPU time under the inference lock and
+            # stores post-stop tokens in the prompt cache (#613). The full text
+            # (including the stop marker) is kept so the caller's post-hoc
+            # truncate_at_stop still trims it and sets finish_reason.
+            stop_scanner = (
+                StopScanner(stop_sequences, thinking_aware=thinking_expected)
+                if stop_sequences
+                else None
+            )
+            mlx_gen = mlx_lm.stream_generate(
                 lm.model,
                 lm.tokenizer,
                 prompt=prompt,
                 max_tokens=max_tokens,
                 **gen_kwargs,
-            ):
-                text_parts.append(response.text)
-                if generated_tokens_out is not None:
-                    tok_id = getattr(response, "token", None)
-                    if tok_id is not None:
-                        generated_tokens_out.append(tok_id)
-                    else:
-                        logger.debug(
-                            "Skipping token with None ID at generation step %d "
-                            "(cache token sequence will be incomplete)",
-                            len(generated_tokens_out),
-                        )
-                result = response
+            )
+            try:
+                for response in mlx_gen:
+                    text_parts.append(response.text)
+                    if generated_tokens_out is not None:
+                        tok_id = getattr(response, "token", None)
+                        if tok_id is not None:
+                            generated_tokens_out.append(tok_id)
+                        else:
+                            logger.debug(
+                                "Skipping token with None ID at generation step %d "
+                                "(cache token sequence will be incomplete)",
+                                len(generated_tokens_out),
+                            )
+                    result = response
+                    if stop_scanner is not None:
+                        _, stop_hit = stop_scanner.feed(response.text or "")
+                        if stop_hit:
+                            break
+            finally:
+                # Close the generator explicitly on an early (stop) break so
+                # mlx-lm's wired_limit.__exit__ runs its generation-stream sync
+                # now, on this worker thread — mirrors CancellableStream._run.
+                # Guarded: mlx_lm.stream_generate returns a real generator, but
+                # tests may substitute a plain iterator with no close().
+                _close = getattr(mlx_gen, "close", None)
+                if callable(_close):
+                    _close()
             # Store full text on the result for downstream extraction
             if result is not None:
                 result = (result, "".join(text_parts))

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2623,6 +2623,94 @@ class TestFullCompletionInner:
         assert stats.prompt_eval_duration + stats.eval_duration <= stats.total_duration
 
     @pytest.mark.asyncio
+    async def test_stop_sequence_breaks_generation_early(self, mock_manager):
+        """Non-streaming generation must stop pulling tokens as soon as a stop
+        sequence matches, instead of decoding all the way to max_tokens and
+        truncating post-hoc (issue #613)."""
+        from types import SimpleNamespace
+        from olmlx.engine.inference import _full_completion_inner
+
+        lm = mock_manager._loaded["qwen3:latest"]
+
+        pulled: list[int] = []
+
+        def fake_stream_generate(model, tokenizer, prompt, max_tokens, **kw):
+            # "STOP" completes at index 2; indices >= 3 must never be produced
+            # if generation halts at the match.
+            texts = ["hel", "lo ", "STOP", " past-stop-A", " past-stop-B"]
+            for i, t in enumerate(texts):
+                pulled.append(i)
+                yield SimpleNamespace(
+                    text=t,
+                    token=100 + i,
+                    prompt_tokens=3,
+                    generation_tokens=i + 1,
+                    prompt_tps=100.0,
+                    generation_tps=50.0,
+                    finish_reason=None,
+                )
+
+        generated: list[int] = []
+        stats = TimingStats()
+        with (
+            patch("mlx_lm.stream_generate", fake_stream_generate),
+            patch("olmlx.engine.inference.mx", MagicMock()),
+        ):
+            result = await _full_completion_inner(
+                lm,
+                "prompt",
+                200,
+                {},
+                stats,
+                generated_tokens_out=generated,
+                stop_sequences=["STOP"],
+            )
+
+        # Generation halted at the STOP token — later tokens were never decoded.
+        assert pulled == [0, 1, 2]
+        # The stop-bearing token IDs are captured for the prompt cache; nothing
+        # past the stop leaks in.
+        assert generated == [100, 101, 102]
+        # Full text (including the stop marker) is returned so the caller's
+        # post-hoc truncate_at_stop can trim it and set finish_reason.
+        assert result["text"] == "hello STOP"
+
+    @pytest.mark.asyncio
+    async def test_no_stop_sequence_consumes_full_stream(self, mock_manager):
+        """Without a stop sequence, generation runs to natural completion —
+        the early-break path must not alter the default behavior (issue #613)."""
+        from types import SimpleNamespace
+        from olmlx.engine.inference import _full_completion_inner
+
+        lm = mock_manager._loaded["qwen3:latest"]
+        pulled: list[int] = []
+
+        def fake_stream_generate(model, tokenizer, prompt, max_tokens, **kw):
+            for i, t in enumerate(["a", "b", "c"]):
+                pulled.append(i)
+                yield SimpleNamespace(
+                    text=t,
+                    token=i,
+                    prompt_tokens=3,
+                    generation_tokens=i + 1,
+                    prompt_tps=100.0,
+                    generation_tps=50.0,
+                    finish_reason=None,
+                )
+
+        stats = TimingStats()
+        with (
+            patch("mlx_lm.stream_generate", fake_stream_generate),
+            patch("olmlx.engine.inference.mx", MagicMock()),
+        ):
+            result = await _full_completion_inner(
+                lm, "prompt", 200, {}, stats, stop_sequences=None
+            )
+
+        assert pulled == [0, 1, 2]
+        assert result["text"] == "abc"
+
+    @pytest.mark.asyncio
     async def test_length_finish_reason_propagated(self, mock_manager):
         """finish_reason='length' on the last GenerationResponse must be forwarded
         as done_reason='length' so all non-streaming routers can report max_tokens."""

--- a/tests/test_inference_bugs.py
+++ b/tests/test_inference_bugs.py
@@ -867,3 +867,121 @@ class TestInferenceRefKeepAlive:
             f"Per-request keep_alive='1s' must win over default '5m', "
             f"got {real_lm.expires_at - time.time():.1f}s"
         )
+
+
+# ---------------------------------------------------------------------------
+# Bug #604: stop-sequence hit stores a live, still-mutating prompt cache
+# ---------------------------------------------------------------------------
+class TestStopSequenceCachePoisoning:
+    """On a stop-sequence hit, the streaming path must cancel the worker thread
+    and NOT store the still-mutating prompt cache by reference (issue #604)."""
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_worker_and_skips_cache_store(self, mock_manager):
+        from unittest.mock import AsyncMock, patch
+        from olmlx.engine.inference import generate_chat
+        from olmlx.utils.streaming import CancellableStream, StreamToken
+
+        lm = mock_manager._loaded["qwen3:latest"]
+        lm.tokenizer.apply_chat_template = MagicMock(return_value="prompt")
+        lm.tokenizer.bos_token = None
+        lm.tokenizer.encode = MagicMock(return_value=[10, 20, 30])
+
+        mock_stream = MagicMock(spec=CancellableStream)
+        mock_stream.drain_and_join = AsyncMock()
+        mock_stream._thread = None
+        # Worker emits two real tokens, the stop marker, then a buffered-ahead
+        # token it had already decoded into the shared cache before cancel.
+        tokens = [
+            StreamToken(
+                text="hel",
+                token=1,
+                prompt_tokens=3,
+                generation_tokens=1,
+                prompt_tps=100.0,
+                generation_tps=50.0,
+            ),
+            StreamToken(
+                text="lo ",
+                token=2,
+                prompt_tokens=3,
+                generation_tokens=2,
+                prompt_tps=100.0,
+                generation_tps=50.0,
+            ),
+            StreamToken(
+                text="STOP",
+                token=3,
+                prompt_tokens=3,
+                generation_tokens=3,
+                prompt_tps=100.0,
+                generation_tps=50.0,
+            ),
+            StreamToken(
+                text=" past",
+                token=4,
+                prompt_tokens=3,
+                generation_tokens=4,
+                prompt_tps=100.0,
+                generation_tps=50.0,
+            ),
+        ]
+        token_iter = iter(tokens)
+
+        async def anext_impl():
+            try:
+                return next(token_iter)
+            except StopIteration:
+                raise StopAsyncIteration
+
+        mock_stream.__aiter__ = lambda self: self
+        mock_stream.__anext__ = lambda self: anext_impl()
+
+        store_spy = AsyncMock()
+        remove_spy = MagicMock(wraps=lm.prompt_cache_store.remove)
+        lm.prompt_cache_store.remove = remove_spy
+
+        with (
+            patch("olmlx.engine.inference.mx", MagicMock()),
+            patch("olmlx.engine.inference.async_mlx_stream", return_value=mock_stream),
+            patch(
+                "olmlx.engine.inference.make_prompt_cache",
+                MagicMock(return_value=[MagicMock()]),
+            ),
+            patch(
+                "olmlx.engine.inference._store_prompt_cache_after_generation",
+                store_spy,
+            ),
+            patch("olmlx.engine.inference.settings") as mock_settings,
+        ):
+            mock_settings.prompt_cache = True
+            mock_settings.prompt_cache_max_tokens = 32768
+            mock_settings.default_keep_alive = "5m"
+            mock_settings.inference_timeout = None
+            mock_settings.memory_limit_fraction = 0.9
+            mock_settings.sync_mode = "full"
+
+            chunks = []
+            gen = await generate_chat(
+                mock_manager,
+                "qwen3",
+                [{"role": "user", "content": "hi"}],
+                options={"stop": ["STOP"]},
+                stream=True,
+                enable_thinking=False,
+            )
+            async for chunk in gen:
+                chunks.append(chunk)
+
+        # The worker must be cancelled the moment the stop sequence matched, so
+        # it stops decoding past-stop tokens into the shared cache.
+        mock_stream.cancel.assert_called()
+        # The still-mutating cache must NOT be persisted by reference (#604) —
+        # in the buggy code this store WAS awaited on stop.
+        store_spy.assert_not_awaited()
+        # Any stale/shared entry for this cache_id is dropped instead.
+        remove_spy.assert_called()
+        # The done chunk still reports the stop reason.
+        done = chunks[-1]
+        assert done.get("done") is True
+        assert done.get("done_reason") == "stop"


### PR DESCRIPTION
Fixes two stop-sequence handling bugs on the **single-request (non-batched)** inference paths. The batched paths already handle both cases correctly.

## #613 — Non-streaming stop sequences generate to `max_tokens`

`_full_completion` popped `stop` before the lock and only applied it post-hoc via `truncate_at_stop`, so a non-streaming request whose stop fires at token 20 with `max_tokens=4096` burned ~4076 tokens of GPU time holding the global inference lock, and the prompt cache was stored including all post-stop tokens.

**Fix:** `_generate_sync`'s `mlx_lm.stream_generate` loop now feeds a `StopScanner` and breaks at the earliest match (mirroring the streaming/batched paths). The generator is closed explicitly on the early break so mlx-lm's `wired_limit.__exit__` runs its generation-stream sync on the worker thread. The full text (including the stop marker) is preserved so the existing post-hoc `truncate_at_stop` still trims it and sets `finish_reason`. Because non-streaming is single-threaded and pull-driven, the stored cache's token metadata now aligns exactly with the KV offset.

Scope: the standard mlx_lm text path. The VLM and speculative sub-paths are unchanged and continue to rely on post-hoc truncation.

## #604 — Streaming stop-sequence hit stores a live, still-mutating prompt cache

On a stop match, `_stream_completion` broke out of the token loop and stored the prompt cache **without cancelling the generation worker thread**. The worker (queue depth ~32) kept running forward passes that mutated the very `prompt_cache` object being stored by reference, so the stored `tokens` metadata undercounted the cache's real offset — the next request's trim math then resumed positionally misaligned (coherent-looking but wrong output). It also ran `trim`/`_shed_transient_buffers` on the loop thread concurrently with the worker's `update_and_fetch`.

**Fix:** the stop branch now calls `stream.cancel()` (mirroring the timeout path) so the worker stops decoding, and skips the store — dropping any stale/shared entry for the `cache_id` instead. The prefix is re-prefilled on the next turn. This matches how the timeout path and the batched scheduler already behave.

## Tests
- `test_stop_sequence_breaks_generation_early` / `test_no_stop_sequence_consumes_full_stream` — assert `_full_completion_inner` halts the generator at the match (and doesn't when no stop is set), collecting only up-to-stop tokens while returning the full text for post-hoc truncation.
- `test_stop_cancels_worker_and_skips_cache_store` — drives `_stream_completion` end-to-end with a stop-bearing token stream and asserts the worker is cancelled, `_store_prompt_cache_after_generation` is **not** awaited, and the stale entry is removed.

Ran `tests/test_inference*.py`, `tests/test_stop_sequences.py`, `tests/test_streaming*.py`, `tests/test_prompt_cache*.py`, and all router suites — green. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)