### PR TITLE
fix(speculative): GDN-capture hazards, doubled BOS, redundant eval, hook order (#633)

### DIFF
--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -226,6 +226,11 @@ class DFlashDecoder(SpecDecoderBase):
                 for p, q in zip(captured_prefix, captured_last)
             ]
         else:
+            # Single-token prompt: no long prefix to suppress, so the buffer
+            # must be active for this forward so step()'s rollback has the
+            # captured GDN state (mirrors MTP's single-token branch).
+            if self._capture is not None:
+                self._capture.use_buffer(self._capture_buffer)
             target_out = self._target(prompt, cache=self._target_cache)
             captured = list(self._hidden_capture)
             if any(h is None for h in captured):

--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -173,7 +173,6 @@ class DFlashDecoder(SpecDecoderBase):
             # target has no ``GatedDeltaNet`` submodule, so a separate
             # pre-check would just duplicate the same error.
             self._install_gdn_capture()
-            self._capture.use_buffer(self._capture_buffer)
 
         # Two-pass prefill avoids materialising the full [batch, N, vocab] logit
         # (the OOM path for large-vocab models on long contexts).
@@ -191,8 +190,20 @@ class DFlashDecoder(SpecDecoderBase):
             "target_layer_ids — check that the layer indices exist on "
             f"this model (got {target_layer_ids})."
         )
+        # GDN capture is suppressed across the (potentially long) prefix pass
+        # and re-enabled before the tail pass, mirroring MTP (#633): the
+        # patched GDN ``__call__`` *appends* per forward, so capturing every
+        # prompt position would pile activation-scale q/k/v/conv tensors into
+        # the buffer and hold them live until the first ``step()`` clears it —
+        # re-bloating exactly the memory the two-pass split bounds, on the
+        # hybrid GDN targets DFlash names as its primary use case. ``step()``
+        # only ever needs the verify window (it clears the buffer and
+        # re-captures before each rollback), so the prompt captures are never
+        # consumed. ``_capture`` is only set on hybrid GDN targets.
         if prompt.shape[1] > 1:
             prefix, last = prompt[:, :-1], prompt[:, -1:]
+            if self._capture is not None:
+                self._capture.use_buffer(None)
             self._target(prefix, cache=self._target_cache)  # output discarded
             captured_prefix = list(self._hidden_capture)
             if any(h is None for h in captured_prefix):
@@ -204,6 +215,8 @@ class DFlashDecoder(SpecDecoderBase):
             # Reset capture slots so the pass-2 None-check is independent.
             self._hidden_capture[:] = [None] * len(self._hidden_capture)
             _eval_cache(self._target_cache)
+            if self._capture is not None:
+                self._capture.use_buffer(self._capture_buffer)
             target_out = self._target(last, cache=self._target_cache)
             captured_last = list(self._hidden_capture)
             if any(h is None for h in captured_last):

