### PR TITLE
fix(routers): provider protocol-consistency fixes across dialects (#627)

### DIFF
--- a/olmlx/app.py
+++ b/olmlx/app.py
@@ -11,6 +11,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from olmlx.config import settings
@@ -325,6 +326,25 @@ class RootSpanMiddleware(BaseHTTPMiddleware):
             return response
 
 
+def _error_types_for_status(status_code: int) -> tuple[str, str, str]:
+    """Map an HTTP status to ``(anthropic_type, openai_type, openai_code)``.
+
+    Used to give a bare ``HTTPException`` a provider-shaped error envelope
+    consistent with the typed handlers below (#627).
+    """
+    if status_code == 401:
+        return ("authentication_error", "invalid_request_error", "authentication_error")
+    if status_code == 403:
+        return ("permission_error", "invalid_request_error", "permission_denied")
+    if status_code == 404:
+        return ("not_found_error", "invalid_request_error", "not_found")
+    if status_code == 429:
+        return ("rate_limit_error", "rate_limit_error", "rate_limit_exceeded")
+    if 400 <= status_code < 500:
+        return ("invalid_request_error", "invalid_request_error", "invalid_value")
+    return ("api_error", "server_error", "internal_error")
+
+
 def _make_error_response(
     path: str,
     status_code: int,
@@ -395,6 +415,32 @@ def create_app() -> FastAPI:
             "invalid_request_error",
             "invalid_value",
         )
+
+    @app.exception_handler(StarletteHTTPException)
+    async def http_exception_handler(request: Request, exc: StarletteHTTPException):
+        # Router-raised ``HTTPException``s (e.g. 422 for a malformed image
+        # block or bad response_format) would otherwise serialize as
+        # FastAPI's default ``{"detail": ...}``, which provider SDKs can't
+        # parse. Reshape into the surface's provider error envelope,
+        # preserving the status code and any carried headers (#627).
+        detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+        anthropic_type, openai_type, openai_code = _error_types_for_status(
+            exc.status_code
+        )
+        logger.warning(
+            "HTTPException %d on %s: %s", exc.status_code, request.url.path, detail
+        )
+        response = _make_error_response(
+            request.url.path,
+            exc.status_code,
+            detail,
+            anthropic_type,
+            openai_type,
+            openai_code,
+        )
+        for key, value in (exc.headers or {}).items():
+            response.headers[key] = value
+        return response
 
     @app.exception_handler(ValueError)
     async def value_error_handler(request: Request, exc: ValueError):

--- a/olmlx/routers/anthropic.py
+++ b/olmlx/routers/anthropic.py
@@ -15,6 +15,7 @@ from olmlx.engine.inference import (
     count_chat_tokens,
     generate_chat,
 )
+from olmlx.engine.panel import panel_generate_chat
 from olmlx.routers.common import (
     build_inference_options,
     collect_content_parts,
@@ -157,6 +158,45 @@ def _strip_billing_headers(
     return filtered if filtered else None
 
 
+def _append_user_content_parts(messages: list[dict], content_parts: list[dict]) -> None:
+    """Flush accumulated user text/image/audio parts as one ``user`` message.
+
+    Called both before each interleaved ``tool_result`` and at the end of a
+    user turn so the client's block order is preserved (#627): a
+    ``[text, tool_result]`` turn stays user-then-tool instead of being
+    reordered to tool-then-user (which changes the KV-cache prefix for
+    interrupted tool-use turns).
+    """
+    if not content_parts:
+        return
+    # Shared part-type dispatch + image/audio normalization (#471);
+    # a malformed source raises ValueError → 422 at the endpoint.
+    text_parts, user_images, user_audio = collect_content_parts(content_parts)
+    if text_parts or user_images or user_audio:
+        user_msg: dict = {"role": "user", "content": " ".join(text_parts)}
+        if user_images:
+            user_msg["images"] = user_images
+        if user_audio:
+            user_msg["audio"] = user_audio
+        messages.append(user_msg)
+
+
+def _anthropic_stop_reason(done_reason: str | None, has_tools: bool) -> str:
+    """Map the engine's ``done_reason`` to an Anthropic ``stop_reason``.
+
+    The engine sets ``done_reason="stop"`` *only* on a client ``stop_sequences``
+    hit (natural EOS leaves it unset), so a match surfaces as Anthropic's
+    ``"stop_sequence"`` rather than being conflated with ``"end_turn"`` (#627).
+    """
+    if has_tools:
+        return "tool_use"
+    if done_reason in ("timeout", "length"):
+        return "max_tokens"
+    if done_reason == "stop":
+        return "stop_sequence"
+    return "end_turn"
+
+
 def _convert_messages(req: AnthropicMessagesRequest) -> list[dict]:
     """Convert Anthropic message format to internal chat format.
 
@@ -231,6 +271,10 @@ def _convert_messages(req: AnthropicMessagesRequest) -> list[dict]:
             content_parts: list[dict] = []
             for block in msg.content:
                 if block.type == "tool_result":
+                    # Flush any text/image/audio seen so far *before* the tool
+                    # message so the client's block order is preserved (#627).
+                    _append_user_content_parts(messages, content_parts)
+                    content_parts = []
                     result_content = ""
                     if isinstance(block.content, str):
                         result_content = block.content
@@ -252,16 +296,7 @@ def _convert_messages(req: AnthropicMessagesRequest) -> list[dict]:
                     )
                 else:
                     content_parts.append({"type": block.type, "text": block.text})
-            # Shared part-type dispatch + image/audio normalization (#471);
-            # a malformed source raises ValueError → 422 at the endpoint.
-            text_parts, user_images, user_audio = collect_content_parts(content_parts)
-            if text_parts or user_images or user_audio:
-                user_msg: dict = {"role": "user", "content": " ".join(text_parts)}
-                if user_images:
-                    user_msg["images"] = user_images
-                if user_audio:
-                    user_msg["audio"] = user_audio
-                messages.append(user_msg)
+            _append_user_content_parts(messages, content_parts)
 
     if system_parts:
         messages.insert(0, {"role": "system", "content": "\n\n".join(system_parts)})
@@ -481,12 +516,7 @@ async def _stream_buffered_with_tools(
         )
         block_idx += 1
 
-    if tool_uses:
-        stop_reason = "tool_use"
-    elif done_reason in ("timeout", "length"):
-        stop_reason = "max_tokens"
-    else:
-        stop_reason = "end_turn"
+    stop_reason = _anthropic_stop_reason(done_reason, bool(tool_uses))
     yield {
         "stop_reason": stop_reason,
         "output_tokens": output_tokens,
@@ -518,6 +548,7 @@ async def _stream_thinking_state_machine(result):
     split_state: dict = {}
     current: str | None = None  # open block type: None | "thinking" | "text"
     text_block_emitted = False
+    thinking_block_emitted = False
 
     def _close_current() -> list[str]:
         nonlocal block_idx, current
@@ -541,7 +572,7 @@ async def _stream_thinking_state_machine(result):
         at position zero must not produce an empty thinking block (issue
         #307 review round 10; the non-streaming path produces none).
         """
-        nonlocal current, text_block_emitted
+        nonlocal current, text_block_emitted, thinking_block_emitted
         if not fragment:
             return []
         # A whitespace-only *thinking* fragment must not open a thinking block.
@@ -571,6 +602,8 @@ async def _stream_thinking_state_machine(result):
             current = block_type
             if block_type == "text":
                 text_block_emitted = True
+            else:
+                thinking_block_emitted = True
         delta_type = f"{block_type}_delta"
         events.append(
             _sse(
@@ -627,7 +660,11 @@ async def _stream_thinking_state_machine(result):
     if current is not None:
         for event in _close_current():
             yield event
-    if not text_block_emitted:
+    # Emit a trailing empty text block only when *nothing* was emitted, so the
+    # wire shape still carries at least one block. A thinking-only response
+    # must stay [thinking] — the non-streaming and buffered-tools paths both
+    # suppress the empty text block when a thinking block exists (#627).
+    if not text_block_emitted and not thinking_block_emitted:
         yield _sse(
             "content_block_start",
             {
@@ -642,9 +679,7 @@ async def _stream_thinking_state_machine(result):
         block_idx += 1
 
     yield {
-        "stop_reason": "max_tokens"
-        if done_reason in ("timeout", "length")
-        else "end_turn",
+        "stop_reason": _anthropic_stop_reason(done_reason, False),
         "output_tokens": output_tokens,
         "input_tokens": input_tokens,
     }
@@ -711,6 +746,14 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
     )
     resolved_model = _resolve_anthropic_model(req.model)
     manager = request.app.state.model_manager
+    # Dispatch synthetic panels through the panel coordinator here too, so a
+    # panel advertised in /v1/models isn't a 400 "model not found" on this
+    # surface (#627). ``panel_generate_chat`` returns a generate_chat-shaped
+    # result, so the rest of this handler is unchanged.
+    registry = request.app.state.registry
+    dispatch = (
+        panel_generate_chat if registry.is_panel(resolved_model) else generate_chat
+    )
     # A malformed image content block is a client error — surface as 422
     # rather than an uncaught 500 (mirrors the OpenAI surface).
     try:
@@ -746,7 +789,7 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
             )
 
     if req.stream:
-        result = await generate_chat(
+        result = await dispatch(
             manager,
             resolved_model,
             messages,
@@ -885,7 +928,7 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
 
         return StreamingResponse(stream_sse(), media_type="text/event-stream")
     else:
-        result = await generate_chat(
+        result = await dispatch(
             manager,
             resolved_model,
             messages,
@@ -948,12 +991,7 @@ async def anthropic_messages(req: AnthropicMessagesRequest, request: Request):
             content_blocks.append(AnthropicContentBlock(type="text", text=""))
 
         done_reason = result.get("done_reason")
-        if tool_uses:
-            stop_reason = "tool_use"
-        elif done_reason in ("timeout", "length"):
-            stop_reason = "max_tokens"
-        else:
-            stop_reason = "end_turn"
+        stop_reason = _anthropic_stop_reason(done_reason, bool(tool_uses))
         usage = AnthropicUsage(
             input_tokens=stats.prompt_eval_count if stats else 0,
             output_tokens=stats.eval_count if stats else 0,

--- a/olmlx/routers/openai.py
+++ b/olmlx/routers/openai.py
@@ -66,6 +66,19 @@ def _make_id() -> str:
     return f"chatcmpl-{uuid.uuid4().hex[:8]}"
 
 
+def _strip_thinking_full(text: str) -> str:
+    """Strip ``<think>`` / channel reasoning blocks from a full completion.
+
+    ``/v1/completions`` is the one text-generation surface that used to leak
+    reasoning into ``text`` (#627); reuse the streaming stripper over the whole
+    string + flush so the result matches the streaming path and ``/api/generate``.
+    """
+    state: dict = {}
+    visible = strip_thinking_streaming(text, state)
+    visible += flush_thinking_buffer(state)
+    return visible
+
+
 def _to_openai_tool_calls(tool_uses: list[dict]) -> list[dict]:
     """Convert parsed tool_use blocks to OpenAI tool_calls format."""
     return [
@@ -120,7 +133,26 @@ async def _stream_openai_sse(
 
     think_state: dict = {}
     content_emitted = False
+    role_seen = False
     final_stats = None
+
+    def _role_once(choice: dict) -> dict:
+        # OpenAI emits ``role`` only on the first delta, not every content
+        # chunk (#627). ``format_content`` (chat path) carries a role on every
+        # chunk; strip it after the first. The completions path's formatter
+        # has no role, so this is a no-op there.
+        nonlocal role_seen
+        delta = choice.get("delta")
+        if isinstance(delta, dict) and "role" in delta:
+            if role_seen:
+                choice = {
+                    **choice,
+                    "delta": {k: v for k, v in delta.items() if k != "role"},
+                }
+            else:
+                role_seen = True
+        return choice
+
     try:
         async for chunk in result:
             if chunk.get("cache_info"):
@@ -141,7 +173,9 @@ async def _stream_openai_sse(
                 if strip_thinking:
                     flushed = flush_thinking_buffer(think_state)
                     if flushed:
-                        data = _envelope([_compact_choice(format_content(flushed))])
+                        data = _envelope(
+                            [_compact_choice(_role_once(format_content(flushed)))]
+                        )
                         yield f"data: {json.dumps(data)}\n\n"
                         content_emitted = True
                 # Issue #551: if thinking consumed the whole token budget, no
@@ -151,7 +185,7 @@ async def _stream_openai_sse(
                 # detectable. Scoped to the chat path (format_content carries a
                 # role); the completions path uses a text-shaped formatter.
                 if strip_thinking and not content_emitted:
-                    data = _envelope([_compact_choice(format_content(""))])
+                    data = _envelope([_compact_choice(_role_once(format_content("")))])
                     yield f"data: {json.dumps(data)}\n\n"
                     content_emitted = True
                 done_reason = chunk.get("done_reason")
@@ -184,7 +218,7 @@ async def _stream_openai_sse(
                     text = strip_thinking_streaming(text, think_state)
                 if not text:
                     continue
-                data = _envelope([_compact_choice(format_content(text))])
+                data = _envelope([_compact_choice(_role_once(format_content(text)))])
                 yield f"data: {json.dumps(data)}\n\n"
                 content_emitted = True
     except Exception as exc:
@@ -584,16 +618,26 @@ async def openai_completions(req: OpenAICompletionRequest, request: Request):
         )
     include_usage = bool(req.stream_options and req.stream_options.include_usage)
     options = _build_options(req)
-    prompt = req.prompt if isinstance(req.prompt, str) else req.prompt[0]
+    # ``prompt`` may be a list; honor every entry instead of silently using
+    # only ``prompt[0]`` (#627).
+    prompts = [req.prompt] if isinstance(req.prompt, str) else list(req.prompt)
     max_tokens = req.max_tokens or settings.default_max_tokens
     comp_id = f"cmpl-{uuid.uuid4().hex[:8]}"
     created = int(time.time())
 
     if req.stream:
+        # Streaming interleaves choices by index, which we don't implement;
+        # a multi-prompt streaming request would otherwise silently drop all
+        # but the first. Reject it explicitly rather than lose prompts.
+        if len(prompts) > 1:
+            raise ValueError(
+                "streaming completions support a single prompt; send prompts "
+                "individually or set stream=false for a multi-prompt request"
+            )
         result = await generate_completion(
             manager,
             req.model,
-            prompt,
+            prompts[0],
             options,
             stream=True,
             max_tokens=max_tokens,
@@ -608,34 +652,47 @@ async def openai_completions(req: OpenAICompletionRequest, request: Request):
                 "text_completion",
                 lambda text: {"index": 0, "text": text, "finish_reason": None},
                 lambda: {"index": 0, "text": "", "finish_reason": "stop"},
+                # Strip <think> reasoning like /api/generate and the chat path.
+                strip_thinking=True,
                 include_usage=include_usage,
             ),
             media_type="text/event-stream",
         )
     else:
-        result = await generate_completion(
-            manager,
-            req.model,
-            prompt,
-            options,
-            stream=False,
-            max_tokens=max_tokens,
-        )
-        usage = OpenAIUsage.from_stats(result.get("stats"))
-        return OpenAICompletionResponse(
-            id=comp_id,
-            created=created,
-            model=req.model,
-            choices=[
+        choices: list[OpenAICompletionChoice] = []
+        total_prompt = 0
+        total_completion = 0
+        for i, prompt in enumerate(prompts):
+            result = await generate_completion(
+                manager,
+                req.model,
+                prompt,
+                options,
+                stream=False,
+                max_tokens=max_tokens,
+            )
+            usage = OpenAIUsage.from_stats(result.get("stats"))
+            total_prompt += usage.prompt_tokens
+            total_completion += usage.completion_tokens
+            choices.append(
                 OpenAICompletionChoice(
-                    index=0,
-                    text=result.get("text", ""),
+                    index=i,
+                    text=_strip_thinking_full(result.get("text", "")),
                     finish_reason="length"
                     if result.get("done_reason") in ("timeout", "length")
                     else "stop",
                 )
-            ],
-            usage=usage,
+            )
+        return OpenAICompletionResponse(
+            id=comp_id,
+            created=created,
+            model=req.model,
+            choices=choices,
+            usage=OpenAIUsage(
+                prompt_tokens=total_prompt,
+                completion_tokens=total_completion,
+                total_tokens=total_prompt + total_completion,
+            ),
         )
 
 

--- a/olmlx/routers/responses.py
+++ b/olmlx/routers/responses.py
@@ -9,6 +9,7 @@ from fastapi.responses import StreamingResponse
 from olmlx.config import settings
 from olmlx.engine.grammar import GrammarSpec, parse_response_format
 from olmlx.engine.inference import generate_chat
+from olmlx.engine.panel import panel_generate_chat
 from olmlx.engine.responses_state import get_store
 from olmlx.routers.streaming_common import (
     KEEPALIVE_PING_INTERVAL,
@@ -743,6 +744,10 @@ async def _stream_response(
 )
 async def create_response(req: ResponsesRequest, request: Request):
     manager = request.app.state.model_manager
+    # Dispatch synthetic panels through the panel coordinator here too, so an
+    # advertised panel isn't a 400 "model not found" on this surface (#627).
+    registry = request.app.state.registry
+    dispatch = panel_generate_chat if registry.is_panel(req.model) else generate_chat
     logger.info(
         "Responses request: model=%s stream=%s tools=%d prev=%s",
         req.model,
@@ -799,7 +804,7 @@ async def create_response(req: ResponsesRequest, request: Request):
     cache_id = (req.previous_response_id or response_id)[:256]
 
     if req.stream:
-        result = await generate_chat(
+        result = await dispatch(
             manager,
             req.model,
             engine_messages,
@@ -816,7 +821,7 @@ async def create_response(req: ResponsesRequest, request: Request):
             media_type="text/event-stream",
         )
 
-    result = await generate_chat(
+    result = await dispatch(
         manager,
         req.model,
         engine_messages,

--- a/tests/test_routers_anthropic.py
+++ b/tests/test_routers_anthropic.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from olmlx.routers.anthropic import (
+    _anthropic_stop_reason,
     _build_options,
     _convert_messages,
     _convert_tools,
@@ -378,6 +379,47 @@ class TestConvertMessages:
         messages = _convert_messages(req)
         assert all(m["role"] != "system" for m in messages)
 
+    def test_mixed_text_and_tool_result_preserves_order(self):
+        """A user turn ``[text, tool_result]`` must stay user-then-tool, not
+        be reordered to tool-then-user (#627)."""
+        req = AnthropicMessagesRequest(
+            max_tokens=100,
+            model="test",
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=[
+                        AnthropicContentBlock(type="text", text="here is the result"),
+                        AnthropicContentBlock(
+                            type="tool_result",
+                            tool_use_id="tu_1",
+                            content="42",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        messages = _convert_messages(req)
+        assert [m["role"] for m in messages] == ["user", "tool"]
+        assert messages[0]["content"] == "here is the result"
+        assert messages[1]["tool_call_id"] == "tu_1"
+
+
+class TestAnthropicStopReason:
+    def test_stop_sequence_hit_maps_to_stop_sequence(self):
+        # Engine sets done_reason="stop" only on a stop_sequences hit (#627).
+        assert _anthropic_stop_reason("stop", False) == "stop_sequence"
+
+    def test_natural_end_maps_to_end_turn(self):
+        assert _anthropic_stop_reason(None, False) == "end_turn"
+
+    def test_length_maps_to_max_tokens(self):
+        assert _anthropic_stop_reason("length", False) == "max_tokens"
+        assert _anthropic_stop_reason("timeout", False) == "max_tokens"
+
+    def test_tools_take_precedence(self):
+        assert _anthropic_stop_reason("stop", True) == "tool_use"
+
 
 class TestBuildOptions:
     def test_empty(self):
@@ -444,6 +486,64 @@ class TestAnthropicEndpoint:
         assert data["content"][0]["text"] == "Hello from MLX!"
         assert data["usage"]["input_tokens"] == 10
         assert data["usage"]["output_tokens"] == 20
+
+    @pytest.mark.asyncio
+    async def test_stop_sequence_hit_reports_stop_sequence(self, app_client):
+        # A client stop_sequences match (engine done_reason="stop") must report
+        # stop_reason "stop_sequence", not "end_turn" (#627).
+        stats = TimingStats(prompt_eval_count=5, eval_count=3)
+        with patch(
+            "olmlx.routers.anthropic.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = {
+                "text": "partial",
+                "done": True,
+                "done_reason": "stop",
+                "stats": stats,
+            }
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 50,
+                    "stop_sequences": ["STOP"],
+                },
+            )
+        assert resp.status_code == 200
+        assert resp.json()["stop_reason"] == "stop_sequence"
+
+    @pytest.mark.asyncio
+    async def test_panel_model_dispatches_to_panel_coordinator(self, app_client):
+        # A synthetic panel advertised in /v1/models must be dispatchable on
+        # /v1/messages, not a 400 "model not found" (#627).
+        stats = TimingStats(prompt_eval_count=1, eval_count=1)
+        with (
+            patch(
+                "olmlx.routers.anthropic.panel_generate_chat", new_callable=AsyncMock
+            ) as mock_panel,
+            patch(
+                "olmlx.routers.anthropic.generate_chat", new_callable=AsyncMock
+            ) as mock_gen,
+            patch("olmlx.engine.registry.ModelRegistry.is_panel", return_value=True),
+        ):
+            mock_panel.return_value = {
+                "text": "panel answer",
+                "done": True,
+                "stats": stats,
+            }
+            resp = await app_client.post(
+                "/v1/messages",
+                json={
+                    "model": "my-panel",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 50,
+                },
+            )
+        assert resp.status_code == 200
+        assert resp.json()["content"][0]["text"] == "panel answer"
+        mock_panel.assert_called_once()
+        mock_gen.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_missing_max_tokens_returns_400(self, app_client):

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -455,6 +455,38 @@ class TestStripThinkingStreaming:
         # Should contain data lines and end with [DONE]
         assert any("[DONE]" in line for line in lines)
 
+    async def test_streaming_role_only_in_first_delta(self, app_client):
+        # OpenAI emits ``role`` only on the first delta, not every chunk (#627).
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"text": "Hello", "done": False}
+                yield {"text": " world", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.openai.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                },
+            )
+
+        deltas = []
+        for line in resp.text.splitlines():
+            if line.startswith("data: ") and "[DONE]" not in line:
+                payload = json.loads(line[len("data: ") :])
+                for ch in payload.get("choices", []):
+                    deltas.append(ch.get("delta", {}))
+        roles = [d for d in deltas if "role" in d]
+        assert len(roles) == 1, f"role must appear exactly once, got {len(roles)}"
+        # And it must be on the first content-bearing delta.
+        content_deltas = [d for d in deltas if "content" in d]
+        assert "role" in content_deltas[0]
+
     @pytest.mark.asyncio
     async def test_completions_non_streaming(self, app_client):
         mock_result = {
@@ -487,24 +519,54 @@ class TestStripThinkingStreaming:
 
     @pytest.mark.asyncio
     async def test_completions_list_prompt(self, app_client):
-        mock_result = {"text": "result", "done": True, "stats": TimingStats()}
-
+        # Multi-prompt must honor *every* entry (one choice each), not
+        # silently drop all but the first (#627).
         with patch(
             "olmlx.routers.openai.generate_completion", new_callable=AsyncMock
         ) as mock_gen:
-            mock_gen.return_value = mock_result
+            mock_gen.side_effect = [
+                {"text": "one", "done": True, "stats": TimingStats()},
+                {"text": "two", "done": True, "stats": TimingStats()},
+            ]
             resp = await app_client.post(
                 "/v1/completions",
-                json={
-                    "model": "qwen3",
-                    "prompt": ["first prompt", "second prompt"],
-                },
+                json={"model": "qwen3", "prompt": ["first prompt", "second prompt"]},
             )
 
         assert resp.status_code == 200
-        # Should use first prompt
-        call_args = mock_gen.call_args
-        assert call_args[1].get("prompt") is None or call_args[0][2] == "first prompt"
+        data = resp.json()
+        assert [c["index"] for c in data["choices"]] == [0, 1]
+        assert [c["text"] for c in data["choices"]] == ["one", "two"]
+        # Both prompts were forwarded, in order.
+        used = [call.args[2] for call in mock_gen.call_args_list]
+        assert used == ["first prompt", "second prompt"]
+
+    async def test_completions_strips_thinking(self, app_client):
+        # /v1/completions must strip <think> reasoning like /api/generate (#627).
+        with patch(
+            "olmlx.routers.openai.generate_completion", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.return_value = {
+                "text": "<think>secret reasoning</think>answer",
+                "done": True,
+                "stats": TimingStats(),
+            }
+            resp = await app_client.post(
+                "/v1/completions",
+                json={"model": "qwen3", "prompt": "hi"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["choices"][0]["text"] == "answer"
+
+    async def test_completions_streaming_multi_prompt_rejected(self, app_client):
+        # A multi-prompt streaming request would drop prompts; reject clearly.
+        resp = await app_client.post(
+            "/v1/completions",
+            json={"model": "qwen3", "prompt": ["a", "b"], "stream": True},
+        )
+        assert resp.status_code == 400
+        assert "single prompt" in resp.json()["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_embeddings(self, app_client):
@@ -2578,3 +2640,27 @@ class TestLogprobsRejected:
                 },
             )
         assert resp.status_code == 200
+
+
+class TestErrorEnvelopes:
+    """Router-raised HTTPExceptions must be reshaped into the surface's
+    provider error envelope, not FastAPI's default {"detail": ...} (#627)."""
+
+    @pytest.mark.asyncio
+    async def test_openai_httpexception_gets_error_envelope(self, app_client):
+        from fastapi import HTTPException
+
+        with patch(
+            "olmlx.routers.openai.generate_chat", new_callable=AsyncMock
+        ) as mock_gen:
+            mock_gen.side_effect = HTTPException(status_code=422, detail="bad image")
+            resp = await app_client.post(
+                "/v1/chat/completions",
+                json={"model": "qwen3", "messages": [{"role": "user", "content": "hi"}]},
+            )
+
+        assert resp.status_code == 422
+        data = resp.json()
+        assert "detail" not in data
+        assert data["error"]["message"] == "bad image"
+        assert data["error"]["type"] == "invalid_request_error"

--- a/tests/test_routers_openai.py
+++ b/tests/test_routers_openai.py
@@ -2656,7 +2656,10 @@ class TestErrorEnvelopes:
             mock_gen.side_effect = HTTPException(status_code=422, detail="bad image")
             resp = await app_client.post(
                 "/v1/chat/completions",
-                json={"model": "qwen3", "messages": [{"role": "user", "content": "hi"}]},
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
             )
 
         assert resp.status_code == 422


### PR DESCRIPTION
## Summary
Seven grouped wire-format / cross-surface consistency fixes.

1. **Error envelopes** — a shared `HTTPException` handler (`app.py`) reshapes router-raised `HTTPException`s into the surface's provider error envelope instead of FastAPI's default `{"detail": ...}` (which provider SDKs can't parse). Status code + carried headers preserved; a status→error-type map keeps it consistent with the typed handlers.
2. **`/v1/completions`** — honors every prompt in a list (one choice each) instead of silently using `prompt[0]`; streaming rejects a multi-prompt request explicitly. Both paths now strip `<think>` reasoning like `/api/generate`.
3. **Panels** — dispatched on `/v1/messages` and `/v1/responses` via `panel_generate_chat`, so a panel advertised in `/v1/models` isn't a 400 "model not found" there.
4. **Anthropic stop_sequence** — a client `stop_sequences` match reports `stop_reason: "stop_sequence"` instead of `"end_turn"` (the engine sets `done_reason="stop"` only on a stop-sequence hit; natural EOS leaves it unset). Shared `_anthropic_stop_reason` used by all three mapping sites.
5. **Anthropic streaming** — no longer appends a spurious empty text block after a thinking-only response (tracks `thinking_block_emitted`).
6. **`_convert_messages` order** — a `[text, tool_result]` user turn stays user-then-tool instead of being reordered to tool-then-user (which changed KV-cache prefixes for interrupted tool use).
7. **OpenAI deltas** — `role` emitted only on the first delta, not every content chunk.

## Tests
Added for findings 1, 2, 3, 4, 6, 7 (RED-verified where applicable). Full router suite (343 tests) passes; ruff + pyright (0 errors) clean.

## Scope note
Surfacing the matched `stop_sequence` **string** would require engine plumbing across the generation paths (`StopScanner` doesn't return which sequence matched); this router-scoped PR fixes the client-visible `stop_reason` **classification** and leaves the string field as-is.

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)