### PR TITLE
fix(lifecycle): failed-startup rollback, stop() closes models, evictee leaks (#626)

### DIFF
--- a/olmlx/app.py
+++ b/olmlx/app.py
@@ -136,25 +136,46 @@ async def _lifespan_inner(app: FastAPI):
     )
     manager.start_expiry_checker()
 
-    settings.models_dir.mkdir(parents=True, exist_ok=True)
+    # Everything from here to ``yield`` acquires resources whose teardown lives
+    # in the post-``yield`` shutdown block — which never runs if startup raises.
+    # Roll back on failure so a failed startup doesn't orphan the expiry task or
+    # leave the stats collector registered in the module-level REGISTRY (which
+    # would poison every later create_app() with a duplicate-collector error,
+    # e.g. across tests in one process) — #626.
+    try:
+        settings.models_dir.mkdir(parents=True, exist_ok=True)
 
-    app.state.registry = registry
-    app.state.model_manager = manager
-    app.state.model_store = store
+        app.state.registry = registry
+        app.state.model_manager = manager
+        app.state.model_store = store
 
-    # Lazy gauge/counter collector reads the manager at scrape time.
-    stats_collector = metrics_mod.OlmlxStatsCollector(manager)
-    metrics_mod.REGISTRY.register(stats_collector)
-    app.state.metrics_collector = stats_collector
+        # Lazy gauge/counter collector reads the manager at scrape time.
+        stats_collector = metrics_mod.OlmlxStatsCollector(manager)
+        metrics_mod.REGISTRY.register(stats_collector)
+        app.state.metrics_collector = stats_collector
 
-    # Autonomous agent (#445): recover crash-orphaned runs at startup. The
-    # service itself is built in create_app() (gated on agent_enabled) so the
-    # routes exist without a lifespan; this only runs the async startup scan.
-    agent_service = (
-        getattr(app.state, "agent_service", None) if settings.agent_enabled else None
-    )
-    if agent_service is not None:
-        await agent_service.startup()
+        # Autonomous agent (#445): recover crash-orphaned runs at startup. The
+        # service itself is built in create_app() (gated on agent_enabled) so
+        # the routes exist without a lifespan; this only runs the async scan.
+        agent_service = (
+            getattr(app.state, "agent_service", None)
+            if settings.agent_enabled
+            else None
+        )
+        if agent_service is not None:
+            await agent_service.startup()
+    except Exception:
+        await manager.stop()
+        collector = getattr(app.state, "metrics_collector", None)
+        if collector is not None:
+            try:
+                metrics_mod.REGISTRY.unregister(collector)
+            except Exception:
+                logger.debug(
+                    "Failed to unregister collector on failed startup",
+                    exc_info=True,
+                )
+        raise
 
     logger.info("olmlx server started on %s:%d", settings.host, settings.port)
     yield

--- a/olmlx/app.py
+++ b/olmlx/app.py
@@ -165,7 +165,14 @@ async def _lifespan_inner(app: FastAPI):
         if agent_service is not None:
             await agent_service.startup()
     except Exception:
-        await manager.stop()
+        # Each rollback step is independently guarded: if manager.stop() raises
+        # (e.g. a Metal cache-flush failure), the collector unregister must
+        # still run, or the duplicate-collector poison this handler exists to
+        # prevent would come right back on the next create_app().
+        try:
+            await manager.stop()
+        except Exception:
+            logger.exception("manager.stop() failed during failed-startup rollback")
         collector = getattr(app.state, "metrics_collector", None)
         if collector is not None:
             try:

--- a/olmlx/engine/model_manager.py
+++ b/olmlx/engine/model_manager.py
@@ -1044,7 +1044,15 @@ class ModelManager(SpeculativeLoaderMixin):
             if drained:
                 await self._flush_metal()
         self._pending_load_tasks.clear()
+        # Close all still-resident models before dropping them — otherwise
+        # Flash prefetcher/weight-store executors (threads + per-layer fds),
+        # batch schedulers, and the whisper ModelHolder strong reference leak
+        # (#626). ``stop()`` is the documented lifecycle exit (used by tests and
+        # any embedding of the manager); process exit only masks this in prod.
+        resident = list(self._loaded.values())
         self._loaded.clear()
+        if resident:
+            await self._close_evictees(resident)
 
     def _resolve_keep_alive(self, keep_alive: int | str | None) -> float | None:
         """Parse keep_alive, falling back to the global default."""
@@ -1258,6 +1266,21 @@ class ModelManager(SpeculativeLoaderMixin):
                 if v.active_refs == 0 and v._adapter_child_refs == 0
             }
             if not evictable:
+                # Close the victims already popped this call before bailing —
+                # they're gone from ``_loaded`` and would otherwise leak their
+                # prefetcher/weight-store pools (threads + fds) + disk cache +
+                # grammar-cache drops, since the caller never receives the list
+                # to close (#626). A synchronous close under the lock is fine on
+                # this hard-failure path (nothing can be loaded anyway).
+                for victim in evictees:
+                    try:
+                        self._close_loaded_model(victim)
+                    except Exception:
+                        logger.warning(
+                            "Error closing evictee %s during failed eviction",
+                            victim.name,
+                            exc_info=True,
+                        )
                 raise RuntimeError(
                     "All loaded models are in use, cannot evict to load a new model"
                 )
@@ -1386,6 +1409,7 @@ class ModelManager(SpeculativeLoaderMixin):
         # resident across our awaits (download + off-thread build); once the
         # adapter is registered, ``_adapter_child_refs`` takes over the pinning.
         base_lm = await self.ensure_loaded(cfg.base, keep_alive=keep_alive, pin=True)
+        evictees: list[LoadedModel] = []
         try:
             self._reject_adapter_base(base_lm)
 
@@ -1411,7 +1435,6 @@ class ModelManager(SpeculativeLoaderMixin):
             )
             expires = time.time() + ka if ka is not None else None
 
-            evictees: list[LoadedModel] = []
             async with self._lock:
                 # Another coroutine may have loaded the same adapter during our
                 # awaits — discard our build and return theirs.
@@ -1459,6 +1482,15 @@ class ModelManager(SpeculativeLoaderMixin):
                     base_in_loaded._adapter_child_refs += 1
                 if pin:
                     lm.acquire_ref()
+        except BaseException:
+            # A failure after the evictees were popped (LoadedModel build, the
+            # lock block exiting abnormally, cancellation) must still close them
+            # — they're gone from _loaded and would otherwise leak their
+            # prefetcher/weight-store pools + disk cache. ``ensure_loaded``'s
+            # own exception handling does this; the adapter path must too (#626).
+            if evictees:
+                await self._close_evictees(evictees)
+            raise
         finally:
             # Release the temporary base pin; the child-ref now keeps it alive.
             base_lm.release_ref()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -693,3 +693,39 @@ class TestLifespanRollback:
         app2 = create_app()
         async with lifespan(app2):
             pass
+
+    @pytest.mark.asyncio
+    async def test_failed_startup_unregisters_collector_even_if_stop_fails(
+        self, registry, mock_store, monkeypatch, tmp_path
+    ):
+        """The rollback must unregister the collector even if manager.stop()
+        raises (e.g. a Metal flush failure) — otherwise the duplicate-collector
+        poison comes right back on the next create_app() (#626)."""
+        from unittest.mock import AsyncMock
+
+        from olmlx.app import create_app, lifespan
+
+        monkeypatch.setattr("olmlx.app.settings.models_dir", tmp_path / "m")
+        # stop() fails only on the first call (the rollback); the second run's
+        # clean shutdown succeeds.
+        monkeypatch.setattr(
+            "olmlx.engine.model_manager.ModelManager.stop",
+            AsyncMock(side_effect=[RuntimeError("stop boom")] + [None] * 10),
+        )
+
+        app = create_app()
+        monkeypatch.setattr("olmlx.app.settings.agent_enabled", True)
+        failing = MagicMock()
+        failing.startup = AsyncMock(side_effect=RuntimeError("startup boom"))
+        app.state.agent_service = failing
+
+        with pytest.raises(RuntimeError, match="startup boom"):
+            async with lifespan(app):
+                pass
+
+        # A second, clean startup must still succeed — the collector was
+        # unregistered despite stop() raising during the rollback.
+        monkeypatch.setattr("olmlx.app.settings.agent_enabled", False)
+        app2 = create_app()
+        async with lifespan(app2):
+            pass

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -658,3 +658,38 @@ class TestRequestIDFormatter:
         result = formatter.format(record)
         assert "Processing request" in result
         assert "[abc12345]" not in result
