### PR TITLE
fix(engine): draft-cache trim off-by-one (#617) + VLM prompt-cache async_get post-await guards (#618)

### DIFF
--- a/olmlx/engine/eagle/decoder.py
+++ b/olmlx/engine/eagle/decoder.py
@@ -424,24 +424,24 @@ class EagleDecoder(SpecDecoderBase):
         # caches grew by block_size+1 (target) and block_size (draft)
         # during this step. Trim them back to the accepted prefix.
         num_accepted = len(accepted)
-        # Target and draft caches trim by the same amount.
-        # - Target grew by block_size + 1; we keep num_accepted; trim
-        #   away (block_size + 1 - num_accepted).
-        # - Draft grew by block_size; we keep num_accepted - 1 (the
-        #   draft emits drafts, not the seed); trim away
-        #   (block_size - (num_accepted - 1)) = (block_size + 1 -
-        #   num_accepted).
-        # Both algebra paths land at the same value. Keep one
-        # variable so a future change to either side has to update
-        # the trim formula in one spot — two identically-computed
-        # variables would be a maintenance trap (e.g. EAGLE-2 tree
-        # speculation could change the draft accounting while target
-        # stays the same).
-        trim = (self._block_size + 1) - num_accepted
-        if trim > 0:
+        # Target and draft caches keep ``num_accepted`` committed entries
+        # each, but grew by different amounts, so they trim by different
+        # amounts (#617 — a single shared ``trim`` dropped the last
+        # accepted token's draft KV entry every step):
+        # - Target grew by block_size + 1 (verify fed [seed, D_1..D_bs]);
+        #   keep num_accepted; trim away (block_size + 1 - num_accepted).
+        # - Draft grew by block_size (loop fed [seed, D_1..D_{bs-1}]);
+        #   keep num_accepted; trim away (block_size - num_accepted). On
+        #   full acceptance (num_accepted == block_size + 1) that is -1:
+        #   the draft cache is one entry short of the committed prefix, so
+        #   an align-forward below feeds the last accepted draft token to
+        #   catch it up (mirrors speculative.py's classic decoder).
+        trim_target = (self._block_size + 1) - num_accepted
+        trim_draft = self._block_size - num_accepted
+        if trim_target > 0:
             if self._target_can_trim:
                 if trim_prompt_cache is not None:
-                    trim_prompt_cache(self._target_cache, trim)
+                    trim_prompt_cache(self._target_cache, trim_target)
             else:
                 # Hybrid linear-attention path. ``_capture`` was created
                 # in prefill; same control-flow invariant guards as
@@ -477,13 +477,27 @@ class EagleDecoder(SpecDecoderBase):
                     self._capture_buffer,
                     self._target_cache,
                     accepted=num_accepted - 1,
-                    trim=trim,
+                    trim=trim_target,
                 )
         # Draft cache trim — the draft is always a standard-attention
         # transformer with trim-able KVCache, so this path is the same
         # regardless of target architecture.
-        if trim_prompt_cache is not None and trim > 0:
-            trim_prompt_cache(self._draft_cache, trim)
+        if trim_prompt_cache is not None and trim_draft > 0:
+            trim_prompt_cache(self._draft_cache, trim_draft)
+        elif num_accepted > self._block_size:
+            # Full acceptance: the draft cache holds only block_size
+            # entries but all block_size drafts (plus the bonus token)
+            # were committed, so it is one entry short. Feed the last
+            # accepted draft token to append its KV — ``cur_hidden`` is
+            # the draft hidden that conditions it (the running hidden the
+            # loop left after producing ``draft_tokens[-1]``), matching
+            # how positions 1..block_size-1 were built. Mirrors the
+            # classic decoder's align-forward (speculative.py).
+            align_tok = mx.array([[draft_tokens[-1]]], dtype=mx.int32)
+            align_logits, _ = self._draft(
+                token_ids=align_tok, h_prev=cur_hidden, cache=self._draft_cache
+            )
+            mx.eval(align_logits)
 
         # New seed: the last accepted token, with target's hidden at
         # the corresponding position. captured spans positions

