### PR TITLE
fix(thinking): strip \n after </think> across chunk boundary (#686)

### DIFF
--- a/olmlx/routers/thinking_split.py
+++ b/olmlx/routers/thinking_split.py
@@ -111,6 +111,7 @@ def split_thinking_parts(text: str, state: dict) -> list[tuple[str, str]]:
     parts: list[tuple[str, str]] = []
     phase = state.get("phase", "detect")
     expected_close = state.get("expected_close", "")
+    pending_strip = bool(state.get("pending_strip"))
     thinking_expected = bool(state.get("thinking_expected"))
     detect_limit = int(
         state.get(
@@ -144,8 +145,9 @@ def split_thinking_parts(text: str, state: dict) -> list[tuple[str, str]]:
                     "split_thinking_parts: orphaned %r at byte %d", close_tag, close_idx
                 )
                 emit("thinking", buf[:close_idx])
-                buf = buf[close_idx + len(close_tag) :].lstrip("\n")
+                buf = buf[close_idx + len(close_tag) :]
                 phase = "passthrough"
+                pending_strip = True
             elif open_idx != -1:
                 emit("content", buf[:open_idx])
                 buf = buf[open_idx + len(open_tag) :]
@@ -186,11 +188,24 @@ def split_thinking_parts(text: str, state: dict) -> list[tuple[str, str]]:
                     buf = buf[-hold:]
                 break
             emit("thinking", buf[:end])
-            buf = buf[end + len(expected_close) :].lstrip("\n")
+            buf = buf[end + len(expected_close) :]
             expected_close = ""
             phase = "passthrough"
+            pending_strip = True
 
         else:  # passthrough
+            if pending_strip:
+                # A thinking block just closed (possibly in a prior chunk).
+                # The model emits trailing ``\n`` after ``</think>`` that the
+                # non-streaming path strips over the whole completion; strip
+                # it here too (issue #686).  Newlines may span chunks, so the
+                # flag persists until a non-newline byte is seen — an all-
+                # newline buffer keeps it armed for the next chunk.
+                stripped = buf.lstrip("\n")
+                pending_strip = not stripped
+                buf = stripped
+                if not buf:
+                    break
             open_idx, open_tag, paired_close = _find_earliest_open(buf)
             if open_idx == -1:
                 longest_partial = _longest_open_tag_suffix(buf)
@@ -209,6 +224,7 @@ def split_thinking_parts(text: str, state: dict) -> list[tuple[str, str]]:
     state["buffer"] = buf
     state["phase"] = phase
     state["expected_close"] = expected_close
+    state["pending_strip"] = pending_strip
     return parts
 
 
@@ -241,6 +257,7 @@ def flush_split_thinking(state: dict) -> tuple[str, str]:
     state["buffer"] = ""
     state["phase"] = "detect"
     state["expected_close"] = ""
+    state["pending_strip"] = False
     state["thinking_expected"] = False
     if not buf:
         return "", ""

--- a/tests/test_routers_chat.py
+++ b/tests/test_routers_chat.py
@@ -857,6 +857,52 @@ class TestChatRouter:
         assert content.strip() == "391"
 
     @pytest.mark.asyncio
+    async def test_chat_streaming_no_leading_newline_after_think_across_chunks(
+        self, app_client
+    ):
+        """Issue #686: end-to-end through the ``/api/chat`` streaming surface,
+        the ``</think>`` close tag and the trailing ``\\n\\n`` arrive in
+        *separate* chunks (as a real model emits them).  The assembled
+        ``message.content`` must not leak a leading newline — parity with the
+        non-streaming response, which strips it.  Asserts exact content (no
+        ``.strip()``) so a regression in the caller's state threading is
+        caught, not just in the splitter unit."""
+
+        async def mock_stream(*args, **kwargs):
+            async def gen():
+                yield {"thinking_expected": True}
+                yield {"text": "<think>reasoning", "done": False}
+                yield {"text": "</think>", "done": False}
+                yield {"text": "\n\n", "done": False}
+                yield {"text": "9 × 6 = 54.", "done": False}
+                yield {"text": "", "done": True, "stats": TimingStats()}
+
+            return gen()
+
+        with patch("olmlx.routers.chat.generate_chat", side_effect=mock_stream):
+            resp = await app_client.post(
+                "/api/chat",
+                json={
+                    "model": "qwen3",
+                    "messages": [{"role": "user", "content": "9*6"}],
+                    "stream": True,
+                },
+            )
+
+        assert resp.status_code == 200
+        content = ""
+        thinking = ""
+        for line in resp.text.strip().split("\n"):
+            if not line.strip():
+                continue
+            msg = json.loads(line).get("message", {})
+            content += msg.get("content", "")
+            thinking += msg.get("thinking", "") or ""
+
+        assert content == "9 × 6 = 54."
+        assert thinking == "reasoning"
+
+    @pytest.mark.asyncio
     async def test_chat_streaming_orphan_preamble_over_limit_leaks_to_content(
         self, app_client
     ):

--- a/tests/test_routers_chat.py
+++ b/tests/test_routers_chat.py
@@ -60,6 +60,31 @@ class TestSplitThinkingStreaming:
         assert content == prefix + "vis"
         assert thinking == "hidden"
 
+    def test_newlines_after_close_in_later_chunk_stripped(self):
+        """Issue #686: the ``\\n\\n`` a model emits after ``</think>`` arrives
+        in a *separate* chunk from the close tag.  The streamed content must
+        strip it to match the non-streaming path (which strips over the whole
+        completion at once), not leak a leading ``\\n\\n``."""
+        state: dict = {}
+        content = ""
+        for chunk in ["<think>reasoning</think>", "\n\n", "answer"]:
+            _, c = split_thinking_streaming(chunk, state)
+            content += c
+        c = flush_split_thinking(state)[1]
+        content += c
+        assert content == "answer"
+
+    def test_newlines_after_close_split_across_boundary_stripped(self):
+        """Issue #686: newlines split across the close-tag boundary (one in
+        the closing chunk, one in the next) are all stripped."""
+        state: dict = {}
+        content = ""
+        for chunk in ["<think>reasoning</think>\n", "\nanswer"]:
+            _, c = split_thinking_streaming(chunk, state)
+            content += c
+        content += flush_split_thinking(state)[1]
+        assert content == "answer"
+
     def test_detect_limit_state_override_honored(self):
         """An explicit ``state["detect_limit"]`` overrides the default so
         callers can widen (or narrow) the detect window."""


### PR DESCRIPTION
Fixes #686.

## Problem

For thinking-capable models (e.g. Qwen3), streamed `content`/`text` deltas across **all three** chat surfaces — Ollama `/api/chat`, OpenAI `/v1/chat/completions`, Anthropic `/v1/messages` — leaked a leading `"\n\n"` immediately after the `</think>` close tag. The non-streaming response for the identical request strips it, so a client concatenating SSE/NDJSON deltas got a different string than one using the non-streaming response.

## Root cause

`split_thinking_parts` (`olmlx/routers/thinking_split.py`) stripped trailing newlines with an inline `.lstrip("\n")` **only in the same call that found the close tag**. In practice the model emits `</think>` in one chunk and the following `"\n\n"` in a *later* chunk — by which point `phase` has already advanced to `"passthrough"`, whose branch had no whitespace-stripping logic, so the newlines passed straight through as visible content.

The non-streaming path runs the same splitter over the entire completion string at once, so the close tag and trailing newlines are always in the same buffer and get stripped — masking the bug there.

## Fix

Track a `pending_strip` flag in `state`:
- Set `True` on both close transitions (`in_think`→`passthrough` and the orphan-close `detect`→`passthrough`), replacing the inline `lstrip`.
- At the top of the `passthrough` branch, when armed, `lstrip("\n")` the buffer.
- Keep the flag armed across chunks while the buffer is all-newlines (or empty), clearing once a non-newline byte appears — so newlines split across the close-tag boundary are all consumed.

This mirrors the whole-completion strip the non-streaming path already does, restoring streaming/non-streaming parity.

## Tests

- New TDD tests `test_newlines_after_close_in_later_chunk_stripped` and `test_newlines_after_close_split_across_boundary_stripped` — fail before, pass after.
- Full splitter unit class + `test_routers_chat`, `test_routers_openai`, `test_routers_anthropic`, `test_stop_sequences` — **318 passed**.
- Direct simulation confirms streamed content now equals non-streamed for the issue's exact `9*6` prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)