### PR TITLE
fix(prefill): correct fresh/cache-covered attribution on checkpoint path

### DIFF
--- a/olmlx/engine/inference.py
+++ b/olmlx/engine/inference.py
@@ -3402,6 +3402,42 @@ async def _stream_completion_batched(
                 )
 
 
+def _prefill_coverage(
+    cache_read_tokens: int,
+    cache_creation_tokens: int,
+    full_prompt_tokens: list[int] | None,
+    stream_prompt_tokens: int | None,
+) -> tuple[int, int, bool]:
+    """Return ``(covered, fresh, cache_hit)`` for the prefill summary.
+
+    ``covered`` is the number of prompt tokens served from the prompt cache;
+    ``fresh`` is the number actually prefilled this turn; ``cache_hit`` is True
+    iff any prefix was reused.
+
+    ``covered`` comes from ``cache_read_tokens`` — the reuse-decision count set
+    at cache setup — **not** mlx-lm's post-hoc ``token.prompt_tokens``. On the
+    hybrid-GDN checkpoint / deferred-prefill path the prefill is driven outside
+    mlx-lm's stream, so ``token.prompt_tokens`` reports 1 regardless of how many
+    tokens were freshly prefilled; using it mis-attributed a cold 69k prefill as
+    a cache hit (#503 Phase 0 findings).
+
+    ``full_prompt_tokens`` is the authoritative total when known (text paths).
+    When it is ``None`` (VLM — the text count misses image-patch expansion; or
+    the no-cache path) the total is recovered from the cache counts, falling
+    back to mlx-lm's ``stream_prompt_tokens`` (accurate on the flat no-cache
+    path, where mlx-lm prefills the whole prompt itself).
+    """
+    covered = max(0, cache_read_tokens)
+    if full_prompt_tokens is not None:
+        total = len(full_prompt_tokens)
+    elif cache_read_tokens or cache_creation_tokens:
+        total = cache_read_tokens + cache_creation_tokens
+    else:
+        total = stream_prompt_tokens or 0
+    fresh = max(0, total - covered)
+    return covered, fresh, covered > 0
+
+
 async def _stream_completion(
     lm: LoadedModel,
     prompt: str | list[int],
@@ -3779,9 +3815,17 @@ async def _stream_completion(
             )
             # ttft_ns: the prefill forward runs lazily inside the stream's
             # first iteration (worker thread), so the prefill *span* can't time
-            # it; surface the measured prefill duration here instead. cache_hit:
-            # mlx re-prefilled fewer tokens than the full prompt → a prefix was
-            # served from the prompt cache.
+            # it; surface the measured prefill duration here instead. covered /
+            # cache_hit come from the cache-reuse decision (cache_read_tokens),
+            # not mlx-lm's token.prompt_tokens — which reports 1 on the
+            # checkpoint/deferred-prefill path and mis-attributes a cold prefill
+            # as a hit (#503 Phase 0 findings).
+            _covered, _fresh, _cache_hit = _prefill_coverage(
+                cache_read_tokens,
+                cache_creation_tokens,
+                full_prompt_tokens,
+                getattr(token, "prompt_tokens", None) if token is not None else None,
+            )
             _decode_span.set_attributes(
                 {
                     "eval_count": stats.eval_count,
@@ -3792,24 +3836,16 @@ async def _stream_completion(
                         else stats.prompt_eval_duration
                     ),
                     "ttft_measured": ttft_measured_ns is not None,
-                    "cache_hit": bool(full_prompt_tokens)
-                    and token is not None
-                    and (token.prompt_tokens or 0) < len(full_prompt_tokens),
+                    "cache_hit": _cache_hit,
                 }
             )
             if ttft_measured_ns is not None and token is not None:
-                _fresh = token.prompt_tokens or 0
-                _full = (
-                    len(full_prompt_tokens)
-                    if full_prompt_tokens is not None
-                    else _fresh
-                )
                 logger.info(
                     "prefill %.2fs (fresh %d/%d tok, cache-covered %d)",
                     ttft_measured_ns / 1e9,
                     _fresh,
-                    _full,
-                    max(0, _full - _fresh),
+                    _covered + _fresh,
+                    _covered,
                 )
 
         stats.total_duration = total_timer.duration_ns

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2334,6 +2334,82 @@ class TestGenerateCompletion:
         assert ttft_ns >= 20_000_000, f"ttft_ns {ttft_ns} looks heuristic, not measured"
 
     @pytest.mark.asyncio
+    async def test_streaming_cache_hit_attr_uses_reuse_offset_not_stream_count(
+        self, mock_manager, otel_memory_exporter
+    ):
+        """Wiring guard (#503): on the checkpoint/deferred-prefill path mlx-lm
+        reports token.prompt_tokens == 1, so the decode-span cache_hit must come
+        from the cache-reuse offset (cache_read_tokens=0 here → cold miss), not
+        that count. Before the fix this logged fresh 1/N and cache_hit=True on a
+        cold cache."""
+        # Drive _stream_completion directly with use_prompt_cache=True — the
+        # entry points gate that flag differently, and this is the exact
+        # function whose wiring changed.
+        from olmlx.engine.inference import _CacheSetupResult, _stream_completion
+        from olmlx.utils.timing import TimingStats
+
+        _tracing, exporter = otel_memory_exporter
+        mock_mx = MagicMock()
+        lm = mock_manager._loaded["qwen3:latest"]
+
+        # Deferred-prefill path: mlx-lm reports only the 1-token seeding forward.
+        tok = StreamToken(
+            text="Hi",
+            token=1,
+            prompt_tokens=1,
+            generation_tokens=1,
+            prompt_tps=1000.0,
+            generation_tps=1000.0,
+        )
+        token_iter = iter([tok])
+
+        async def anext_impl():
+            try:
+                return next(token_iter)
+            except StopIteration:
+                raise StopAsyncIteration
+
+        mock_stream = MagicMock(spec=CancellableStream)
+        mock_stream.drain_and_join = AsyncMock()
+        mock_stream._thread = None
+        mock_stream.__aiter__ = lambda self: self
+        mock_stream.__anext__ = lambda self: anext_impl()
+
+        # Cold cache: 100-token prompt, 0 reused (cache_read_tokens=0).
+        cs = _CacheSetupResult(
+            prompt=[0] * 100,
+            cache_read_tokens=0,
+            cache_creation_tokens=100,
+            full_prompt_tokens=[0] * 100,
+            cache_setup_done=True,
+        )
+
+        setup_mock = AsyncMock(return_value=cs)
+        with (
+            patch("olmlx.engine.inference.mx", mock_mx),
+            patch("olmlx.engine.inference._setup_prompt_cache", setup_mock),
+            patch(
+                "olmlx.engine.inference._store_prompt_cache_after_generation",
+                AsyncMock(),
+            ),
+            patch("olmlx.engine.inference.async_mlx_stream", return_value=mock_stream),
+        ):
+            gen = _stream_completion(
+                lm, "Hi", 8, {}, TimingStats(), use_prompt_cache=True
+            )
+            async for _ in gen:
+                pass
+
+        # Guard against a vacuous pass: the crafted cold-cache cs must actually
+        # have driven the code path (else cache_hit would be False trivially).
+        setup_mock.assert_awaited()
+        decode_spans = [s for s in exporter.get_finished_spans() if s.name == "decode"]
+        assert decode_spans, "decode span was not recorded"
+        attrs = dict(decode_spans[0].attributes)
+        # Cold miss: 0 tokens reused despite mlx-lm reporting prompt_tokens=1.
+        assert attrs["cache_hit"] is False
+
+    @pytest.mark.asyncio
     async def test_streaming_prepends_thinking_expected_meta(self, mock_manager):
         """Streaming completion yields a thinking_expected meta chunk first."""
         mock_mx = MagicMock()

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -60,6 +60,53 @@ def otel_memory_exporter():
     tracing.shutdown_tracing()
 
 
+class TestPrefillCoverage:
+    """Unit tests for _prefill_coverage — (covered, fresh, cache_hit) for the
+    prefill summary. Covered must come from the cache-reuse decision
+    (cache_read_tokens), NOT mlx-lm's post-hoc token.prompt_tokens, which
+    reports 1 on the checkpoint/deferred-prefill path (#503 findings)."""
+
+    def test_cold_checkpoint_path_counts_all_fresh(self):
+        # The bug: on a cold hybrid-GDN prefill mlx-lm reports prompt_tokens=1,
+        # but the cache was empty (cache_read_tokens=0) and all 69445 tokens
+        # were freshly prefilled. Must be (0, 69445, False) — NOT (0, 1, True).
+        from olmlx.engine.inference import _prefill_coverage
+
+        covered, fresh, hit = _prefill_coverage(
+            cache_read_tokens=0,
+            cache_creation_tokens=69445,
+            full_prompt_tokens=[0] * 69445,
+            stream_prompt_tokens=1,
+        )
+        assert (covered, fresh, hit) == (0, 69445, False)
+
+    def test_warm_checkpoint_path_counts_reused_prefix(self):
+        from olmlx.engine.inference import _prefill_coverage
+
+        covered, fresh, hit = _prefill_coverage(
+            cache_read_tokens=69444,
+            cache_creation_tokens=1,
+            full_prompt_tokens=[0] * 69445,
+            stream_prompt_tokens=1,
+        )
+        assert (covered, fresh, hit) == (69444, 1, True)
+
+    def test_no_cache_falls_back_to_stream_prompt_tokens(self):
+        # No prompt cache: full_prompt_tokens is None and cache counts are 0,
+        # so the real prompt size is mlx-lm's stream count (accurate on that
+        # flat path). covered=0, no hit.
+        from olmlx.engine.inference import _prefill_coverage
+
+        assert _prefill_coverage(0, 0, None, 42) == (0, 42, False)
+
+    def test_vlm_path_uses_cache_counts_when_full_is_none(self):
+        # VLM: full_prompt_tokens is None (text count misses image patches) but
+        # cache_read/creation come from mlx_vlm and are accurate.
+        from olmlx.engine.inference import _prefill_coverage
+
+        assert _prefill_coverage(10, 90, None, 5) == (10, 90, True)
+
+
 class TestDeriveTimingStats:
     """Unit tests for _derive_timing_stats — the helper that converts
     mlx-lm's rates + a wall-clock fallback into Ollama-convention durations."""


### PR DESCRIPTION
Follow-up #1 from the #503 Phase 0 findings (PR #689) — a bug the measurement exposed.

## Bug
On the hybrid-GDN **checkpoint / deferred-prefill** path, prefill is driven outside mlx-lm's stream, so mlx-lm reports `token.prompt_tokens == 1` regardless of how many tokens were actually prefilled. The measured prefill summary and the `decode`-span `cache_hit` attribute derived fresh/covered from that count, so a **cold** 69k prefill logged `fresh 1/69445 tok, cache-covered 69444` and set `cache_hit=True` — on an empty cache.

The measured *wall-clock* was always correct (190 s cold vs 0.56 s warm); only the fresh/covered *split* and `cache_hit` were wrong on this path.

## Fix
Extract `_prefill_coverage(cache_read_tokens, cache_creation_tokens, full_prompt_tokens, stream_prompt_tokens) -> (covered, fresh, cache_hit)` and compute covered from `cache_read_tokens` — the reuse-decision count set at cache setup — instead of `token.prompt_tokens`. Falls back to the cache counts, then mlx-lm's stream count, for the VLM / no-cache paths (where the latter is accurate). Wired into `_stream_completion`.

## Verification
- Unit tests (`TestPrefillCoverage`, 4 cases) encode the exact real-world inputs: cold checkpoint `(0, 69445, [0]*69445, 1) → (0, 69445, False)`, warm, VLM, no-cache.
- End-to-end on `Qwythos-9B` (`qwen3_5` hybrid checkpoint path):
  - cold: `prefill 1.54s (fresh 578/578 tok, cache-covered 0)` ✅
  - warm: `prefill 1.25s (fresh 498/578 tok, cache-covered 80)` ✅
- Full `tests/test_inference.py`: 290 passed. ruff clean.

Log/span-only; no inference-behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)