--- a/olmlx/engine/eagle/decoder.py
+++ b/olmlx/engine/eagle/decoder.py
@@ -195,14 +195,21 @@ class EagleDecoder(SpecDecoderBase):
         sub-chunk loop to check between), and is an experimental strategy
         off the default path.
         """
+        # Build the target cache *before* patching layer hooks (mirrors
+        # DFlash, #633): ``make_prompt_cache`` walks ``model.layers`` to pick
+        # a per-layer cache type (sliding vs. full attention) by probing the
+        # layer object. Today it uses ``hasattr``, which ``_LayerHook.
+        # __getattr__`` proxies through, but a future ``isinstance`` check
+        # would silently get the wrong cache type for a ``_LayerHook``-wrapped
+        # layer. Building the cache first decouples cache selection from the
+        # patch.
+        self._target_cache = make_prompt_cache(self._target)
+        self._draft_cache = self._draft.make_cache()
+
         # Hook the chosen target layer so its output is captured into
         # ``_hidden_storage[0]`` on every target forward.
         self._install_layer_hooks([self._target_layer_id], self._hidden_storage)
         self._bind_draft()
-
-        # Build fresh caches for both models.
-        self._target_cache = make_prompt_cache(self._target)
-        self._draft_cache = self._draft.make_cache()
 
         # (Classic ``SpeculativeDecoder.prefill`` resets ``_position_ids``
         # / ``_rope_deltas`` on the target here for mlx-vlm targets,
@@ -259,24 +266,34 @@ class EagleDecoder(SpecDecoderBase):
         # prefill``'s try/reset, so the model is never left patched and
         # the ``_GDN_PATCH_LOCK`` never stays held.
         if not self._target_can_trim:
-            # Install the patch — must happen *before* the prompt
-            # forward so the patched ``__call__`` records the prompt's
-            # GDN state, which subsequent rollbacks may need to replay
-            # against. ``GDNStateCapture.__init__`` acquires
-            # ``_GDN_PATCH_LOCK``; ``reset()`` releases it via
-            # ``capture.close()``. ``_install_gdn_capture`` locates the
-            # GDN class, constructs the capture and a buffer
-            # pre-populated with the target's GDN modules in
-            # forward-pass order; activating the buffer makes subsequent
-            # forwards snapshot into it.
+            # Install the patch — must happen *before* the prompt forward
+            # so the patched ``__call__`` is in place. ``GDNStateCapture.
+            # __init__`` acquires ``_GDN_PATCH_LOCK``; ``reset()`` releases
+            # it via ``capture.close()``. ``_install_gdn_capture`` locates
+            # the GDN class and constructs the capture + a buffer
+            # pre-populated with the target's GDN modules in forward-pass
+            # order. The buffer is *not* activated here: see the two-pass
+            # block below.
             self._install_gdn_capture()
-            self._capture.use_buffer(self._capture_buffer)
 
         # Run the target on the prompt and capture its last-layer hidden.
         # Two-pass: prefix fills the KV cache without materialising the
         # full [batch, seq_len, vocab] logit; final single-token pass
         # produces a [1, 1, vocab] logit and refreshes the capture slot.
+        #
+        # GDN capture is suppressed across the (potentially long) prefix
+        # pass and re-enabled before the tail pass, mirroring MTP (#633):
+        # the patched GDN ``__call__`` *appends* per forward, so capturing
+        # every prompt position piles activation-scale q/k/v/conv tensors
+        # into the buffer and holds them live until the first ``step()``
+        # clears it. ``step()`` only needs the verify window — it clears the
+        # buffer and re-captures before each rollback — so the prompt
+        # captures are never consumed (the previous "rollbacks may replay
+        # against the prompt state" justification was incorrect). ``_capture``
+        # is only set on hybrid GDN targets.
         if prompt.shape[1] > 1:
+            if self._capture is not None:
+                self._capture.use_buffer(None)
             self._target(prompt[:, :-1], cache=self._target_cache)
             # Force the pass-1 hidden (if captured) before dropping the
             # slot reference, mirroring DFlash. Correctness does not
@@ -290,8 +307,12 @@ class EagleDecoder(SpecDecoderBase):
             # an active guard rather than dead code.
             self._hidden_storage[0] = None
             _eval_cache(self._target_cache)
+            if self._capture is not None:
+                self._capture.use_buffer(self._capture_buffer)
             target_out = self._target(prompt[:, -1:], cache=self._target_cache)
         else:
+            if self._capture is not None:
+                self._capture.use_buffer(self._capture_buffer)
             target_out = self._target(prompt, cache=self._target_cache)
         target_logits = _logits(target_out)
         captured = self._hidden_storage[0]

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -3605,7 +3605,12 @@ async def _stream_completion(
                     and not lm.is_vlm
                 ):
                     spec_tokens = (
-                        lm.text_tokenizer.encode(prompt)
+                        # ``tokenize_for_cache`` replicates mlx-lm's BOS
+                        # heuristic; plain ``.encode`` (add_special_tokens=True)
+                        # would double the BOS on BOS-prefixed templates
+                        # (Llama 3 / Gemma / Mistral), diverging from the
+                        # non-speculative path (#633).
+                        tokenize_for_cache(lm.text_tokenizer, prompt)
                         if isinstance(prompt, str)
                         else list(prompt)
                     )
@@ -4267,7 +4272,10 @@ async def _full_completion_inner(
             )
 
             if isinstance(prompt, str):
-                prompt_tokens = lm.text_tokenizer.encode(prompt)
+                # BOS heuristic (see the buffered speculative path / #633):
+                # plain ``.encode`` would double the BOS on BOS-prefixed
+                # templates, diverging from the non-speculative path.
+                prompt_tokens = tokenize_for_cache(lm.text_tokenizer, prompt)
             else:
                 prompt_tokens = prompt
 

--- a/olmlx/engine/mtp/decoder.py
+++ b/olmlx/engine/mtp/decoder.py
@@ -203,14 +203,20 @@ class MTPDecoder(SpecDecoderBase):
         one sub-chunk. ``speculative_stream_generate`` catches it for a
         clean, token-less stream exit.
         """
