### PR TITLE
refactor(speculative): dedup _logits + chunk EAGLE prefill (#628)

### DIFF
--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -405,5 +405,3 @@ class DFlashDecoder(SpecDecoderBase):
         self._stats_accepted_draft += accepted_drafts
 
         return accepted, self._block_size
-
-

--- a/olmlx/engine/dflash/decoder.py
+++ b/olmlx/engine/dflash/decoder.py
@@ -45,6 +45,7 @@ from olmlx.engine.spec_decoder_base import (
     # classic/PLD/EAGLE share the same rotating-aware trim.
     _HAS_ROTATING_KV_PRIVATES as _HAS_ROTATING_KV_PRIVATES,
     _LayerHook as _LayerHook,
+    _logits,
     _patch_model as _patch_model,
     _probe_rotating_kv_privates as _probe_rotating_kv_privates,
     _trim_recent_cache as _trim_recent_cache,
@@ -406,6 +407,3 @@ class DFlashDecoder(SpecDecoderBase):
         return accepted, self._block_size
 
 
-def _logits(out: Any) -> mx.array:
-    """Unwrap mlx-vlm ``LanguageModelOutput`` if needed."""
-    return getattr(out, "logits", out)

--- a/olmlx/engine/eagle/decoder.py
+++ b/olmlx/engine/eagle/decoder.py
@@ -46,8 +46,12 @@ from olmlx.engine.gdn_rollback import (
     get_model_layers as _get_layers,
 )
 from olmlx.engine.eagle.draft_model import EagleDraftModel
-from olmlx.engine.spec_decoder_base import SpecDecoderBase, _trim_recent_cache
-from olmlx.engine.speculative import _eval_cache
+from olmlx.engine.spec_decoder_base import (
+    SpecDecoderBase,
+    _logits,
+    _trim_recent_cache,
+)
+from olmlx.engine.speculative import PrefillCancelled, _chunked_prefill, _eval_cache
 
 try:
     from mlx_lm.models.cache import (
@@ -59,11 +63,6 @@ except ImportError:  # pragma: no cover - mlx-lm always installed in production
     can_trim_prompt_cache = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
-
-
-def _logits(out: Any) -> mx.array:
-    # mlx-vlm wraps logits in a dataclass; mlx-lm returns the raw array.
-    return getattr(out, "logits", out)
 
 
 class EagleDecoder(SpecDecoderBase):
@@ -294,7 +293,20 @@ class EagleDecoder(SpecDecoderBase):
         if prompt.shape[1] > 1:
             if self._capture is not None:
                 self._capture.use_buffer(None)
-            self._target(prompt[:, :-1], cache=self._target_cache)
+            # Pass 1 is sub-chunked (mirrors MTP / classic / PLD, #628): a
+            # single forward over a long prefix forces ``lm_head`` over every
+            # position — a [1, seq-1, vocab] tensor that exceeds Metal's
+            # single-buffer limit and 500s ~38k-token prompts. ``_chunked_prefill``
+            # bounds peak activation memory to one sub-chunk (KV-cached
+            # attention is chunking-invariant, so the cache state is identical)
+            # and honours ``cancel_event`` at each sub-chunk boundary, so a
+            # client disconnect interrupts the prefill.
+            _chunked_prefill(
+                self._target,
+                prompt[:, :-1],
+                self._target_cache,
+                cancel_event=cancel_event,
+            )
             # Force the pass-1 hidden (if captured) before dropping the
             # slot reference, mirroring DFlash. Correctness does not
             # require it today — _eval_cache transitively materialises
@@ -309,6 +321,8 @@ class EagleDecoder(SpecDecoderBase):
             _eval_cache(self._target_cache)
             if self._capture is not None:
                 self._capture.use_buffer(self._capture_buffer)
+            if cancel_event is not None and cancel_event.is_set():
+                raise PrefillCancelled()
             target_out = self._target(prompt[:, -1:], cache=self._target_cache)
         else:
             if self._capture is not None:

--- a/olmlx/engine/mtp/decoder.py
+++ b/olmlx/engine/mtp/decoder.py
@@ -50,7 +50,7 @@ from olmlx.engine.gdn_rollback import (
     get_model_layers as _get_layers,
 )
 from olmlx.engine.mtp.draft_model import MTPDraftModel
-from olmlx.engine.spec_decoder_base import SpecDecoderBase
+from olmlx.engine.spec_decoder_base import SpecDecoderBase, _logits
 from olmlx.engine.speculative import (
     PrefillCancelled,
     _chunked_prefill,
@@ -68,11 +68,6 @@ except ImportError:  # pragma: no cover - mlx-lm always installed in production
     can_trim_prompt_cache = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
-
-
-def _logits(out: Any) -> mx.array:
-    # mlx-vlm wraps logits in a dataclass; mlx-lm returns the raw array.
-    return getattr(out, "logits", out)
 
 
 class MTPDecoder(SpecDecoderBase):

--- a/olmlx/engine/self_speculative/decoder.py
+++ b/olmlx/engine/self_speculative/decoder.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import Any, cast
+from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -20,7 +20,7 @@ except ImportError:  # pragma: no cover — mlx-lm is always available at runtim
     trim_prompt_cache = None
 
 from olmlx.engine.gdn_rollback import find_gdn_class, get_model_layers
-from olmlx.engine.spec_decoder_base import SpecDecoderBase
+from olmlx.engine.spec_decoder_base import SpecDecoderBase, _logits
 from olmlx.engine.speculative import PrefillCancelled
 
 logger = logging.getLogger(__name__)
@@ -58,10 +58,6 @@ _LM_HEAD_PATHS: tuple[tuple[str, ...], ...] = (
     ("model", "lm_head"),
     ("language_model", "model", "lm_head"),
 )
-
-
-def _logits(out: Any) -> mx.array:
-    return cast(mx.array, getattr(out, "logits", out))
 
 
 def _eval_cache(cache: list) -> None:

--- a/olmlx/engine/spec_decoder_base.py
+++ b/olmlx/engine/spec_decoder_base.py
@@ -254,6 +254,16 @@ def verify_draft_greedy(
     return accepted
 
 
+def _logits(out: Any) -> mx.array:
+    """Unwrap a forward pass's logits.
+
+    mlx-vlm's ``language_model`` returns a ``LanguageModelOutput(logits=...)``
+    dataclass; mlx-lm models return the raw ``mx.array``. Shared by every
+    speculative decoder (was defined identically in five modules, #628).
+    """
+    return getattr(out, "logits", out)
+
+
 def _strategy_label_for(cls: type) -> str:
     """Tracing/metrics ``strategy`` label for a decoder class, reusing the
     metrics class→label map (classic/pld/dflash/eagle/mtp/self)."""

--- a/olmlx/engine/speculative.py
+++ b/olmlx/engine/speculative.py
@@ -15,7 +15,7 @@ import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -36,7 +36,10 @@ from olmlx.engine.spec_decoder_base import (
     SpecDecoderBase,
     # Canonical home moved to spec_decoder_base (#467); re-exported here
     # for remaining importers (tests; the decoders verify via the base's
-    # ``_verify_greedy`` instead).
+    # ``_verify_greedy`` instead). ``_logits`` joined them in #628 (was
+    # defined identically in four decoder modules); still re-exported here
+    # for proxy_tuning and the speculative/lookahead tests.
+    _logits as _logits,
     _trim_recent_cache,
     verify_draft_greedy as verify_draft_greedy,
 )
@@ -264,12 +267,6 @@ def _spec_reuse_decision(
     if already_covered <= 0 or already_covered >= prompt_len:
         return (False, 0)
     return (True, already_covered)
-
-
-def _logits(out: Any) -> mx.array:
-    # mlx-vlm's language_model returns LanguageModelOutput(logits=...);
-    # mlx-lm models return a raw mx.array.
-    return cast(mx.array, getattr(out, "logits", out))
 
 
 def _eval_cache(cache: list) -> None:

--- a/tests/test_eagle.py
+++ b/tests/test_eagle.py
@@ -12,6 +12,8 @@ Covers:
 
 from __future__ import annotations
 
+import threading
+
 import mlx.core as mx
 import mlx.nn as nn
 import pytest
@@ -893,3 +895,53 @@ class TestEagleDecoderGDNPath:
         decoder.reset()
         # close should fire on reset
         assert captured_calls["close"] == 1
+
+
+class TestEagleDecoderChunkedPrefill:
+    """Pass-1 of ``prefill`` must sub-chunk the prefix and honour
+    ``cancel_event`` — mirrors the MTP decoder (#628). A single un-chunked
+    forward over a long prefix materialises ``lm_head`` over every position
+    (a ``[1, seq-1, vocab]`` tensor) which OOMs Metal's single-buffer limit
+    on long agentic prompts."""
+
+    def test_prefill_subchunks_long_prefix(self, monkeypatch):
+        from olmlx.engine import speculative
+
+        monkeypatch.setattr(speculative, "_PREFILL_CHUNK", 4)
+
+        decoder, target, _ = _make_decoder()
+
+        seq_lens: list[int] = []
+        orig_call = type(target).__call__
+
+        def recording_call(self, input_ids, cache=None):
+            seq_lens.append(input_ids.shape[1])
+            return orig_call(self, input_ids, cache=cache)
+
+        monkeypatch.setattr(type(target), "__call__", recording_call)
+
+        prompt = mx.arange(1, 21, dtype=mx.int32)[None, :]  # (1, 20)
+        decoder.prefill(prompt)
+
+        # No single target forward may span more than one sub-chunk's worth
+        # of prefix tokens; the trailing single-token pass-2 forward is
+        # allowed.
+        assert seq_lens, "target was never called"
+        assert max(seq_lens) <= 4, f"un-chunked prefix forward: {seq_lens}"
+        assert seq_lens[-1] == 1, f"pass-2 should be a single token: {seq_lens}"
+
+    def test_prefill_honors_cancel_event(self):
+        """A cancel_event set before prefill aborts with PrefillCancelled
+        and leaves the decoder reset (caches dropped, target un-patched)."""
+        from olmlx.engine.speculative import PrefillCancelled
+
+        decoder, _, _ = _make_decoder()
+        cancel = threading.Event()
+        cancel.set()
+
+        prompt = mx.arange(1, 21, dtype=mx.int32)[None, :]
+        with pytest.raises(PrefillCancelled):
+            decoder.prefill(prompt, cancel_event=cancel)
+
+        assert decoder._target_cache is None
+        assert decoder._patched is False


### PR DESCRIPTION
## Summary

Addresses the [Fable 5 review](https://github.com/motsognirr/olmlx/issues/628) findings on EAGLE/MTP decoder duplication.

- **Dedup `_logits`**: the forward-output unwrapper (mlx-vlm `LanguageModelOutput(logits=...)` vs mlx-lm raw `mx.array`) was defined identically in **five** decoder modules (`speculative`, `eagle`, `mtp`, `dflash`, `self_speculative`). Moved the single canonical copy to `spec_decoder_base._logits`; still re-exported from `speculative` for `proxy_tuning` and the speculative/lookahead tests.
- **Chunk EAGLE's target pass-1 prefill**: it ran a single un-chunked forward over the whole prefix — materialising `lm_head` over every position (a `[1, seq-1, vocab]` tensor that OOMs Metal's single-buffer limit on long agentic prompts) and ignoring `cancel_event`. Now routes through the shared `_chunked_prefill` (mirroring MTP/classic/PLD): bounds peak activation memory to one sub-chunk (KV-cached attention is chunking-invariant) and honours `cancel_event` at each sub-chunk boundary and before the pass-2 single-token forward.

## Tests

New `TestEagleDecoderChunkedPrefill` asserts the prefix is sub-chunked and a pre-set `cancel_event` aborts with `PrefillCancelled` leaving the decoder reset. Both fail against the un-chunked forward (verified by reverting). Full speculative suite (240 tests) green.

## Scope note

The broader full base-class extraction of EAGLE/MTP the issue floats is deliberately **deferred** — it can't be validated against real models in CI, and the concrete prefill bug + `_logits` dedup are the actionable, low-risk wins.

Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)