### PR TITLE
fix(chat/agent): per-token SQLite batching, live skill reg, MCP transport, templating None (#636)

### DIFF
--- a/olmlx/chat/mcp_client.py
+++ b/olmlx/chat/mcp_client.py
@@ -87,11 +87,23 @@ class MCPClientManager:
         """
         attempts = max(max_attempts if max_attempts is not None else 3, 1)
         for name, server_cfg in config.items():
+            transport = server_cfg.get("transport")
+            if transport not in ("stdio", "sse"):
+                # Previously an unknown transport matched neither branch and
+                # the loop ``break``d as if the connection had succeeded — no
+                # log, no error, zero tools discovered (#636). Surface it.
+                logger.warning(
+                    "Skipping MCP server %r: unknown transport %r "
+                    "(expected 'stdio' or 'sse')",
+                    name,
+                    transport,
+                )
+                continue
             for attempt in range(attempts):
                 try:
-                    if server_cfg["transport"] == "stdio":
+                    if transport == "stdio":
                         await self._connect_stdio(name, server_cfg)
-                    elif server_cfg["transport"] == "sse":
+                    else:  # "sse" — validated above
                         await self._connect_sse(name, server_cfg)
                     break
                 except Exception as exc:

--- a/olmlx/chat/session.py
+++ b/olmlx/chat/session.py
@@ -980,8 +980,6 @@ class ChatSession:
             if r:
                 result_msg = r["message"]
                 if tu["name"] == "question":
-                    import json
-
                     content = result_msg.get("content", "")
                     # Only a well-formed ``__question__:`` payload emits the
                     # interactive question event. A denied/errored ``question``

--- a/olmlx/engine/agent/orchestrator.py
+++ b/olmlx/engine/agent/orchestrator.py
@@ -44,6 +44,10 @@ CONTINUATION_NUDGE = (
 #: streamed chunk ≈ one token under mlx-lm streaming.
 _TOKEN_EVENT_TYPES = frozenset({"token", "thinking_token"})
 
+#: How many buffered token events to accumulate before a batched SQLite flush
+#: (#636). Small enough that live SSE tailers see near-real-time output.
+_TOKEN_FLUSH_BATCH = 16
+
 
 class _Session(Protocol):
     messages: list[dict]
@@ -164,16 +168,36 @@ class Orchestrator:
 
                 finished = False
                 summary = ""
+                # Buffer high-frequency token events and flush them in batches,
+                # rather than paying an ``asyncio.to_thread`` + SQLite round-trip
+                # per token (which throttled generation to thread-pool rate,
+                # #636). Ordered events (tool_call/result/status) flush the
+                # buffer first so SSE replay preserves order, then persist
+                # immediately for prompt live delivery.
+                token_buffer: list[dict] = []
+
+                async def _flush_tokens() -> None:
+                    nonlocal token_buffer
+                    if token_buffer:
+                        await self.store.append_events(self.run_id, token_buffer)
+                        token_buffer = []
+
                 async for event in self.session.send_message(prompt):
-                    await self.store.append_event(self.run_id, event)
                     etype = event.get("type")
                     if etype in _TOKEN_EVENT_TYPES:
+                        token_buffer.append(event)
                         tokens += 1
-                    elif etype == "tool_call" and event.get("name") == "finish":
+                        if len(token_buffer) >= _TOKEN_FLUSH_BATCH:
+                            await _flush_tokens()
+                        continue
+                    await _flush_tokens()
+                    await self.store.append_event(self.run_id, event)
+                    if etype == "tool_call" and event.get("name") == "finish":
                         finished = True
                         args = event.get("arguments")
                         if isinstance(args, dict):
                             summary = str(args.get("summary", "")).strip()
+                await _flush_tokens()
 
                 iterations += 1
                 runtime = elapsed()

--- a/olmlx/engine/agent/service.py
+++ b/olmlx/engine/agent/service.py
@@ -301,7 +301,9 @@ class AgentService:
         # offered to this one (the self-improving loop's read side).
         skills = SkillManager(config.skills_dir)
         skills.load()
-        builtin = AgentToolManager(config, context)
+        # Pass the live SkillManager so a mid-run create_skill registers into
+        # it and is immediately usable via use_skill (#636).
+        builtin = AgentToolManager(config, context, skills=skills)
         # Gate the mutating/exec builtins per policy; every other tool stays
         # ALLOW so the agent still runs autonomously. AUTO routes through an LLM
         # safety judge (fail-closed); "deny" blocks outright; "allow" trusts.

--- a/olmlx/engine/agent/store.py
+++ b/olmlx/engine/agent/store.py
@@ -320,6 +320,34 @@ class AgentStore:
     async def append_event(self, run_id: str, event: dict[str, Any]) -> int:
         return await asyncio.to_thread(self._append_event, run_id, event)
 
+    async def append_events(self, run_id: str, events: list[dict[str, Any]]) -> None:
+        """Persist a batch of events in a single thread-hop + transaction.
+
+        The orchestrator buffers high-frequency token events and flushes them
+        here so generation isn't throttled to one ``asyncio.to_thread`` +
+        SQLite round-trip *per token* (#636).
+        """
+        if not events:
+            return
+        await asyncio.to_thread(self._append_events, run_id, events)
+
+    def _append_events(self, run_id: str, events: list[dict[str, Any]]) -> None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT COALESCE(MAX(seq) + 1, 0) AS seq FROM events WHERE run_id = ?",
+                (run_id,),
+            ).fetchone()
+            seq = int(row["seq"])
+            now = time.time()
+            self._conn.executemany(
+                "INSERT INTO events (run_id, seq, type, data, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                [
+                    (run_id, seq + i, str(e.get("type", "")), json.dumps(e), now)
+                    for i, e in enumerate(events)
+                ],
+            )
+
     def _append_event(self, run_id: str, event: dict[str, Any]) -> int:
         with self._lock:
             row = self._conn.execute(

--- a/olmlx/engine/agent/tools.py
+++ b/olmlx/engine/agent/tools.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from olmlx.chat.builtin_tools import BuiltinToolManager
 from olmlx.chat.config import ChatConfig
@@ -159,9 +159,13 @@ _EXCLUDED_BUILTINS = frozenset({"question"})
 class AgentToolManager(BuiltinToolManager):
     """Builtin tools plus the agent's control tools, bound to an AgentContext."""
 
-    def __init__(self, config: ChatConfig, context: "AgentContext"):
+    def __init__(self, config: ChatConfig, context: "AgentContext", skills: Any = None):
         super().__init__(config)
         self._context = context
+        # The live SkillManager (when the agent rides a ChatSession), so a
+        # ``create_skill`` mid-run is immediately usable via ``use_skill``
+        # (#636). None in tests / bare tool-manager use.
+        self._skills = skills
         self._agent_defs: list[dict] = [
             _FINISH_DEF,
             _REMEMBER_DEF,
@@ -245,13 +249,24 @@ class AgentToolManager(BuiltinToolManager):
         description = str(arguments.get("description", "")).strip()
         body = str(arguments.get("body", ""))
         try:
-            path = await asyncio.to_thread(
-                write_skill_file,
-                self._config.skills_dir,
-                name,
-                description,
-                body,
-            )
+            if self._skills is not None:
+                # Route through the live SkillManager so the new skill is
+                # registered in-memory and an immediate ``use_skill`` finds it,
+                # not just written to disk for the next run to reload (#636).
+                # This is also SkillManager.create_skill's only production
+                # caller (was otherwise dead code).
+                skill = await asyncio.to_thread(
+                    self._skills.create_skill, name, description, body
+                )
+                path = skill.path
+            else:
+                path = await asyncio.to_thread(
+                    write_skill_file,
+                    self._config.skills_dir,
+                    name,
+                    description,
+                    body,
+                )
         except ValueError as exc:
             return ToolError(
                 message=f"Invalid skill: {exc}",

--- a/olmlx/engine/chat_templating.py
+++ b/olmlx/engine/chat_templating.py
@@ -41,10 +41,14 @@ def _inject_tools_into_system(messages: list[dict], tools: list[dict]) -> list[d
 
     messages = list(messages)  # shallow copy
     if messages and messages[0].get("role") == "system":
-        messages[0] = {
-            **messages[0],
-            "content": messages[0]["content"] + "\n\n" + tool_block,
-        }
+        # ``content`` may be None (OpenAIChatMessage permits it for system
+        # messages) or a non-string (multimodal parts) — coerce to "" so the
+        # concat doesn't 500 (#636). Mirrors ``_add_native_tool_hint``'s guard.
+        existing = messages[0].get("content")
+        if not isinstance(existing, str):
+            existing = ""
+        new_content = f"{existing}\n\n{tool_block}" if existing else tool_block
+        messages[0] = {**messages[0], "content": new_content}
     else:
         messages.insert(0, {"role": "system", "content": tool_block})
     return messages

--- a/olmlx/engine/flash/flash_mlp.py
+++ b/olmlx/engine/flash/flash_mlp.py
@@ -71,16 +71,28 @@ class WindowManager:
         self._dirty[layer_idx] = False
         return self._cached_window[layer_idx]
 
-    def update(self, layer_idx: int, active_indices: mx.array) -> None:
-        """Record newly activated neurons for this token."""
+    def update(
+        self,
+        layer_idx: int,
+        active_indices: mx.array,
+        active_list: list[int] | None = None,
+    ) -> None:
+        """Record newly activated neurons for this token.
+
+        ``active_list`` lets the caller pass an already-computed
+        ``active_indices.tolist()`` so this doesn't re-eval + re-convert the
+        same array a second time per layer per token (#636).
+        """
         if layer_idx not in self._history:
             if self._budget_neurons is not None:
                 self._history[layer_idx] = deque()
             else:
                 self._history[layer_idx] = deque(maxlen=self.window_size)
             self._cached_window[layer_idx] = set()
-        mx.eval(active_indices)
-        self._history[layer_idx].append(set(active_indices.tolist()))
+        if active_list is None:
+            mx.eval(active_indices)
+            active_list = active_indices.tolist()
+        self._history[layer_idx].append(set(active_list))
         self._dirty[layer_idx] = True
 
         # Enforce max window size for dynamic mode
@@ -182,7 +194,9 @@ class FlashMLP(nn.Module):
         # Update window before submit — update calls mx.eval internally,
         # and submit enqueues prediction to a background thread whose
         # mx.eval must not overlap with the main thread's mx.eval.
-        self.window_manager.update(self.layer_idx, predicted)
+        self.window_manager.update(
+            self.layer_idx, predicted, active_list=predicted_list
+        )
 
         # Start prefetch for the NEXT layer before blocking on current I/O.
         # Uses flat_x (pre-MLP hidden state) as an approximate signal for

--- a/tests/test_agent_orchestrator.py
+++ b/tests/test_agent_orchestrator.py
@@ -312,6 +312,37 @@ class TestStall:
         assert (await store.get_run("r1"))["iterations"] == 5
 
 
+class TestTokenBatching:
+    async def test_token_events_batched_and_ordered(self, store):
+        """Token events are buffered and flushed in a batch, but must still be
+        persisted before the following ordered event so SSE replay preserves
+        order (#636)."""
+        await store.create_run(run_id="r1", goal="G", model="m", config={})
+        turn = {
+            "events": [
+                {"type": "token", "text": "a"},
+                {"type": "token", "text": "b"},
+                {
+                    "type": "tool_call",
+                    "name": "finish",
+                    "arguments": {"summary": "done"},
+                    "id": "t1",
+                },
+            ],
+            "messages": [_assistant("x")],
+        }
+        session = FakeSession([turn])
+        orch = Orchestrator(session=session, context=_ctx(store), budgets=Budgets())
+        await orch.run()
+        events = await store.get_events("r1")
+        types = [e["type"] for e in events]
+        assert types.count("token") == 2
+        # Both tokens land before the tool_call.
+        assert max(i for i, t in enumerate(types) if t == "token") < types.index(
+            "tool_call"
+        )
+
+
 class TestResume:
     async def test_resume_rehydrates_messages_and_counters(self, store):
         await store.create_run(run_id="r1", goal="G", model="m", config={})

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -109,6 +109,22 @@ class TestCreateSkillTool:
         persisted = await context.store.get_skill("git-bisect")
         assert persisted["source_run"] == "r1"
 
+    async def test_create_skill_registers_in_live_manager(self, context, tmp_path):
+        """create_skill routed through the live SkillManager must register the
+        skill in-memory so an immediate use_skill finds it, not just write it to
+        disk for the next run's reload (#636)."""
+        config = ChatConfig(model_name="m", skills_dir=tmp_path / "skills")
+        skills = SkillManager(tmp_path / "skills")
+        skills.load()
+        tools = AgentToolManager(config, context, skills=skills)
+        await context.store.create_run(run_id="r1", goal="g", model="m", config={})
+        assert skills.get_skill("new-skill") is None
+        await tools.call_tool(
+            "create_skill",
+            {"name": "new-skill", "description": "d", "body": "Body."},
+        )
+        assert skills.get_skill("new-skill") is not None
+
     async def test_malformed_name_rejected(self, tools, context):
         await context.store.create_run(run_id="r1", goal="g", model="m", config={})
         result = await tools.call_tool(

--- a/tests/test_chat_mcp.py
+++ b/tests/test_chat_mcp.py
@@ -94,3 +94,17 @@ class TestMCPToolRouting:
         assert "Unknown tool" in result.message
         assert result.tool_name == "nonexistent"
         assert result.is_user_error is True
+
+
+class TestConnectAll:
+    @pytest.mark.asyncio
+    async def test_unknown_transport_skipped_with_warning(self, caplog):
+        """An unknown transport must be logged and skipped, not silently
+        treated as a successful connection with zero tools (#636)."""
+        import logging
+
+        mgr = MCPClientManager()
+        with caplog.at_level(logging.WARNING, logger="olmlx.chat.mcp_client"):
+            await mgr.connect_all({"srv": {"transport": "grpc"}})
+        assert "unknown transport" in caplog.text.lower()
+        assert mgr.get_tools_for_chat() == []

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -880,6 +880,18 @@ class TestInjectToolsIntoSystem:
         result = _inject_tools_into_system(messages, tools)
         assert "direct_tool" in result[0]["content"]
 
+    def test_system_message_with_none_content_does_not_crash(self):
+        """A system message with content=None (permitted by OpenAIChatMessage)
+        must not 500 on the string concat (#636)."""
+        messages = [
+            {"role": "system", "content": None},
+            {"role": "user", "content": "hi"},
+        ]
+        tools = [{"name": "s", "description": "d", "parameters": {}}]
+        result = _inject_tools_into_system(messages, tools)
+        assert result[0]["role"] == "system"
+        assert "s" in result[0]["content"]
+
 
 class TestAddNativeToolHint:
     def test_appends_hint_when_function_pattern_present(self):


### PR DESCRIPTION
## Summary
Grouped cleanup/robustness fixes across the chat session, agent store, skills, MCP client, and templating.

1. **Per-token SQLite** — the orchestrator no longer pays an `asyncio.to_thread` + SQLite round-trip *per token* (which throttled generation to thread-pool rate). It buffers token/thinking_token events and flushes them via a new batched `store.append_events` (single thread-hop + transaction); ordered events (tool_call/result/status) flush the buffer first so SSE replay preserves order.
2. **Live skill registration** — the agent's `create_skill` routes through the live `SkillManager`, so a skill authored mid-run is immediately usable via `use_skill` instead of invisible until the next run's disk reload. Also the only production caller of `SkillManager.create_skill` (was dead code).
3. **MCP transport** — `connect_all` validates the transport up front and logs+skips an unknown one, instead of matching neither branch and `break`-ing as if connected (silent zero-tools).
4. **Templating None-content** — `_inject_tools_into_system` guards a system message with `content=None` (permitted by `OpenAIChatMessage`), so tools + a no-native-tools template no longer 500 on the string concat.
5. Removed a duplicate local `import json` in `session.py`.
6. `WindowManager.update` accepts an already-computed `active_list` so `FlashMLP` doesn't eval + `tolist` the predicted-neuron array twice per layer per token.

## Tests
Added for findings 1, 2, 3, 4. Chat/agent suites pass; ruff clean.

Closes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)