+        # Build the target cache *before* patching layer hooks (mirrors
+        # DFlash, #633): ``make_prompt_cache`` walks ``model.layers`` to pick
+        # a per-layer cache type by probing the layer object. Today it uses
+        # ``hasattr`` (which ``_LayerHook.__getattr__`` proxies through), but a
+        # future ``isinstance`` check would silently get the wrong cache type
+        # for a ``_LayerHook``-wrapped layer. Building the cache first
+        # decouples cache selection from the patch.
+        self._target_cache = make_prompt_cache(self._target)
+        self._draft_cache = self._draft.make_cache()
+
         # Hook the chosen target layer so its output is captured into
         # ``_hidden_storage[0]`` on every target forward.
         self._install_layer_hooks([self._target_layer_id], self._hidden_storage)
         self._bind_draft()
-
-        # Build fresh caches for both models.
-        self._target_cache = make_prompt_cache(self._target)
-        self._draft_cache = self._draft.make_cache()
 
         # (Classic ``SpeculativeDecoder.prefill`` resets ``_position_ids``
         # / ``_rope_deltas`` on the target here for mlx-vlm targets,

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -645,6 +645,15 @@ class SpeculativeDecoder(SpecDecoderBase):
     # ------------------------------------------------------------------
 
     def _reset_state(self) -> None:
+        # Detach the decoder-lifetime GDN capture from any buffer. The base
+        # ``step()`` runs this on a mid-step exception, but the capture (and
+        # its class-level ``GatedDeltaNet.__call__`` patch) outlives the
+        # request; if the buffer stays routed, every subsequent GDN call —
+        # including *other* hybrid models' non-speculative inference sharing
+        # the patched class — keeps appending into the stale buffer, growing
+        # memory without bound until the next ``prefill`` (#633).
+        if self._gdn_capture is not None:
+            self._gdn_capture.use_buffer(None)
         self._target_cache = None
         self._draft_cache = None
         self._cache_seq_len = 0
@@ -944,12 +953,16 @@ class SpeculativeDecoder(SpecDecoderBase):
             align_logits = _logits(self._draft(last_draft, cache=self._draft_cache))
             mx.eval(align_logits)
 
-        # 5. Update state
+        # 5. Update state.
+        # The next pending token is definitionally ``accepted[-1]``:
+        # ``verify_draft_greedy`` already argmax'd ``verification_logits[
+        # num_accepted - 1]`` to produce it (a correction on partial accept,
+        # the bonus on full accept). Re-deriving it here forced a second
+        # ``mx.eval`` + ``.item()`` Metal round-trip per decode step for an
+        # identical result; take the shortcut PLD already documents.
         self._cache_seq_len += num_accepted
         assert num_accepted >= 1, "step(): _verify() must return at least 1 token"
