### PR TITLE
chore(github): add pull request template with Closes-per-issue reminder

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+One `Closes` line per issue so GitHub auto-closes each on merge.
+Bundled shorthand (`Closes #1, #2`) only closes the FIRST — repeat the keyword.
+Bare references like `(#123)` or `## #123` do NOT close anything.
+-->
+
+Closes #
+
+## Summary
+
+<!-- What this changes and why. One short section per issue for multi-issue PRs. -->
+
+## Tests
+
+<!-- New/updated tests, and the suites you ran. TDD: confirm red before green. -->
+
+---
+
+- [ ] `ruff check` + `ruff format` clean
+- [ ] Tests pass (`uv run pytest`)
+- [ ] Each fixed issue has its own `Closes #N` line above


### PR DESCRIPTION
Closes #

## Summary

Recent merged PRs referenced their issues via bare links (`(#595)`, `## #623`) or bundled shorthand (`Closes #1, #2`), so GitHub did not auto-close them on merge — it only closes on a `Closes/Fixes/Resolves #N` keyword with the number immediately after, one keyword per issue.

This adds `.github/PULL_REQUEST_TEMPLATE.md` so every new PR is seeded with:

- A `Closes #` line at the top, with an HTML comment spelling out the keyword rules (bundled shorthand closes only the first; bare `(#123)` references close nothing).
- Summary + Tests sections matching the existing PR style.
- A checklist covering `ruff check`/`ruff format`, `uv run pytest`, and the per-issue `Closes #N` reminder.

Docs-only; no runtime code touched. (The `Closes #` line above is intentionally blank — this PR fixes no issue.)

## Tests

None — repository-metadata / documentation change with no runtime surface.

---

- [x] `ruff check` + `ruff format` clean (no Python changed)
- [x] Tests pass (no code changed)
- [x] Each fixed issue has its own `Closes #N` line above (n/a — no issue)