--- a/olmlx/engine/mtp/decoder.py
+++ b/olmlx/engine/mtp/decoder.py
@@ -461,24 +461,24 @@ class MTPDecoder(SpecDecoderBase):
         # caches grew by block_size+1 (target) and block_size (draft)
         # during this step. Trim them back to the accepted prefix.
         num_accepted = len(accepted)
-        # Target and draft caches trim by the same amount.
-        # - Target grew by block_size + 1; we keep num_accepted; trim
-        #   away (block_size + 1 - num_accepted).
-        # - Draft grew by block_size; we keep num_accepted - 1 (the
-        #   draft emits drafts, not the seed); trim away
-        #   (block_size - (num_accepted - 1)) = (block_size + 1 -
-        #   num_accepted).
-        # Both algebra paths land at the same value. Keep one
-        # variable so a future change to either side has to update
-        # the trim formula in one spot — two identically-computed
-        # variables would be a maintenance trap (e.g. EAGLE-2 tree
-        # speculation could change the draft accounting while target
-        # stays the same).
-        trim = (self._block_size + 1) - num_accepted
-        if trim > 0:
+        # Target and draft caches keep ``num_accepted`` committed entries
+        # each, but grew by different amounts, so they trim by different
+        # amounts (#617 — a single shared ``trim`` dropped the last
+        # accepted token's draft KV entry every step):
+        # - Target grew by block_size + 1 (verify fed [seed, D_1..D_bs]);
+        #   keep num_accepted; trim away (block_size + 1 - num_accepted).
+        # - Draft grew by block_size (loop fed [seed, D_1..D_{bs-1}]);
+        #   keep num_accepted; trim away (block_size - num_accepted). On
+        #   full acceptance (num_accepted == block_size + 1) that is -1:
+        #   the draft cache is one entry short of the committed prefix, so
+        #   an align-forward below feeds the last accepted draft token to
+        #   catch it up (mirrors speculative.py's classic decoder).
+        trim_target = (self._block_size + 1) - num_accepted
+        trim_draft = self._block_size - num_accepted
+        if trim_target > 0:
             if self._target_can_trim:
                 if trim_prompt_cache is not None:
-                    trim_prompt_cache(self._target_cache, trim)
+                    trim_prompt_cache(self._target_cache, trim_target)
             else:
                 # Hybrid linear-attention path. ``_capture`` was created
                 # in prefill; same control-flow invariant guards as
@@ -514,13 +514,27 @@ class MTPDecoder(SpecDecoderBase):
                     self._capture_buffer,
                     self._target_cache,
                     accepted=num_accepted - 1,
-                    trim=trim,
+                    trim=trim_target,
                 )
         # Draft cache trim — the draft is always a standard-attention
         # transformer with trim-able KVCache, so this path is the same
         # regardless of target architecture.
-        if trim_prompt_cache is not None and trim > 0:
-            trim_prompt_cache(self._draft_cache, trim)
+        if trim_prompt_cache is not None and trim_draft > 0:
+            trim_prompt_cache(self._draft_cache, trim_draft)
+        elif num_accepted > self._block_size:
+            # Full acceptance: the draft cache holds only block_size
+            # entries but all block_size drafts (plus the bonus token)
+            # were committed, so it is one entry short. Feed the last
+            # accepted draft token to append its KV — ``cur_hidden`` is
+            # the draft hidden that conditions it (the running hidden the
+            # loop left after producing ``draft_tokens[-1]``), matching
+            # how positions 1..block_size-1 were built. Mirrors the
+            # classic decoder's align-forward (speculative.py).
+            align_tok = mx.array([[draft_tokens[-1]]], dtype=mx.int32)
+            align_logits, _ = self._draft(
+                token_ids=align_tok, h_prev=cur_hidden, cache=self._draft_cache
+            )
+            mx.eval(align_logits)
 
         # New seed: the last accepted token, with target's hidden at
         # the corresponding position. captured spans positions