-        self._last_target_logit = verification_logits[num_accepted - 1]
-        mx.eval(self._last_target_logit)
-        self._pending_token = int(mx.argmax(self._last_target_logit).item())
+        self._pending_token = int(accepted[-1])
 
         num_accepted_draft = self._update_acceptance_rate(num_accepted)
 
@@ -1442,6 +1455,12 @@ class PromptLookupDecoder(SpecDecoderBase):
             self.reset()
 
     def _reset_state(self) -> None:
+        # Detach the decoder-lifetime GDN capture from any buffer on reset —
+        # otherwise a mid-step exception leaves the class-level patch routed
+        # to a stale buffer that every later GDN call keeps growing (#633).
+        # See the classic decoder's ``_reset_state`` for the full rationale.
+        if self._gdn_capture is not None:
+            self._gdn_capture.use_buffer(None)
         self._target_cache = None
         self._cache_seq_len = 0
         self._pending_token = None

--- a/tests/test_speculative_hybrid.py
+++ b/tests/test_speculative_hybrid.py
@@ -253,6 +253,25 @@ class TestLifecycle:
         dec.close()
         assert dec._gdn_capture is None
 
+    def test_reset_state_detaches_gdn_buffer(self):
+        """``_reset_state`` (run by the base ``step()`` on a mid-step
+        exception) must detach the decoder-lifetime GDN capture from any
+        buffer. Otherwise the class-level ``GatedDeltaNet.__call__`` patch
+        stays routed to a stale buffer and every subsequent GDN call — from
+        this or *any* other hybrid model — keeps appending, leaking memory
+        until the next prefill (#633).
+        """
+        gdn = _make_fake_gdn_cls()
+        target = _make_hybrid_model(gdn_cls=gdn)
+        draft = _make_hybrid_model(gdn_cls=gdn)
+        dec = SpeculativeDecoder(draft, target)
+        try:
+            dec._gdn_capture.use_buffer = MagicMock()
+            dec._reset_state()
+            dec._gdn_capture.use_buffer.assert_called_once_with(None)
+        finally:
+            dec.close()
+
     def test_del_swallows_exceptions(self):
         """__del__ runs during GC and must never raise."""
         gdn = _make_fake_gdn_cls()


### PR DESCRIPTION
## Summary
Five grouped fixes across the speculative decoders (SWA-trim and off-by-one are tracked separately).

1. **GDN capture across prompt prefill (memory)** — DFlash/EAGLE activated the GDN capture buffer *before* the prompt forward, so the patched `GatedDeltaNet.__call__` appended activation-scale q/k/v/conv tensors for every prompt position, held live until the first `step()` cleared it — on exactly the hybrid GDN targets these strategies name as their use case. Now suppress the buffer across the prefix pass and re-enable before the tail pass (mirroring MTP). `step()` only ever needs the verify window.

2. **Stale GDN buffer after a mid-step exception (memory)** — Classic/PLD now detach the decoder-lifetime GDN capture in `_reset_state` (which the base `step()` runs on exception). Previously the class-level patch stayed routed to a stale buffer, so every later GDN call — including *other* hybrid models' non-speculative inference sharing the patched class — kept appending, leaking until the next prefill. Regression test added.

3. **Doubled BOS on speculative paths** — both speculative tokenize sites use `tokenize_for_cache` instead of plain `encode`, replicating mlx-lm's BOS heuristic. Plain encode doubled the BOS on BOS-prefixed templates (Llama 3 / Gemma / Mistral), diverging from the non-speculative path.

4. **Redundant Metal sync for the pending token** — classic step derives the next token from `accepted[-1]` (already argmax'd by `verify_draft_greedy`) instead of a second `mx.eval` + `argmax` + `.item()` per decode step. Exactness-preserving; PLD already does this.

5. **Hook-patch ordering** — EAGLE/MTP build `make_prompt_cache` before patching layer hooks (mirroring DFlash), so cache-type selection can't be fooled by a `_LayerHook`-wrapped layer under a future mlx-lm `isinstance` probe.

## Tests
New regression for (2); full speculative suite (240 tests) passes; ruff clean.

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)