### PR TITLE
fix(schemas): reject unrecognized chat message roles with 400 (#696)

### DIFF
--- a/olmlx/schemas/chat.py
+++ b/olmlx/schemas/chat.py
@@ -14,6 +14,11 @@ class ToolCall(BaseModel):
     function: ToolCallFunction
 
 
+# Allow-list mirrors the role branches handled in engine/chat_templating.py;
+# unknown roles would render to nothing in common chat templates.
+_VALID_ROLES = frozenset({"system", "user", "assistant", "tool"})
+
+
 class Message(BaseModel):
     role: str
     content: str = Field("", max_length=1_000_000)
@@ -21,6 +26,13 @@ class Message(BaseModel):
     images: list[str] | None = None
     audio: list[str] | None = None
     tool_calls: list[ToolCall] | None = None
+
+    @field_validator("role")
+    @classmethod
+    def validate_role(cls, v: str) -> str:
+        if v not in _VALID_ROLES:
+            raise ValueError(f"role must be one of {sorted(_VALID_ROLES)}, got {v!r}")
+        return v
 
 
 class Tool(BaseModel):

--- a/tests/test_routers_chat.py
+++ b/tests/test_routers_chat.py
@@ -1217,6 +1217,21 @@ class TestEmptyMessagesRejected:
         assert "empty" in body
 
 
+class TestUnknownRoleRejected:
+    @pytest.mark.asyncio
+    async def test_api_chat_rejects_unknown_role(self, app_client):
+        resp = await app_client.post(
+            "/api/chat",
+            json={
+                "model": "qwen3",
+                "messages": [{"role": "bogus_role", "content": "hi"}],
+            },
+        )
+        assert resp.status_code == 400
+        body = resp.text.lower()
+        assert "role" in body
+
+
 class TestXCacheIDHeader:
     @pytest.mark.asyncio
     async def test_header_passed_to_generate_chat(self, app_client):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -223,6 +223,10 @@ class TestChatSchemas:
         with pytest.raises(ValidationError, match="messages"):
             ChatRequest(model="test", messages=[])
 
+    def test_message_rejects_unknown_role(self):
+        with pytest.raises(ValidationError, match="role"):
+            Message(role="bogus_role", content="x")
+
     def test_chat_request_think_defaults_none(self):
         req = ChatRequest(model="test", messages=[Message(role="user", content="hi")])
         assert req.think is None


### PR DESCRIPTION
## Bug

`Message.role` in `olmlx/schemas/chat.py` was a bare `str`, so `/api/chat` accepted any role string. `chat_templating.py` only special-cases `"tool"` and `"assistant"`+tool_calls; any other role (e.g. `bogus_role`) fell through into the Jinja `apply_chat_template` render, where common templates (Qwen included) branch on system/user/assistant/tool with no else — the message rendered to nothing and its content was silently dropped, producing a plausible-looking HTTP 200 hallucination instead of an error.

## Fix

Add a `@field_validator("role")` on `Message` restricting the role to the allow-list `{system, user, assistant, tool}` (mirroring the role branches in `engine/chat_templating.py`). The `ValueError` rides the existing `RequestValidationError` → 400 pipeline in `app.py` — no new exception plumbing. OpenAI/Anthropic schemas are deliberately untouched.

## Tests (TDD — written failing first)

- `tests/test_schemas.py::TestChatSchemas::test_message_rejects_unknown_role` — constructing `Message(role="bogus_role", ...)` raises `ValidationError`.
- `tests/test_routers_chat.py::TestUnknownRoleRejected::test_api_chat_rejects_unknown_role` — POST `/api/chat` with an unknown role returns 400 mentioning `role` (previously 200).

Full suite: 5736 passed, 40 skipped; the 2 failures (`test_rerank_model.py::test_self_attention_fused_sdpa_matches_reference`, `test_routers_speech.py::test_speech_non_tts_model_400`) are pre-existing on `main`, verified via stash.

Fixes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)