--- a/olmlx/engine/prompt_cache/vlm_state.py
+++ b/olmlx/engine/prompt_cache/vlm_state.py
@@ -63,6 +63,10 @@ class VlmPromptCacheStore:
         self._capacity = max(int(capacity), 0)
         # Insertion-ordered dict as an LRU: first key is least-recently-used.
         self._entries: dict[str, Any] = {}
+        # Bumped by every bulk drop (``clear``) so an ``async_get`` whose disk
+        # restore was in flight across the drop can tell its result is stale
+        # and skip the re-insert (#618; mirrors PromptCacheStore).
+        self._evict_generation = 0
         # Cumulative reuse counters surfaced on /api/ps (acceptance criterion 1).
         self._hits = 0
         self._misses = 0
@@ -99,6 +103,8 @@ class VlmPromptCacheStore:
         the in-memory tier; the disk tier is reclaimed lazily by the cap.
         """
         self._entries.clear()
+        # Signal any in-flight async_get that its restore is now stale (#618).
+        self._evict_generation += 1
 
     def note_hit(self, reused_tokens: int) -> None:
         self._hits += 1
@@ -162,9 +168,23 @@ class VlmPromptCacheStore:
             return mem
         if not self._disk_enabled or not self.enabled():
             return None
+        gen_before = self._evict_generation
         loaded = await asyncio.to_thread(self._load_from_disk, cache_id)
         if loaded is None:
             return None
+        # If a bulk clear() (memory-pressure flush) landed during the await,
+        # the eviction was intentional — don't re-insert the stale disk copy
+        # and undo the flush. Leave the disk file intact for a later restore.
+        if self._evict_generation != gen_before:
+            return None
+        # Another coroutine may have inserted a fresher state for this id
+        # during the await; keep it and discard the stale disk load rather
+        # than let _insert_capture's pop() clobber it.
+        existing = self._entries.get(cache_id)
+        if existing is not None:
+            self._entries.pop(cache_id, None)  # refresh to MRU
+            self._entries[cache_id] = existing
+            return existing
         # Promote the restored entry; spill whatever it evicts.
         for over_id, over_state in self._insert_capture(cache_id, loaded):
             await self._spill(over_id, over_state)

--- a/olmlx/engine/prompt_cache/vlm_state.py
+++ b/olmlx/engine/prompt_cache/vlm_state.py
@@ -178,12 +178,11 @@ class VlmPromptCacheStore:
         if self._evict_generation != gen_before:
             return None
         # Another coroutine may have inserted a fresher state for this id
-        # during the await; keep it and discard the stale disk load rather
-        # than let _insert_capture's pop() clobber it.
-        existing = self._entries.get(cache_id)
+        # during the await; keep it (get() refreshes it to MRU) and discard
+        # the stale disk load rather than let _insert_capture's pop() clobber
+        # it.
+        existing = self.get(cache_id)
         if existing is not None:
-            self._entries.pop(cache_id, None)  # refresh to MRU
-            self._entries[cache_id] = existing
             return existing
         # Promote the restored entry; spill whatever it evicts.
         for over_id, over_state in self._insert_capture(cache_id, loaded):

--- a/tests/test_eagle.py
+++ b/tests/test_eagle.py
@@ -612,13 +612,19 @@ class TestEagleDecoderPrefillStep:
         EagleDecoder(target_model=target, draft_model=draft, target_layer_id=n - 1)
 
     def test_draft_cache_growth_is_bounded_per_step(self):
-        """The draft cache must grow by exactly ``num_accepted - 1``
-        positions per ``step()`` — that's the cumulative output count.
-        A regression that skipped the draft trim (e.g. flipped
-        ``if trim > 0``) would let the cache grow by ``block_size``
-        per step instead, accumulating ``block_size - num_accepted``
-        extra positions every verify and blowing up memory on long
-        generations. Lock this in.
+        """The draft cache must grow by exactly ``num_accepted``
+        positions per ``step()`` — one entry per committed token, so the
+        draft's KV history and RoPE positions stay aligned with the
+        committed sequence (#617).
+
+        Two failure modes this pins:
+        - Skipping the draft trim (e.g. flipping ``if trim_draft > 0``)
+          lets the cache grow by ``block_size`` per step, accumulating
+          extra positions and blowing up memory on long generations.
+        - Over-trimming (the pre-#617 ``block_size + 1 - num_accepted``,
+          which kept only ``num_accepted - 1``) drops the last accepted
+          token's KV entry every step, compressing RoPE positions by one
+          per step and degrading acceptance cumulatively.
         """
         decoder, _, _ = _make_decoder(block_size=2)
         decoder.prefill(mx.array([[1, 2, 3]], dtype=mx.int32))
