### PR TITLE
fix(agent): false stall on truncation, resume double-run, unbounded polling (#622)

### DIFF
--- a/olmlx/engine/agent/orchestrator.py
+++ b/olmlx/engine/agent/orchestrator.py
@@ -153,7 +153,14 @@ class Orchestrator:
 
                 prompt = goal if first else CONTINUATION_NUDGE
                 first = False
-                before = len(self.session.messages)
+                # Identify this turn's new messages by object identity, not a
+                # positional index: ``send_message`` may call
+                # ``_check_memory_and_truncate``, which rebinds
+                # ``session.messages`` to a shorter list. A stale ``before``
+                # index would then slice an empty/misaligned range, making the
+                # stall signature ``"[]"`` every iteration and falsely killing
+                # long runs as "stall" once truncation kicks in (#622).
+                before_ids = {id(m) for m in self.session.messages}
 
                 finished = False
                 summary = ""
@@ -170,7 +177,9 @@ class Orchestrator:
 
                 iterations += 1
                 runtime = elapsed()
-                new_messages = self.session.messages[before:]
+                new_messages = [
+                    m for m in self.session.messages if id(m) not in before_ids
+                ]
                 await self.store.append_checkpoint(
                     self.run_id, self.session.messages, iterations, tokens
                 )

--- a/olmlx/engine/agent/service.py
+++ b/olmlx/engine/agent/service.py
@@ -163,6 +163,17 @@ class AgentService:
                 f"run {run_id} has status {run['status']!r}, not resumable "
                 f"(must be one of {sorted(RESUMABLE_STATUSES)})"
             )
+        # Guard against a concurrent double-resume: the persisted status check
+        # above can pass for two quick /resume calls before either transitions
+        # to 'running' inside the task, and both would ``_start`` — two
+        # orchestrators interleaving append_event/checkpoint seqs, double-
+        # spending tokens, and leaving the run uncancellable when the first
+        # task's finally pops the second's handle (#622). A live handle means a
+        # task is already driving this run; there is no ``await`` between this
+        # check and ``_start``, so the check-and-set is atomic on the loop.
+        existing = self._handles.get(run_id)
+        if existing is not None and (existing.task is None or not existing.task.done()):
+            raise ValueError(f"run {run_id} is already running")
         self._start(run, resume=True)
         return await self.store.get_run(run_id)
 
