### PR TITLE
fix(speculative): rotating-aware cache trim on SWA targets (#605)

### DIFF
--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -27,7 +27,6 @@ from typing import Any
 import mlx.core as mx
 import mlx.nn as nn
 from mlx_lm.models.cache import (
-    RotatingKVCache,
     can_trim_prompt_cache,
     make_prompt_cache,
 )
@@ -40,94 +39,20 @@ from olmlx.engine.gdn_rollback import (
 )
 from olmlx.engine.spec_decoder_base import (
     SpecDecoderBase,
-    # Canonical home moved to spec_decoder_base (#467); re-exported here
-    # because cli, prepare, eagle/mtp tests and scripts import them from
-    # this module.
+    # Canonical home moved to spec_decoder_base; re-exported here because cli,
+    # prepare, eagle/mtp tests and scripts import them from this module.
+    # ``_trim_recent_cache`` (+ its rotating-KV probe) moved there in #605 so
+    # classic/PLD/EAGLE share the same rotating-aware trim.
+    _HAS_ROTATING_KV_PRIVATES as _HAS_ROTATING_KV_PRIVATES,
     _LayerHook as _LayerHook,
     _patch_model as _patch_model,
+    _probe_rotating_kv_privates as _probe_rotating_kv_privates,
+    _trim_recent_cache as _trim_recent_cache,
     _unpatch_model as _unpatch_model,
 )
 from olmlx.engine.speculative import _eval_cache
 
-
-# ``_trim_recent_cache`` reaches into ``RotatingKVCache._temporal_order`` and
-# ``._idx`` to reorder + slice the rotating buffer. These are private to mlx-lm
-# and may be renamed without a semver bump. Probe at import time so an
-# incompatible mlx-lm release fails fast (rather than mid-generation when
-# DFlash first hits a sliding-window draft cache). ``_temporal_order`` is a
-# method (class-level), but ``_idx`` is set in ``__init__`` (instance-level),
-# so it must be probed via a sentinel instance — and its semantic (integer
-# write-position counter that advances with ``update_and_fetch``) must hold
-# too, otherwise the trim writes a corrupt value back.
-def _probe_rotating_kv_privates() -> bool:
-    if not hasattr(RotatingKVCache, "_temporal_order"):
-        return False
-    try:
-        c = RotatingKVCache(max_size=4, keep=0)
-        if not hasattr(c, "_idx"):
-            return False
-        if not isinstance(c._idx, int) or c._idx != 0:
-            return False
-        # One ``update_and_fetch`` should advance ``_idx`` by exactly the
-        # number of tokens written. If the semantic changed (e.g. it
-        # became a ring-buffer wrap counter or a bool flag), the trim
-        # math in ``_trim_recent_cache`` would silently corrupt state.
-        k = v = mx.zeros((1, 1, 1, 4))
-        c.update_and_fetch(k, v)
-        return isinstance(c._idx, int) and c._idx == 1
-    except Exception:
-        return False
-
-
-_HAS_ROTATING_KV_PRIVATES = _probe_rotating_kv_privates()
-
 logger = logging.getLogger(__name__)
-
-
-def _trim_recent_cache(cache: list[Any], num_tokens: int) -> None:
-    """Trim trailing ``num_tokens`` from each layer's KV cache.
-
-    Special-cases ``RotatingKVCache`` (must reorder before slicing).
-    Skips entries with no ``trim`` method — the GDN rollback path
-    handles those separately.
-    """
-    if num_tokens <= 0:
-        return
-    for c in cache:
-        n = min(getattr(c, "offset", num_tokens), num_tokens)
-        if n <= 0:
-            continue
-        if isinstance(c, RotatingKVCache) and c.keys is not None:
-            if not _HAS_ROTATING_KV_PRIVATES:
-                raise RuntimeError(
-                    "DFlash trims target or draft KV caches with rotating "
-                    "windows via the private mlx-lm API "
-                    "``RotatingKVCache._temporal_order`` / ``._idx``. The "
-                    "installed mlx-lm version no longer exposes them — pin "
-                    "a compatible version or file an olmlx bug to update "
-                    "the private-API access pattern."
-                )
-            # ``cache.offset`` is the *absolute* token counter mlx-lm
-            # passes to RoPE as the next-write base position — not the
-            # buffer size. A previous version set ``c.offset =
-            # actual_stored - n``, which threw away the absolute count
-            # and applied wrong RoPE positions to all subsequent
-            # writes for sliding-window targets that had already
-            # rotated. Decrementing ``c.offset`` by exactly ``n``
-            # preserves the absolute-position semantic. ``c._idx`` is
-            # the in-buffer write pointer; setting it to the new buffer
-            # length leaves ``update_and_fetch`` to grow / rotate the
-            # buffer normally on the next write.
-            actual_stored = min(c.offset, c.keys.shape[2])
-            n = min(n, actual_stored)
-            c.keys = c._temporal_order(c.keys)
-            c.values = c._temporal_order(c.values)
-            c.keys = c.keys[..., :-n, :]
-            c.values = c.values[..., :-n, :]
-            c.offset = c.offset - n
-            c._idx = c.keys.shape[2]
-        elif hasattr(c, "trim"):
-            c.trim(n)
 
 
 # ---------------------------------------------------------------------------

--- a/olmlx/engine/eagle/decoder.py
+++ b/olmlx/engine/eagle/decoder.py
@@ -46,18 +46,16 @@ from olmlx.engine.gdn_rollback import (
     get_model_layers as _get_layers,
 )
 from olmlx.engine.eagle.draft_model import EagleDraftModel
-from olmlx.engine.spec_decoder_base import SpecDecoderBase
+from olmlx.engine.spec_decoder_base import SpecDecoderBase, _trim_recent_cache
 from olmlx.engine.speculative import _eval_cache
 
 try:
     from mlx_lm.models.cache import (
         can_trim_prompt_cache,
         make_prompt_cache,
-        trim_prompt_cache,
     )
 except ImportError:  # pragma: no cover - mlx-lm always installed in production
     make_prompt_cache = None  # type: ignore[assignment]
-    trim_prompt_cache = None  # type: ignore[assignment]
     can_trim_prompt_cache = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
@@ -440,8 +438,13 @@ class EagleDecoder(SpecDecoderBase):
         trim_draft = self._block_size - num_accepted
         if trim_target > 0:
             if self._target_can_trim:
-                if trim_prompt_cache is not None:
-                    trim_prompt_cache(self._target_cache, trim_target)
+                # Rotating-aware trim: mlx-lm's ``trim_prompt_cache`` is
+                # all-or-nothing and silently no-ops on filled
+                # sliding-window (``RotatingKVCache``) targets, leaving
+                # rejected draft tokens resident and corrupting output
+                # (#605). ``_target_can_trim`` was frozen at prefill on the
+                # empty cache, so a rotating target reaches this branch.
+                _trim_recent_cache(self._target_cache, trim_target)
             else:
                 # Hybrid linear-attention path. ``_capture`` was created
                 # in prefill; same control-flow invariant guards as
@@ -482,8 +485,8 @@ class EagleDecoder(SpecDecoderBase):
         # Draft cache trim — the draft is always a standard-attention
         # transformer with trim-able KVCache, so this path is the same
         # regardless of target architecture.
-        if trim_prompt_cache is not None and trim_draft > 0:
-            trim_prompt_cache(self._draft_cache, trim_draft)
+        if trim_draft > 0:
+            _trim_recent_cache(self._draft_cache, trim_draft)
         elif num_accepted > self._block_size:
             # Full acceptance: the draft cache holds only block_size
             # entries but all block_size drafts (plus the bonus token)

--- a/olmlx/engine/spec_decoder_base.py
+++ b/olmlx/engine/spec_decoder_base.py
@@ -45,6 +45,11 @@ from typing import Any
 import mlx.core as mx
 import mlx.nn as nn
 
+try:  # mlx-lm is a hard runtime dep, but keep import-safe like speculative.py
+    from mlx_lm.models.cache import RotatingKVCache
+except ImportError:  # pragma: no cover - environments without mlx-lm
+    RotatingKVCache = None  # type: ignore[assignment,misc]
+
 from olmlx.engine.gdn_rollback import (
     GDNBuffer,
     GDNStateCapture,
@@ -53,6 +58,98 @@ from olmlx.engine.gdn_rollback import (
 from olmlx.utils import tracing as _tracing
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Rotating-aware cache trim (shared by every speculative decoder)
+# ---------------------------------------------------------------------------
+#
+# ``_trim_recent_cache`` reaches into ``RotatingKVCache._temporal_order`` and
+# ``._idx`` to reorder + slice the rotating buffer. These are private to mlx-lm
+# and may be renamed without a semver bump. Probe at import time so an
+# incompatible mlx-lm release fails fast (rather than mid-generation when a
+# decoder first hits a sliding-window cache). ``_temporal_order`` is a method
+# (class-level), but ``_idx`` is set in ``__init__`` (instance-level), so it
+# must be probed via a sentinel instance — and its semantic (integer
+# write-position counter that advances with ``update_and_fetch``) must hold
+# too, otherwise the trim writes a corrupt value back.
+def _probe_rotating_kv_privates() -> bool:
+    if RotatingKVCache is None or not hasattr(RotatingKVCache, "_temporal_order"):
+        return False
+    try:
+        c = RotatingKVCache(max_size=4, keep=0)
+        if not hasattr(c, "_idx"):
+            return False
+        if not isinstance(c._idx, int) or c._idx != 0:
+            return False
+        # One ``update_and_fetch`` should advance ``_idx`` by exactly the
+        # number of tokens written. If the semantic changed (e.g. it
+        # became a ring-buffer wrap counter or a bool flag), the trim
+        # math in ``_trim_recent_cache`` would silently corrupt state.
+        k = v = mx.zeros((1, 1, 1, 4))
+        c.update_and_fetch(k, v)
+        return isinstance(c._idx, int) and c._idx == 1
+    except Exception:
+        return False
+
+
+_HAS_ROTATING_KV_PRIVATES = _probe_rotating_kv_privates()
+
+
+def _trim_recent_cache(cache: list[Any], num_tokens: int) -> None:
+    """Trim trailing ``num_tokens`` from each layer's KV cache.
+
+    Special-cases ``RotatingKVCache`` (must reorder before slicing).
+    Skips entries with no ``trim`` method — the GDN rollback path
+    handles those separately.
+
+    Used in place of mlx-lm's ``trim_prompt_cache`` on the speculative
+    reject-rollback path: that helper is all-or-nothing and silently
+    no-ops once *any* rotating layer's window has filled
+    (``is_trimmable()`` is ``offset < max_size``), leaving rejected draft
+    tokens resident on sliding-window targets (#605).
+    """
+    if num_tokens <= 0:
+        return
+    for c in cache:
+        n = min(getattr(c, "offset", num_tokens), num_tokens)
+        if n <= 0:
+            continue
+        if (
+            RotatingKVCache is not None
+            and isinstance(c, RotatingKVCache)
+            and c.keys is not None
+        ):
+            if not _HAS_ROTATING_KV_PRIVATES:
+                raise RuntimeError(
+                    "Speculative decoding trims KV caches with rotating "
+                    "windows via the private mlx-lm API "
+                    "``RotatingKVCache._temporal_order`` / ``._idx``. The "
+                    "installed mlx-lm version no longer exposes them — pin "
+                    "a compatible version or file an olmlx bug to update "
+                    "the private-API access pattern."
+                )
+            # ``cache.offset`` is the *absolute* token counter mlx-lm
+            # passes to RoPE as the next-write base position — not the
+            # buffer size. A previous version set ``c.offset =
+            # actual_stored - n``, which threw away the absolute count
+            # and applied wrong RoPE positions to all subsequent
+            # writes for sliding-window targets that had already
+            # rotated. Decrementing ``c.offset`` by exactly ``n``
+            # preserves the absolute-position semantic. ``c._idx`` is
+            # the in-buffer write pointer; setting it to the new buffer
+            # length leaves ``update_and_fetch`` to grow / rotate the
+            # buffer normally on the next write.
+            actual_stored = min(c.offset, c.keys.shape[2])
+            n = min(n, actual_stored)
+            c.keys = c._temporal_order(c.keys)
+            c.values = c._temporal_order(c.values)
+            c.keys = c.keys[..., :-n, :]
+            c.values = c.values[..., :-n, :]
+            c.offset = c.offset - n
+            c._idx = c.keys.shape[2]
+        elif hasattr(c, "trim"):
+            c.trim(n)
 
 
 # ---------------------------------------------------------------------------

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -37,6 +37,7 @@ from olmlx.engine.spec_decoder_base import (
     # Canonical home moved to spec_decoder_base (#467); re-exported here
     # for remaining importers (tests; the decoders verify via the base's
     # ``_verify_greedy`` instead).
+    _trim_recent_cache,
     verify_draft_greedy as verify_draft_greedy,
 )
 from olmlx.utils import tracing as _tracing
@@ -914,8 +915,12 @@ class SpeculativeDecoder(SpecDecoderBase):
                     accepted=num_accepted - 1,
                     trim=trim_target,
                 )
-            elif trim_prompt_cache is not None:
-                trim_prompt_cache(self._target_cache, trim_target)
+            else:
+                # Rotating-aware trim: mlx-lm's ``trim_prompt_cache`` is
+                # all-or-nothing and silently no-ops on sliding-window
+                # (``RotatingKVCache``) targets once the window fills,
+                # leaving rejected draft tokens resident (#605).
+                _trim_recent_cache(self._target_cache, trim_target)
 
         if trim_draft > 0:
             if self._draft_gdn_buffer is not None and self._gdn_capture is not None:
@@ -926,8 +931,8 @@ class SpeculativeDecoder(SpecDecoderBase):
                     num_keep_steps=num_accepted,
                     trim=trim_draft,
                 )
-            elif trim_prompt_cache is not None:
-                trim_prompt_cache(self._draft_cache, trim_draft)
+            else:
+                _trim_recent_cache(self._draft_cache, trim_draft)
 
         # On full acceptance, align draft cache with target cache.
         # ``use_buffer(None)`` was already called after the target
@@ -1638,9 +1643,10 @@ class PromptLookupDecoder(SpecDecoderBase):
                     trim=trim_target,
                 )
             else:
-                # ``trim_prompt_cache`` is guaranteed non-None here
-                # because ``__init__`` enforces it at construction.
-                trim_prompt_cache(self._target_cache, trim_target)
+                # Rotating-aware trim (see classic decoder / #605):
+                # mlx-lm's ``trim_prompt_cache`` no-ops on filled
+                # sliding-window caches, corrupting SWA targets.
+                _trim_recent_cache(self._target_cache, trim_target)
 
         # 5. Update state. The cache now contains the original prompt
         # plus the pending token plus the first (num_accepted - 1)

--- a/tests/test_eagle.py
+++ b/tests/test_eagle.py
@@ -853,17 +853,18 @@ class TestEagleDecoderGDNPath:
 
         monkeypatch.setattr(base_mod, "GDNStateCapture", _FakeCapture)
 
-        # ``trim_prompt_cache`` for target should NOT be called when
-        # we're in the GDN regime. Patch it to detect.
+        # The rotating-aware trim (``_trim_recent_cache``, #605) for the
+        # target should NOT be called when we're in the GDN regime — the
+        # rollback path handles it instead. Patch it to detect.
         target_trim_calls = {"count": 0}
-        original_trim = decoder_mod.trim_prompt_cache
+        original_trim = decoder_mod._trim_recent_cache
 
         def recording_trim(cache, n):
             target_trim_calls["count"] += 1
             if original_trim is not None:
                 original_trim(cache, n)
 