@@ -635,16 +641,41 @@ class TestEagleDecoderPrefillStep:
             accepted, _ = decoder.step()
             total_accepted += len(accepted)
 
-        # Net growth per step = num_accepted - 1 (see step()'s comment
-        # block on trim arithmetic). Cumulative offset growth after N
-        # steps = ``sum_i (num_accepted_i - 1)`` = total_accepted - N.
-        expected = total_accepted - steps
+        # Net growth per step = num_accepted (see step()'s comment block
+        # on trim arithmetic). Cumulative offset growth after N steps =
+        # ``sum_i num_accepted_i`` = total_accepted.
+        expected = total_accepted
         actual = _cache_offset() - baseline
         assert actual == expected, (
             f"draft cache offset grew by {actual} after {steps} steps "
             f"with {total_accepted} total accepted tokens; expected "
-            f"{expected}. Regression: the per-step trim no longer "
-            "matches ``num_accepted - 1``."
+            f"{expected}. Regression: the per-step draft trim no longer "
+            "keeps exactly ``num_accepted`` committed entries."
+        )
+
+    def test_full_acceptance_aligns_draft_cache(self, monkeypatch):
+        """On full acceptance (all block_size drafts + the bonus token
+        committed) the draft cache is one entry short of the committed
+        prefix, so ``step`` must run an align-forward to append the last
+        accepted draft token's KV (#617). Force full acceptance and assert
+        the draft cache grew by exactly num_accepted = block_size + 1.
+        """
+        decoder, _, _ = _make_decoder(block_size=3)
+        decoder.prefill(mx.array([[1, 2, 3]], dtype=mx.int32))
+        assert decoder._draft_cache is not None
+        baseline = decoder._draft_cache[0].offset
+
+        # Accept every draft plus a bonus token -> num_accepted = bs + 1.
+        monkeypatch.setattr(
+            decoder, "_verify_greedy", lambda drafts, logits: [*drafts, 7]
+        )
+        accepted, _ = decoder.step()
+        assert len(accepted) == decoder._block_size + 1  # full acceptance
+        grew = decoder._draft_cache[0].offset - baseline
+        assert grew == len(accepted), (
+            f"draft cache grew by {grew} on full acceptance; expected "
+            f"{len(accepted)} — the align-forward did not append the "
+            "last accepted draft token's KV entry."
         )
 
     def test_step_clears_hidden_storage_before_verify(self):

--- a/tests/test_mtp_decoder.py
+++ b/tests/test_mtp_decoder.py
@@ -75,6 +75,61 @@ def test_mtp_prefill_then_step_produces_accepted_tokens():
     assert stats["steps"] == 1 and stats["block_size"] == 2
 
 
