### PR TITLE
fix(speculative): tree-mode crash + emitted/state divergence on GDN (#632)

### DIFF
--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -600,6 +600,20 @@ class SpeculativeDecoder(SpecDecoderBase):
                 self._draft_gdn_buffer = None
                 raise
 
+        # Tree speculation is unsupported on hybrid GatedDeltaNet models
+        # (#632): the tree attention mask is a (1,1,n,n) additive mask that
+        # GDN layers can't consume (they expect a (B,S) boolean mask), GDN
+        # recurrence can't honor per-branch tree isolation, and a depth-1
+        # sibling acceptance drives the draft rollback to
+        # ``num_keep_steps == 0``, which ``rollback_autoregressive`` rejects.
+        # Fall back to linear speculation, which is correct on GDN targets.
+        if self._use_tree and self._gdn_capture is not None:
+            logger.warning(
+                "Tree speculation (tree_width>=2) is not supported on hybrid "
+                "GatedDeltaNet models; falling back to linear speculation."
+            )
+            self._use_tree = False
+
     def close(self) -> None:
         """Release the GDN class-level monkey-patch (idempotent).
 
@@ -1151,6 +1165,16 @@ class SpeculativeDecoder(SpecDecoderBase):
         self._cache_seq_len += num_accepted
         assert num_accepted >= 1, "step(): _verify() must return at least 1 token"
         self._pending_token = int(mx.argmax(self._last_target_logit).item())
+
+        if used_sibling:
+            # The bonus at ``accepted[-1]`` was read from the tree forward at
+            # the sibling's flat, mispositioned-RoPE slot; the rebuild forward
+            # above recomputed the position-correct next-token logit into
+            # ``_last_target_logit``. Its argmax (== ``_pending_token``) is the
+            # token the target actually predicts after the sibling, so emit
+            # that instead — otherwise the client-visible token diverges from
+            # the token conditioning subsequent generation (#632).
+            accepted[-1] = self._pending_token
 
         num_accepted_draft = self._update_acceptance_rate(num_accepted)
 

--- a/tests/test_speculative_hybrid.py
+++ b/tests/test_speculative_hybrid.py
@@ -218,6 +218,32 @@ class TestGDNDetection:
         ):
             SpeculativeDecoder(draft, target)
 
+    def test_tree_mode_disabled_on_hybrid_gdn_model(self):
+        """Tree speculation is unsupported on hybrid GatedDeltaNet models
+        (mask shape break, GDN recurrence can't honor tree isolation, and a
+        depth-1 sibling acceptance crashes the draft rollback). It must fall
+        back to linear speculation rather than crash mid-generation (#632).
+        """
+        gdn = _make_fake_gdn_cls()
+        target = _make_hybrid_model(gdn_cls=gdn)
+        draft = _make_hybrid_model(gdn_cls=gdn)
+        dec = SpeculativeDecoder(draft, target, tree_width=3)
+        try:
+            assert dec._gdn_capture is not None
+            assert dec._use_tree is False  # disabled despite tree_width >= 2
+        finally:
+            dec.close()
+
+    def test_tree_mode_stays_enabled_on_non_hybrid_model(self):
+        target = _make_hybrid_model(gdn_cls=None)
+        draft = _make_hybrid_model(gdn_cls=None)
+        dec = SpeculativeDecoder(draft, target, tree_width=3)
+        try:
+            assert dec._gdn_capture is None
+            assert dec._use_tree is True
+        finally:
+            dec.close()
+
 
 # ---------------------------------------------------------------------------
 # Lifecycle: close() and __del__


### PR DESCRIPTION
## Summary
The opt-in tree-speculation mode (`tree_width>=2`, classic decoder only) had a crash in its most common branch case plus an exactness gap.

**Findings 1 + 3 — GDN incompatibility → disable tree mode on GDN.** On a hybrid GatedDeltaNet target/draft:
- the `(1,1,n,n)` additive tree mask can't be consumed by GDN layers (they expect a `(B,S)` boolean mask),
- GDN recurrence can't honor per-branch tree isolation, and
- a **depth-1 sibling acceptance** drives the draft rollback to `num_keep_steps == 0`, which `rollback_autoregressive` rejects with `ValueError` — a 500 in the *common* branch case.

Tree speculation is now disabled (falls back to linear speculation, with a warning) when the target or draft is hybrid GDN. Linear speculation is correct on GDN targets.

**Finding 2 — emitted/state divergence on sibling acceptance.** The emitted bonus (`accepted[-1]`) was read from the tree forward at the sibling's flat, mispositioned-RoPE slot, while the next pending token was recomputed from the position-correct rebuild forward. When they differed, the client-visible token diverged from the token conditioning subsequent generation. The sibling path now emits the position-correct rebuilt token (`accepted[-1] = _pending_token`).

## Tests
Tree mode is disabled on hybrid GDN models and stays enabled on non-hybrid models. Finding 2 is a reasoned one-line exactness fix in the sibling rebuild path; end-to-end `_step_tree` coverage would require a full Qwen-like fake target (`.model.{embed_tokens,layers,norm}` + outer `lm_head`), out of scope for this experimental opt-in path. Full speculative suite (197 tests) passes; ruff clean.

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)