-        monkeypatch.setattr(decoder_mod, "trim_prompt_cache", recording_trim)
+        monkeypatch.setattr(decoder_mod, "_trim_recent_cache", recording_trim)
 
         decoder, _, _ = _make_decoder(block_size=2)
         decoder.prefill(mx.array([[1, 2, 3]], dtype=mx.int32))

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -112,6 +112,51 @@ class TestSpeculativeDecoder:
         assert decoder._cache_seq_len == 3 + len(accepted)
         assert decoder._target_cache[0].offset == decoder._cache_seq_len
 
+    def test_cache_trimmed_on_rejection_sliding_window(self):
+        """Rejected draft tokens must be trimmed from a *filled* sliding-window
+        target cache. mlx-lm's ``trim_prompt_cache`` is all-or-nothing and
+        silently no-ops once a ``RotatingKVCache``'s window has rotated
+        (``is_trimmable()`` is ``offset < max_size``) — leaving rejected tokens
+        resident and corrupting subsequent generation (#605). The decoder must
+        use the rotating-aware trim instead.
+        """
+        from mlx_lm.models.cache import RotatingKVCache
+
+        from olmlx.engine.speculative import SpeculativeDecoder
+
+        vocab_size, hidden_size = 32, 16
+        draft = MockModel(vocab_size, hidden_size)
+        target = MockModel(vocab_size, hidden_size)
+        decoder = SpeculativeDecoder(
+            draft_model=draft,
+            target_model=target,
+            num_speculative_tokens=4,
+        )
+
+        prompt = mx.array([[1, 2, 3]])
+        decoder.prefill(prompt)
+
+        # Swap in filled sliding-window target caches whose window has already
+        # rotated (max_size == prompt length, so offset == max_size). mlx-lm's
+        # blind ``trim_prompt_cache`` no-ops on these.
+        seq = decoder._cache_seq_len
+        rotating = [RotatingKVCache(max_size=seq, keep=0) for _ in target.layers]
+        target(prompt, cache=rotating)
+        for c in rotating:
+            assert not c.is_trimmable(), "window must be full for the regression"
+        decoder._target_cache = rotating
+
+        # Force a partial rejection (accept 2 of 4 drafts) so a trim is required.
+        decoder._verify = lambda draft_tokens, _logits: list(draft_tokens[:2])
+
+        accepted, _ = decoder.step()
+
+        assert len(accepted) == 2
+        assert decoder._cache_seq_len == seq + 2
+        # Trim must have removed the rejected suffix; a no-op leaves the cache
+        # offset inflated past the committed length.
+        assert decoder._target_cache[0].offset == decoder._cache_seq_len
+
     def test_reset_clears_state(self, shared_decoder):
         prompt = mx.array([[1, 2, 3]])
         shared_decoder.prefill(prompt)

