### PR TITLE
fix(flash): correctness fixes across Flash / Flash-MoE subsystem (#624)

### DIFF
--- a/olmlx/engine/flash/flash_model.py
+++ b/olmlx/engine/flash/flash_model.py
@@ -111,10 +111,28 @@ class FlashModelWrapper(nn.Module):
     ) -> None:
         """Replace each TransformerBlock.mlp with a FlashMLP."""
         layers = self._model.layers
+        bundled = weight_store.layer_indices
         replaced = 0
         for i, layer in enumerate(layers):
             if not hasattr(layer, "mlp"):
                 continue
+
+            if i not in bundled:
+                # The layer exposes an ``.mlp`` but has no bundled FFN weights.
+                # This happens on mixed dense/MoE models: the flash bundler
+                # only bundles dense FFN layers, but MoE blocks also satisfy
+                # ``hasattr(layer, "mlp")``. Wrapping it would KeyError in
+                # ``_read_neuron_raw`` on the first forward (#624). Fail at
+                # load with a clear, actionable message instead.
+                raise RuntimeError(
+                    f"Flash layer {i} has an MLP but no bundled weights in "
+                    f"flash_layout.json (bundled layers: "
+                    f"{sorted(bundled)}). This usually means a mixed "
+                    f"dense/MoE model was flash-prepared — only dense FFN "
+                    f"layers get bundled, but MoE blocks also expose an "
+                    f"``.mlp``. Flash (dense FFN offload) does not support "
+                    f"MoE layers; use flash-MoE for MoE models."
+                )
 
             flash_mlp = FlashMLP(
                 layer_idx=i,

--- a/olmlx/engine/flash/prepare.py
+++ b/olmlx/engine/flash/prepare.py
@@ -361,6 +361,25 @@ class _RecordingMLP(nn.Module):
         return result
 
 
+def _embed_normalizer(model: Any, inner: Any, hidden_size: int) -> float:
+    """Return the embedding scale a model applies in its forward pass.
+
+    Gemma-family models (gemma / gemma2 / gemma3_text / gemma3n /
+    gemma4_text) scale embeddings by ``sqrt(hidden_size)`` inside the model
+    forward — *not* inside ``embed_tokens``. Streaming calibration seeds
+    ``h = embed(input_ids)`` directly, so without replicating that scale the
+    predictors train on hidden states ~``sqrt(hidden_size)``x smaller than
+    the serving-time residual stream, dropping genuinely-active neurons from
+    the FFN output (quality corruption, #624). Non-Gemma models embed at
+    unit scale, so this returns ``1.0``.
+    """
+    for obj in (model, inner):
+        model_type = getattr(getattr(obj, "args", None), "model_type", None)
+        if isinstance(model_type, str) and model_type.startswith("gemma"):
+            return float(hidden_size) ** 0.5
+    return 1.0
+
+
 def _stream_record_activations(
     model_path: str,
     calibration_texts: list[str],
@@ -431,11 +450,18 @@ def _stream_record_activations(
 
     mx.eval(embed.parameters())
 
+    # Gemma-family models scale embeddings by sqrt(hidden_size) in the model
+    # forward; seeding calibration from a bare ``embed(...)`` would train the
+    # predictors on hidden states far too small vs serving time (#624).
+    embed_scale = _embed_normalizer(model, inner, hidden_size)
+
     hidden_states: list[mx.array | None] = []
     for text in calibration_texts:
         tokens = _encode_tokens(tokenizer, text)
         input_ids = mx.array([tokens])
         h = embed(input_ids)
+        if embed_scale != 1.0:
+            h = h * embed_scale
         mx.eval(h)
         hidden_states.append(h)
 

--- a/olmlx/engine/flash/weight_store.py
+++ b/olmlx/engine/flash/weight_store.py
@@ -76,9 +76,27 @@ class PreallocatedNeuronBuffer:
     def num_used(self) -> int:
         return self._num_used
 
+    @property
+    def capacity(self) -> int:
+        """Maximum number of neurons the buffer can hold."""
+        return self._max
+
     def contains(self, neuron_idx: int) -> bool:
         with self._lock:
             return neuron_idx in self._neuron_to_slot
+
+    def touch(self, neuron_indices: list[int]) -> None:
+        """Mark the given cached neurons most-recently-used.
+
+        Absent neurons are ignored. Refreshing the LRU order of the neurons
+        needed for the current forward *before* inserting its missing batch
+        guarantees the inserts evict only unrequested neurons (#624) — safe
+        whenever the distinct request count does not exceed ``capacity``.
+        """
+        with self._lock:
+            for idx in neuron_indices:
+                if idx in self._access_order:
+                    self._access_order.move_to_end(idx)
 
     def insert(
         self,
@@ -167,6 +185,12 @@ class FlashWeightStore:
         self._layouts = self._load_layouts()
 
         if use_preallocated_buffer:
+            if cache_budget_neurons < 1:
+                raise ValueError(
+                    "flash_cache_budget_neurons must be >= 1 when "
+                    "flash_preallocated_buffer is enabled; a zero-capacity "
+                    f"buffer can hold no neurons (got {cache_budget_neurons})."
+                )
             for layer_idx, layout in self._layouts.items():
                 np_dtype = _NP_DTYPE[layout.dtype]
                 # Pass mx_dtype for reinterpretation when numpy can't represent
@@ -189,6 +213,16 @@ class FlashWeightStore:
         except Exception:
             self.close()
             raise
+
+    @property
+    def layer_indices(self) -> frozenset[int]:
+        """Layer indices with bundled FFN weights in ``flash_layout.json``.
+
+        A layer with an ``.mlp`` but no entry here has no bundled weights —
+        wrapping it with a ``FlashMLP`` would ``KeyError`` on the first
+        forward (mixed dense/MoE model, #624).
+        """
+        return frozenset(self._layouts.keys())
 
     def _load_layouts(self) -> dict[int, BundledLayerLayout]:
         config_path = self._flash_dir / "flash_layout.json"
@@ -285,9 +319,29 @@ class FlashWeightStore:
         """Load neurons using the preallocated buffer path.
 
         Determines cached/missing under the lock to prevent TOCTOU races,
-        then releases for I/O, then re-acquires for insert + read.
+        then releases for I/O, then re-acquires to touch-insert-read.
+
+        Before inserting the missing batch the requested neurons are touched
+        to most-recently-used, so the inserts evict only *unrequested*
+        neurons — this is what stops a requested-but-cached neuron from being
+        evicted mid-forward and then KeyError-ing in ``get_matrices`` (#624).
+        That guarantee only holds when the number of distinct requested
+        neurons does not exceed the buffer capacity, so reject that up front
+        with a clear error instead of failing cryptically later.
         """
         buf = self._buffers[layer_idx]
+
+        distinct = set(neuron_indices)
+        if len(distinct) > buf.capacity:
+            raise RuntimeError(
+                f"Flash preallocated-buffer layer {layer_idx} needs "
+                f"{len(distinct)} active neurons in one forward but the buffer "
+                f"holds only {buf.capacity} (flash_cache_budget_neurons). "
+                f"Increase flash_cache_budget_neurons to at least the "
+                f"active-neuron count, cap active neurons "
+                f"(flash_max_active_neurons), or disable "
+                f"flash_preallocated_buffer."
+            )
 
         # Determine missing under lock to prevent concurrent eviction
         with buf.lock:
@@ -305,15 +359,17 @@ class FlashWeightStore:
 
         # Insert under lock, then check for eviction races
         with buf.lock:
+            buf.touch(neuron_indices)
             for idx, (gate, up, down) in loaded.items():
                 buf.insert(idx, gate, up, down)
             _, still_missing = buf.get_cached_indices(neuron_indices)
             if not still_missing:
                 return buf.get_matrices(neuron_indices)
 
-        # Re-fetch evicted neurons outside the lock (rare path)
+        # Re-fetch neurons evicted by a concurrent forward (rare path)
         extra = {idx: self._read_neuron_raw(layer_idx, idx) for idx in still_missing}
         with buf.lock:
+            buf.touch(neuron_indices)
             for idx, (gate, up, down) in extra.items():
                 buf.insert(idx, gate, up, down)
             return buf.get_matrices(neuron_indices)

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -3209,6 +3209,7 @@ class ModelManager(SpeculativeLoaderMixin):
         # them or every failed attempt permanently leaks num_layers fds + the
         # thread pools (#624).
         wrapped: Any = None
+        draft_model: Any = None
         try:
             # Load lookahead predictors if available (for speculative prefetching)
             lookahead_bank = None
@@ -3248,7 +3249,7 @@ class ModelManager(SpeculativeLoaderMixin):
                     "Loading draft model %s for speculative decoding",
                     flash_config.flash_speculative_draft_model,
                 )
-                draft_model, draft_tokenizer = load_model_with_strict_fallback(
+                draft_model, _draft_tokenizer = load_model_with_strict_fallback(
                     flash_config.flash_speculative_draft_model, lazy=False
                 )
 
@@ -3296,6 +3297,12 @@ class ModelManager(SpeculativeLoaderMixin):
                 weight_store.close()
             except Exception:
                 logger.exception("Error closing weight store after failed flash load")
+            # If the speculative branch loaded a draft model before failing
+            # (e.g. the vocab-mismatch raise), drop its reference and return
+            # its GPU weights to the pool promptly rather than waiting for GC.
+            if draft_model is not None:
+                del draft_model
+                mx.clear_cache()
             raise
 
     def _flash_moe_dir(self, hf_path: str) -> Path | None:

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -3203,66 +3203,100 @@ class ModelManager(SpeculativeLoaderMixin):
             use_preallocated_buffer=model_exp.flash_preallocated_buffer,
         )
 
-        # Load lookahead predictors if available (for speculative prefetching)
-        lookahead_bank = None
-        lookahead_path = flash_dir / "lookahead_predictors"
-        if flash_config.prefetch and lookahead_path.exists():
+        # ``FlashWeightStore.__init__`` opened one fd per layer and a thread
+        # pool; ``FlashModelWrapper`` adds a prefetcher pool. Any failure from
+        # here on (wrapper build, draft-model load, vocab mismatch) must close
+        # them or every failed attempt permanently leaks num_layers fds + the
+        # thread pools (#624).
+        wrapped: Any = None
+        try:
+            # Load lookahead predictors if available (for speculative prefetching)
+            lookahead_bank = None
+            lookahead_path = flash_dir / "lookahead_predictors"
+            if flash_config.prefetch and lookahead_path.exists():
+                try:
+                    lookahead_bank = LookaheadBank.load(lookahead_path)
+                    logger.info(
+                        "Loaded lookahead predictor bank from %s", lookahead_path
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to load lookahead predictors, falling back to "
+                        "sparsity predictor",
+                        exc_info=True,
+                    )
+
+            # Wrap model — this replaces FFN layers and frees original weights
+            wrapped = FlashModelWrapper(
+                model,
+                predictor_bank,
+                weight_store,
+                runtime_flash_config,
+                lookahead_bank,
+            )
+
+            if flash_config.flash_speculative:
+                from olmlx.engine.flash.speculative import SpeculativeFlashDecoder
+
+                if not flash_config.flash_speculative_draft_model:
+                    raise ValueError(
+                        "flash_speculative requires flash_speculative_draft_model "
+                        "to be set (OLMLX_FLASH_SPECULATIVE_DRAFT_MODEL)"
+                    )
+
+                logger.info(
+                    "Loading draft model %s for speculative decoding",
+                    flash_config.flash_speculative_draft_model,
+                )
+                draft_model, draft_tokenizer = load_model_with_strict_fallback(
+                    flash_config.flash_speculative_draft_model, lazy=False
+                )
+
+                # Verify vocab compatibility — a mismatch causes silent token ID errors
+                target_vocab = getattr(
+                    getattr(wrapped, "args", None), "vocab_size", None
+                )
+                draft_vocab = getattr(
+                    getattr(draft_model, "args", None), "vocab_size", None
+                )
+                if (
+                    target_vocab is not None
+                    and draft_vocab is not None
+                    and target_vocab != draft_vocab
+                ):
+                    raise ValueError(
+                        f"Draft model vocab_size ({draft_vocab}) does not match "
+                        f"target model vocab_size ({target_vocab}). "
+                        f"Speculative decoding requires matching vocabularies."
+                    )
+
+                decoder = SpeculativeFlashDecoder(
+                    draft_model=draft_model,
+                    target_model=wrapped,
+                    num_speculative_tokens=flash_config.flash_speculative_tokens,
+                    prefetcher=wrapped.prefetcher,
+                )
+                return wrapped, tokenizer, is_vlm, caps, decoder
+
+            return wrapped, tokenizer, is_vlm, caps, None
+        except Exception:
+            # Teardown in the same order as ``_close_loaded_model``: prefetcher
+            # before the weight store (prefetch tasks submit into the store's
+            # pool, so reversing the order references a closed store).
+            if wrapped is not None:
+                prefetcher = getattr(wrapped, "prefetcher", None)
+                if prefetcher is not None:
+                    try:
+                        prefetcher.close()
+                    except Exception:
+                        logger.exception(
+                            "Error closing prefetcher after failed flash load"
+                        )
             try:
-                lookahead_bank = LookaheadBank.load(lookahead_path)
-                logger.info("Loaded lookahead predictor bank from %s", lookahead_path)
+                weight_store.close()
             except Exception:
-                logger.warning(
-                    "Failed to load lookahead predictors, falling back to sparsity predictor",
-                    exc_info=True,
-                )
-
-        # Wrap model — this replaces FFN layers and frees original weights
-        wrapped = FlashModelWrapper(
-            model, predictor_bank, weight_store, runtime_flash_config, lookahead_bank
-        )
-
-        if flash_config.flash_speculative:
-            from olmlx.engine.flash.speculative import SpeculativeFlashDecoder
-
-            if not flash_config.flash_speculative_draft_model:
-                raise ValueError(
-                    "flash_speculative requires flash_speculative_draft_model to be set "
-                    "(OLMLX_FLASH_SPECULATIVE_DRAFT_MODEL)"
-                )
-
-            logger.info(
-                "Loading draft model %s for speculative decoding",
-                flash_config.flash_speculative_draft_model,
-            )
-            draft_model, draft_tokenizer = load_model_with_strict_fallback(
-                flash_config.flash_speculative_draft_model, lazy=False
-            )
-
-            # Verify vocabulary compatibility — a mismatch causes silent token ID errors
-            target_vocab = getattr(getattr(wrapped, "args", None), "vocab_size", None)
-            draft_vocab = getattr(
-                getattr(draft_model, "args", None), "vocab_size", None
-            )
-            if (
-                target_vocab is not None
-                and draft_vocab is not None
-                and target_vocab != draft_vocab
-            ):
-                raise ValueError(
-                    f"Draft model vocab_size ({draft_vocab}) does not match "
-                    f"target model vocab_size ({target_vocab}). "
-                    f"Speculative decoding requires matching vocabularies."
-                )
-
-            decoder = SpeculativeFlashDecoder(
-                draft_model=draft_model,
-                target_model=wrapped,
-                num_speculative_tokens=flash_config.flash_speculative_tokens,
-                prefetcher=wrapped.prefetcher,
-            )
-            return wrapped, tokenizer, is_vlm, caps, decoder
-
-        return wrapped, tokenizer, is_vlm, caps, None
+                logger.exception("Error closing weight store after failed flash load")
+            raise
 
     def _flash_moe_dir(self, hf_path: str) -> Path | None:
         """Return the flash-MoE directory for a model, if it exists."""

--- a/tests/test_flash_mlp.py
+++ b/tests/test_flash_mlp.py
@@ -490,6 +490,35 @@ class TestFlashModelWrapperShard:
         with pytest.raises(ValueError, match="n_kv_heads.*not divisible"):
             wrapper.shard(FakeGroup(rank=0, size=8))
 
+    def test_replace_mlps_rejects_unbundled_mlp_layer(self, tmp_path):
+        """A layer with an ``.mlp`` but no bundled weights (mixed dense/MoE
+        model — only dense FFN layers get bundled, but MoE blocks also expose
+        ``.mlp``) must fail at load with a clear error naming the mismatch,
+        not a cryptic ``KeyError`` mid-forward in ``_read_neuron_raw`` (#624).
+        """
+        from types import SimpleNamespace
+
+        from olmlx.engine.flash.flash_model import FlashConfig, FlashModelWrapper
+
+        dim, n_heads, n_kv_heads = 64, 8, 4
+        inter = 32
+        # Model has 3 layers with ``.mlp``, but the bundle covers only 2.
+        model = _FakeModel(dim, n_heads, n_kv_heads, num_layers=3)
+        flash_dir, _, _ = _make_bundled_model(
+            tmp_path, hidden=dim, inter=inter, num_layers=2
+        )
+        store = FlashWeightStore(flash_dir, num_io_threads=2, cache_budget_neurons=64)
+        # Enough predictors that the guard — not an IndexError — is what fires.
+        predictor_bank = SimpleNamespace(
+            predictors=[SparsityPredictor(dim, inter, rank=4) for _ in range(3)],
+        )
+        config = FlashConfig(hidden_size=dim, intermediate_size=inter, num_layers=2)
+        try:
+            with pytest.raises(RuntimeError, match="no bundled weights"):
+                FlashModelWrapper(model, predictor_bank, store, config)
+        finally:
+            store.close()
+
     def test_shard_raises_if_called_twice(self, wrapper_setup):
         """A retry after a *successful* shard() must say so — not claim a
         mid-loop failure that never happened."""

--- a/tests/test_flash_preallocated_buffer.py
+++ b/tests/test_flash_preallocated_buffer.py
@@ -2,6 +2,7 @@
 
 import mlx.core as mx
 import numpy as np
+import pytest
 
 from olmlx.engine.flash.bundler import bundle_ffn_weights
 from olmlx.engine.flash.weight_store import (
@@ -180,6 +181,68 @@ class TestFlashWeightStorePreallocated:
         expected = mx.array(gate_w[indices].T)
         assert mx.allclose(gate_cols, expected, atol=1e-6)
         store.close()
+
+    def test_requested_cached_neurons_survive_missing_inserts(self, tmp_path):
+        """A cached-but-requested neuron must not be evicted by inserting the
+        missing batch for the *same* forward. ``get_cached_indices`` is
+        membership-only (no LRU refresh), so without touching the requested
+        neurons an insert could evict one, then ``get_matrices`` KeyErrors
+        mid-forward (#624). Buffer holds [0,1,2]; requesting [0,1,3] inserts
+        3 and must evict 2 (unrequested), keeping 0 and 1.
+        """
+        from safetensors.numpy import load_file
+
+        hidden, inter, num_layers = 16, 8, 1
+        model_dir = _make_synthetic_mlp_weights(hidden, inter, num_layers, tmp_path)
+        output_dir = tmp_path / "flash"
+        bundle_ffn_weights(model_dir, output_dir)
+
+        gate_w = load_file(str(model_dir / "model.safetensors"))[
+            "model.layers.0.mlp.gate_proj.weight"
+        ]
+
+        store = FlashWeightStore(
+            output_dir, use_preallocated_buffer=True, cache_budget_neurons=3
+        )
+        try:
+            store.load_neurons(0, [0, 1, 2])  # fill the buffer
+            gate_cols, _, _ = store.load_neurons(0, [0, 1, 3])
+            expected = mx.array(gate_w[[0, 1, 3]].T)
+            assert mx.allclose(gate_cols, expected, atol=1e-6)
+        finally:
+            store.close()
+
+    def test_more_active_neurons_than_capacity_raises_clear_error(self, tmp_path):
+        """Requesting more distinct neurons than the buffer can hold is
+        physically impossible to satisfy; it must raise a clear error naming
+        the capacity, not a cryptic KeyError mid-forward (#624)."""
+        hidden, inter, num_layers = 16, 8, 1
+        model_dir = _make_synthetic_mlp_weights(hidden, inter, num_layers, tmp_path)
+        output_dir = tmp_path / "flash"
+        bundle_ffn_weights(model_dir, output_dir)
+
+        store = FlashWeightStore(
+            output_dir, use_preallocated_buffer=True, cache_budget_neurons=2
+        )
+        try:
+            with pytest.raises(RuntimeError, match="active neurons"):
+                store.load_neurons(0, [0, 1, 2])
+        finally:
+            store.close()
+
+    def test_zero_cache_budget_preallocated_rejected(self, tmp_path):
+        """A preallocated buffer with capacity 0 can hold nothing; construction
+        must reject it clearly rather than crashing later on
+        ``_access_order.popitem`` on an empty dict (#624)."""
+        hidden, inter, num_layers = 16, 8, 1
+        model_dir = _make_synthetic_mlp_weights(hidden, inter, num_layers, tmp_path)
+        output_dir = tmp_path / "flash"
+        bundle_ffn_weights(model_dir, output_dir)
+
+        with pytest.raises(ValueError, match="cache_budget_neurons"):
+            FlashWeightStore(
+                output_dir, use_preallocated_buffer=True, cache_budget_neurons=0
+            )
 
     def test_backward_compat_neuron_cache(self, tmp_path):
         """use_preallocated_buffer=False still uses NeuronCache."""

--- a/tests/test_flash_prepare.py
+++ b/tests/test_flash_prepare.py
@@ -142,6 +142,63 @@ class FakeTokenizer:
         return list(range(1, min(len(text) + 1, 20)))
 
 
+class TestEmbedNormalizer:
+    """Gemma-family models scale embeddings by sqrt(hidden_size) in the model
+    forward (not in embed_tokens). Streaming calibration must replicate that
+    scale or predictors train on hidden states ~sqrt(hidden_size)x too small
+    (#624)."""
+
+    @staticmethod
+    def _model(model_type):
+        class _Args:
+            pass
+
+        args = _Args()
+        if model_type is not None:
+            args.model_type = model_type
+
+        class _Model:
+            pass
+
+        m = _Model()
+        m.args = args
+        return m
+
+    @pytest.mark.parametrize(
+        "mt", ["gemma", "gemma2", "gemma3_text", "gemma3n", "gemma4_text"]
+    )
+    def test_gemma_family_gets_sqrt_hidden_scale(self, mt):
+        from olmlx.engine.flash.prepare import _embed_normalizer
+
+        m = self._model(mt)
+        assert _embed_normalizer(m, m, 2304) == pytest.approx(2304**0.5)
+
+    def test_non_gemma_is_identity(self):
+        from olmlx.engine.flash.prepare import _embed_normalizer
+
+        m = self._model("qwen3")
+        assert _embed_normalizer(m, m, 4096) == 1.0
+
+    def test_missing_model_type_is_identity(self):
+        from olmlx.engine.flash.prepare import _embed_normalizer
+
+        class _Bare:
+            pass
+
+        bare = _Bare()
+        assert _embed_normalizer(bare, bare, 4096) == 1.0
+
+    def test_inner_model_type_used_when_outer_missing(self):
+        from olmlx.engine.flash.prepare import _embed_normalizer
+
+        class _Bare:
+            pass
+
+        outer = _Bare()
+        inner = self._model("gemma3_text")
+        assert _embed_normalizer(outer, inner, 1152) == pytest.approx(1152**0.5)
+
+
 class TestNullifyModuleParams:
     def test_replaces_all_params_with_placeholders(self):
         """After nullification, all parameter arrays should be size 1."""

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -3031,6 +3031,84 @@ class TestLoadWithModelTypeFallbackEosFix:
         assert json.loads((tmp_path / "config.json").read_text()) == original_cfg
 
 
+class TestFlashLoadFailureCleanup:
+    """A flash load that fails after the FlashWeightStore is constructed must
+    close it (and the wrapper's prefetcher) — otherwise every failed attempt
+    leaks per-layer fds + the store/prefetcher thread pools (#624)."""
+
+    def test_wrapper_build_failure_closes_weight_store(self, tmp_path, monkeypatch):
+        from types import SimpleNamespace
+
+        import olmlx.engine.flash.flash_model as fm
+        import olmlx.engine.flash.predictor as fp
+        import olmlx.engine.flash.prepare as fprep
+        import olmlx.engine.flash.weight_store as ws
+        import olmlx.engine.model_manager as mm
+
+        closed = {"store": 0}
+
+        class _SpyStore:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def close(self):
+                closed["store"] += 1
+
+        monkeypatch.setattr(ws, "FlashWeightStore", _SpyStore)
+        monkeypatch.setattr(
+            fp.PredictorBank, "load", classmethod(lambda cls, path: object())
+        )
+        monkeypatch.setattr(
+            fprep,
+            "load_model_with_strict_fallback",
+            lambda path, *, lazy: (object(), object()),
+        )
+        monkeypatch.setattr(mm, "detect_caps", lambda tok: TemplateCaps())
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("wrapper build failed")
+
+        monkeypatch.setattr(fm, "FlashModelWrapper", _boom)
+
+        flash_dir = tmp_path / "flash"
+        flash_dir.mkdir()
+        (flash_dir / "flash_layout.json").write_text(
+            json.dumps(
+                {
+                    "hidden_size": 16,
+                    "intermediate_size": 8,
+                    "num_layers": 1,
+                    "layers": {},
+                }
+            )
+        )
+
+        from olmlx.config import ExperimentalSettings
+
+        model_exp = ExperimentalSettings(_env_file=None)
+        flash_config = SimpleNamespace(
+            sparsity_threshold=0.5,
+            min_active_neurons=0,
+            max_active_neurons=0,
+            memory_budget_fraction=0.9,
+            prefetch=False,
+            flash_speculative=False,
+            flash_speculative_draft_model=None,
+            flash_speculative_tokens=4,
+        )
+
+        manager = ModelManager(MagicMock(), MagicMock())
+        with pytest.raises(RuntimeError, match="wrapper build failed"):
+            manager._load_flash_model(
+                "hf/model",
+                str(tmp_path),
+                flash_dir,
+                model_exp=model_exp,
+                flash_config=flash_config,
+            )
+        assert closed["store"] == 1, "weight store must be closed on failed load"
+
+
 class TestExpiryChecker:
     @pytest.mark.asyncio
     async def test_expired_models_removed(self, registry, mock_store):

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -3108,6 +3108,94 @@ class TestFlashLoadFailureCleanup:
             )
         assert closed["store"] == 1, "weight store must be closed on failed load"
 
+    def test_speculative_vocab_mismatch_releases_draft_and_store(
+        self, tmp_path, monkeypatch
+    ):
+        """A speculative-flash failure *after* the draft model loads (vocab
+        mismatch) must close the store and drop the draft model's GPU weights
+        back to the pool — otherwise the draft leaks until GC (#624)."""
+        from types import SimpleNamespace
+
+        import olmlx.engine.flash.flash_model as fm
+        import olmlx.engine.flash.predictor as fp
+        import olmlx.engine.flash.prepare as fprep
+        import olmlx.engine.flash.weight_store as ws
+        import olmlx.engine.model_manager as mm
+
+        closed = {"store": 0, "clear_cache": 0}
+
+        class _SpyStore:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def close(self):
+                closed["store"] += 1
+
+        monkeypatch.setattr(ws, "FlashWeightStore", _SpyStore)
+        monkeypatch.setattr(
+            fp.PredictorBank, "load", classmethod(lambda cls, path: object())
+        )
+
+        def _fake_load(path, *, lazy):
+            if path == "draft/x":
+                return SimpleNamespace(args=SimpleNamespace(vocab_size=200)), object()
+            return object(), object()
+
+        monkeypatch.setattr(fprep, "load_model_with_strict_fallback", _fake_load)
+        monkeypatch.setattr(mm, "detect_caps", lambda tok: TemplateCaps())
+        # Wrapper succeeds with a vocab that mismatches the draft.
+        monkeypatch.setattr(
+            fm,
+            "FlashModelWrapper",
+            lambda *a, **k: SimpleNamespace(
+                args=SimpleNamespace(vocab_size=100), prefetcher=None
+            ),
+        )
+        monkeypatch.setattr(
+            mm.mx,
+            "clear_cache",
+            lambda: closed.__setitem__("clear_cache", closed["clear_cache"] + 1),
+        )
+
+        flash_dir = tmp_path / "flash"
+        flash_dir.mkdir()
+        (flash_dir / "flash_layout.json").write_text(
+            json.dumps(
+                {
+                    "hidden_size": 16,
+                    "intermediate_size": 8,
+                    "num_layers": 1,
+                    "layers": {},
+                }
+            )
+        )
+
+        from olmlx.config import ExperimentalSettings
+
+        model_exp = ExperimentalSettings(_env_file=None)
+        flash_config = SimpleNamespace(
+            sparsity_threshold=0.5,
+            min_active_neurons=0,
+            max_active_neurons=0,
+            memory_budget_fraction=0.9,
+            prefetch=False,
+            flash_speculative=True,
+            flash_speculative_draft_model="draft/x",
+            flash_speculative_tokens=4,
+        )
+
+        manager = ModelManager(MagicMock(), MagicMock())
+        with pytest.raises(ValueError, match="vocab_size"):
+            manager._load_flash_model(
+                "hf/model",
+                str(tmp_path),
+                flash_dir,
+                model_exp=model_exp,
+                flash_config=flash_config,
+            )
+        assert closed["store"] == 1, "weight store must be closed on failed load"
+        assert closed["clear_cache"] >= 1, "draft weights must be released to the pool"
+
 
 class TestExpiryChecker:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Addresses the Flash / Flash-MoE findings from the Fable review. Finding **#2** (the `wrap_flash_moe` empty-`parameters()` no-op) was already fixed separately; its inner-model `mx.eval(model.parameters())` remains in place, so this PR covers the other four.

## Findings fixed

**#1 — Preallocated-buffer `KeyError` mid-forward** (`flash/weight_store.py`)
- `_load_neurons_preallocated` now `touch`es the requested neurons to MRU *before* inserting the missing batch, so inserts evict only **unrequested** neurons. A requested-but-cached neuron can no longer be evicted mid-forward and then `KeyError` in `get_matrices`. (Regression test: buffer `[0,1,2]`, request `[0,1,3]` — insert `3` must evict `2`, keep `0,1`.)
- Requests exceeding buffer capacity (physically unsatisfiable) raise a clear error naming the capacity instead of a cryptic `KeyError`.
- A zero `flash_cache_budget_neurons` in preallocated mode is rejected at construction (was `_access_order.popitem` on an empty dict).

**#4 — Gemma calibration misses the embed scale** (`flash/prepare.py`) — *silent quality corruption.* Gemma-family models scale embeddings by `sqrt(hidden_size)` in the model forward (verified across gemma/gemma2/gemma3_text/gemma3n/gemma4_text). Streaming calibration seeded `h = embed(input_ids)` without it, training predictors on hidden states ~`sqrt(hidden_size)`× too small vs the serving-time residual stream. New `_embed_normalizer` replicates the scale.

**#3 — fd leak on failed flash load** (`model_manager.py`) — a failure after `FlashWeightStore` is built (wrapper build, draft load, vocab mismatch) now closes the prefetcher then the weight store in a try/except, matching `_close_loaded_model`'s teardown order. No more leaked per-layer fds + thread pools per failed attempt.

**#5 — mixed dense/MoE crash** (`flash/flash_model.py`) — `_replace_mlps` raises a clear **load-time** error when a layer exposes `.mlp` but has no bundled weights (MoE blocks satisfy `hasattr(layer, "mlp")` but aren't bundled), instead of `KeyError` in `_read_neuron_raw` on the first forward. Adds `FlashWeightStore.layer_indices`.

## Tests
New RED-verified tests for #1, #3, #4, #5. Full flash suite (131 tests) + flash model_manager tests pass; ruff clean.

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)