@@ -477,6 +488,10 @@ class AgentService:
         fully drained. Polling (rather than a pub/sub) keeps it decoupled from
         the run's task and trivially correct across reconnects.
         """
+        # Cap the idle poll interval so a long-lived running-but-quiet run
+        # doesn't hammer SQLite at 1/poll_interval Hz forever (#622).
+        max_poll_interval = 1.0
+        idle_rounds = 0
         last_seq = -1
         while True:
             events = await self.store.get_events(run_id, after_seq=last_seq)
@@ -488,11 +503,22 @@ class AgentService:
                 "finished",
                 "failed",
                 "cancelled",
+                # A paused/interrupted run's task is no longer producing events
+                # on this stream (a resume spawns a fresh task the client
+                # reconnects to), so stop tailing instead of polling forever
+                # (#622).
+                "paused",
+                "interrupted",
             )
             if terminal and not events:
                 return
-            if not events:
-                await asyncio.sleep(poll_interval)
+            if events:
+                idle_rounds = 0
+            else:
+                await asyncio.sleep(
+                    min(poll_interval * (2**idle_rounds), max_poll_interval)
+                )
+                idle_rounds += 1
 
     async def aclose(self) -> None:
         for handle in list(self._handles.values()):

--- a/tests/test_agent_delegate.py
+++ b/tests/test_agent_delegate.py
@@ -239,3 +239,49 @@ class TestDelegateTool:
         result = await tools.call_tool("delegate", {"goal": "sub"})
         assert isinstance(result, ToolError)
         assert result.is_user_error
+
+
+class TestServiceLifecycle:
+    """Run-lifecycle guards in AgentService (#622)."""
+
+    async def test_resume_rejects_concurrent_double_run(self, store):
+        from olmlx.engine.agent.orchestrator import AgentContext
+        from olmlx.engine.agent.service import _RunHandle
+
+        svc = _service(store, _finish_factory)
+        await store.create_run(run_id="r1", goal="G", model="m", config={})
+        await store.update_run("r1", status="interrupted")
+
+        # Simulate a run already being driven: a live handle whose task is not
+        # done. A second resume must be rejected rather than starting a second
+        # orchestrator on the same run.
+        async def _blocking():
+            await asyncio.Event().wait()
+
+        task = asyncio.create_task(_blocking())
+        ctx = AgentContext(run_id="r1", store=store)
+        svc._handles["r1"] = _RunHandle(
+            cancel_event=asyncio.Event(), context=ctx, task=task
+        )
+        try:
+            with pytest.raises(ValueError, match="already running"):
+                await svc.resume("r1")
+        finally:
+            task.cancel()
+
+    async def test_stream_events_terminates_for_interrupted_run(self, store):
+        svc = _service(store, _finish_factory)
+        await store.create_run(run_id="r1", goal="G", model="m", config={})
+        await store.append_event("r1", {"type": "token", "text": "hi"})
+        await store.update_run("r1", status="interrupted")
+
+        events: list = []
+
+        async def _collect():
+            async for ev in svc.stream_events("r1", poll_interval=0.01):
+                events.append(ev)
+
+        # Must terminate — an interrupted run's task produces no more events, so
+        # tailing it should not loop forever.
+        await asyncio.wait_for(_collect(), timeout=2.0)
+        assert any(e.get("type") == "token" for e in events)

--- a/tests/test_agent_orchestrator.py
+++ b/tests/test_agent_orchestrator.py
@@ -42,7 +42,11 @@ class FakeSession:
         self._i += 1
         self.messages.append({"role": "user", "content": user_text})
         for msg in script.get("messages", []):
-            self.messages.append(msg)
+            # Append a fresh copy each turn — a real ChatSession produces new
+            # message objects per turn, and the orchestrator's stall signature
+            # now diffs by object identity (#622), so reusing one object would
+            # mask a legitimate identical-output stall.
+            self.messages.append(dict(msg))
         for event in script.get("events", []):
             yield event
         yield {"type": "done"}
@@ -274,6 +278,38 @@ class TestStall:
         assert result["reason"] == "stall"
         # iter1 sets baseline, iter2 +1, iter3 +2 == threshold.
         assert (await store.get_run("r1"))["iterations"] == 3
+
+    async def test_no_false_stall_when_history_truncated(self, store):
+        """When ``send_message`` rebinds ``messages`` to a shorter list
+        (memory truncation), a positional ``before`` slice would yield an
+        empty ``"[]"`` signature every iteration and falsely stall a run that
+        is making real progress. The identity-based diff must still see each
+        turn's distinct assistant output (#622).
+        """
+        await store.create_run(run_id="r1", goal="G", model="m", config={})
+
+        class TruncatingSession(FakeSession):
+            async def send_message(self, user_text):
+                self.prompts.append(user_text)
+                i = self._i
+                self._i += 1
+                # Simulate _check_memory_and_truncate: rebind messages to a
+                # fresh, shorter list — but with DISTINCT assistant content.
+                self.messages = [{"role": "system", "content": "summary"}]
+                self.messages.append({"role": "user", "content": user_text})
+                self.messages.append(_assistant(f"progress step {i}"))
+                yield {"type": "done"}
+
+        session = TruncatingSession([])
+        orch = Orchestrator(
+            session=session,
+            context=_ctx(store),
+            budgets=Budgets(max_iterations=5, stall_max_no_progress=2),
+        )
+        result = await orch.run()
+        # Must run to the iteration cap, NOT be killed as a stall.
+        assert result["reason"] != "stall"
+        assert (await store.get_run("r1"))["iterations"] == 5
 
 
 class TestResume:


### PR DESCRIPTION
## Summary
Three defects in the autonomous-agent run lifecycle.

1. **False stall on history truncation.** The stall signature was computed from `session.messages[before:]` using a positional index snapshotted before `send_message`. `_check_memory_and_truncate` rebinds `session.messages` to a shorter list, so the stale index sliced an empty/misaligned range — `"[]"` every iteration — tripping `stall_max_no_progress` and killing long runs as `failed/stall` exactly once truncation kicks in (i.e. the runs that matter). Now diff the turn's new messages by **object identity**, robust to the list being rebound.
2. **`resume` double-run race.** `resume` checked only the persisted status; two quick `/resume` calls could both pass (before either transitioned to `running` inside the task) and both `_start`, interleaving event/checkpoint seqs, double-spending tokens, and leaving the run uncancellable. Added a **live-handle guard** (atomic check-and-`_start` on the loop).
3. **`stream_events` never terminated for interrupted/paused runs** — the terminal set was only `finished/failed/cancelled`, so tailing a dead-task run polled SQLite forever at 20 Hz. Added `paused`/`interrupted` to the terminal set and **exponential idle backoff** (capped at 1s) so a quiet running run doesn't hammer the store either.

## Tests
Added for all three: no-false-stall-under-truncation, resume-rejects-concurrent-double-run, stream_events-terminates-for-interrupted-run. (`FakeSession` now appends fresh message copies per turn, matching a real ChatSession, since the stall signature diffs by identity.) Agent suites (43 tests) pass; ruff clean.

Closes #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)