### PR TITLE
fix(store): verify snapshot_download produced model files before reporting pull success

### DIFF
--- a/olmlx/models/store.py
+++ b/olmlx/models/store.py
@@ -338,6 +338,17 @@ class ModelStore:
             # resume on retry.  The .downloading marker keeps is_downloaded()
             # safe either way.
             snapshot_download(repo_id=hf_path, local_dir=str(local_dir))
+            # huggingface_hub silently no-ops on a 404 (logs a warning and
+            # returns the empty local_dir), so "didn't raise" is not proof of
+            # success (#695). Verify the download actually produced model
+            # files BEFORE clearing the marker — is_downloaded() must stay
+            # False so the empty dir is never surfaced by list_local()/show().
+            if not (local_dir / "config.json").exists():
+                raise FileNotFoundError(
+                    f"Download of '{hf_path}' produced no model files "
+                    "(no config.json) — the repo may not exist or the "
+                    "download failed"
+                )
             try:
                 marker.unlink(missing_ok=True)
             except OSError:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,6 +2,7 @@
 
 import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -219,8 +220,21 @@ def mock_mlx_primitives(request, monkeypatch):
     )
     # _find_common_prefix is pure Python — let it run unpatched
 
-    # HuggingFace download
-    _start("huggingface_hub.snapshot_download", MagicMock(return_value="/tmp/fake"))
+    # HuggingFace download — a successful real download materializes files,
+    # and ensure_downloaded() verifies config.json exists (#695), so the
+    # default mock must write one into the requested local_dir.
+    def _fake_snapshot_download(repo_id=None, local_dir=None, **kwargs):
+        if local_dir is not None:
+            target = Path(local_dir)
+            target.mkdir(parents=True, exist_ok=True)
+            (target / "config.json").write_text("{}")
+            return str(target)
+        return "/tmp/fake"
+
+    _start(
+        "huggingface_hub.snapshot_download",
+        MagicMock(side_effect=_fake_snapshot_download),
+    )
 
     # Memory functions — patch mx on the utils.memory module for Metal memory,
     # but patch get_system_memory_bytes directly to avoid @functools.cache poisoning

--- a/tests/test_model_manager.py
+++ b/tests/test_model_manager.py
@@ -1604,6 +1604,18 @@ class TestLoadModel:
         local_dir.mkdir(parents=True, exist_ok=True)
         (local_dir / "config.json").write_text("{}")
 
+    def _fake_download(self, mock_store, hf_path):
+        """side_effect for snapshot_download that writes a fake config.json.
+
+        ensure_downloaded() rejects downloads that produce no files (#695),
+        so success-path tests must simulate real file materialization.
+        """
+
+        def _download(**kwargs):
+            self._pre_download(mock_store, hf_path)
+
+        return _download
+
     def test_load_text_model(self, registry, mock_store):
         manager = self._make_manager(registry, mock_store)
         self._pre_download(mock_store, "test/path")
@@ -2030,7 +2042,10 @@ class TestLoadModel:
         mock_mlx_lm.load.return_value = (mock_model, mock_tokenizer)
 
         with patch.object(manager, "_detect_model_kind", return_value="text"):
-            with patch("huggingface_hub.snapshot_download") as mock_dl:
+            with patch(
+                "huggingface_hub.snapshot_download",
+                side_effect=self._fake_download(mock_store, "test/path"),
+            ) as mock_dl:
                 with patch.dict("sys.modules", {"mlx_lm": mock_mlx_lm}):
                     manager._load_model("test/path")
 
@@ -2065,7 +2080,10 @@ class TestLoadModel:
         mock_mlx_lm.load.return_value = (mock_model, mock_tokenizer)
 
         with patch.object(manager, "_detect_model_kind", return_value="text"):
-            with patch("huggingface_hub.snapshot_download"):
+            with patch(
+                "huggingface_hub.snapshot_download",
+                side_effect=self._fake_download(mock_store, "test/path"),
+            ):
                 with patch.dict("sys.modules", {"mlx_lm": mock_mlx_lm}):
                     manager._load_model("test/path")
 
@@ -2092,7 +2110,10 @@ class TestLoadModel:
             return original_unlink(self_path, **kwargs)
 
         with patch.object(manager, "_detect_model_kind", return_value="text"):