--- a/tests/test_speculative_hybrid.py
+++ b/tests/test_speculative_hybrid.py
@@ -300,7 +300,7 @@ class TestStepRollbackDispatch:
     def test_target_hybrid_calls_rollback_single(self):
         """Hybrid target + dense draft: target rollback uses
         rollback_single with accepted=num_accepted-1; draft falls
-        through to plain trim_prompt_cache."""
+        through to the rotating-aware _trim_recent_cache."""
         dec = self._make_decoder(target_hybrid=True, draft_hybrid=False)
         try:
             # Simulate post-prefill state.
@@ -319,7 +319,7 @@ class TestStepRollbackDispatch:
             # Patch rollback methods.
             dec._gdn_capture.rollback_single = MagicMock()
             dec._gdn_capture.rollback_autoregressive = MagicMock()
-            with patch("olmlx.engine.speculative.trim_prompt_cache") as trim_fn:
+            with patch("olmlx.engine.speculative._trim_recent_cache") as trim_fn:
                 dec.step()
             # Target rollback: single-forward, accepted=num_accepted-1=1, trim=λ+1-na=3
             dec._gdn_capture.rollback_single.assert_called_once_with(
@@ -328,9 +328,9 @@ class TestStepRollbackDispatch:
                 accepted=1,
                 trim=3,
             )
-            # Draft rollback: no GDN — falls through to trim_prompt_cache
+            # Draft rollback: no GDN — falls through to _trim_recent_cache
             dec._gdn_capture.rollback_autoregressive.assert_not_called()
-            # trim_prompt_cache called on draft only (target uses rollback_single)
+            # _trim_recent_cache called on draft only (target uses rollback_single)
             trim_fn.assert_called_once_with(dec._draft_cache, 2)
         finally:
             dec.close()
@@ -338,7 +338,7 @@ class TestStepRollbackDispatch:
     def test_draft_hybrid_calls_rollback_autoregressive(self):
         """Dense target + hybrid draft: draft uses
         rollback_autoregressive with num_steps=λ, num_keep_steps=
