### PR TITLE
fix(cli): CLI & config robustness (#635) + guarded prepare download (#630)

### DIFF
--- a/olmlx/app.py
+++ b/olmlx/app.py
@@ -235,12 +235,15 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         metrics_mod.HTTP_IN_FLIGHT.inc()
         start = time.perf_counter()
         status_code = 500
-        response = None
-        try:
-            response = await call_next(request)
-            status_code = response.status_code
-            return response
-        finally:
+        recorded = False
+
+        def _record():
+            # Idempotent: called once — either from the body-iterator finalizer
+            # (normal streaming path) or the except branch (call_next raised).
+            nonlocal recorded
+            if recorded:
+                return
+            recorded = True
             metrics_mod.HTTP_IN_FLIGHT.dec()
             # Prefer the matched route template to bound cardinality; fall back
             # to a literal for unmatched paths (404 with no route).
@@ -249,7 +252,43 @@ class MetricsMiddleware(BaseHTTPMiddleware):
             metrics_mod.record_http_request(
                 label_path, request.method, status_code, time.perf_counter() - start
             )
+
+        try:
+            response = await call_next(request)
+        except BaseException:
+            _record()
+            raise
+        finally:
+            # surface_var only needs to guard this middleware's own frame:
+            # BaseHTTPMiddleware runs the inner app in a sub-task with a
+            # *copied* context, so resetting here does not clobber the value
+            # the streaming body sees (same reason RequestIDMiddleware resets
+            # in its finally). Keeping it here — rather than in the body
+            # finalizer — also avoids resetting a ContextVar Token from a
+            # different context than the one it was created in.
             surface_var.reset(surface_token)
+
+        status_code = response.status_code
+
+        # Defer HTTP_IN_FLIGHT.dec() and the duration histogram until the whole
+        # response body has streamed. With BaseHTTPMiddleware, ``call_next``
+        # returns at TTFT (when the inner app sends http.response.start), so
+        # recording in a plain ``finally`` would clock streaming responses —
+        # the dominant /api/chat and /v1/chat/completions workload — at ~TTFT
+        # and read in-flight as 0 during active generation (#635). Wrapping the
+        # body iterator records when the last chunk is sent. Buffered responses
+        # stream their single chunk immediately, so their timing is unchanged.
+        original_iterator = response.body_iterator
+
+        async def _instrumented_body():
+            try:
+                async for chunk in original_iterator:
+                    yield chunk
+            finally:
+                _record()
+
+        response.body_iterator = _instrumented_body()
+        return response
 
 
 class RootSpanMiddleware(BaseHTTPMiddleware):

--- a/olmlx/cli.py
+++ b/olmlx/cli.py
@@ -44,8 +44,12 @@ def ensure_config():
     config_dir = settings.models_config.parent
     config_dir.mkdir(parents=True, exist_ok=True)
     if not settings.models_config.exists():
-        with open(settings.models_config, "w") as f:
-            json.dump(DEFAULT_MODELS, f, indent=2)
+        # Atomic temp-file-plus-rename: a crash mid-write must not leave a
+        # truncated models.json, which the strict loader would then
+        # hard-refuse to start on every subsequent run (#635).
+        from olmlx.engine.registry import _atomic_write_json
+
+        _atomic_write_json(DEFAULT_MODELS, settings.models_config)
         print(f"Created {settings.models_config} with example models")
 
 
@@ -151,51 +155,11 @@ def _legacy_speculative_values_in_dotenv() -> dict[str, str]:
     ``Settings.model_config`` declares ``env_file=".env"`` (cwd-relative);
     pydantic-settings reads it into Settings without touching
     ``os.environ``, so a shell-only scan would miss legacy values in the
-    file. The format accepted is a subset of pydantic-settings' own
-    ``.env`` parser: ``KEY=value`` lines (optionally ``export KEY=...``),
-    with ``#`` comments and blank lines ignored, and surrounding single
-    or double quotes stripped from the value.
+    file. Delegates to the single canonical ``.env`` parser (#635).
     """
-    dotenv_path = Path(".env")
-    try:
-        text = dotenv_path.read_text()
-    except (FileNotFoundError, OSError):
-        return {}
-    found: dict[str, str] = {}
-    legacy = set(_DEPRECATED_SPECULATIVE_ENV_VARS)
-    for raw_line in text.splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if "=" not in line:
-            continue
-        key, _, value = line.partition("=")
-        key = key.strip()
-        if key.startswith("export "):
-            key = key[len("export ") :].strip()
-        value = value.strip()
-        # Require length >= 2 so a literal single quote ``"`` doesn't
-        # collapse to the empty string.
-        is_quoted = len(value) >= 2 and (
-            (value.startswith('"') and value.endswith('"'))
-            or (value.startswith("'") and value.endswith("'"))
-        )
-        if is_quoted:
-            value = value[1:-1]
-        else:
-            # Strip inline ``# comment`` from unquoted values. Without
-            # this, a line like ``KEY=true  # enable`` would parse
-            # ``true  # enable``, which the boolean forwarder coerces
-            # to ``False`` — the opposite of intent. Limitation: an
-            # unquoted value containing a literal ``#`` (e.g. a path
-            # fragment) is silently truncated. Quote the value to
-            # disable this stripping.
-            comment_idx = value.find("#")
-            if comment_idx != -1:
-                value = value[:comment_idx].rstrip()
-        if key in legacy and key not in found:
-            found[key] = value
-    return found
+    from olmlx.config import parse_dotenv_values
+
+    return parse_dotenv_values(_DEPRECATED_SPECULATIVE_ENV_VARS)
 
 
 def _forward_legacy_speculative_env(
@@ -384,45 +348,14 @@ def _surface_legacy_speculative_env() -> None:
 
 def _legacy_kv_cache_quant_in_dotenv() -> str | None:
     """Return the value of ``OLMLX_EXPERIMENTAL_KV_CACHE_QUANT`` from the
-    project ``.env`` file, or None if not present or the file is unreadable."""
-    dotenv_path = Path(".env")
-    try:
-        text = dotenv_path.read_text()
-    except (FileNotFoundError, OSError):
-        return None
-    for raw_line in text.splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if "=" not in line:
-            continue
-        key, _, value = line.partition("=")
-        key = key.strip()
-        if key.startswith("export "):
-            key = key[len("export ") :].strip()
-        if key != "OLMLX_EXPERIMENTAL_KV_CACHE_QUANT":
-            continue
-        value = value.strip()
-        # Detect surrounding quotes first; a ``#`` inside quotes is
-        # preserved.  If no quotes are found, strip trailing inline
-        # comments and re-check — ``"turboquant:4" # comment`` has no
-        # terminating quote until the comment is removed.
-        is_quoted = len(value) >= 2 and (
-            (value.startswith('"') and value.endswith('"'))
-            or (value.startswith("'") and value.endswith("'"))
-        )
-        if not is_quoted:
-            comment_idx = value.find("#")
-            if comment_idx != -1:
-                value = value[:comment_idx].rstrip()
-                is_quoted = len(value) >= 2 and (
-                    (value.startswith('"') and value.endswith('"'))
-                    or (value.startswith("'") and value.endswith("'"))
-                )
-        if is_quoted:
-            value = value[1:-1]
-        return value
-    return None
+    project ``.env`` file, or None if not present or the file is unreadable.
+
+    Delegates to the single canonical ``.env`` parser (#635)."""
+    from olmlx.config import parse_dotenv_values
+
+    return parse_dotenv_values(("OLMLX_EXPERIMENTAL_KV_CACHE_QUANT",)).get(
+        "OLMLX_EXPERIMENTAL_KV_CACHE_QUANT"
+    )
 
 
 def _surface_legacy_kv_cache_quant_env() -> None:
@@ -1767,6 +1700,38 @@ def _create_store():
     return ModelStore(registry)
 
 
+def _resolve_and_download(model: str, *, download: bool = True):
+    """Resolve *model* to an hf_path and return ``(store, local_dir)``.
+
+    The single guarded resolve+download path shared by the prepare-family
+    subcommands (#630). Each used to inline this block with no error
+    handling, so a typo'd / offline / gated model name dumped a raw
+    ``huggingface_hub`` traceback; here a resolve/download failure prints a
+    clean message to stderr and exits 1 instead — matching ``cmd_models_pull``.
+
+    ``download=False`` (used by ``flash info``) returns the local path via
+    ``local_path`` without fetching. ``ModelsConfigError`` is re-raised so
+    ``cli_main``'s dedicated handler can report it (naming the file) rather
+    than collapsing it into a generic exit.
+    """
+    from olmlx.engine.registry import ModelsConfigError
+
+    try:
+        store = _create_store()
+        resolved = store.registry.resolve(model)
+        hf_path = resolved.hf_path if resolved is not None else model
+        if download:
+            local_dir = store.ensure_downloaded(hf_path)
+        else:
+            local_dir = store.local_path(hf_path)
+    except ModelsConfigError:
+        raise
+    except Exception as exc:
+        print(f"Error resolving {model!r}: {exc}", file=sys.stderr)
+        sys.exit(1)
+    return store, local_dir
+
+
 def _format_size(size_bytes: int) -> str:
     """Format byte size to human-readable string."""
     if size_bytes >= 1e9:
@@ -2607,10 +2572,7 @@ def cmd_spectral_prepare(args):
     """Prepare a model for spectral quant (eigenspectral calibration)."""
     _configure_logging()
 
-    store = _create_store()
-    _resolved = store.registry.resolve(args.model)
-    hf_path = _resolved.hf_path if _resolved is not None else args.model
-    local_dir = store.ensure_downloaded(hf_path)
+    _store, local_dir = _resolve_and_download(args.model)
     model_path = str(local_dir)
 
     print(f"Running spectral calibration for {args.model}...")
@@ -2643,10 +2605,7 @@ def cmd_shard_prepare(args):
     """Prepare a model for shard quant (per-head PCA-K + VQ-V calibration)."""
     _configure_logging()
 
-    store = _create_store()
-    _resolved = store.registry.resolve(args.model)
-    hf_path = _resolved.hf_path if _resolved is not None else args.model
-    local_dir = store.ensure_downloaded(hf_path)
+    _store, local_dir = _resolve_and_download(args.model)
     model_path = str(local_dir)
 
     print(f"Running shard calibration for {args.model}...")
@@ -2684,10 +2643,7 @@ def cmd_flash_prepare(args):
     # does not forward values).
     _warn_legacy_flash_env()
 
-    store = _create_store()
-    _resolved = store.registry.resolve(args.model)
-    hf_path = _resolved.hf_path if _resolved is not None else args.model
-    local_dir = store.ensure_downloaded(hf_path)
+    _store, local_dir = _resolve_and_download(args.model)
     model_path = str(local_dir)
 
     # Auto-detect MoE model
@@ -2760,10 +2716,7 @@ def cmd_dflash_precompute(args):
     """Precompute target hidden states for DFlash draft training."""
     _configure_logging()
 
-    store = _create_store()
-    _resolved = store.registry.resolve(args.model)
-    hf_path = _resolved.hf_path if _resolved is not None else args.model
-    local_dir = store.ensure_downloaded(hf_path)
+    _store, local_dir = _resolve_and_download(args.model)
     model_path = str(local_dir)
 
     target_layer_ids: list[int] | None = None
@@ -2882,10 +2835,7 @@ def cmd_dflash_prepare(args):
             "or the other."
         )
 
-    store = _create_store()
-    _resolved = store.registry.resolve(args.model)
-    hf_path = _resolved.hf_path if _resolved is not None else args.model
-    local_dir = store.ensure_downloaded(hf_path)
+    _store, local_dir = _resolve_and_download(args.model)
     model_path = str(local_dir)
 
     target_layer_ids: list[int] | None = None
@@ -2981,10 +2931,7 @@ def cmd_eagle_prepare(args):
             "deepest layer from the concatenated ladder)."
         )
 