-            with patch("huggingface_hub.snapshot_download"):
+            with patch(
+                "huggingface_hub.snapshot_download",
+                side_effect=self._fake_download(mock_store, "test/path"),
+            ):
                 with patch.dict("sys.modules", {"mlx_lm": mock_mlx_lm}):
                     with patch.object(Path, "unlink", unlink_that_fails_on_downloading):
                         model, tok, is_vlm, caps, _ = manager._load_model("test/path")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -15,6 +15,22 @@ from olmlx.models.store import (
 )
 
 
+def _fake_download_for(store: ModelStore, hf_path: str):
+    """side_effect for snapshot_download that writes a fake config.json.
+
+    A bare no-op MagicMock mirrors the real huggingface_hub 404 behavior
+    (no files written), which ensure_downloaded() now rejects (#695) — so
+    success-path tests must simulate a download that produced files.
+    """
+
+    def _download(**kwargs):
+        local_dir = store.local_path(hf_path)
+        local_dir.mkdir(parents=True, exist_ok=True)
+        (local_dir / "config.json").write_text("{}")
+
+    return _download
+
+
 class TestRegisterSpeculativeDraft:
     """ModelStore.register_speculative_draft persists curated draft config (#514)."""
 
@@ -324,7 +340,10 @@ class TestModelStore:
     async def test_pull(self, mock_store, tmp_path):
         from unittest.mock import patch
 
-        with patch("huggingface_hub.snapshot_download"):
+        with patch(
+            "huggingface_hub.snapshot_download",
+            side_effect=_fake_download_for(mock_store, "Qwen/Qwen3-8B-MLX"),
+        ):
             events = []
             async for event in mock_store.pull("qwen3"):
                 events.append(event)
@@ -344,7 +363,10 @@ class TestModelStore:
         models_json = tmp_path / "models.json"
         monkeypatch.setattr("olmlx.engine.registry.settings.models_config", models_json)
 
-        with patch("huggingface_hub.snapshot_download"):
+        with patch(
+            "huggingface_hub.snapshot_download",
+            side_effect=_fake_download_for(mock_store, "Qwen/Qwen3-8B-MLX"),
+        ):
             async for _ in mock_store.pull("qwen3"):
                 pass
 
@@ -375,7 +397,10 @@ class TestModelStore:
     async def test_pull_hf_path_direct(self, mock_store, tmp_path):
         from unittest.mock import patch
 
-        with patch("huggingface_hub.snapshot_download"):
+        with patch(
+            "huggingface_hub.snapshot_download",
+            side_effect=_fake_download_for(mock_store, "org/some-model"),
+        ):
             events = []
             async for event in mock_store.pull("org/some-model"):
                 events.append(event)
@@ -411,7 +436,10 @@ class TestModelStore:
         """On successful download, .downloading marker is removed."""
         from unittest.mock import patch
 
-        with patch("huggingface_hub.snapshot_download"):
+        with patch(
+            "huggingface_hub.snapshot_download",
+            side_effect=_fake_download_for(mock_store, "Qwen/Qwen3-8B-MLX"),
+        ):
             async for _ in mock_store.pull("qwen3"):
                 pass
 
@@ -434,7 +462,10 @@ class TestModelStore:
             return original_unlink(self_path, **kwargs)
 
         with (
-            patch("huggingface_hub.snapshot_download"),
+            patch(
+                "huggingface_hub.snapshot_download",
+                side_effect=_fake_download_for(mock_store, "Qwen/Qwen3-8B-MLX"),
+            ),
             patch.object(Path, "unlink", unlink_that_fails_on_downloading),
         ):
             events = []
@@ -452,6 +483,29 @@ class TestModelStore:
         with pytest.raises(ValueError, match="not found"):
             async for _ in mock_store.pull("totally_unknown"):
                 pass
+
+    @pytest.mark.asyncio
+    async def test_pull_raises_when_download_produces_no_files(self, mock_store):
+        """Pull of a nonexistent repo must fail, not yield success (#695).
+
+        huggingface_hub silently no-ops on a 404 (logs a warning, returns the
+        empty local_dir), so pull() must not write a manifest or yield a
+        success event for an empty directory.
+        """
+        from unittest.mock import patch
+
+        with patch("huggingface_hub.snapshot_download"):
+            events = []
+            with pytest.raises(FileNotFoundError, match="Qwen/Qwen3-8B-MLX"):
+                async for event in mock_store.pull("qwen3"):
+                    events.append(event)
+
+        statuses = [e["status"] for e in events]
+        assert "success" not in statuses
+        # No manifest — a phantom entry must not surface in list_local().
+        local_dir = mock_store.local_path("Qwen/Qwen3-8B-MLX")
+        assert not (local_dir / "manifest.json").exists()
+        assert mock_store.list_local() == []
 
 
 class TestConcurrentPull:
@@ -540,13 +594,34 @@ class TestEnsureDownloaded:
         """Downloads model and removes .downloading marker on success."""
         from unittest.mock import patch
 
-        with patch("huggingface_hub.snapshot_download"):
+        with patch(
+            "huggingface_hub.snapshot_download",
+            side_effect=_fake_download_for(mock_store, "Qwen/Qwen3-8B-MLX"),
+        ):
             result = mock_store.ensure_downloaded("Qwen/Qwen3-8B-MLX")
 
         local_dir = mock_store.local_path("Qwen/Qwen3-8B-MLX")
         assert result == local_dir
         assert local_dir.exists()
         assert not (local_dir / ".downloading").exists()
+
+    def test_raises_when_download_produces_no_files(self, mock_store):
+        """A no-op snapshot_download (real hub 404 behavior) must raise (#695).
+
+        The installed huggingface_hub logs a warning and returns the empty
+        local_dir on a 404 instead of raising, so 'didn't raise' is not proof
+        of success — verify config.json actually materialized.
+        """
+        from unittest.mock import patch
+
+        with patch("huggingface_hub.snapshot_download"):
+            with pytest.raises(FileNotFoundError, match="Qwen/Qwen3-8B-MLX"):
+                mock_store.ensure_downloaded("Qwen/Qwen3-8B-MLX")
+
+        # Marker must survive so the empty dir is never treated as downloaded.
+        local_dir = mock_store.local_path("Qwen/Qwen3-8B-MLX")
+        assert (local_dir / ".downloading").exists()
+        assert not mock_store.is_downloaded("Qwen/Qwen3-8B-MLX")
 
     def test_keeps_partial_dir_on_failure(self, mock_store):
         """Partial directory is kept for resume on download failure."""
@@ -576,7 +651,10 @@ class TestEnsureDownloaded:
             return original_unlink(self_path, **kwargs)
 
         with (
-            patch("huggingface_hub.snapshot_download"),
+            patch(
+                "huggingface_hub.snapshot_download",
+                side_effect=_fake_download_for(mock_store, "Qwen/Qwen3-8B-MLX"),
+            ),
             patch.object(Path, "unlink", unlink_that_fails_on_downloading),
         ):
             result = mock_store.ensure_downloaded("Qwen/Qwen3-8B-MLX")


### PR DESCRIPTION
## Bug

`/api/pull` for a nonexistent HF repo returned `{"status":"success"}`. The installed `huggingface_hub` silently no-ops on a 404 (logs a warning, returns the empty `local_dir`), but `ModelStore.ensure_downloaded()` treated "`snapshot_download()` didn't raise" as success — so `pull()` proceeded to write a real `manifest.json` for an empty directory and the phantom model appeared in `/api/tags` forever. The same `ensure_downloaded()` call inside `ModelManager._load_model()` littered `~/.olmlx/models/` on any mistyped model name in `/api/chat` (auto-pull-on-inference).

## Fix

`ensure_downloaded()` now verifies `(local_dir / "config.json").exists()` after `snapshot_download()` returns and raises `FileNotFoundError` naming the repo. The raise happens **before** the `.downloading`-marker cleanup, so `is_downloaded()` stays `False` and the empty directory is never surfaced by `list_local()`/`show()`. No changes to `pull()` or `model_manager.py` — the propagating exception closes both paths (`routers/manage.py` already converts store errors into a 500 / streaming error line).

`ensure_adapter_downloaded()` has the same latent bug but is deliberately left for a follow-up issue.

## Tests

- New (written failing-first): `TestEnsureDownloaded::test_raises_when_download_produces_no_files` and `TestModelStore::test_pull_raises_when_download_produces_no_files` — no success event, no manifest, `is_downloaded()` stays `False`, `list_local()` stays empty.
- Existing success-path tests that mocked `snapshot_download` as a bare no-op MagicMock now use a `side_effect` that writes a fake `config.json` (mirroring the existing `TestConcurrentPull` / integration `fake_download` pattern): 7 in `tests/test_store.py`, 3 in `tests/test_model_manager.py`, plus the default mock in `tests/integration/conftest.py`.
- Full suite: 5736 passed; the only 2 failures (`test_self_attention_fused_sdpa_matches_reference`, `test_speech_non_tts_model_400`) are pre-existing on `main` (verified with these changes stashed).

Fixes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)