-        num_accepted; target falls through to plain trim_prompt_cache."""
+        num_accepted; target falls through to the rotating-aware _trim_recent_cache."""
         dec = self._make_decoder(target_hybrid=False, draft_hybrid=True)
         try:
             dec._pending_token = 1
@@ -352,7 +352,7 @@ class TestStepRollbackDispatch:
             dec._verify = MagicMock(return_value=[1])  # num_accepted=1
             dec._gdn_capture.rollback_single = MagicMock()
             dec._gdn_capture.rollback_autoregressive = MagicMock()
-            with patch("olmlx.engine.speculative.trim_prompt_cache") as trim_fn:
+            with patch("olmlx.engine.speculative._trim_recent_cache") as trim_fn:
                 dec.step()
             # Draft rollback: autoregressive, num_keep_steps=1, trim=λ-na=3
             dec._gdn_capture.rollback_autoregressive.assert_called_once_with(
@@ -363,7 +363,7 @@ class TestStepRollbackDispatch:
                 trim=3,
             )
             dec._gdn_capture.rollback_single.assert_not_called()
-            # Target trim via plain trim_prompt_cache (trim_target=4).
+            # Target trim via the rotating-aware _trim_recent_cache (trim_target=4).
             trim_fn.assert_called_once_with(dec._target_cache, 4)
         finally:
             dec.close()
