### PR TITLE
build(packaging): make olmlx pip-installable + PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Build wheel + sdist
         run: uv build
       - name: Validate metadata

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,95 @@
+# Publish olmlx to (Test)PyPI via trusted publishing (OIDC — no API token).
+#
+# One-time setup before this works (see the checklist in the PR/README):
+#   1. Create GitHub environments named `testpypi` and `pypi`
+#      (Settings -> Environments), optionally with required reviewers.
+#   2. Register a "pending publisher" on each index so OIDC is trusted:
+#        PyPI:     https://pypi.org/manage/account/publishing/
+#        TestPyPI: https://test.pypi.org/manage/account/publishing/
+#      Values:  PyPI project name = olmlx
+#               Owner              = motsognirr
+#               Repository         = olmlx
+#               Workflow name      = publish.yml
+#               Environment        = pypi   (and testpypi for the TestPyPI form)
+#
+# Usage:
+#   - Validate first: Actions -> "Publish" -> Run workflow  => TestPyPI.
+#   - Release: push a version tag matching pyproject `version`, e.g.
+#         git tag v0.1.0 && git push origin v0.1.0     => PyPI.
+#
+# NOTE: keep the git tag in lockstep with `version` in pyproject.toml — the tag
+# only triggers the run; the version published is whatever the wheel declares.
+#
+# Action SHA pinning: checkout / upload-artifact are pinned to match the SHAs
+# already vetted in ci.yml. download-artifact and gh-action-pypi-publish are on
+# release tags below; pin them to SHAs before merging to match repo convention.
+
+name: Publish
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Publish target (manual runs only ever go to TestPyPI)"
+        type: choice
+        options: [testpypi]
+        default: testpypi
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Build wheel + sdist
+        run: uv build
+      - name: Validate metadata
+        run: uvx twine check dist/*
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write # OIDC token for trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4 # TODO: pin to SHA before merge
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1 # TODO: pin to SHA before merge
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # OIDC token for trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4 # TODO: pin to SHA before merge
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1 # TODO: pin to SHA before merge

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,9 @@
 # NOTE: keep the git tag in lockstep with `version` in pyproject.toml — the tag
 # only triggers the run; the version published is whatever the wheel declares.
 #
-# Action SHA pinning: checkout / upload-artifact are pinned to match the SHAs
-# already vetted in ci.yml. download-artifact and gh-action-pypi-publish are on
-# release tags below; pin them to SHAs before merging to match repo convention.
+# Action SHA pinning: all actions are pinned to full commit SHAs (checkout /
+# upload-artifact reuse the SHAs already vetted in ci.yml). download-artifact is
+# pinned to v4.x to match the v4 artifact format that upload-artifact writes.
 
 name: Publish
 
@@ -71,11 +71,11 @@ jobs:
     permissions:
       id-token: write # OIDC token for trusted publishing
     steps:
-      - uses: actions/download-artifact@v4 # TODO: pin to SHA before merge
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1 # TODO: pin to SHA before merge
+      - uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -88,8 +88,8 @@ jobs:
     permissions:
       id-token: write # OIDC token for trusted publishing
     steps:
-      - uses: actions/download-artifact@v4 # TODO: pin to SHA before merge
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1 # TODO: pin to SHA before merge
+      - uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Daniel Palmqvist
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@ uv run olmlx
 
 The server starts on `http://localhost:11434` — the same default port as Ollama.
 
+### Optional extras
+
+Text-to-speech (`/v1/audio/speech`, `olmlx chat --voice`) ships in the `audio`
+extra; the `voice` extra adds microphone capture on top:
+
+```bash
+uv tool install "olmlx[audio]"    # Kokoro TTS
+uv tool install "olmlx[voice]"    # + push-to-talk mic capture
+```
+
+Kokoro's English text processing needs the spaCy `en_core_web_sm` model, which
+is **not on PyPI** (spaCy distributes its models as GitHub-release wheels), so
+it is not pulled in automatically. Fetch it once after installing the extra —
+otherwise the first `/v1/audio/speech` request fails with a spaCy load error:
+
+```bash
+python -m spacy download en_core_web_sm
+```
+
+(Installs from source with `uv sync` provision this automatically; the manual
+step is only needed for `pip`/`uv tool` installs of the published package.)
+
 ## CLI
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -48,24 +48,28 @@ The server starts on `http://localhost:11434` — the same default port as Ollam
 ### Optional extras
 
 Text-to-speech (`/v1/audio/speech`, `olmlx chat --voice`) ships in the `audio`
-extra; the `voice` extra adds microphone capture on top:
+extra; the `voice` extra adds microphone capture on top.
+
+Kokoro's English text processing also needs the spaCy `en_core_web_sm` model,
+which is **not on PyPI** (spaCy distributes its models as GitHub-release
+wheels), so it is not pulled in automatically. Because `uv tool` / `pipx`
+installs are isolated, the model has to go **into the same environment** as
+olmlx — a bare `python -m spacy download` would target the wrong interpreter.
+Install it alongside the extra:
 
 ```bash
-uv tool install "olmlx[audio]"    # Kokoro TTS
-uv tool install "olmlx[voice]"    # + push-to-talk mic capture
+# uv — install the extra and the spaCy model into olmlx's isolated tool env
+uv tool install "olmlx[audio]" \
+  --with "en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"
+
+# ...or with pipx — install the extra, then inject the model into its venv
+pipx install "olmlx[audio]"
+pipx inject olmlx "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"
 ```
 
-Kokoro's English text processing needs the spaCy `en_core_web_sm` model, which
-is **not on PyPI** (spaCy distributes its models as GitHub-release wheels), so
-it is not pulled in automatically. Fetch it once after installing the extra —
-otherwise the first `/v1/audio/speech` request fails with a spaCy load error:
-
-```bash
-python -m spacy download en_core_web_sm
-```
-
-(Installs from source with `uv sync` provision this automatically; the manual
-step is only needed for `pip`/`uv tool` installs of the published package.)
+Swap `audio` for `voice` to also get push-to-talk mic capture. Source installs
+(`uv sync`) provision the model automatically — no extra step. Without it, the
+first `/v1/audio/speech` request fails with a spaCy load error.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,27 @@ Drop-in Ollama API replacement powered by Apple's [MLX](https://github.com/ml-ex
 
 ## Install
 
-### Option 1: Global install (recommended)
+### Option 1: Install from PyPI (recommended)
+
+Requires Apple Silicon — the MLX backend is arm64-only.
 
 ```bash
-# Install globally — no clone needed
-uv tool install git+ssh://git@github.com/motsognirr/olmlx.git
+# With uv (recommended) — installs an isolated tool, Python handled for you
+uv tool install olmlx
+
+# ...or with pipx
+pipx install olmlx
 
 # Start the server
 olmlx
+```
+
+Upgrade later with `uv tool upgrade olmlx` (or `pipx upgrade olmlx`).
+
+To install the latest unreleased version straight from git instead:
+
+```bash
+uv tool install git+https://github.com/motsognirr/olmlx.git
 ```
 
 On first run, `~/.olmlx/models.json` is created with example model mappings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,18 @@
 name = "olmlx"
 version = "0.1.0"
 description = "Ollama API-compatible server using Apple MLX for inference"
+readme = "README.md"
 requires-python = ">=3.11"
+license = "MIT"
+license-files = ["LICENSE"]
+classifiers = [
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: MacOS",
+    "Environment :: GPU",
+    "Intended Audience :: Developers",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 dependencies = [
     "fastapi>=0.104",
     "uvicorn[standard]>=0.24",
@@ -42,6 +53,13 @@ dependencies = [
     "rich>=13.0",
     "xgrammar>=0.2.1",
     "mlx-whisper>=0.4.3",
+    # numba is a transitive dep (mlx-whisper -> numba -> llvmlite). Without a
+    # floor, a fresh resolve of the *published wheel* (which ships no uv.lock)
+    # backtracks to numba 0.53.1 / llvmlite 0.36.0, which only build on Python
+    # <3.10 and hard-fail `pip install olmlx` on 3.11/3.12. The floor keeps
+    # resolution in the Python-3.11+-compatible region. Declared directly so it
+    # travels in wheel metadata (uv.lock does not reach PyPI users).
+    "numba>=0.60",
     "prometheus-client>=0.20",
 ]
 
@@ -64,13 +82,15 @@ audio = [
     # processing; without it /v1/audio/speech raises ImportError at generate
     # time. The [en] extra pulls the English pipeline (spacy etc.). Issue #367.
     "misaki[en]>=0.9.4",
-    # misaki.en calls spacy.load("en_core_web_sm") at generate time. spaCy's
-    # runtime auto-download does NOT become importable in-process, so a fresh
-    # `uv sync` would otherwise 500 on the first /v1/audio/speech request.
-    # The wheel (3.8.x matches the locked spaCy 3.8.x) is pinned via
-    # [tool.uv.sources] below so it's present after sync; bump in lockstep with
-    # spaCy's major.minor. Issue #367.
-    "en-core-web-sm",
+    # NOTE: misaki.en also needs the spaCy model `en_core_web_sm` at generate
+    # time. It is NOT declared here: spaCy models are not on PyPI (distributed
+    # as GitHub-release wheels), so a bare `en-core-web-sm` Requires-Dist is
+    # unresolvable for `pip install "olmlx[audio]"`. The [tool.uv.sources] URL
+    # override only applies to `uv` — it does not travel in published wheel
+    # metadata. Dev installs get it via the `dev` dependency-group below;
+    # end users installing `[audio]` from PyPI must fetch it once with:
+    #   python -m spacy download en_core_web_sm
+    # (documented in the README audio/voice setup section). Issue #367.
 ]
 # Terminal voice chat (`olmlx chat --voice`, #444): mic capture + playback via
 # PortAudio, plus the TTS stack it speaks through (self-referential extra).
@@ -108,4 +128,9 @@ dev = [
     "pyright>=1.1.380",
     "openai>=1.66",
     "ruff>=0.9",
+    # spaCy English model for Kokoro TTS (#367). Lives here (not in the [audio]
+    # extra) so `uv sync` provisions it for dev via the [tool.uv.sources] URL
+    # override, without emitting an unresolvable Requires-Dist into the
+    # published wheel. End users get it via `python -m spacy download`.
+    "en-core-web-sm",
 ]

--- a/tests/test_packaging_audio_extra.py
+++ b/tests/test_packaging_audio_extra.py
@@ -4,6 +4,14 @@ A default ``uv sync`` must not pull mlx-audio + misaki + spaCy + the
 en_core_web_sm wheel (TTS-only) or torchvision (transformers falls back to
 its PIL image-processor backend). torch stays installed transitively via
 xgrammar and mlx-whisper but must not be pinned by olmlx itself.
+
+The spaCy model ``en_core_web_sm`` is a special case: spaCy models are not on
+PyPI (distributed as GitHub-release wheels), so a bare ``en-core-web-sm``
+requirement is unresolvable for ``pip install "olmlx[audio]"`` and the
+``[tool.uv.sources]`` URL override does not travel in published wheel metadata.
+It therefore lives in the ``dev`` dependency-group (so ``uv sync`` still
+provisions it) and is NOT in the published ``[audio]`` extra; end users fetch
+it once with ``python -m spacy download en_core_web_sm``.
 """
 
 import tomllib
@@ -15,9 +23,14 @@ PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 
 @pytest.fixture(scope="module")
-def project():
+def pyproject():
     with PYPROJECT.open("rb") as f:
-        return tomllib.load(f)["project"]
+        return tomllib.load(f)
+
+
+@pytest.fixture(scope="module")
+def project(pyproject):
+    return pyproject["project"]
 
 
 def _names(requirements):
@@ -39,8 +52,28 @@ def test_audio_deps_not_in_core_dependencies(project):
 
 def test_audio_extra_carries_tts_deps(project):
     audio = _names(project["optional-dependencies"]["audio"])
-    for dep in ("mlx-audio", "misaki", "en-core-web-sm"):
+    for dep in ("mlx-audio", "misaki"):
         assert dep in audio, f"{dep} missing from the [audio] extra"
+
+
+def test_spacy_model_excluded_from_published_extras(project):
+    # en-core-web-sm is unresolvable on PyPI, so it must NOT appear in any
+    # published extra — otherwise `pip install "olmlx[audio]"` fails on an
+    # unsatisfiable Requires-Dist.
+    for extra, reqs in project["optional-dependencies"].items():
+        assert "en-core-web-sm" not in _names(reqs), (
+            f"en-core-web-sm must not be in the published [{extra}] extra "
+            "(not on PyPI — provisioned via the dev group instead)"
+        )
+
+
+def test_spacy_model_provisioned_via_dev_group(pyproject):
+    # Kept for dev: `uv sync` must still install the spaCy model via the
+    # [tool.uv.sources] URL override, which only applies to the dev group.
+    dev = _names(pyproject["dependency-groups"]["dev"])
+    assert "en-core-web-sm" in dev, (
+        "en-core-web-sm must stay in the dev group so `uv sync` provisions it"
+    )
 
 
 def test_voice_extra_includes_audio_extra(project):
@@ -62,5 +95,6 @@ def test_lockfile_expands_voice_extra_to_audio_deps():
     extras = olmlx["optional-dependencies"]
     audio = {d["name"] for d in extras["audio"]}
     voice = {d["name"] for d in extras["voice"]}
-    assert {"mlx-audio", "misaki", "en-core-web-sm"} <= audio
+    assert {"mlx-audio", "misaki"} <= audio
+    assert "en-core-web-sm" not in audio
     assert audio | {"sounddevice"} <= voice

--- a/uv.lock
+++ b/uv.lock
@@ -2816,6 +2816,7 @@ dependencies = [
     { name = "mlx-lm" },
     { name = "mlx-vlm" },
     { name = "mlx-whisper" },
+    { name = "numba" },
     { name = "prometheus-client" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -2827,7 +2828,6 @@ dependencies = [
 
 [package.optional-dependencies]
 audio = [
-    { name = "en-core-web-sm" },
     { name = "misaki", extra = ["en"] },
     { name = "mlx-audio" },
 ]
@@ -2839,7 +2839,6 @@ search = [
     { name = "ddgs" },
 ]
 voice = [
-    { name = "en-core-web-sm" },
     { name = "misaki", extra = ["en"] },
     { name = "mlx-audio" },
     { name = "sounddevice" },
@@ -2848,6 +2847,7 @@ voice = [
 [package.dev-dependencies]
 dev = [
     { name = "datasets" },
+    { name = "en-core-web-sm" },
     { name = "httpx" },
     { name = "matplotlib" },
     { name = "openai" },
@@ -2863,7 +2863,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ddgs", marker = "extra == 'search'", specifier = ">=9.0" },
-    { name = "en-core-web-sm", marker = "extra == 'audio'", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
     { name = "fastapi", specifier = ">=0.104" },
     { name = "huggingface-hub", specifier = ">=0.20" },
     { name = "jinja2", specifier = ">=3.0" },
@@ -2874,6 +2873,7 @@ requires-dist = [
     { name = "mlx-lm", specifier = ">=0.31.3,<0.32" },
     { name = "mlx-vlm", specifier = ">=0.6.4,<0.7" },
     { name = "mlx-whisper", specifier = ">=0.4.3" },
+    { name = "numba", specifier = ">=0.60" },
     { name = "olmlx", extras = ["audio"], marker = "extra == 'voice'" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.27" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.27" },
@@ -2891,6 +2891,7 @@ provides-extras = ["search", "otel", "audio", "voice"]
 [package.metadata.requires-dev]
 dev = [
     { name = "datasets", specifier = ">=3.0" },
+    { name = "en-core-web-sm", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "matplotlib", specifier = ">=3.9" },
     { name = "openai", specifier = ">=1.66" },


### PR DESCRIPTION
## Summary

Stage 1 of making olmlx a distributable, installable package. This is everything needed for a working `pip install olmlx` / `uv tool install olmlx`, **clean-room verified** in a fresh Python 3.12 venv (build → install → run entry point → import full engine/router stack).

No rewrite, no dependency drop — the packaging path is independent of mlx-lm/mlx-vlm.

## Changes

- **`numba>=0.60` floor (critical).** A published wheel ships no `uv.lock`, so a fresh resolve backtracked the transitive `numba` to 0.53.1 → `llvmlite` 0.36.0, which only build on Python <3.10 and hard-failed `pip install olmlx` on 3.11/3.12. The floor keeps resolution in the Python-3.11+-compatible region (verified: numba 0.66.0 / llvmlite 0.48.0).
- **Decouple spaCy `en_core_web_sm` from the `audio`/`voice` extras.** spaCy models aren't on PyPI, so the `[tool.uv.sources]` GitHub-URL override (uv-only, doesn't travel in wheel metadata) became an unresolvable `Requires-Dist` for pip users of `olmlx[audio]`. Moved the model to the `dev` group (so `uv sync` is unchanged) and documented the one-time `python -m spacy download en_core_web_sm` step in the README.
- **MIT license** (+ `LICENSE` file), `readme`, and PyPI classifiers.
- **`publish.yml`** — trusted-publishing (OIDC, no stored token) workflow: `workflow_dispatch` → TestPyPI, `v*` tag → PyPI. Builds on `ubuntu-latest` (pure-Python `py3-none-any` wheel — no self-hosted Mac needed); build/publish split so the OIDC `id-token` is scoped to the publish step only.

## Verification

- `uv build` → `twine check` passes on both wheel and sdist.
- Fresh Py 3.12 venv: wheel installs alone, `olmlx --help` runs, `olmlx.app.create_app` + engine imports load clean.
- `olmlx[audio]` extra now resolves (previously failed on `en-core-web-sm`).
- PyPI name `olmlx` confirmed available.

## Before first publish (one-time, maintainer)

- Register pending publishers on PyPI + TestPyPI (values in the `publish.yml` header comment).
- Create GitHub environments `pypi` / `testpypi`.
- Pin the two `TODO: pin to SHA` actions (`download-artifact`, `gh-action-pypi-publish`) to match repo convention.
- Recommended: dispatch to TestPyPI first, then tag `v0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)