-    store = _create_store()
-    _resolved = store.registry.resolve(args.model)
-    hf_path = _resolved.hf_path if _resolved is not None else args.model
-    local_dir = store.ensure_downloaded(hf_path)
+    _store, local_dir = _resolve_and_download(args.model)
     model_path = str(local_dir)
 
     print(f"Training EAGLE draft for {args.model}...")
@@ -3031,10 +2978,7 @@ def cmd_flash_info(args):
     # Warn about stale ``OLMLX_EXPERIMENTAL_FLASH*`` env vars (warn-only;
     # does not forward values).
     _warn_legacy_flash_env()
-    store = _create_store()
-    _resolved = store.registry.resolve(args.model)
-    hf_path = _resolved.hf_path if _resolved is not None else args.model
-    local_dir = store.local_path(hf_path)
+    _store, local_dir = _resolve_and_download(args.model, download=False)
 
     # Check for Flash-MoE first
     flash_moe_dir = local_dir / "flash_moe"
@@ -4014,5 +3958,14 @@ def cli_main():
             print(f"Error: {exc}", file=sys.stderr)
             sys.exit(1)
 
-    # Unknown subcommand — print help for the parent command
-    parser.parse_args([cmd, "--help"])
+    # Unknown or missing subcommand. Print the parent command's help to
+    # stderr (not stdout) and exit non-zero so scripts / CI don't read the
+    # no-op as success — ``parser.parse_args([cmd, "--help"])`` would print
+    # to stdout and exit 0 (#635).
+    subparser = None
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            subparser = action.choices.get(cmd)
+            break
+    (subparser or parser).print_help(sys.stderr)
+    sys.exit(2)

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -808,6 +808,18 @@ def warn_legacy_flash_env() -> None:
     )
 
 