@@ -392,10 +392,10 @@ class TestStepRollbackDispatch:
             dec._gdn_capture.rollback_autoregressive = MagicMock()
             # Avoid the align step's real forward by stubbing it.
             dec._draft = MagicMock(return_value=mx.zeros((1, 1, 50)))
-            with patch("olmlx.engine.speculative.trim_prompt_cache") as trim_fn:
+            with patch("olmlx.engine.speculative._trim_recent_cache") as trim_fn:
                 dec.step()
             # Full acceptance: trim_target=0, trim_draft<0 (clamped to 0).
-            # Neither rollback nor trim_prompt_cache should fire.
+            # Neither rollback nor _trim_recent_cache should fire.
             dec._gdn_capture.rollback_single.assert_not_called()
             dec._gdn_capture.rollback_autoregressive.assert_not_called()
             trim_fn.assert_not_called()
@@ -408,7 +408,7 @@ class TestStepRollbackDispatch:
     def test_both_hybrid_partial_acceptance(self):
         """The primary new scenario this PR enables — Qwen3.5+Qwen3.5
         with partial acceptance. BOTH rollback paths must fire with the
-        right args, no plain ``trim_prompt_cache`` call escapes to the
+        right args, no the rotating-aware ``_trim_recent_cache`` call escapes to the
         underlying hybrid caches."""
         dec = self._make_decoder(target_hybrid=True, draft_hybrid=True)
         try:
@@ -429,7 +429,7 @@ class TestStepRollbackDispatch:
             dec._target = MagicMock(return_value=target_logits)
             dec._gdn_capture.rollback_single = MagicMock()
             dec._gdn_capture.rollback_autoregressive = MagicMock()
-            with patch("olmlx.engine.speculative.trim_prompt_cache") as trim_fn:
+            with patch("olmlx.engine.speculative._trim_recent_cache") as trim_fn:
                 dec.step()
             # Partial acceptance: num_accepted=3, λ=4 → trim_target=2,
             # trim_draft=1.
@@ -446,7 +446,7 @@ class TestStepRollbackDispatch:
                 num_keep_steps=3,  # num_accepted
                 trim=1,  # λ - num_accepted
             )
-            # Crucially: plain ``trim_prompt_cache`` must NOT be called.
+            # Crucially: the rotating-aware ``_trim_recent_cache`` must NOT be called.
             # If it were, the hybrid caches' ArraysCache layers would
             # silently desync — exactly the bug this PR fixes.
             trim_fn.assert_not_called()


### PR DESCRIPTION
## Summary
Classic, PLD, and EAGLE speculative decoders called mlx-lm's `trim_prompt_cache` blindly after rejecting draft tokens. That helper is all-or-nothing: once **any** `RotatingKVCache` layer's window fills (`is_trimmable()` is `offset < max_size`), it trims **no** layer and returns 0. On sliding-window targets (gpt-oss, Gemma 3/4) this silently left rejected draft tokens resident — conditioning subsequent generation on garbage and drifting the cache offset from `_cache_seq_len`.

## Fix
- Promote DFlash's rotating-aware `_trim_recent_cache` (and its private-API probe `_probe_rotating_kv_privates` / `_HAS_ROTATING_KV_PRIVATES`) from `dflash/decoder.py` to the shared `spec_decoder_base.py`; re-export from dflash for existing importers.
- Use `_trim_recent_cache` in place of `trim_prompt_cache` on every reject-rollback path: classic (target + draft), PLD (target), EAGLE (target + draft). RotatingKVCache is `_temporal_order`-reordered before slicing and its absolute offset counter is preserved; standard `KVCache` trims unchanged. GDN rollback paths are untouched.

## Test
New regression `test_cache_trimmed_on_rejection_sliding_window` drives the classic decoder against a **filled** sliding-window target cache and asserts the rejected suffix is trimmed (`offset == committed length`), where the old blind trim left it inflated (verified RED before the fix: offset 8 vs 5). Existing EAGLE/hybrid trim tests retargeted to the shared helper.

Full speculative test set (281 tests across speculative/dflash/eagle/mtp/tree/hybrid/coverage) passes; ruff clean.

Closes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)