+def test_mtp_draft_cache_growth_is_bounded_per_step():
+    """The MTP draft cache must grow by exactly ``num_accepted`` positions
+    per ``step()`` — one entry per committed token, keeping the draft's KV
+    history and RoPE positions aligned with the committed sequence (#617).
+
+    The pre-#617 arithmetic trimmed ``block_size + 1 - num_accepted`` on the
+    draft cache (keeping only ``num_accepted - 1``), dropping the last
+    accepted token's KV entry every step and compressing RoPE positions by
+    one per step — cumulative acceptance-rate degradation on long runs.
+    """
+    decoder, _, _ = _make_mtp_decoder(block_size=2)
+    decoder.prefill(mx.array([[1, 2, 3]], dtype=mx.int32))
+    assert decoder._draft_cache is not None
+
+    def _cache_offset() -> int:
+        assert decoder._draft_cache is not None
+        return decoder._draft_cache[0].offset
+
+    baseline = _cache_offset()
+    steps = 3
+    total_accepted = 0
+    for _ in range(steps):
+        accepted, _ = decoder.step()
+        total_accepted += len(accepted)
+
+    expected = total_accepted
+    actual = _cache_offset() - baseline
+    assert actual == expected, (
+        f"MTP draft cache offset grew by {actual} after {steps} steps "
+        f"with {total_accepted} total accepted tokens; expected {expected}. "
+        "Regression: the per-step draft trim no longer keeps exactly "
+        "``num_accepted`` committed entries."
+    )
+
+
+def test_mtp_full_acceptance_aligns_draft_cache(monkeypatch):
+    """On full acceptance the MTP draft cache is one entry short of the
+    committed prefix, so ``step`` must run an align-forward to append the
+    last accepted draft token's KV (#617)."""
+    decoder, _, _ = _make_mtp_decoder(block_size=3)
+    decoder.prefill(mx.array([[1, 2, 3]], dtype=mx.int32))
+    assert decoder._draft_cache is not None
+    baseline = decoder._draft_cache[0].offset
+
+    monkeypatch.setattr(decoder, "_verify_greedy", lambda drafts, logits: [*drafts, 7])
+    accepted, _ = decoder.step()
+    assert len(accepted) == decoder._block_size + 1  # full acceptance
+    grew = decoder._draft_cache[0].offset - baseline
+    assert grew == len(accepted), (
+        f"MTP draft cache grew by {grew} on full acceptance; expected "
+        f"{len(accepted)} — the align-forward did not append the last "
+        "accepted draft token's KV entry."
+    )
+
+
 def test_mtp_step_before_prefill_raises():
     decoder, _, _ = _make_mtp_decoder()
     try:

--- a/tests/test_vlm_prompt_cache_store.py
+++ b/tests/test_vlm_prompt_cache_store.py
@@ -170,6 +170,50 @@ async def test_empty_state_not_spilled(tmp_path):
     assert not a_file.exists()
 
 
+async def test_async_get_skips_reinsert_after_bulk_clear(tmp_path):
+    """A memory-pressure ``clear()`` during the threaded disk restore must
+    cancel the re-insert — otherwise the stale disk copy is written straight
+    back in, partly defeating the flush (#618). Mirrors the text store's
+    eviction-generation guard.
+    """
+    store = _disk_store(tmp_path, capacity=2)
+    disk_state = _filled_state([1, 2, 3])
+
+    def load_with_concurrent_clear(cid):
+        # Simulate ``clear()`` (the memory-pressure path) landing while the
+        # disk read is in flight: it bumps the eviction generation.
+        store._evict_generation += 1
+        return disk_state
+
+    store._load_from_disk = load_with_concurrent_clear
+    got = await store.async_get("a")
+    # The restore is abandoned: nothing re-enters memory.
+    assert got is None
+    assert store.get("a") is None
+    assert "a" not in store._entries
+
+
+async def test_async_get_keeps_fresher_concurrent_insert(tmp_path):
+    """If another coroutine inserts a fresher state for the same id during
+    the threaded disk restore, ``async_get`` must return that fresher entry
+    and discard the stale disk copy — not clobber it (#618)."""
+    store = _disk_store(tmp_path, capacity=2)
+    stale_disk = _filled_state([1, 2, 3])
+    fresher = _filled_state([1, 2, 3, 4, 5])
+
+    def load_with_concurrent_insert(cid):
+        # Simulate a fresher insert for the same id completing during the
+        # await (direct dict write bypasses the loop-thread assert, exactly
+        # as the text-store guard test bumps _evict_generation directly).
+        store._entries[cid] = fresher
+        return stale_disk
+
+    store._load_from_disk = load_with_concurrent_insert
+    got = await store.async_get("a")
+    assert got is fresher
+    assert store.get("a") is fresher
+
+
 async def test_cleanup_respects_byte_cap(tmp_path):
     # Cap below one entry's size → the oldest spilled file is reclaimed.
     store = _disk_store(tmp_path, capacity=1, max_bytes=1)