+
+
+class TestLifespanRollback:
+    @pytest.mark.asyncio
+    async def test_failed_startup_unregisters_collector(
+        self, registry, mock_store, monkeypatch, tmp_path
+    ):
+        """A startup that fails after the stats collector is registered must
+        unregister it (and stop the manager), so a later create_app()/lifespan
+        doesn't hit a duplicate-collector error against the module-level
+        REGISTRY (#626)."""
+        from unittest.mock import AsyncMock
+
+        from olmlx.app import create_app, lifespan
+
+        monkeypatch.setattr("olmlx.app.settings.models_dir", tmp_path / "m")
+
+        # First startup fails inside the agent scan (after the collector is
+        # registered).
+        app = create_app()
+        monkeypatch.setattr("olmlx.app.settings.agent_enabled", True)
+        failing = MagicMock()
+        failing.startup = AsyncMock(side_effect=RuntimeError("startup boom"))
+        app.state.agent_service = failing
+
+        with pytest.raises(RuntimeError, match="startup boom"):
+            async with lifespan(app):
+                pass
+
+        # A second, clean startup must succeed — the first must not have left a
+        # collector registered.
+        monkeypatch.setattr("olmlx.app.settings.agent_enabled", False)
+        app2 = create_app()
+        async with lifespan(app2):
+            pass

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -520,6 +520,54 @@ class TestModelManager:
         await mock_manager.stop()
         assert mock_manager._loaded == {}
 
+    async def test_stop_closes_resident_models(self, mock_manager):
+        """stop() must close still-resident models, not just clear the dict —
+        otherwise Flash pools / whisper holder / batch schedulers leak (#626)."""
+        closed: list[str] = []
+        mock_manager._close_loaded_model = lambda lm: closed.append(lm.name)  # type: ignore[assignment]
+        resident = [lm.name for lm in mock_manager._loaded.values()]
+        assert resident  # precondition: at least one model loaded
+        await mock_manager.stop()
+        assert mock_manager._loaded == {}
+        assert closed == resident
+
+    def test_pop_lru_evictees_closes_partial_on_failure(
+        self, registry, mock_store, monkeypatch
+    ):
+        """When eviction pops some victims then fails (all remaining models in
+        use), the already-popped victims must be closed, not leaked (#626)."""
+        monkeypatch.setattr("olmlx.engine.model_manager.settings.max_loaded_models", 1)
+        manager = ModelManager(registry, mock_store)
+        closed: list[str] = []
+        manager._close_loaded_model = lambda lm: closed.append(lm.name)  # type: ignore[assignment]
+
+        active = LoadedModel(
+            name="active:latest",
+            hf_path="a/repo",
+            model=MagicMock(),
+            tokenizer=MagicMock(),
+            template_caps=TemplateCaps(),
+        )
+        active.acquire_ref()  # pinned — cannot be evicted
+        idle = LoadedModel(
+            name="idle:latest",
+            hf_path="b/repo",
+            model=MagicMock(),
+            tokenizer=MagicMock(),
+            template_caps=TemplateCaps(),
+            loaded_at=time.time() - 100,
+        )
+        manager._loaded["active:latest"] = active
+        manager._loaded["idle:latest"] = idle
+
+        with pytest.raises(RuntimeError, match="in use"):
+            manager._pop_lru_evictees()
+
+        # The idle victim was popped then closed; the active one stays resident.
+        assert closed == ["idle:latest"]
+        assert "idle:latest" not in manager._loaded
+        assert "active:latest" in manager._loaded
+
     @pytest.mark.asyncio
     async def test_stop_cancels_pending_cleanups(self, mock_manager):
         """stop() cancels and clears pending cleanup tasks."""


### PR DESCRIPTION
## Summary
Three lifecycle defects in app / model-manager teardown.

1. **Failed startup poisoned the metrics registry.** There was no exception protection between `manager.start_expiry_checker()` and `yield`, so if `mkdir` / `REGISTRY.register` / `agent_service.startup()` raised, the post-`yield` shutdown never ran: the expiry task was orphaned and the stats collector stayed registered in the module-level `REGISTRY` — making every later `create_app()` (e.g. across tests in one process) fail with a duplicate-collector error. Now the post-`start_expiry_checker` startup is wrapped in try/except that calls `manager.stop()` + unregisters the collector before re-raising.
2. **`ModelManager.stop()` cleared `_loaded` without closing the models** — leaking Flash prefetcher/weight-store executors (threads + per-layer fds), batch schedulers, and the whisper `ModelHolder` strong ref. Now it closes all resident models via `_close_evictees` before clearing.
3. **Evictees leaked on two exception paths.** (a) `_pop_lru_evictees` raised `RuntimeError` mid-loop after popping victims into its local list — those models were gone from `_loaded` but never closed; it now closes the already-popped victims before raising. (b) `_load_adapter_model` leaked the popped evictees on any raise between `_pop_lru_evictees()` and `_close_evictees()`; it now closes them in an `except` handler like `ensure_loaded` already does.

## Tests
Added for all three: failed-startup-unregisters-collector (a second lifespan succeeds), stop()-closes-resident-models, _pop_lru_evictees-closes-partial-on-failure. Affected suites pass; ruff clean.

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)