### PR TITLE
fix(prompt-cache): deepcopy constants, filename collisions, grammar lock, shard estimate, stale counts (#634)

### DIFF
--- a/olmlx/engine/grammar.py
+++ b/olmlx/engine/grammar.py
@@ -183,8 +183,19 @@ def _get_compiler(tokenizer: Any, vocab_size: int) -> Any:
         cached = _live_value(_compiler_cache.get(key), tokenizer)
         if cached is not None:
             return cached
-        info = xgr.TokenizerInfo.from_huggingface(tokenizer, vocab_size=vocab_size)
-        compiler = xgr.GrammarCompiler(info, max_threads=4)
+    # Build OUTSIDE the lock: ``from_huggingface`` + ``GrammarCompiler`` walk
+    # the full vocabulary (the heaviest step) and would otherwise serialize
+    # every concurrent structured-output request — including ones for
+    # *unrelated* tokenizers — behind this single mutex (#634). The
+    # duplicate-build race is harmless: compilers for the same tokenizer are
+    # equivalent, so the loser of the race just discards its result — the same
+    # losers-discard reconciliation ``_compile_cache`` uses.
+    info = xgr.TokenizerInfo.from_huggingface(tokenizer, vocab_size=vocab_size)
+    compiler = xgr.GrammarCompiler(info, max_threads=4)
+    with _compiler_cache_lock:
+        cached = _live_value(_compiler_cache.get(key), tokenizer)
+        if cached is not None:
+            return cached
         _sweep_dead_entries_locked(_compiler_cache)
         ref = _make_ref(tokenizer)
         if ref is not None:

--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -832,6 +832,15 @@ def estimate_kv_cache_bytes(
             # Conservative estimate using avg_bits (actual varies per head)
             sq_per_entry = head_dim // (8 // quant_bits) + 4
             _tq_ratio = sq_per_entry / fp16_per_entry
+        elif method == "shard":
+            # ShardQuant: PCA-basis-projected packed indices + float32 norm.
+            # Rank truncation makes the real footprint smaller than this, so
+            # the turboquant-style estimate is a safe upper bound — but still
+            # far below fp16. Without it, shard-quant models were estimated at
+            # full fp16 KV size, 503-ing long prompts that would actually fit
+            # (#634).
+            shard_per_entry = head_dim // (8 // quant_bits) + 4
+            _tq_ratio = shard_per_entry / fp16_per_entry
 
     # Try layer introspection for NAS/variable-attention/hybrid models.
     # ``args_owner`` was set above to the component whose args we resolved
@@ -2530,6 +2539,12 @@ async def _kv_cache_preflight_check(
                 estimate_tokens = cache_read_tokens + num_prefill_tokens
                 if full_prompt_tokens is not None and not lm.is_vlm:
                     result.prompt = full_prompt_tokens
+                    # The trimmed cache was just dropped and the full prompt
+                    # restored for a fresh re-prefill, so the prefix reuse the
+                    # caller would otherwise report never happens — reset the
+                    # counts to reflect the full re-prefill (#634).
+                    result.cache_read_tokens = 0
+                    result.cache_creation_tokens = len(full_prompt_tokens)
             estimate_total = estimate_tokens + max_tokens
             kv_bytes = estimate_kv_cache_bytes(
                 lm.model,

--- a/olmlx/engine/prompt_cache/store.py
+++ b/olmlx/engine/prompt_cache/store.py
@@ -227,7 +227,11 @@ class PromptCacheStore:
     def _disk_file_path(self, cache_id: str) -> Path:
         """Return the disk file path for a given cache_id."""
         safe_name = re.sub(r"[^\w\-.]", "_", cache_id) or "_default"
-        return self._disk_dir() / f"{safe_name}.safetensors"
+        # Append a short hash of the *raw* cache_id so distinct ids that
+        # sanitize to the same string (e.g. "agent/1" and "agent_1") don't
+        # collide onto one file and silently overwrite each other's spill (#634).
+        digest = hashlib.sha1(cache_id.encode("utf-8")).hexdigest()[:12]
+        return self._disk_dir() / f"{safe_name}-{digest}.safetensors"
 
     def _save_to_disk(self, cache_id: str, state: CachedPromptState) -> None:
         """Save a cache entry to disk."""

--- a/olmlx/engine/prompt_cache/vlm_state.py
+++ b/olmlx/engine/prompt_cache/vlm_state.py
@@ -49,12 +49,16 @@ logger = logging.getLogger(__name__)
 
 
 def _safe_name(name: str) -> str:
-    # Append a short hash of the raw name so distinct ids that sanitize to the
-    # same string (e.g. "agent/1" and "agent_1") don't collide onto one file
-    # and silently overwrite each other's spill (#634).
-    safe = re.sub(r"[^\w\-.]", "_", name) or "_default"
-    digest = hashlib.sha1(name.encode("utf-8")).hexdigest()[:12]
-    return f"{safe}-{digest}"
+    return re.sub(r"[^\w\-.]", "_", name) or "_default"
+
+
+def _safe_cache_id_name(cache_id: str) -> str:
+    # Append a short hash of the raw cache_id so distinct ids that sanitize to
+    # the same string (e.g. "agent/1" and "agent_1") don't collide onto one
+    # file and silently overwrite each other's spill (#634). Only the per-id
+    # filename needs this — the model-name dir is stable per store.
+    digest = hashlib.sha1(cache_id.encode("utf-8")).hexdigest()[:12]
+    return f"{_safe_name(cache_id)}-{digest}"
 
 
 class VlmPromptCacheStore:
@@ -231,7 +235,7 @@ class VlmPromptCacheStore:
         return self._disk_path / _safe_name(self._model_name)
 
     def _disk_file_path(self, cache_id: str) -> Path:
-        return self._disk_dir() / f"{_safe_name(cache_id)}.safetensors"
+        return self._disk_dir() / f"{_safe_cache_id_name(cache_id)}.safetensors"
 
     def _save_to_disk(self, cache_id: str, state: Any) -> None:
         """Serialize one PromptCacheState to disk. Best-effort: a save failure

--- a/olmlx/engine/prompt_cache/vlm_state.py
+++ b/olmlx/engine/prompt_cache/vlm_state.py
@@ -27,6 +27,7 @@ cleanup bounds disk use. Remaining v1 limits: no radix-takeover, no KV-quant.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import re
@@ -48,7 +49,12 @@ logger = logging.getLogger(__name__)
 
 
 def _safe_name(name: str) -> str:
-    return re.sub(r"[^\w\-.]", "_", name) or "_default"
+    # Append a short hash of the raw name so distinct ids that sanitize to the
+    # same string (e.g. "agent/1" and "agent_1") don't collide onto one file
+    # and silently overwrite each other's spill (#634).
+    safe = re.sub(r"[^\w\-.]", "_", name) or "_default"
+    digest = hashlib.sha1(name.encode("utf-8")).hexdigest()[:12]
+    return f"{safe}-{digest}"
 
 
 class VlmPromptCacheStore:

--- a/olmlx/engine/shardquant_cache.py
+++ b/olmlx/engine/shardquant_cache.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+import copy
 from pathlib import Path
 from typing import Any
 
@@ -282,6 +283,38 @@ class ShardKVCache(_BaseCache):
         if len(parts_k) == 1:
             return parts_k[0], parts_v[0]
         return mx.concatenate(parts_k, axis=2), mx.concatenate(parts_v, axis=2)
+
+    #: Immutable per-layer calibration constants — shared by reference in
+    #: ``__deepcopy__`` instead of duplicated into every checkpoint snapshot.
+    _SHARED_CONSTANTS = frozenset(
+        {"k_basis", "k_codebook", "v_rotation", "v_codebooks", "k_mean"}
+    )
+
+    def __deepcopy__(self, memo):
+        """Deep-copy hook for the checkpoint snapshot path.
+
+        The default ``copy.deepcopy`` duplicates the read-only calibration
+        constants (``k_basis`` is ``(H, D, D)`` — ~512 KB/layer, ~16 MB per
+        32-layer snapshot — plus the V codebooks / rotation), and
+        ``_estimate_state_bytes`` then charges each duplicate against the
+        prompt-cache RAM budget per stored entry (#634). They are never mutated
+        (only read in ``shard_compress_*``), so share them by reference and
+        deep-copy only the mutable packed buffers. Eager-eval owned arrays first
+        so the snapshot is thread-safe regardless of where it is later consumed
+        (the #284 Metal-stream hazard), mirroring ``TurboQuantKVCache``.
+        """
+        owned = [v for v in self.__dict__.values() if isinstance(v, mx.array)]
+        if owned:
+            mx.eval(owned)
+        cls = type(self)
+        new = cls.__new__(cls)
+        memo[id(self)] = new
+        for k, v in self.__dict__.items():
+            if k in self._SHARED_CONSTANTS:
+                new.__dict__[k] = v
+            else:
+                new.__dict__[k] = copy.deepcopy(v, memo)
+        return new
 
     @property
     def state(self):

--- a/olmlx/engine/spectralquant_cache.py
+++ b/olmlx/engine/spectralquant_cache.py
@@ -11,6 +11,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
+import copy
+
 import mlx.core as mx
 
 from mlx_lm.models.cache import KVCache, _BaseCache, create_attention_mask
@@ -210,6 +212,43 @@ class SpectralQuantKVCache(_BaseCache):
             dtype=input_dtype,
         )
         return k_full[..., : self.offset, :], v_full[..., : self.offset, :]
+
+    #: Immutable per-layer calibration constants — shared by reference in
+    #: ``__deepcopy__`` instead of duplicated into every checkpoint snapshot.
+    _SHARED_CONSTANTS = frozenset(
+        {
+            "rotation_key",
+            "rotation_value",
+            "codebook_sem_key",
+            "codebook_tail_key",
+            "codebook_sem_value",
+            "codebook_tail_value",
+        }
+    )
+
+    def __deepcopy__(self, memo):
+        """Deep-copy hook for the checkpoint snapshot path.
+
+        The default ``copy.deepcopy`` duplicates the read-only rotation
+        matrices + codebooks into every stored entry, which
+        ``_estimate_state_bytes`` then charges against the prompt-cache RAM
+        budget per entry (#634). They are never mutated (only read in
+        ``spectral_quantize``), so share them by reference and deep-copy only
+        the mutable packed buffers. Eager-eval owned arrays first for
+        cross-thread safety (#284), mirroring ``TurboQuantKVCache``.
+        """
+        owned = [v for v in self.__dict__.values() if isinstance(v, mx.array)]
+        if owned:
+            mx.eval(owned)
+        cls = type(self)
+        new = cls.__new__(cls)
+        memo[id(self)] = new
+        for k, v in self.__dict__.items():
+            if k in self._SHARED_CONSTANTS:
+                new.__dict__[k] = v
+            else:
+                new.__dict__[k] = copy.deepcopy(v, memo)
+        return new
 
     @property
     def state(self):

--- a/olmlx/engine/turboquant_cache.py
+++ b/olmlx/engine/turboquant_cache.py
@@ -431,9 +431,15 @@ class TurboQuantKVCache(_BaseCache):
         new = cls.__new__(cls)
         memo[id(self)] = new
         for k, v in self.__dict__.items():
-            if k == "_dequant_dtype":
-                # mx.Dtype is an immutable singleton; share by reference
-                # because the default pickle-based deepcopy would fail.
+            if k in ("_dequant_dtype", "rotation_key", "rotation_value"):
+                # ``_dequant_dtype`` is an immutable mx.Dtype singleton (the
+                # default pickle-based deepcopy would fail). ``rotation_key`` /
+                # ``rotation_value`` are immutable per-layer calibration
+                # constants (each two DxD float32 matrices + ``matrix_T``) that
+                # are never mutated — deep-copying them into every checkpoint
+                # snapshot wasted RAM and double-charged the prompt-cache RAM
+                # budget via ``_estimate_state_bytes`` (#634). Share by
+                # reference; safe exactly like ``_dequant_dtype``.
                 new.__dict__[k] = v
             else:
                 new.__dict__[k] = copy.deepcopy(v, memo)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -4472,6 +4472,24 @@ class TestEstimateKvCacheBytes:
         assert tq2_result < fp16_result
         assert fp16_result / tq2_result == pytest.approx(256 / 36, rel=0.01)
 
+    def test_shard_reduces_estimate(self):
+        """ShardQuant KV cache must reduce the estimate too — before #634 it
+        was ignored, so shard-quant models were estimated at full fp16 and
+        503'd long prompts that would actually fit.
+        """
+        model = self._make_model(
+            num_hidden_layers=80,
+            num_attention_heads=64,
+            num_key_value_heads=8,
+            head_dim=128,
+            hidden_size=8192,
+        )
+        fp16_result = estimate_kv_cache_bytes(model, 37000)
+        shard_result = estimate_kv_cache_bytes(model, 37000, kv_cache_quant="shard:4")
+        assert shard_result < fp16_result
+        # Same conservative packed formula as turboquant: 256 → 68 bytes.
+        assert fp16_result / shard_result == pytest.approx(256 / 68, rel=0.01)
+
     def test_turboquant_none_unchanged(self):
         """Passing kv_cache_quant=None should give the same result as no arg."""
         model = self._make_model()

--- a/tests/test_kv_disk_cache.py
+++ b/tests/test_kv_disk_cache.py
@@ -378,8 +378,9 @@ class TestPromptCacheStoreEvictAllToDisk:
         )
         disk_dir = tmp_path / "test-model"
         disk_dir.mkdir(parents=True)
-        (disk_dir / "a.safetensors").write_bytes(b"x" * 80)
-        (disk_dir / "b.safetensors").write_bytes(b"x" * 80)
+        # Write via _disk_file_path so remove("a") finds the same (hashed) name.
+        store._disk_file_path("a").write_bytes(b"x" * 80)
+        store._disk_file_path("b").write_bytes(b"x" * 80)
         # Prime the metric by running cleanup.
         store._cleanup_disk()
         assert store.metrics.bytes_on_disk == 160

--- a/tests/test_prompt_cache_store.py
+++ b/tests/test_prompt_cache_store.py
@@ -208,3 +208,15 @@ class TestTake:
         store.set("a", _make_state(1))
         await store.async_take("a")
         assert unlinked == [store._disk_file_path("a")]
+
+    def test_disk_file_path_distinct_ids_do_not_collide(self, tmp_path):
+        """cache_ids that sanitize to the same string (e.g. "agent/1" and
+        "agent_1") must map to different disk files, not silently overwrite
+        each other's spill (#634)."""
+        store = PromptCacheStore(max_slots=4, disk_path=tmp_path, model_name="m")
+        paths = {
+            store._disk_file_path(cid) for cid in ("agent/1", "agent_1", "agent:1")
+        }
+        assert len(paths) == 3
+        # Same id is still stable (round-trips to the same file).
+        assert store._disk_file_path("agent/1") == store._disk_file_path("agent/1")

--- a/tests/test_shardquant_cache.py
+++ b/tests/test_shardquant_cache.py
@@ -268,6 +268,16 @@ class TestShardKVCacheStateAndCopy:
         _feed(cache, 40)
         assert not any(isinstance(v, mx.Dtype) for v in cache.__dict__.values())
 
+    def test_deepcopy_shares_calibration_constants(self):
+        """The immutable per-layer calibration constants must be shared by
+        reference in a snapshot, not duplicated (k_basis is (H, D, D)) — that
+        wasted RAM and double-charged the prompt-cache budget (#634)."""
+        cache = _make_cache()
+        _feed(cache, 40)
+        snap = copy.deepcopy(cache)
+        for attr in ("k_basis", "k_codebook", "v_rotation", "v_codebooks"):
+            assert getattr(snap, attr) is getattr(cache, attr), attr
+
 
 class TestMakeShardCache:
     def _calib_entry(self, D=16, H=2, bits=4):


### PR DESCRIPTION
## Summary
Five grouped fixes in the prompt-cache store, checkpointing, grammar cache, and KV estimation.

1. **Checkpoint deepcopy of calibration constants** — snapshots no longer duplicate immutable per-layer constants. `TurboQuantKVCache` shares `rotation_key`/`rotation_value` by reference in `__deepcopy__` (like `_dequant_dtype`); `ShardKVCache` and `SpectralQuantKVCache` gain `__deepcopy__` hooks that share their read-only basis/codebooks/rotations (`k_basis` is `(H, D, D)` ≈ 512 KB/layer) and deep-copy only the mutable packed buffers. These were duplicated per snapshot **and** double-charged against the RAM budget by `_estimate_state_bytes`.
2. **Filename collisions** — disk-cache filenames append a short sha1 of the *raw* `cache_id`, so distinct ids that sanitize to the same string (`agent/1` vs `agent_1`) no longer collide onto one file and silently overwrite each other's spill (`store.py` + `vlm_state.py`).
3. **Grammar lock** — `_get_compiler` builds `TokenizerInfo.from_huggingface` + `GrammarCompiler` (the full-vocab walk) **outside** the global cache lock now, with double-checked locking + losers-discard reconciliation — no longer serializing every concurrent structured-output request (even for unrelated tokenizers) behind one mutex.
4. **Shard preflight estimate** — `estimate_kv_cache_bytes` handles `shard:` quantization (it only knew turboquant/spectral), so shard-quant models aren't estimated at full fp16 KV size and 503'd on long prompts that would fit.
5. **Stale reuse counts** — when the KV preflight drops the trimmed cache and restores the full prompt for a fresh re-prefill, `cache_read_tokens` / `cache_creation_tokens` are reset to reflect the full re-prefill instead of the pre-eviction prefix reuse that no longer happens (metrics).

## Tests
Added for findings 1 (shard shares constants), 2 (no filename collision), 4 (shard reduces estimate). Findings 3 (covered by existing grammar tests) and 5 (metrics-only). Prompt-cache/quant/grammar suites (342 tests) pass; ruff clean.

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)