### PR DESCRIPTION
Two correctness fixes surfaced by the whole-repo Fable 5 review, both with reference implementations already in the tree. Closes #617, closes #618.

## #617 — EAGLE/MTP draft-cache trim off-by-one

The EAGLE and MTP draft loops trimmed their draft KV cache with the **same** `trim` value used for the target cache (`block_size + 1 - num_accepted`). But the two caches grow by different amounts per step:

- **Target** grew by `block_size + 1` (verify fed `[seed, D₁..D_bs]`) → keep `num_accepted` → trim `block_size + 1 - num_accepted`. ✅ correct.
- **Draft** grew by `block_size` (loop fed `[seed, D₁..D_{bs-1}]`) → should keep `num_accepted`, i.e. trim `block_size - num_accepted`.

Sharing one value kept only `num_accepted - 1` draft entries — **discarding the last accepted draft token's KV entry every step** and compressing the draft's RoPE positions by one per step boundary. Exactness held (the target verifies), but acceptance rate degraded cumulatively on long generations. On full acceptance the code also lacked the classic decoder's align-forward, leaving the draft cache one entry short again.

**Fix** (`eagle/decoder.py`, `mtp/decoder.py`): split into `trim_target` (unchanged) and `trim_draft = block_size - num_accepted`; on full acceptance feed the last accepted draft token (conditioned on the draft's running hidden) to append its KV — mirroring `speculative.py`'s classic decoder.

The existing EAGLE growth test locked in the wrong `num_accepted - 1` invariant; it's updated to `num_accepted`, and matching MTP growth + full-acceptance tests are added. New invariant: **the draft cache grows by exactly `num_accepted` per step** (one entry per committed token).

## #618 — VlmPromptCacheStore.async_get missing post-await guards

The VLM disk-tier `async_get` re-inserted the disk-restored state unconditionally after its threaded load, lacking the two guards `PromptCacheStore.async_get` has:

1. **Stale clobber** — a fresher in-memory entry inserted for the same `cache_id` during the await was discarded (not even spilled) and replaced with the stale disk copy.
2. **Defeated flush** — a memory-pressure `clear()` landing during the await was undone by the re-insert.

**Fix** (`prompt_cache/vlm_state.py`): add an `_evict_generation` counter (bumped by `clear()`) and re-check both it and `cache_id in self._entries` after the await, mirroring the text store.

## Tests

TDD throughout — each test reproduced the bug (red) before the fix (green):

- `test_eagle.py::TestEagleDecoderPrefillStep::{test_draft_cache_growth_is_bounded_per_step, test_full_acceptance_aligns_draft_cache}`
- `test_mtp_decoder.py::{test_mtp_draft_cache_growth_is_bounded_per_step, test_mtp_full_acceptance_aligns_draft_cache}`
- `test_vlm_prompt_cache_store.py::{test_async_get_skips_reinsert_after_bulk_clear, test_async_get_keeps_fresher_concurrent_insert}`

`uv run pytest tests/test_eagle.py tests/test_mtp_decoder.py tests/test_vlm_prompt_cache_store.py tests/test_mtp_integration.py tests/test_prompt_cache_store.py tests/test_loop_affinity.py` → all pass. ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)