+def _looks_quoted(value: str) -> bool:
+    """True if *value* is wrapped in matching single or double quotes.
+
+    Length >= 2 so a lone quote character doesn't count as its own pair
+    (and thus collapse to the empty string when the quotes are stripped).
+    """
+    return len(value) >= 2 and (
+        (value.startswith('"') and value.endswith('"'))
+        or (value.startswith("'") and value.endswith("'"))
+    )
+
+
 def parse_dotenv_values(
     names: Iterable[str], dotenv_path: Path | None = None
 ) -> dict[str, str]:
@@ -846,11 +858,7 @@ def parse_dotenv_values(
         if key not in wanted or key in found:
             continue
         value = value.strip()
-        # Require length >= 2 so a lone quote character doesn't collapse to "".
-        is_quoted = len(value) >= 2 and (
-            (value.startswith('"') and value.endswith('"'))
-            or (value.startswith("'") and value.endswith("'"))
-        )
+        is_quoted = _looks_quoted(value)
         if not is_quoted:
             # Strip a trailing inline comment from an unquoted value, then
             # re-check for surrounding quotes — a quoted value only becomes
@@ -858,10 +866,7 @@ def parse_dotenv_values(
             comment_idx = value.find("#")
             if comment_idx != -1:
                 value = value[:comment_idx].rstrip()
-                is_quoted = len(value) >= 2 and (
-                    (value.startswith('"') and value.endswith('"'))
-                    or (value.startswith("'") and value.endswith("'"))
-                )
+                is_quoted = _looks_quoted(value)
         if is_quoted:
             value = value[1:-1]
         found[key] = value

--- a/olmlx/config.py
+++ b/olmlx/config.py
@@ -1,6 +1,7 @@
 import logging
 import math
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Literal
@@ -807,29 +808,73 @@ def warn_legacy_flash_env() -> None:
     )
 
 
-def _legacy_names_in_dotenv(names: tuple[str, ...]) -> set[str]:
-    """Return the subset of *names* present as keys in the project ``.env``.
+def parse_dotenv_values(
+    names: Iterable[str], dotenv_path: Path | None = None
+) -> dict[str, str]:
+    """Return ``{name: value}`` for each of *names* present in the project
+    ``.env`` file (cwd-relative by default).
 
-    Key membership only — ``warn_legacy_flash_env`` warns on presence
-    regardless of value, so values are never parsed.
+    The single canonical ``.env`` parser: three legacy-forwarding helpers
+    (``_legacy_names_in_dotenv`` here, ``_legacy_speculative_values_in_dotenv``
+    and ``_legacy_kv_cache_quant_in_dotenv`` in ``cli``) used to hand-roll
+    this, and had drifted — the kv-quant variant re-checked for quotes after
+    stripping an inline comment while the speculative one did not, so
+    ``KEY="v" # note`` parsed differently across them (#635).
+
+    The format is a subset of pydantic-settings' own ``.env`` parser:
+    ``KEY=value`` lines (optionally ``export KEY=...``), ``#`` comments and
+    blank lines ignored, surrounding single/double quotes stripped. For an
+    *unquoted* value a trailing ``# comment`` is stripped and quotes are
+    re-checked (so ``KEY="v" # note`` → ``v``); a ``#`` *inside* quotes is
+    preserved. First occurrence of a key wins.
     """
-    dotenv_path = Path(".env")
+    path = dotenv_path if dotenv_path is not None else Path(".env")
     try:
-        text = dotenv_path.read_text()
+        text = path.read_text()
     except (FileNotFoundError, OSError):
-        return set()
-    found: set[str] = set()
-    legacy = set(names)
+        return {}
+    wanted = set(names)
+    found: dict[str, str] = {}
     for raw_line in text.splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
-        key = line.partition("=")[0].strip()
+        key, _, value = line.partition("=")
+        key = key.strip()
         if key.startswith("export "):
             key = key[len("export ") :].strip()
-        if key in legacy:
-            found.add(key)
+        if key not in wanted or key in found:
+            continue
+        value = value.strip()
+        # Require length >= 2 so a lone quote character doesn't collapse to "".
+        is_quoted = len(value) >= 2 and (
+            (value.startswith('"') and value.endswith('"'))
+            or (value.startswith("'") and value.endswith("'"))
+        )
+        if not is_quoted:
+            # Strip a trailing inline comment from an unquoted value, then
+            # re-check for surrounding quotes — a quoted value only becomes
+            # syntactically quoted once its trailing ``# comment`` is gone.
+            comment_idx = value.find("#")
+            if comment_idx != -1:
+                value = value[:comment_idx].rstrip()
+                is_quoted = len(value) >= 2 and (
+                    (value.startswith('"') and value.endswith('"'))
+                    or (value.startswith("'") and value.endswith("'"))
+                )
+        if is_quoted:
+            value = value[1:-1]
+        found[key] = value
     return found
+
+
+def _legacy_names_in_dotenv(names: tuple[str, ...]) -> set[str]:
+    """Return the subset of *names* present as keys in the project ``.env``.
+
+    Key membership only — ``warn_legacy_flash_env`` warns on presence
+    regardless of value, so values are discarded here.
+    """
+    return set(parse_dotenv_values(names))
 
 
 def resolve_experimental(

--- a/olmlx/engine/registry.py
+++ b/olmlx/engine/registry.py
@@ -1551,14 +1551,30 @@ class ModelRegistry:
                     self._raw_unrecognized[normalized] = v
             self._validate_panels()
         if self._aliases_path.exists():
+            # Unlike models.json (authoritative — a parse error blocks
+            # startup), aliases.json is rebuildable: warn and fall back to an
+            # empty table on any problem. Catch OSError too (a permissions
+            # error would otherwise propagate a raw traceback out of load()),
+            # and validate the parsed value is a dict — a valid-JSON non-dict
+            # (e.g. a list) would sail past json.load and only blow up later
+            # at ``self._aliases[normalized]`` in resolve() (#635).
             try:
                 with open(self._aliases_path) as f:
-                    self._aliases = json.load(f)
-            except json.JSONDecodeError as exc:
+                    loaded = json.load(f)
+            except (json.JSONDecodeError, OSError) as exc:
                 logger.warning(
-                    "Corrupted %s, ignoring aliases: %s",
+                    "Could not read %s, ignoring aliases: %s",
                     self._aliases_path,
                     exc,
+                )
+                loaded = {}
+            if isinstance(loaded, dict):
+                self._aliases = loaded
+            else:
+                logger.warning(
+                    "%s must contain a JSON object, got %s; ignoring aliases",
+                    self._aliases_path,
+                    type(loaded).__name__,
                 )
                 self._aliases = {}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,29 @@ class TestEnsureConfig:
         data = json.loads(config_path.read_text())
         assert data == existing
 
+    def test_seed_write_is_atomic_on_crash(self, tmp_path, monkeypatch):
+        """A crash mid-seed must not leave a truncated models.json.
+
+        The strict loader hard-refuses every subsequent start on an
+        unparseable models.json, so a partial seed write would brick the
+        server. The atomic writer builds a temp file and renames, so a
+        failure mid-write leaves the target absent, not truncated (#635).
+        """
+        import olmlx.engine.registry as registry_mod
+
+        config_path = tmp_path / "models.json"
+        monkeypatch.setattr("olmlx.cli.settings.models_config", config_path)
+
+        def _boom(obj, fp, *args, **kwargs):
+            fp.write("{partial")  # write some bytes, then die like a crash
+            raise RuntimeError("crash mid-write")
+
+        monkeypatch.setattr(registry_mod.json, "dump", _boom)
+        with pytest.raises(RuntimeError):
+            ensure_config()
+        # Atomic write only ever exposed a temp file; the target is untouched.
+        assert not config_path.exists()
+
 
 def test_default_models_include_whisper():
     from olmlx.cli import DEFAULT_MODELS
@@ -144,6 +167,84 @@ class TestServiceInstall:
         captured = capsys.readouterr()
         assert "could not be loaded" in captured.err.lower()
         assert "Load failed" in captured.err
+
+
+class TestResolveAndDownload:
+    """The shared resolve+download helper for the prepare-family subcommands
+    (#630) — replaces six unguarded, copy-pasted blocks that dumped a raw
+    huggingface_hub traceback on a typo'd/offline/gated model name."""
+
+    def test_happy_path_returns_store_and_local_dir(self, monkeypatch, tmp_path):
+        from olmlx.cli import _resolve_and_download
+
+        mock_store = MagicMock()
+        resolved = MagicMock()
+        resolved.hf_path = "org/model"
+        mock_store.registry.resolve.return_value = resolved
+        mock_store.ensure_downloaded.return_value = tmp_path / "model"
+        monkeypatch.setattr("olmlx.cli._create_store", lambda: mock_store)
+
+        store, local_dir = _resolve_and_download("mymodel")
+        assert store is mock_store
+        assert local_dir == tmp_path / "model"
+        mock_store.ensure_downloaded.assert_called_once_with("org/model")
+
+    def test_unresolved_name_falls_back_to_the_raw_arg(self, monkeypatch, tmp_path):
+        from olmlx.cli import _resolve_and_download
+
+        mock_store = MagicMock()
+        mock_store.registry.resolve.return_value = None  # direct HF path
+        mock_store.ensure_downloaded.return_value = tmp_path / "model"
+        monkeypatch.setattr("olmlx.cli._create_store", lambda: mock_store)
+
+        _resolve_and_download("org/direct-path")
+        mock_store.ensure_downloaded.assert_called_once_with("org/direct-path")
+
+    def test_download_failure_exits_1_with_clean_stderr(self, monkeypatch, capsys):
+        from olmlx.cli import _resolve_and_download
+
+        mock_store = MagicMock()
+        mock_store.registry.resolve.return_value = None
+        mock_store.ensure_downloaded.side_effect = OSError(
+            "Repository Not Found for url: https://huggingface.co/not-a-model"
+        )
+        monkeypatch.setattr("olmlx.cli._create_store", lambda: mock_store)
+
+        with pytest.raises(SystemExit) as exc_info:
+            _resolve_and_download("not-a-model")
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "error" in captured.err.lower()
+        assert "not-a-model" in captured.err
+
+    def test_no_download_uses_local_path(self, monkeypatch, tmp_path):
+        from olmlx.cli import _resolve_and_download
+
+        mock_store = MagicMock()
+        resolved = MagicMock()
+        resolved.hf_path = "org/model"
+        mock_store.registry.resolve.return_value = resolved
+        mock_store.local_path.return_value = tmp_path / "model"
+        monkeypatch.setattr("olmlx.cli._create_store", lambda: mock_store)
+
+        store, local_dir = _resolve_and_download("mymodel", download=False)
+        assert local_dir == tmp_path / "model"
+        mock_store.local_path.assert_called_once_with("org/model")
+        mock_store.ensure_downloaded.assert_not_called()
+
+    def test_models_config_error_propagates_to_cli_main(self, monkeypatch):
+        from olmlx.cli import _resolve_and_download
+        from olmlx.engine.registry import ModelsConfigError
+
+        def _boom():
+            raise ModelsConfigError("bad models.json")
+
+        monkeypatch.setattr("olmlx.cli._create_store", _boom)
+        # Must NOT be swallowed into a generic exit(1) — cli_main has a
+        # dedicated clean-exit handler for this that names the file.
+        with pytest.raises(ModelsConfigError):
+            _resolve_and_download("mymodel")
 
 
 class TestServiceUninstall:
@@ -1676,17 +1777,22 @@ class TestCliMain:
         cli_main()
         mock_fn.assert_called_once()
 
-    def test_models_no_subcommand_shows_help(self, monkeypatch):
+    def test_models_no_subcommand_shows_help(self, monkeypatch, capsys):
+        # A command that requires a subcommand exits non-zero with help on
+        # stderr, so scripts / CI don't read the no-op as success (#635).
         monkeypatch.setattr("sys.argv", ["olmlx", "models"])
         with pytest.raises(SystemExit) as exc_info:
             cli_main()
-        assert exc_info.value.code == 0
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "usage" in captured.err.lower()
 
     def test_config_no_subcommand_shows_help(self, monkeypatch):
         monkeypatch.setattr("sys.argv", ["olmlx", "config"])
         with pytest.raises(SystemExit) as exc_info:
             cli_main()
-        assert exc_info.value.code == 0
+        assert exc_info.value.code == 2
 
     # --- Dispatch gaps: unregistered subcommand fallback paths ---
 
@@ -1694,13 +1800,13 @@ class TestCliMain:
         monkeypatch.setattr("sys.argv", ["olmlx", "service"])
         with pytest.raises(SystemExit) as exc_info:
             cli_main()
-        assert exc_info.value.code == 0
+        assert exc_info.value.code == 2
 
     def test_flash_no_subcommand_shows_help(self, monkeypatch):
         monkeypatch.setattr("sys.argv", ["olmlx", "flash"])
         with pytest.raises(SystemExit) as exc_info:
             cli_main()
-        assert exc_info.value.code == 0
+        assert exc_info.value.code == 2
 
     def test_flash_prepare_calls_handler(self, monkeypatch):
         monkeypatch.setattr("sys.argv", ["olmlx", "flash", "prepare", "some/model"])
@@ -1720,7 +1826,7 @@ class TestCliMain:
         monkeypatch.setattr("sys.argv", ["olmlx", "spectral"])
         with pytest.raises(SystemExit) as exc_info:
             cli_main()
-        assert exc_info.value.code == 0
+        assert exc_info.value.code == 2
 
     def test_spectral_prepare_calls_handler(self, monkeypatch):
         monkeypatch.setattr("sys.argv", ["olmlx", "spectral", "prepare", "some/model"])
@@ -1733,7 +1839,7 @@ class TestCliMain:
         monkeypatch.setattr("sys.argv", ["olmlx", "bench"])
         with pytest.raises(SystemExit) as exc_info:
             cli_main()
-        assert exc_info.value.code == 0
+        assert exc_info.value.code == 2
 
     def test_bench_run_calls_handler(self, monkeypatch):
         monkeypatch.setattr("sys.argv", ["olmlx", "bench", "run"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -739,3 +739,73 @@ class TestLegacyNamesInDotenv:
 
         monkeypatch.chdir(tmp_path)
         assert _legacy_names_in_dotenv(("OLMLX_EXPERIMENTAL_FLASH",)) == set()
+
+
+class TestParseDotenvValues:
+    """The single canonical ``.env`` value parser that the three legacy
+    dotenv helpers delegate to (#635)."""
+
+    def test_basic_assignment(self, monkeypatch, tmp_path):
+        from olmlx.config import parse_dotenv_values
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("KEY=value\n")
+        assert parse_dotenv_values(("KEY",)) == {"KEY": "value"}
+
+    def test_export_prefix_stripped(self, monkeypatch, tmp_path):
+        from olmlx.config import parse_dotenv_values
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("export KEY=value\n")
+        assert parse_dotenv_values(("KEY",)) == {"KEY": "value"}
+
+    def test_surrounding_quotes_stripped(self, monkeypatch, tmp_path):
+        from olmlx.config import parse_dotenv_values
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text('KEY="value"\n')
+        assert parse_dotenv_values(("KEY",)) == {"KEY": "value"}
+
+    def test_unquoted_inline_comment_stripped(self, monkeypatch, tmp_path):
+        from olmlx.config import parse_dotenv_values
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("KEY=value  # note\n")
+        assert parse_dotenv_values(("KEY",)) == {"KEY": "value"}
+
+    def test_hash_inside_quotes_preserved(self, monkeypatch, tmp_path):
+        from olmlx.config import parse_dotenv_values
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text('KEY="a#b"\n')
+        assert parse_dotenv_values(("KEY",)) == {"KEY": "a#b"}
+
+    def test_quoted_value_with_trailing_comment(self, monkeypatch, tmp_path):
+        """``KEY="turboquant:4" # note`` — the divergence the three parsers
+        disagreed on. The comment must be stripped AND the now-terminating
+        quotes removed, so the value is the bare ``turboquant:4``."""
+        from olmlx.config import parse_dotenv_values
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text('KEY="turboquant:4" # note\n')
+        assert parse_dotenv_values(("KEY",)) == {"KEY": "turboquant:4"}
+
+    def test_first_occurrence_wins(self, monkeypatch, tmp_path):
+        from olmlx.config import parse_dotenv_values
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("KEY=first\nKEY=second\n")
+        assert parse_dotenv_values(("KEY",)) == {"KEY": "first"}
+
+    def test_only_requested_names_returned(self, monkeypatch, tmp_path):
+        from olmlx.config import parse_dotenv_values
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("KEY=value\nOTHER=x\n")
+        assert parse_dotenv_values(("KEY",)) == {"KEY": "value"}
+
+    def test_missing_file_returns_empty(self, monkeypatch, tmp_path):
+        from olmlx.config import parse_dotenv_values
+
+        monkeypatch.chdir(tmp_path)
+        assert parse_dotenv_values(("KEY",)) == {}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1522,6 +1522,50 @@ class TestCorruptedJsonFiles:
         reg.load()
         assert reg._aliases == {}
 
+    def test_load_non_dict_aliases_json_ignored(self, tmp_path, monkeypatch):
+        """Valid-JSON-but-non-dict aliases.json must not be assigned raw.
+
+        A list of names is valid JSON, so ``json.load`` succeeds — but the
+        old code assigned it straight to ``self._aliases``, so ``resolve()``
+        would raise ``TypeError`` (``self._aliases[normalized]`` on a list)
+        on the *next request*, a 500 instead of a startup warning (#635).
+        """
+        config_path = tmp_path / "models.json"
+        config_path.write_text("{}")
+        aliases_path = tmp_path / "aliases.json"
+        aliases_path.write_text('["foo", "bar"]')
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+        reg.load()
+        assert reg._aliases == {}
+        # resolve() must not raise TypeError for a plain name lookup.
+        assert reg.resolve("foo") is None
+
+    def test_load_unreadable_aliases_json_ignored(self, tmp_path, monkeypatch):
+        """An OSError reading aliases.json must warn-and-skip, not propagate.
+
+        aliases.json is rebuildable, so a permissions error should degrade to
+        an empty alias table rather than a raw traceback out of ``load()``
+        (#635).
+        """
+        config_path = tmp_path / "models.json"
+        config_path.write_text("{}")
+        aliases_path = tmp_path / "aliases.json"
+        aliases_path.write_text('{"a:latest": "b:latest"}')
+        monkeypatch.setattr("olmlx.engine.registry.settings.models_config", config_path)
+        reg = ModelRegistry()
+
+        real_open = open
+
+        def _raise_on_aliases(path, *args, **kwargs):
+            if str(path) == str(aliases_path):
+                raise PermissionError("denied")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", _raise_on_aliases)
+        reg.load()  # must not raise
+        assert reg._aliases == {}
+
 
 class TestExtraKeysPreserved:
     """Unknown JSON keys in model config dicts must survive round-trips."""

--- a/tests/test_routers_metrics.py
+++ b/tests/test_routers_metrics.py
@@ -51,6 +51,49 @@ def test_metrics_middleware_counts_requests_and_sets_surface():
     assert metrics.HTTP_IN_FLIGHT._value.get() == 0.0
 
 
+def test_in_flight_and_duration_span_the_whole_streaming_body():
+    """MetricsMiddleware must record duration / decrement in-flight only after
+    the *entire* response body has streamed — not at TTFT, which is when
+    BaseHTTPMiddleware's ``call_next`` returns for a streaming response.
+
+    Old behavior: the ``finally`` block decremented HTTP_IN_FLIGHT and recorded
+    the duration histogram as soon as headers were sent, so in-flight read 0
+    and the duration measured ~TTFT during the entire generation (#635).
+    """
+    from olmlx.app import MetricsMiddleware
+
+    app = FastAPI()
+    app.add_middleware(MetricsMiddleware)
+    inflight_during: list[float] = []
+
+    @app.get("/v1/chat/completions")
+    async def stream():
+        async def body():
+            for i in range(3):
+                inflight_during.append(metrics.HTTP_IN_FLIGHT._value.get())
+                yield f"chunk{i}\n"
+
+        return StreamingResponse(body())
+
+    client = TestClient(app)
+    baseline = metrics.HTTP_IN_FLIGHT._value.get()
+    before = metrics.HTTP_REQUESTS.labels(
+        path="/v1/chat/completions", method="GET", status="200"
+    )._value.get()
+
+    resp = client.get("/v1/chat/completions")
+    assert resp.status_code == 200
+    # While the body streams, the request is still in flight (baseline + 1).
+    assert inflight_during == [baseline + 1.0] * 3
+    # After the full body is consumed, in-flight returns to baseline and the
+    # request is counted exactly once.
+    assert metrics.HTTP_IN_FLIGHT._value.get() == baseline
+    after = metrics.HTTP_REQUESTS.labels(
+        path="/v1/chat/completions", method="GET", status="200"
+    )._value.get()
+    assert after == before + 1
+
+
 def test_surface_var_survives_into_streaming_body():
     """Regression: the engine reads surface_var.get() while the streaming body
     is being consumed, which happens AFTER MetricsMiddleware.dispatch's finally


### PR DESCRIPTION
Two grouped robustness issues from the Fable 5 whole-repo review, both CLI/config-scoped and fully unit-tested (no GPU).

## #635 — config / CLI / observability robustness
- **aliases.json** (`registry.py`): now catches `OSError` and validates the parsed value is a dict. A valid-JSON non-dict (e.g. a list of names) used to sail past `json.load` and only blow up later at `self._aliases[normalized]` in `resolve()` — a 500 on every request for that name instead of a startup warning. A permissions error used to propagate a raw traceback out of `load()`.
- **MetricsMiddleware TTFT** (`app.py`): wraps the response body iterator so `HTTP_IN_FLIGHT` / the duration histogram record when the *entire* body has streamed, not at TTFT. With `BaseHTTPMiddleware`, `call_next` returns when headers are sent, so streaming `/api/chat` + `/v1/chat/completions` requests (the dominant workload) were clocked at ~TTFT and read in-flight `0` during active generation.
- **`.env` parser drift** (`config.py` + `cli.py`): one canonical `parse_dotenv_values()` replaces three hand-rolled parsers that had diverged — the kv-quant variant re-checked for quotes after stripping an inline comment while the speculative one did not, so `KEY="turboquant:4" # note` parsed differently across them. The three legacy helpers now delegate.
- **Non-atomic seed** (`cli.py`): `ensure_config` seeds `models.json` via the existing atomic writer, so a crash mid-write can't leave a truncated file that the strict loader then hard-refuses to start on.
- **Exit codes** (`cli.py`): a command that requires a subcommand (`olmlx models`, `config`, …) now prints help to **stderr** and exits **2** instead of stdout + exit 0, so scripts/CI don't read the no-op as success.

## #630 — prepare-family robustness
- One guarded `_resolve_and_download()` helper replaces six copy-pasted `resolve + ensure_downloaded` blocks that dumped a raw `huggingface_hub` traceback on a typo'd/offline/gated model name. It now prints a clean error and exits 1 (re-raising `ModelsConfigError` so `cli_main`'s dedicated handler still reports it). `flash info` reuses it with `download=False`.
- The dead `OLMLX_EXPERIMENTAL_FLASH_MOE=true` instruction the issue also named was already fixed in a prior change (both sites now print `OLMLX_FLASH_MOE=true`), so only the resolve+download half remained.

## Testing
TDD throughout — each fix has a test written to fail first. New/updated tests in `test_registry.py`, `test_config.py`, `test_routers_metrics.py`, `test_cli.py`. Full affected sweep green (647 passed); the one pre-existing local-only `test_lists_no_models` failure is unrelated (dev `models.json` synthetic panels — fails on `main` too, clean on CI). `ruff check` + `ruff format` clean.

Closes #635
Closes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)