### PR TITLE
fix(engine): offload event-loop-blocking work to worker threads (#614)

### DIFF
--- a/olmlx/chat/builtin_tools.py
+++ b/olmlx/chat/builtin_tools.py
@@ -263,7 +263,14 @@ async def _handle_glob(args: dict) -> str:
     pattern = args.get("pattern", "")
     path = args.get("path", ".")
 
-    matches = sorted(glob_module.glob(pattern, root_dir=path, recursive=True))
+    # A model-issued ``**/*`` over a large tree (or ``/``) would block the
+    # whole event loop — in server/agent mode that freezes every endpoint,
+    # not just this chat. Offload like the other file handlers (#614).
+    matches = sorted(
+        await asyncio.to_thread(
+            glob_module.glob, pattern, root_dir=path, recursive=True
+        )
+    )
     if not matches:
         return "No matches found."
 

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -1655,7 +1655,12 @@ class ModelManager(SpeculativeLoaderMixin):
                 weight_quant_str = model_config.resolved_weight_quant()
                 # Whisper models (issue #366) have no LLM KV cache — never
                 # apply KV-cache quantization / spectral calibration to them.
-                _model_kind = self._detect_model_kind(hf_path)
+                # ``_detect_model_kind`` can fall through to a blocking
+                # ``hf_hub_download(config.json)`` on first load of a
+                # not-yet-cached model; run it off the event loop so the whole
+                # server doesn't freeze for the round trip (#614). It is
+                # recomputed on the worker thread in ``_load_model`` anyway.
+                _model_kind = await asyncio.to_thread(self._detect_model_kind, hf_path)
                 if _model_kind in ("whisper", "tts", "reranker"):
                     kv_cache_quant = None
                     kv_eviction = None

--- a/tests/test_builtin_tools.py
+++ b/tests/test_builtin_tools.py
@@ -230,6 +230,29 @@ class TestGlob:
         )
         assert "no matches" in result.lower() or result.strip() == ""
 
+    @pytest.mark.asyncio
+    async def test_glob_runs_off_event_loop(self, manager, tmp_path):
+        """A model-issued ``**/*`` over a large tree must not block the event
+        loop — the glob is offloaded to a worker thread (#614)."""
+        import threading
+
+        from olmlx.chat import builtin_tools
+
+        (tmp_path / "a.py").write_text("")
+        recorded: dict = {}
+        real_glob = builtin_tools.glob_module.glob
+
+        def _recording_glob(*args, **kwargs):
+            recorded["thread"] = threading.current_thread()
+            return real_glob(*args, **kwargs)
+
+        with patch.object(builtin_tools.glob_module, "glob", _recording_glob):
+            result = await manager.call_tool(
+                "glob", {"pattern": "*.py", "path": str(tmp_path)}
+            )
+        assert "a.py" in result
+        assert recorded["thread"] is not threading.main_thread()
+
 
 class TestGrep:
     @pytest.mark.asyncio

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -5323,7 +5323,15 @@ class TestEvictLruIfNeeded:
             side_effect=lambda n: f"{n}:latest"
         )
 
-        async def _abort_load(*_a, **_kw):
+        # ``_detect_model_kind`` is offloaded via ``asyncio.to_thread`` before
+        # the load (#614); let that call through (stub it fast, no network) and
+        # abort only the load itself.
+        manager._detect_model_kind = lambda hf_path: "text"  # type: ignore[method-assign]
+        real_to_thread = asyncio.to_thread
+
+        async def _abort_load(func, *a, **kw):
+            if func is manager._detect_model_kind:
+                return await real_to_thread(func, *a, **kw)
             raise RuntimeError("stop before load")
 
         monkeypatch.setattr("olmlx.engine.model_manager.asyncio.to_thread", _abort_load)


### PR DESCRIPTION
## Summary
Two of the three reported paths ran blocking work directly on the asyncio event loop, freezing all HTTP endpoints / SSE streams / keepalives.

1. **`_detect_model_kind` under the manager lock** — ran synchronously in `ensure_loaded` and, on first load of a not-yet-cached model, fell through to a blocking `hf_hub_download(config.json)` on the loop thread. It's recomputed on the worker in `_load_model` anyway, so the loop-thread call is now offloaded via `asyncio.to_thread`.
2. **`_handle_glob`** — ran `glob(pattern, recursive=True)` inline, so a model-issued `**/*` over a large tree (or `/`) blocked the whole loop. Offloaded to a worker thread like every other file handler.

**Already fixed (finding 2):** the checkpoint-mechanism prefill no longer runs on the loop — `_setup_via_checkpoint_path` returns a `_deferred_prefill` closure that runs the drive on the generation worker thread (part of the mlx 0.32 thread-local-streams migration, which post-dates this issue), with the checkpoint insert marshalled back to the loop via `call_soon_threadsafe`. Noted for completeness.

## Tests
New test: glob runs off the event-loop thread. Existing detect/`ensure_loaded` tests updated for the new (earlier) `to_thread` offload. Targeted model_manager + builtin_tools suites pass; ruff clean.

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)