### PR TITLE
feat: REAP expert pruning phases 1-2 — calibrate/plan/apply/report (#701)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Single-user, localhost-only inference server:
 olmlx/
 ├── app.py              # FastAPI app factory, middleware, router registration
 ├── config.py           # Settings (pydantic-settings, OLMLX_ env prefix)
-├── cli/                # CLI package: one module per subcommand family (serve, distributed_launch, service, models_cmd, chat_cmd, bench_cmd, prepare_cmd, parser); __init__ re-exports everything + owns dispatch
+├── cli/                # CLI package: one module per subcommand family (serve, distributed_launch, service, models_cmd, chat_cmd, bench_cmd, prepare_cmd, reap_cmd, parser); __init__ re-exports everything + owns dispatch
 ├── chat/               # In-process terminal chat + MCP agent loop
 │   └── voice/          # Push-to-talk STT (Whisper) + Kokoro TTS
 ├── engine/
@@ -43,7 +43,8 @@ olmlx/
 │   ├── dflash/         # Block-diffusion speculative decoder + training
 │   ├── eagle/          # EAGLE speculative decoder + training
 │   ├── mtp/            # Qwen3.6 native MTP head decoder
-│   └── agent/          # Autonomous agent: orchestrator/store/memory/skills/delegate (OLMLX_AGENT_*)
+│   ├── agent/          # Autonomous agent: orchestrator/store/memory/skills/delegate (OLMLX_AGENT_*)
+│   └── reap/           # REAP expert pruning: calibrate/plan/apply/report (olmlx reap *)
 ├── routers/
 │   ├── anthropic.py / openai.py / responses.py / audio.py / rerank.py / metrics.py
 │   ├── streaming_common.py  # shared tools-mode buffering + keepalive

--- a/docs/superpowers/plans/2026-07-28-reap-phase1-2.md
+++ b/docs/superpowers/plans/2026-07-28-reap-phase1-2.md
@@ -1,0 +1,2854 @@
+# REAP Expert Pruning — Phases 1–2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #701 phases 1–2: streaming REAP saliency calibration with per-source tagging, uniform/global/graded planning, overlap + perplexity reporting, and uniform-prune safetensors surgery producing stock-mlx-lm-loadable artifacts — gated by the invariant test suite.
+
+**Architecture:** New `olmlx/engine/reap/` package (arch introspection, corpus builder, streaming calibrator, planner, applier, verifier, reporter) plus an `olmlx reap calibrate|plan|apply|report` CLI family. Calibration taps read routing from the model's own forward (wrap `switch_mlp`/`gate` per layer, layer-at-a-time streaming so peak RAM ≈ one layer). Apply is shard-by-shard tensor surgery reusing `moe_bundler`'s format detection. Nothing in the serving path changes.
+
+**Tech Stack:** Python 3.11, mlx / mlx-lm 0.31.x, numpy, safetensors (via `mx.load`/`mx.save_safetensors`), HF `datasets` (streaming), pytest.
+
+**Scope notes (deviations & deferrals):**
+- CLI shape is `olmlx reap <sub>` (family-first), not the issue's literal `olmlx prepare reap-*`. The issue's stated intent was "matching the existing prepare family", and the actual repo convention is `olmlx <family> <sub>` (`flash prepare`, `dflash prepare`, …) — there is no top-level `prepare` command. Dispatch table keys make either trivial to rename later.
+- Phases 3–4 (Flash-MoE per-layer counts + graded two-bank `gather_qmm`; in-RAM TwoBankSwitchGLU) are **separate future plans**. Invariant test 4 (two banks ≡ single bank) belongs to phase 3 and is NOT in this plan. Invariant tests 1, 2, 3, 5 are in this plan.
+- `reap-apply` accepts **uniform** plans only in phase 2; `global`/`graded` plans are produced by `reap plan` (phase 1 deliverable) but `apply` rejects them with a clear error until phase 3 serving support exists.
+- Gemma4-VLM-style MoE (router on the decoder layer) is out of scope; `find_moe_module` returns `None` for it and calibration raises a clear error if no MoE layers are found.
+
+## Global Constraints
+
+- **TDD**: every task writes its failing test first (CLAUDE.md mandate).
+- **Run ruff before every commit**: `uv run ruff check --fix olmlx tests && uv run ruff format olmlx tests` (user's standing rule).
+- **Never call `mlx_lm.load` / `snapshot_download` in tests** — the autouse `block_real_model_loads` fixture (tests/conftest.py:19) fails the test. Build tiny models in-process from mlx-lm model classes and patch loader seams (`load_model_with_strict_fallback`).
+- Tests must pass on CPU (`OLMLX_TESTS_CPU_DEVICE=1` is how CI runs); use float (not quantized) tiny models for any test that runs a forward pass. Quantized tests may only do tensor slicing, never `gather_qmm`.
+- All commands are synchronous (`cli_main` has no asyncio); progress via the `Callable[[str, float], None]` callback shape (`_flash_progress`).
+- Fetch calibration texts **before** loading the model (ordering rule documented at `spectralquant_calibrate.py:399`).
+- Engine imports inside CLI handlers are function-local (repo convention, keeps CLI startup fast).
+- Config keys for expert counts vary by arch: probe `n_routed_experts` → `num_local_experts` → `num_experts` → `moe_num_experts`, unwrapping `text_config` first (same order as `moe_bundler.py:456-467`).
+- New unknown config keys must go in the raw `config.json` dict, never expected on `model.args` (mlx-lm `BaseModelArgs.from_dict` filters them).
+- Git: work on a feature branch `feat/reap-phase1-2` created from `main` (`git checkout -b feat/reap-phase1-2 main`) before Task 1. Commit messages end with the Claude Code trailer.
+- Author real code — no TODO/TBD. If an mlx-lm `ModelArgs` dataclass requires a field this plan's tiny-config omits, add it with a minimal value at the failing-construction step; that is the only sanctioned deviation.
+
+## File Structure
+
+```
+olmlx/engine/reap/
+├── __init__.py      # docstring + re-exports
+├── arch.py          # MoE module discovery, router-style dispatch, applied-score math
+├── corpus.py        # per-source streaming corpus builder (tagging, CJK filter, interleave)
+├── calibrate.py     # SaliencyAccumulator, SaliencyTap, full-forward + streaming calibration, npz io
+├── plan.py          # ReapPlan, uniform/global/graded planners, plan json io
+├── apply.py         # shard-by-shard pruning surgery, config/index rewrite, provenance
+├── verify.py        # mask_dropped_experts (−inf equivalence), max_logit_divergence
+└── report.py        # per-source overlap analysis, streaming perplexity gate
+olmlx/cli/reap_cmd.py    # cmd_reap_calibrate/plan/apply/report
+olmlx/cli/parser.py      # + reap subparser group (dest="reap_command")
+olmlx/cli/__init__.py    # + imports + 4 dispatch entries
+tests/reap_factories.py  # tiny in-process qwen3_moe / deepseek_v3 / gpt_oss models + on-disk writer
+tests/test_reap_arch.py
+tests/test_reap_corpus.py
+tests/test_reap_calibrate.py
+tests/test_reap_plan.py
+tests/test_reap_apply.py
+tests/test_reap_equivalence.py   # invariant tests 2 + 3
+tests/test_reap_report.py
+tests/test_reap_cli.py
+```
+
+---
+
+### Task 1: Package skeleton + `arch.py` (router-style dispatch, applied scores) + tiny-model factories
+
+**Files:**
+- Create: `olmlx/engine/reap/__init__.py`, `olmlx/engine/reap/arch.py`
+- Create: `tests/reap_factories.py`, `tests/test_reap_arch.py`
+
+**Interfaces (Produces):**
+```python
+# olmlx/engine/reap/arch.py
+STYLE_QWEN3 = "qwen3"; STYLE_QWEN3_NEXT = "qwen3_next"; STYLE_MINIMAX = "minimax"
+STYLE_DEEPSEEK = "deepseek"; STYLE_GPT_OSS = "gpt_oss"
+
+@dataclass
+class MoeModuleInfo:
+    attr_name: str        # "mlp" | "block_sparse_moe" | "mixer"
+    module: Any           # the MoE block
+    container_name: str   # "switch_mlp" | "experts"
+    gate_attr: str        # "gate" | "router"
+    style: str
+    num_experts: int
+    top_k: int
+
+def detect_router_style(moe_module) -> str
+def find_moe_module(layer, *, top_k_hint: int | None = None) -> MoeModuleInfo | None
+def applied_scores(style: str, moe_module, gate_out, inds: mx.array) -> mx.array
+
+# tests/reap_factories.py
+def make_tiny_qwen3_moe(*, num_experts=8, top_k=2, num_layers=2, hidden=64, vocab=128) -> tuple[nn.Module, Any]  # (model, args)
+def make_tiny_gpt_oss(*, num_experts=8, top_k=2, num_layers=2, hidden=64, vocab=128) -> tuple[nn.Module, Any]
+def make_tiny_deepseek_v3(*, num_experts=8, top_k=2, num_layers=2, hidden=64, vocab=128) -> tuple[nn.Module, Any]
+def save_tiny_model(model, config: dict, out_dir: Path) -> Path   # model.safetensors + config.json
+def tiny_config_dict(args, model_type: str) -> dict               # dataclass -> json-able config
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/reap_factories.py` (test helper, no test functions):
+
+```python
+"""Tiny in-process MoE models for REAP tests. Never touches mlx_lm.load."""
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+
+def _build(module, args):
+    model = module.Model(args)
+    mx.eval(model.parameters())
+    return model, args
+
+
+def make_tiny_qwen3_moe(*, num_experts=8, top_k=2, num_layers=2, hidden=64, vocab=128):
+    from mlx_lm.models import qwen3_moe
+
+    args = qwen3_moe.ModelArgs(
+        model_type="qwen3_moe", hidden_size=hidden, num_hidden_layers=num_layers,
+        intermediate_size=hidden * 2, num_attention_heads=4, num_key_value_heads=2,
+        head_dim=hidden // 4, rms_norm_eps=1e-5, vocab_size=vocab, rope_theta=10000.0,
+        max_position_embeddings=2048, tie_word_embeddings=False,
+        num_experts=num_experts, num_experts_per_tok=top_k,
+        moe_intermediate_size=hidden // 2, decoder_sparse_step=1,
+        mlp_only_layers=[], norm_topk_prob=True,
+    )
+    return _build(qwen3_moe, args)
+
+
+def make_tiny_gpt_oss(*, num_experts=8, top_k=2, num_layers=2, hidden=64, vocab=128):
+    from mlx_lm.models import gpt_oss
+
+    args = gpt_oss.ModelArgs(
+        model_type="gpt_oss", hidden_size=hidden, num_hidden_layers=num_layers,
+        intermediate_size=hidden // 2, num_attention_heads=4, num_key_value_heads=2,
+        head_dim=hidden // 4, rms_norm_eps=1e-5, vocab_size=vocab,
+        num_local_experts=num_experts, num_experts_per_tok=top_k,
+        sliding_window=4096, rope_theta=10000.0,
+        layer_types=["full_attention"] * num_layers,
+    )
+    return _build(gpt_oss, args)
+
+
+def make_tiny_deepseek_v3(*, num_experts=8, top_k=2, num_layers=2, hidden=64, vocab=128):
+    from mlx_lm.models import deepseek_v3
+
+    args = deepseek_v3.ModelArgs(
+        model_type="deepseek_v3", hidden_size=hidden, num_hidden_layers=num_layers,
+        intermediate_size=hidden * 2, moe_intermediate_size=hidden // 2,
+        num_attention_heads=4, num_key_value_heads=4, vocab_size=vocab,
+        n_routed_experts=num_experts, n_shared_experts=1, num_experts_per_tok=top_k,
+        routed_scaling_factor=1.0, topk_method="noaux_tc", n_group=1, topk_group=1,
+        norm_topk_prob=True, first_k_dense_replace=1, moe_layer_freq=1,
+        kv_lora_rank=16, q_lora_rank=0, qk_rope_head_dim=16, qk_nope_head_dim=16,
+        v_head_dim=16, max_position_embeddings=2048, rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+    )
+    return _build(deepseek_v3, args)
+
+
+def tiny_config_dict(args, model_type: str) -> dict:
+    cfg = dataclasses.asdict(args)
+    cfg["model_type"] = model_type
+    return cfg
+
+
+def save_tiny_model(model, config: dict, out_dir: Path) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    weights = dict(tree_flatten(model.parameters()))
+    mx.eval(*weights.values())
+    mx.save_safetensors(str(out_dir / "model.safetensors"), weights)
+    (out_dir / "config.json").write_text(json.dumps(config, indent=2))
+    return out_dir
+```
+
+If a `ModelArgs` constructor rejects a field or demands another, adjust the factory minimally (this is the sanctioned deviation; keep dims tiny and `n_group=1`).
+
+`tests/test_reap_arch.py`:
+
+```python
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from olmlx.engine.reap.arch import (
+    STYLE_DEEPSEEK, STYLE_GPT_OSS, STYLE_MINIMAX, STYLE_QWEN3, STYLE_QWEN3_NEXT,
+    applied_scores, detect_router_style, find_moe_module,
+)
+from tests.reap_factories import make_tiny_deepseek_v3, make_tiny_gpt_oss, make_tiny_qwen3_moe
+
+
+class TestDetectRouterStyle:
+    def test_qwen3_moe(self):
+        model, _ = make_tiny_qwen3_moe()
+        assert detect_router_style(model.model.layers[0].mlp) == STYLE_QWEN3
+
+    def test_gpt_oss(self):
+        model, _ = make_tiny_gpt_oss()
+        assert detect_router_style(model.model.layers[0].mlp) == STYLE_GPT_OSS
+
+    def test_deepseek_v3_moe_layer(self):
+        model, args = make_tiny_deepseek_v3()
+        # first_k_dense_replace=1 -> layer 0 dense, layer 1 MoE
+        assert detect_router_style(model.model.layers[1].mlp) == STYLE_DEEPSEEK
+
+    def test_qwen3_next_style_via_fake(self):
+        class Fake(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.gate = nn.Linear(8, 4, bias=False)
+                self.shared_expert_gate = nn.Linear(8, 1, bias=False)
+        assert detect_router_style(Fake()) == STYLE_QWEN3_NEXT
+
+    def test_minimax_style_via_fake(self):
+        class Fake(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.gate = nn.Linear(8, 4, bias=False)
+                self.e_score_correction_bias = mx.zeros((4,))
+        assert detect_router_style(Fake()) == STYLE_MINIMAX
+
+
+class TestFindMoeModule:
+    def test_qwen3_moe(self):
+        model, args = make_tiny_qwen3_moe(num_experts=8, top_k=2)
+        info = find_moe_module(model.model.layers[0])
+        assert info is not None
+        assert (info.attr_name, info.container_name, info.gate_attr) == ("mlp", "switch_mlp", "gate")
+        assert info.num_experts == 8 and info.top_k == 2
+
+    def test_gpt_oss_container_is_experts(self):
+        model, _ = make_tiny_gpt_oss()
+        info = find_moe_module(model.model.layers[0])
+        assert (info.container_name, info.gate_attr) == ("experts", "router")
+
+    def test_dense_layer_returns_none(self):
+        model, _ = make_tiny_deepseek_v3()
+        assert find_moe_module(model.model.layers[0]) is None  # dense (first_k_dense_replace=1)
+        assert find_moe_module(model.model.layers[1]) is not None
+
+
+class TestAppliedScores:
+    def test_qwen3_matches_block_math(self):
+        model, _ = make_tiny_qwen3_moe(num_experts=8, top_k=2)
+        moe = model.model.layers[0].mlp
+        x = mx.random.normal((3, 5, 64))
+        logits = moe.gate(x)
+        probs = mx.softmax(logits.astype(mx.float32), axis=-1)
+        inds = mx.stop_gradient(mx.argpartition(-probs, kth=1, axis=-1)[..., :2])
+        scores = applied_scores(STYLE_QWEN3, moe, logits, inds)
+        expected = mx.take_along_axis(probs, inds, axis=-1)
+        expected = expected / mx.sum(expected, axis=-1, keepdims=True)  # norm_topk_prob=True
+        assert mx.allclose(scores, expected, atol=1e-6)
+
+    def test_scores_sum_to_one_when_renormed(self):
+        model, _ = make_tiny_qwen3_moe()
+        moe = model.model.layers[0].mlp
+        x = mx.random.normal((2, 4, 64))
+        logits = moe.gate(x)
+        inds = mx.argpartition(-logits, kth=1, axis=-1)[..., :2]
+        s = applied_scores(STYLE_QWEN3, moe, logits, inds)
+        assert mx.allclose(mx.sum(s, axis=-1), mx.ones(s.shape[:-1]), atol=1e-5)
+
+    def test_gpt_oss_softmax_over_selected(self):
+        model, _ = make_tiny_gpt_oss(num_experts=8, top_k=2)
+        moe = model.model.layers[0].mlp
+        x = mx.random.normal((2, 4, 64))
+        logits = moe.router(x)
+        inds = mx.argpartition(-logits, kth=1, axis=-1)[..., :2]
+        s = applied_scores(STYLE_GPT_OSS, moe, logits, inds)
+        assert mx.allclose(s, mx.softmax(mx.take_along_axis(logits, inds, axis=-1), axis=-1), atol=1e-6)
+
+    def test_deepseek_passthrough(self):
+        model, _ = make_tiny_deepseek_v3()
+        moe = model.model.layers[1].mlp
+        x = mx.random.normal((2, 4, 64))
+        gate_out = moe.gate(x)          # (inds, scores)
+        s = applied_scores(STYLE_DEEPSEEK, moe, gate_out, gate_out[0])
+        assert mx.array_equal(s, gate_out[1])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_reap_arch.py -x -q`
+Expected: FAIL at import — `ModuleNotFoundError: No module named 'olmlx.engine.reap'`. (Factory construction errors surface here too — fix factories per the sanctioned deviation until only the missing-module failure remains.)
+
+- [ ] **Step 3: Implement `arch.py`**
+
+`olmlx/engine/reap/__init__.py`:
+```python
+"""REAP expert pruning: calibration, planning, pruning surgery, and reporting (#701)."""
+```
+
+`olmlx/engine/reap/arch.py`:
+```python
+"""Per-architecture MoE introspection for REAP.
+
+Mirrors the router-style dispatch chain in flash/flash_moe_model.py
+_replace_moe_layers (detection order is load-bearing there and here).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+STYLE_QWEN3 = "qwen3"            # plain linear gate, softmax before top-k
+STYLE_QWEN3_NEXT = "qwen3_next"  # linear gate + shared_expert_gate
+STYLE_MINIMAX = "minimax"        # linear gate + block-level e_score_correction_bias
+STYLE_DEEPSEEK = "deepseek"      # custom gate module returning (inds, scores)
+STYLE_GPT_OSS = "gpt_oss"        # `router` linear + `experts` container
+
+_MOE_ATTRS = ("mlp", "block_sparse_moe", "mixer")
+_CONTAINER_ATTRS = ("switch_mlp", "experts")
+_PROJ_PROBES = ("gate_proj", "fc1")
+
+
+@dataclass
+class MoeModuleInfo:
+    attr_name: str
+    module: Any
+    container_name: str
+    gate_attr: str
+    style: str
+    num_experts: int
+    top_k: int
+
+
+def _gate_is_linear(gate: Any) -> bool:
+    linear_types: tuple[type, ...] = (nn.Linear,)
+    if hasattr(nn, "QuantizedLinear"):
+        linear_types = (nn.Linear, nn.QuantizedLinear)
+    return isinstance(gate, linear_types)
+
+
+def detect_router_style(moe_module: Any) -> str:
+    gate = getattr(moe_module, "gate", None)
+    if _gate_is_linear(gate) and hasattr(moe_module, "shared_expert_gate"):
+        return STYLE_QWEN3_NEXT
+    if _gate_is_linear(gate) and hasattr(moe_module, "e_score_correction_bias"):
+        return STYLE_MINIMAX
+    if _gate_is_linear(gate):
+        return STYLE_QWEN3
+    if gate is not None:
+        return STYLE_DEEPSEEK
+    if getattr(moe_module, "router", None) is not None:
+        return STYLE_GPT_OSS
+    raise ValueError("unrecognized MoE router layout")
+
+
+def _find_container(moe_module: Any) -> tuple[str, Any] | None:
+    for name in _CONTAINER_ATTRS:
+        cont = getattr(moe_module, name, None)
+        if cont is None:
+            continue
+        for probe in _PROJ_PROBES:
+            proj = getattr(cont, probe, None)
+            if proj is not None and getattr(proj, "weight", None) is not None:
+                return name, cont
+    return None
+
+
+def _top_k_of(moe_module: Any) -> int | None:
+    for owner in (moe_module, getattr(moe_module, "gate", None)):
+        if owner is None:
+            continue
+        for attr in ("top_k", "num_experts_per_tok", "num_local_experts_per_tok"):
+            val = getattr(owner, attr, None)
+            if isinstance(val, int) and val > 0:
+                return val
+    config = getattr(getattr(moe_module, "gate", None), "config", None)
+    val = getattr(config, "num_experts_per_tok", None)
+    return val if isinstance(val, int) else None
+
+
+def find_moe_module(layer: Any, *, top_k_hint: int | None = None) -> MoeModuleInfo | None:
+    for attr in _MOE_ATTRS:
+        moe = getattr(layer, attr, None)
+        if moe is None:
+            continue
+        found = _find_container(moe)
+        if found is None:
+            continue
+        container_name, container = found
+        try:
+            style = detect_router_style(moe)
+        except ValueError:
+            continue
+        # gpt-oss keeps experts under the same attr the container probe found;
+        # in that layout `moe` IS the block and `container` its SwitchGLU.
+        proj = getattr(container, "gate_proj", None) or getattr(container, "fc1", None)
+        num_experts = int(proj.weight.shape[0])
+        top_k = _top_k_of(moe) or top_k_hint
+        if top_k is None:
+            raise ValueError(f"cannot determine top_k for MoE module {attr!r}")
+        gate_attr = "router" if style == STYLE_GPT_OSS else "gate"
+        return MoeModuleInfo(
+            attr_name=attr, module=moe, container_name=container_name,
+            gate_attr=gate_attr, style=style, num_experts=num_experts, top_k=int(top_k),
+        )
+    return None
+
+
+def applied_scores(style: str, moe_module: Any, gate_out: Any, inds: mx.array) -> mx.array:
+    """Routing weight actually applied to each selected expert's output.
+
+    gate_out is the raw gate/router output: logits for linear styles, the
+    (inds, scores) tuple for DeepSeek-style custom gates.
+    """
+    if style == STYLE_DEEPSEEK:
+        return gate_out[1]
+    if style in (STYLE_QWEN3, STYLE_QWEN3_NEXT):
+        probs = mx.softmax(gate_out.astype(mx.float32), axis=-1, precise=True)
+        scores = mx.take_along_axis(probs, inds, axis=-1)
+        if getattr(moe_module, "norm_topk_prob", False):
+            scores = scores / mx.sum(scores, axis=-1, keepdims=True)
+        return scores
+    if style == STYLE_MINIMAX:
+        probs = mx.sigmoid(gate_out.astype(mx.float32))
+        scores = mx.take_along_axis(probs, inds, axis=-1)
+        return scores / mx.sum(scores, axis=-1, keepdims=True)
+    if style == STYLE_GPT_OSS:
+        return mx.softmax(mx.take_along_axis(gate_out, inds, axis=-1), axis=-1)
+    raise ValueError(f"unknown router style {style!r}")
+```
+
+Before finalizing, open the installed mlx-lm sources named in the exploration (`.venv/.../mlx_lm/models/qwen3_moe.py:110-140`, `gpt_oss.py:130-160`, `deepseek_v3.py:193-260`) and confirm the score math matches line-for-line (softmax `precise` flag, renorm condition names). Adjust `applied_scores` to match the installed version exactly — the tests in Step 1 compare against the real modules.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_reap_arch.py -q`
+Expected: PASS (all).
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+uv run ruff check --fix olmlx tests && uv run ruff format olmlx tests
+git add olmlx/engine/reap/ tests/reap_factories.py tests/test_reap_arch.py
+git commit -m "feat(reap): arch introspection + router-style dispatch (#701)"
+```
+
+---
+
+### Task 2: `calibrate.py` part 1 — SaliencyAccumulator, SaliencyTap, full-forward collection, npz io
+
+**Files:**
+- Create: `olmlx/engine/reap/calibrate.py`
+- Create: `tests/test_reap_calibrate.py`
+
+**Interfaces:**
+- Consumes: `find_moe_module`, `applied_scores`, `MoeModuleInfo` from Task 1.
+- Produces:
+```python
+class SaliencyAccumulator:
+    sources: list[str]
+    sum: np.ndarray    # (num_moe_layers, num_sources, num_experts) float64
+    count: np.ndarray  # same shape, int64
+    def __init__(self, num_moe_layers: int, num_experts: int, sources: list[str]) -> None
+    def add(self, layer_pos: int, source_idx: int, expert_ids: np.ndarray, contribs: np.ndarray) -> None
+    def saliency(self, sources: list[str] | None = None) -> np.ndarray  # (L, E) mean contribution
+    def frequency(self, sources: list[str] | None = None) -> np.ndarray # (L, E) routed-token counts
+
+def save_saliency(path: Path, acc: SaliencyAccumulator, meta: dict) -> None
+def load_saliency(path: Path) -> tuple[SaliencyAccumulator, dict]
+
+class SaliencyTap(nn.Module):
+    def __init__(self, info: MoeModuleInfo, layer_pos: int, acc: SaliencyAccumulator,
+                 source_ref: dict[str, int]) -> None
+    def __call__(self, x, *args, **kwargs)  # runs wrapped block, records, returns block output
+
+def install_taps(model_layers, acc, source_ref, *, top_k_hint=None) -> list[tuple[int, Any, str]]
+    # returns [(layer_idx, original_block, attr_name)] for restore; taps every MoE layer
+def remove_taps(model_layers, installed) -> None
+def collect_saliency(model, tokenizer, tagged_texts: list[tuple[str, str]], *,
+                     max_tokens: int = 512, progress_callback=None) -> tuple[SaliencyAccumulator, dict]
+```
+- `meta` dict keys: `model_type`, `num_experts`, `top_k`, `moe_layer_indices` (list[int], actual decoder-layer indices), `sources`, `num_samples`, `max_tokens`, `prepared_at`.
+- REAP formula recorded per routed (token, slot): `contrib = applied_score * ||expert_out||_2`; `saliency = sum(contrib)/count` per (layer, expert).
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_reap_calibrate.py`:
+
+```python
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from olmlx.engine.reap.calibrate import (
+    SaliencyAccumulator, collect_saliency, load_saliency, save_saliency,
+)
+from tests.reap_factories import make_tiny_deepseek_v3, make_tiny_gpt_oss, make_tiny_qwen3_moe
+
+
+class FakeTokenizer:
+    """Maps each character to a token id; enough for tiny-vocab models."""
+    def encode(self, text):
+        return [ord(c) % 100 + 1 for c in text]
+
+
+def _tagged(n_per_source=3):
+    return [("english", "hello world " * 8), ("code", "def f(x): return x " * 6)][:2] * n_per_source
+
+
+class TestAccumulator:
+    def test_add_and_mean(self):
+        acc = SaliencyAccumulator(2, 4, ["a", "b"])
+        acc.add(0, 0, np.array([1, 1, 3]), np.array([2.0, 4.0, 6.0]))
+        sal = acc.saliency(["a"])
+        assert sal.shape == (2, 4)
+        assert sal[0, 1] == pytest.approx(3.0)   # mean of 2,4
+        assert sal[0, 3] == pytest.approx(6.0)
+        assert sal[0, 0] == 0.0 and sal[1, 1] == 0.0
+
+    def test_source_combination(self):
+        acc = SaliencyAccumulator(1, 4, ["a", "b"])
+        acc.add(0, 0, np.array([0]), np.array([1.0]))
+        acc.add(0, 1, np.array([0]), np.array([3.0]))
+        assert acc.saliency(["a"])[0, 0] == pytest.approx(1.0)
+        assert acc.saliency(None)[0, 0] == pytest.approx(2.0)  # pooled mean
+
+    def test_npz_roundtrip(self, tmp_path):
+        acc = SaliencyAccumulator(1, 4, ["a"])
+        acc.add(0, 0, np.array([2]), np.array([5.0]))
+        meta = {"model_type": "qwen3_moe", "num_experts": 4, "top_k": 2,
+                "moe_layer_indices": [0], "sources": ["a"]}
+        save_saliency(tmp_path / "s.npz", acc, meta)
+        acc2, meta2 = load_saliency(tmp_path / "s.npz")
+        np.testing.assert_array_equal(acc.sum, acc2.sum)
+        np.testing.assert_array_equal(acc.count, acc2.count)
+        assert acc2.sources == ["a"] and meta2["model_type"] == "qwen3_moe"
+
+
+@pytest.mark.parametrize("factory", [make_tiny_qwen3_moe, make_tiny_gpt_oss, make_tiny_deepseek_v3])
+class TestCollectSaliency:
+    def test_counts_and_meta(self, factory):
+        mx.random.seed(0)
+        model, args = factory()
+        acc, meta = collect_saliency(model, FakeTokenizer(), _tagged(), max_tokens=16)
+        n_moe = len(meta["moe_layer_indices"])
+        assert acc.sum.shape == (n_moe, 2, 8)
+        # every routed token contributes exactly top_k slots per MoE layer
+        total_tokens = sum(min(len(FakeTokenizer().encode(t)), 16) for _, t in _tagged())
+        assert acc.count.sum() == n_moe * total_tokens * meta["top_k"]
+        assert (acc.sum >= 0).all()
+        assert meta["num_experts"] == 8 and meta["top_k"] == 2
+
+    def test_taps_removed_after_collect(self, factory):
+        model, _ = factory()
+        layers = model.model.layers
+        before = [type(getattr(l, "mlp", None)).__name__ for l in layers]
+        collect_saliency(model, FakeTokenizer(), _tagged(1), max_tokens=8)
+        after = [type(getattr(l, "mlp", None)).__name__ for l in layers]
+        assert before == after
+
+    def test_forward_unchanged_by_tap(self, factory):
+        mx.random.seed(1)
+        model, _ = factory()
+        ids = mx.array([[1, 2, 3, 4, 5]])
+        ref = np.array(model(ids), copy=True)
+        collect_saliency(model, FakeTokenizer(), _tagged(1), max_tokens=8)
+        out = np.array(model(ids))
+        np.testing.assert_allclose(out, ref, atol=1e-5)
+
+
+class TestSaliencyMatchesManualReference:
+    def test_qwen3_hand_computed(self):
+        """Independent reimplementation of REAP S_j for one batch pins the tap."""
+        mx.random.seed(2)
+        model, _ = make_tiny_qwen3_moe(num_layers=1)
+        text = "abcdefghij"
+        acc, meta = collect_saliency(model, FakeTokenizer(), [("src", text)], max_tokens=32)
+
+        moe = model.model.layers[0].mlp
+        ids = mx.array([FakeTokenizer().encode(text)])
+        h = model.model.embed_tokens(ids)
+        # reference: run the pre-MoE part by calling the layer's attention manually is
+        # overkill; instead recompute routing on the *hidden states the MoE saw* by
+        # re-running the model with a capture of the MoE input.
+        seen = {}
+        orig_call = type(moe).__call__
+        def capture(self_, x):
+            seen["x"] = x
+            return orig_call(self_, x)
+        type(moe).__call__ = capture
+        try:
+            model(ids)
+        finally:
+            type(moe).__call__ = orig_call
+        x = seen["x"].reshape(-1, seen["x"].shape[-1])
+        probs = mx.softmax(moe.gate(x).astype(mx.float32), axis=-1, precise=True)
+        inds = mx.argpartition(-probs, kth=1, axis=-1)[..., :2]
+        scores = mx.take_along_axis(probs, inds, axis=-1)
+        scores = scores / mx.sum(scores, axis=-1, keepdims=True)
+        ys = moe.switch_mlp(x, inds)
+        norms = mx.linalg.norm(ys.astype(mx.float32), axis=-1)
+        expected = np.zeros(8); counts = np.zeros(8)
+        np.add.at(expected, np.array(inds).reshape(-1), np.array(scores * norms, dtype=np.float64).reshape(-1))
+        np.add.at(counts, np.array(inds).reshape(-1), 1)
+        np.testing.assert_allclose(acc.sum[0, 0], expected, rtol=1e-4)
+        np.testing.assert_array_equal(acc.count[0, 0], counts)
+```
+
+(The reference test intentionally reimplements the routing math from the mlx-lm source rather than importing `applied_scores` — it pins the tap against an independent computation.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_reap_calibrate.py -x -q`
+Expected: FAIL — `ModuleNotFoundError` / `ImportError` for `olmlx.engine.reap.calibrate`.
+
+- [ ] **Step 3: Implement**
+
+`olmlx/engine/reap/calibrate.py` (part 1 — streaming added in Task 4):
+
+```python
+"""REAP saliency calibration: taps, accumulator, full-forward + streaming drivers."""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from olmlx.engine.reap.arch import MoeModuleInfo, applied_scores, find_moe_module
+
+logger = logging.getLogger(__name__)
+
+
+class SaliencyAccumulator:
+    def __init__(self, num_moe_layers: int, num_experts: int, sources: list[str]) -> None:
+        self.sources = list(sources)
+        self.sum = np.zeros((num_moe_layers, len(self.sources), num_experts), dtype=np.float64)
+        self.count = np.zeros_like(self.sum, dtype=np.int64)
+
+    def add(self, layer_pos: int, source_idx: int, expert_ids: np.ndarray, contribs: np.ndarray) -> None:
+        np.add.at(self.sum[layer_pos, source_idx], expert_ids, contribs)
+        np.add.at(self.count[layer_pos, source_idx], expert_ids, 1)
+
+    def _source_indices(self, sources: list[str] | None) -> list[int]:
+        if sources is None:
+            return list(range(len(self.sources)))
+        missing = [s for s in sources if s not in self.sources]
+        if missing:
+            raise ValueError(f"unknown sources {missing}; calibrated sources: {self.sources}")
+        return [self.sources.index(s) for s in sources]
+
+    def saliency(self, sources: list[str] | None = None) -> np.ndarray:
+        idx = self._source_indices(sources)
+        s = self.sum[:, idx].sum(axis=1)
+        c = self.count[:, idx].sum(axis=1)
+        return s / np.maximum(c, 1)
+
+    def frequency(self, sources: list[str] | None = None) -> np.ndarray:
+        idx = self._source_indices(sources)
+        return self.count[:, idx].sum(axis=1)
+
+
+def save_saliency(path: Path, acc: SaliencyAccumulator, meta: dict) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(path, sum=acc.sum, count=acc.count,
+             sources=np.array(acc.sources), meta=json.dumps(meta))
+
+
+def load_saliency(path: Path) -> tuple[SaliencyAccumulator, dict]:
+    data = np.load(path, allow_pickle=False)
+    sources = [str(s) for s in data["sources"]]
+    acc = SaliencyAccumulator(data["sum"].shape[0], data["sum"].shape[2], sources)
+    acc.sum = data["sum"].astype(np.float64)
+    acc.count = data["count"].astype(np.int64)
+    return acc, json.loads(str(data["meta"]))
+
+
+class _CaptureContainer(nn.Module):
+    def __init__(self, inner: Any, captured: dict) -> None:
+        super().__init__()
+        self.inner = inner
+        self._captured = captured
+
+    def __call__(self, x, inds, **kwargs):
+        out = self.inner(x, inds, **kwargs)
+        self._captured["inds"] = inds
+        self._captured["expert_outs"] = out
+        return out
+
+
+class _CaptureGate(nn.Module):
+    def __init__(self, inner: Any, captured: dict) -> None:
+        super().__init__()
+        self.inner = inner
+        self._captured = captured
+
+    def __call__(self, x):
+        out = self.inner(x)
+        self._captured["gate_out"] = out
+        return out
+
+
+class SaliencyTap(nn.Module):
+    """Replaces a MoE block attr on a decoder layer; records REAP contributions
+    from the block's own forward (no routing reimplementation on the hot path)."""
+
+    def __init__(self, info: MoeModuleInfo, layer_pos: int,
+                 acc: SaliencyAccumulator, source_ref: dict[str, int]) -> None:
+        super().__init__()
+        self.inner = info.module
+        self._info = info
+        self._layer_pos = layer_pos
+        self._acc = acc
+        self._source_ref = source_ref
+
+    def __call__(self, x, *args, **kwargs):
+        info = self._info
+        container = getattr(self.inner, info.container_name)
+        gate = getattr(self.inner, info.gate_attr)
+        captured: dict = {}
+        setattr(self.inner, info.container_name, _CaptureContainer(container, captured))
+        setattr(self.inner, info.gate_attr, _CaptureGate(gate, captured))
+        try:
+            y = self.inner(x, *args, **kwargs)
+        finally:
+            setattr(self.inner, info.container_name, container)
+            setattr(self.inner, info.gate_attr, gate)
+        inds = captured["inds"]
+        scores = applied_scores(info.style, self.inner, captured["gate_out"], inds)
+        norms = mx.linalg.norm(captured["expert_outs"].astype(mx.float32), axis=-1)
+        contribs = np.asarray((scores * norms).reshape(-1), dtype=np.float64)
+        experts = np.asarray(inds.reshape(-1))
+        self._acc.add(self._layer_pos, self._source_ref["idx"], experts, contribs)
+        return y
+
+
+def install_taps(model_layers, acc: SaliencyAccumulator, source_ref: dict[str, int],
+                 *, top_k_hint: int | None = None) -> list[tuple[int, Any, str]]:
+    installed: list[tuple[int, Any, str]] = []
+    layer_pos = 0
+    for i, layer in enumerate(model_layers):
+        info = find_moe_module(layer, top_k_hint=top_k_hint)
+        if info is None:
+            continue
+        tap = SaliencyTap(info, layer_pos, acc, source_ref)
+        installed.append((i, info.module, info.attr_name))
+        setattr(layer, info.attr_name, tap)
+        layer_pos += 1
+    return installed
+
+
+def remove_taps(model_layers, installed: list[tuple[int, Any, str]]) -> None:
+    for i, original, attr in installed:
+        setattr(model_layers[i], attr, original)
+
+
+def _encode(tokenizer, text: str, max_tokens: int) -> list[int]:
+    tokens = tokenizer.encode(text)
+    if isinstance(tokens, dict):
+        tokens = tokens["input_ids"]
+    return list(tokens)[:max_tokens]
+
+
+def _moe_scan(layers, top_k_hint=None) -> tuple[list[int], int, int]:
+    indices, num_experts, top_k = [], 0, 0
+    for i, layer in enumerate(layers):
+        info = find_moe_module(layer, top_k_hint=top_k_hint)
+        if info is not None:
+            indices.append(i)
+            num_experts, top_k = info.num_experts, info.top_k
+    if not indices:
+        raise ValueError("model has no recognized MoE layers; REAP requires an MoE model")
+    return indices, num_experts, top_k
+
+
+def _backbone(model):
+    from olmlx.engine.flash.prepare import _get_backbone
+    return _get_backbone(model)
+
+
+def collect_saliency(model, tokenizer, tagged_texts: list[tuple[str, str]], *,
+                     max_tokens: int = 512,
+                     progress_callback: Callable[[str, float], None] | None = None,
+                     ) -> tuple[SaliencyAccumulator, dict]:
+    """Full-forward (non-streaming) saliency collection for models that fit in RAM."""
+    inner = _backbone(model)
+    layers = inner.layers
+    moe_layer_indices, num_experts, top_k = _moe_scan(layers)
+    sources = list(dict.fromkeys(s for s, _ in tagged_texts))
+    acc = SaliencyAccumulator(len(moe_layer_indices), num_experts, sources)
+    source_ref = {"idx": 0}
+    installed = install_taps(layers, acc, source_ref)
+    try:
+        for n, (source, text) in enumerate(tagged_texts):
+            source_ref["idx"] = sources.index(source)
+            ids = _encode(tokenizer, text, max_tokens)
+            if not ids:
+                continue
+            mx.eval(model(mx.array([ids])))
+            if progress_callback:
+                progress_callback(f"Calibrated {n + 1}/{len(tagged_texts)} samples",
+                                  (n + 1) / len(tagged_texts))
+    finally:
+        remove_taps(layers, installed)
+    meta = {
+        "model_type": getattr(getattr(model, "args", None), "model_type", "unknown"),
+        "num_experts": num_experts, "top_k": top_k,
+        "moe_layer_indices": moe_layer_indices, "sources": sources,
+        "num_samples": len(tagged_texts), "max_tokens": max_tokens,
+        "prepared_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    return acc, meta
+```
+
+Notes for the implementer:
+- `model(ids)` on mlx-lm models runs with `cache=None` full-sequence — fine here.
+- `mx.eval(model(...))` forces the tap's captured arrays to be computable; the `np.asarray` conversions inside the tap already force evaluation of `contribs`.
+- Replacing `layer.mlp`-style attrs with an `nn.Module` subclass is the `_RecordingMLP` precedent (flash/prepare.py:303); instance-`__call__` monkeypatching does not work in Python.
+- deepseek: dense layers (`first_k_dense_replace`) simply yield no `find_moe_module` hit; `moe_layer_indices` reflects that.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_reap_calibrate.py -q`
+Expected: PASS. If the manual-reference test diverges, the tap or `applied_scores` doesn't match the installed mlx-lm block math — fix the implementation, not the tolerance.
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+uv run ruff check --fix olmlx tests && uv run ruff format olmlx tests
+git add olmlx/engine/reap/calibrate.py tests/test_reap_calibrate.py
+git commit -m "feat(reap): saliency tap + accumulator + full-forward calibration (#701)"
+```
+
+---
+
+### Task 3: `corpus.py` — per-source tagged corpus builder
+
+**Files:**
+- Create: `olmlx/engine/reap/corpus.py`
+- Create: `tests/test_reap_corpus.py`
+
+**Interfaces (Produces):**
+```python
+@dataclass(frozen=True)
+class SourceSpec:
+    name: str
+    dataset: str
+    config: str | None
+    split: str
+    text_key: str
+    min_chars: int = 100
+    min_cjk_fraction: float = 0.0
+    data_dir: str | None = None
+
+BUILTIN_SOURCES: dict[str, SourceSpec]  # "english", "chinese", "code"
+
+def cjk_fraction(text: str) -> float
+def build_calibration_corpus(sources: list[str], samples_per_source: int, *,
+                             skip: int = 0, char_cap: int = 4096,
+                             progress_callback=None) -> list[tuple[str, str]]
+    # returns round-robin interleaved [(source_name, text), ...]
+def synthetic_source_texts(source: str, n: int) -> list[str]   # offline fallback
+```
+- `skip` reserves a held-out slice: `build_calibration_corpus(..., skip=N)` starts each source stream after its first N accepted samples (report uses this for held-out perplexity).
+- Fallback behavior mirrors `_get_c4_calibration_data` (flash/prepare.py:133): any exception (incl. ImportError of `datasets`) logs a warning and substitutes `synthetic_source_texts` for that source.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_reap_corpus.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from olmlx.engine.reap import corpus as corpus_mod
+from olmlx.engine.reap.corpus import (
+    BUILTIN_SOURCES, build_calibration_corpus, cjk_fraction, synthetic_source_texts,
+)
+
+
+class TestCjkFraction:
+    def test_pure_ascii(self):
+        assert cjk_fraction("hello world") == 0.0
+
+    def test_pure_cjk(self):
+        assert cjk_fraction("你好世界") == 1.0
+
+    def test_mixed(self):
+        assert 0.4 < cjk_fraction("abc你好中文字") < 0.8
+
+    def test_empty(self):
+        assert cjk_fraction("") == 0.0
+
+
+class _FakeStream:
+    """Stands in for datasets.load_dataset(..., streaming=True)."""
+    def __init__(self, rows):
+        self.rows = rows
+        self.closed = False
+    def __iter__(self):
+        return iter(self.rows)
+    def close(self):
+        self.closed = True
+
+
+def _fake_load_dataset(rows_by_key):
+    def load_dataset(dataset, config=None, split=None, streaming=False, data_dir=None):
+        return _FakeStream(rows_by_key[(dataset, config)])
+    return load_dataset
+
+
+class TestBuildCorpus:
+    def _patch(self, monkeypatch, rows_by_key):
+        import datasets
+        monkeypatch.setattr(datasets, "load_dataset", _fake_load_dataset(rows_by_key))
+
+    def test_interleaved_and_tagged(self, monkeypatch):
+        en = [{"text": f"english document number {i} " * 10} for i in range(5)]
+        code = [{"content": f"def fn_{i}(): return {i} " * 10} for i in range(5)]
+        self._patch(monkeypatch, {
+            ("allenai/c4", "en"): en,
+            (BUILTIN_SOURCES["code"].dataset, BUILTIN_SOURCES["code"].config): code,
+        })
+        out = build_calibration_corpus(["english", "code"], 3)
+        assert len(out) == 6
+        # round-robin: e, c, e, c, e, c
+        assert [s for s, _ in out] == ["english", "code"] * 3
+        assert "english document" in out[0][1] and "def fn_" in out[1][1]
+
+    def test_min_chars_filter(self, monkeypatch):
+        rows = [{"text": "short"}] + [{"text": "x" * 200}] * 3
+        self._patch(monkeypatch, {("allenai/c4", "en"): rows})
+        out = build_calibration_corpus(["english"], 2)
+        assert all(len(t) >= 100 for _, t in out)
+
+    def test_cjk_filter_for_chinese(self, monkeypatch):
+        mojibake = {"text": "a" * 200}                       # claims zh, no CJK
+        good = {"text": "中文测试" * 60}
+        self._patch(monkeypatch, {("allenai/c4", "zh"): [mojibake, good, good]})
+        out = build_calibration_corpus(["chinese"], 2)
+        assert len(out) == 2
+        assert all(cjk_fraction(t) >= 0.3 for _, t in out)
+
+    def test_skip_reserves_held_out(self, monkeypatch):
+        rows = [{"text": f"document number {i:03d} " * 10} for i in range(10)]
+        self._patch(monkeypatch, {("allenai/c4", "en"): rows})
+        cal = build_calibration_corpus(["english"], 3)
+        held = build_calibration_corpus(["english"], 2, skip=3)
+        cal_texts = {t for _, t in cal}
+        assert all(t not in cal_texts for _, t in held)
+
+    def test_char_cap(self, monkeypatch):
+        rows = [{"text": "y" * 10_000}] * 2
+        self._patch(monkeypatch, {("allenai/c4", "en"): rows})
+        out = build_calibration_corpus(["english"], 2, char_cap=1000)
+        assert all(len(t) == 1000 for _, t in out)
+
+    def test_fallback_to_synthetic_on_error(self, monkeypatch):
+        import datasets
+        def boom(*a, **k):
+            raise ConnectionError("offline")
+        monkeypatch.setattr(datasets, "load_dataset", boom)
+        out = build_calibration_corpus(["english"], 4)
+        assert len(out) == 4 and all(s == "english" for s, _ in out)
+
+    def test_unknown_source_raises(self):
+        with pytest.raises(ValueError, match="klingon"):
+            build_calibration_corpus(["klingon"], 2)
+
+
+class TestSynthetic:
+    def test_deterministic_and_distinct(self):
+        a = synthetic_source_texts("code", 5)
+        b = synthetic_source_texts("code", 5)
+        assert a == b and len(set(a)) == 5
+        assert synthetic_source_texts("english", 3) != synthetic_source_texts("code", 3)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_reap_corpus.py -x -q`
+Expected: FAIL — no `olmlx.engine.reap.corpus` module.
+
+- [ ] **Step 3: Implement `corpus.py`**
+
+```python
+"""Calibration corpus builder: per-source tagging, CJK filter, round-robin interleave.
+
+Ports the kimi-k3-mlx corpus lessons: per-language C4 configs (pooled multilingual
+C4 is ~97% Latin script), sources interleaved not concatenated (calibration reads
+a prefix), and a CJK-fraction filter to drop mojibake documents.
+"""
+from __future__ import annotations
+
+import itertools
+import logging
+from dataclasses import dataclass
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+_CJK_RANGES = (
+    (0x4E00, 0x9FFF), (0x3400, 0x4DBF),   # CJK unified + ext A
+    (0x3040, 0x30FF),                      # hiragana + katakana
+    (0xAC00, 0xD7AF),                      # hangul
+)
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    name: str
+    dataset: str
+    config: str | None
+    split: str
+    text_key: str
+    min_chars: int = 100
+    min_cjk_fraction: float = 0.0
+    data_dir: str | None = None
+
+
+BUILTIN_SOURCES: dict[str, SourceSpec] = {
+    "english": SourceSpec("english", "allenai/c4", "en", "train", "text"),
+    "chinese": SourceSpec("chinese", "allenai/c4", "zh", "train", "text",
+                          min_cjk_fraction=0.3),
+    "code": SourceSpec("code", "bigcode/the-stack-smol", None, "train", "content",
+                       data_dir="data/python"),
+}
+
+
+def cjk_fraction(text: str) -> float:
+    if not text:
+        return 0.0
+    hits = sum(1 for ch in text if any(lo <= ord(ch) <= hi for lo, hi in _CJK_RANGES))
+    return hits / len(text)
+
+
+_SYNTH_TEMPLATES = {
+    "english": "The {0} of {1} is a widely studied subject in modern research. ",
+    "chinese": "关于{0}与{1}的研究是现代学术领域的重要课题。",
+    "code": "def process_{0}(data):\n    result = [x for x in data if x.{1}]\n    return result\n",
+}
+_SYNTH_TOPICS = [
+    "history", "structure", "analysis", "theory", "design", "behavior", "origin",
+    "measurement", "classification", "evolution", "dynamics", "composition",
+]
+
+
+def synthetic_source_texts(source: str, n: int) -> list[str]:
+    template = _SYNTH_TEMPLATES.get(source, _SYNTH_TEMPLATES["english"])
+    texts = []
+    for i in range(n):
+        a = _SYNTH_TOPICS[i % len(_SYNTH_TOPICS)]
+        b = _SYNTH_TOPICS[(i + 7) % len(_SYNTH_TOPICS)]
+        texts.append((template.format(a, b)) * 12)
+    return texts
+
+
+def _stream_source(spec: SourceSpec, n: int, *, skip: int, char_cap: int) -> list[str]:
+    import datasets
+
+    kwargs = {"split": spec.split, "streaming": True}
+    if spec.data_dir:
+        kwargs["data_dir"] = spec.data_dir
+    stream = datasets.load_dataset(spec.dataset, spec.config, **kwargs) \
+        if spec.config else datasets.load_dataset(spec.dataset, **kwargs)
+    accepted: list[str] = []
+    to_skip = skip
+    try:
+        for row in stream:
+            text = row.get(spec.text_key, "")
+            if len(text) < spec.min_chars:
+                continue
+            if spec.min_cjk_fraction and cjk_fraction(text) < spec.min_cjk_fraction:
+                continue
+            if to_skip > 0:
+                to_skip -= 1
+                continue
+            accepted.append(text[:char_cap])
+            if len(accepted) >= n:
+                break
+    finally:
+        close = getattr(stream, "close", None)
+        if close is not None:
+            close()
+    if len(accepted) < n:
+        raise RuntimeError(f"source {spec.name!r} yielded only {len(accepted)}/{n} samples")
+    return accepted
+
+
+def build_calibration_corpus(sources: list[str], samples_per_source: int, *,
+                             skip: int = 0, char_cap: int = 4096,
+                             progress_callback: Callable[[str, float], None] | None = None,
+                             ) -> list[tuple[str, str]]:
+    unknown = [s for s in sources if s not in BUILTIN_SOURCES]
+    if unknown:
+        raise ValueError(f"unknown calibration sources {unknown}; "
+                         f"available: {sorted(BUILTIN_SOURCES)}")
+    per_source: dict[str, list[str]] = {}
+    for i, name in enumerate(sources):
+        spec = BUILTIN_SOURCES[name]
+        try:
+            per_source[name] = _stream_source(spec, samples_per_source,
+                                              skip=skip, char_cap=char_cap)
+        except Exception as exc:  # noqa: BLE001 — mirror _get_c4_calibration_data
+            logger.warning("calibration source %s unavailable (%s); using synthetic fallback",
+                           name, exc)
+            per_source[name] = [t[:char_cap] for t in
+                                synthetic_source_texts(name, samples_per_source)]
+        if progress_callback:
+            progress_callback(f"Fetched source {name}", (i + 1) / len(sources))
+    # round-robin interleave so a prefix read still covers every source
+    tagged: list[tuple[str, str]] = []
+    for row in itertools.zip_longest(*(
+            [(name, t) for t in per_source[name]] for name in sources)):
+        tagged.extend(item for item in row if item is not None)
+    return tagged
+```
+
+Note: `datasets.load_dataset("allenai/c4", "zh", ...)` — verify the mC4 Chinese config name at implementation time with a quick `datasets.get_dataset_config_names("allenai/c4")` (it may be `"zh"` or `"zh-Latn"`-style); pick the Han-script config. If `bigcode/the-stack-smol` requires different kwargs, the fallback keeps tests offline-green regardless.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_reap_corpus.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+uv run ruff check --fix olmlx tests && uv run ruff format olmlx tests
+git add olmlx/engine/reap/corpus.py tests/test_reap_corpus.py
+git commit -m "feat(reap): tagged per-source calibration corpus builder (#701)"
+```
+
+---
+
+### Task 4: `calibrate.py` part 2 — streaming layer-at-a-time calibration (invariant test 5)
+
+**Files:**
+- Modify: `olmlx/engine/reap/calibrate.py`
+- Test: `tests/test_reap_calibrate.py` (append)
+
+**Interfaces:**
+- Consumes: Task 2's tap/accumulator; `load_model_with_strict_fallback`, `_get_backbone`, `_nullify_module_params`, `_create_causal_mask`, `_embed_normalizer` from `olmlx.engine.flash.prepare`.
+- Produces:
+```python
+def stream_layer_forward(model_path: str, tagged_texts: list[tuple[str, str]], *,
+                         max_tokens: int = 512,
+                         layer_taps: bool = False,
+                         acc_and_ref: tuple[SaliencyAccumulator, dict] | None = None,
+                         keep_head: bool = False,
+                         per_sample_final: Callable[[int, str, mx.array, list[int]], None] | None = None,
+                         progress_callback=None) -> dict
+    # generic layer-at-a-time driver; used by calibration (Task 4) and perplexity (Task 8)
+def calibrate_saliency_streaming(model_path: str, tagged_texts: list[tuple[str, str]], *,
+                                 max_tokens: int = 512, progress_callback=None,
+                                 ) -> tuple[SaliencyAccumulator, dict]
+```
+Driver shape (mirrors `_stream_record_activations`, flash/prepare.py:383):
+1. `load_model_with_strict_fallback(model_path, lazy=True)` (patched in tests).
+2. Materialize only `embed_tokens` (`mx.eval(embed.parameters())`), embed every sample (× `_embed_normalizer`), keep `hidden_states: list[mx.array]` + parallel `token_ids: list[list[int]]` + `source_names: list[str]`.
+3. Nullify embed + head (`_nullify_module_params`) **unless** `keep_head` or tied embeddings; `gc.collect(); mx.clear_cache()`.
+4. Per layer: `mx.eval(layer.parameters())`; if calibrating and layer is MoE → install `SaliencyTap`; for each sample: fresh per-(sample,layer) cache via `mlx_lm.models.cache.make_prompt_cache(model)[i]` (hybrid GDN safety), forward `layer(h, mask=_create_causal_mask(h), cache=cache_i)`, `mx.eval`; restore tap; `_nullify_module_params(layer)`; `gc.collect(); mx.clear_cache()`.
+5. If `keep_head`: apply final norm + `lm_head` (or tied embed-as-linear) per sample and hand logits to `per_sample_final(sample_idx, source, logits, token_ids)`.
+
+- [ ] **Step 1: Write the failing tests** (append to `tests/test_reap_calibrate.py`)
+
+```python
+class TestStreamingEqualsHooked:
+    """Invariant 5: streaming layer-at-a-time saliency == full-forward hooked saliency."""
+
+    @pytest.mark.parametrize("factory", [make_tiny_qwen3_moe, make_tiny_gpt_oss, make_tiny_deepseek_v3])
+    def test_streaming_matches_hooked(self, factory, monkeypatch):
+        from olmlx.engine.reap import calibrate as cal_mod
+
+        mx.random.seed(3)
+        model, args = factory()
+        tok = FakeTokenizer()
+        texts = _tagged(2)
+
+        hooked_acc, hooked_meta = collect_saliency(model, tok, texts, max_tokens=16)
+
+        monkeypatch.setattr(cal_mod, "load_model_with_strict_fallback",
+                            lambda path, lazy: (model, tok))
+        stream_acc, stream_meta = cal_mod.calibrate_saliency_streaming(
+            "/fake/path", texts, max_tokens=16)
+
+        np.testing.assert_allclose(stream_acc.sum, hooked_acc.sum, rtol=1e-3, atol=1e-6)
+        np.testing.assert_array_equal(stream_acc.count, hooked_acc.count)
+        assert stream_meta["moe_layer_indices"] == hooked_meta["moe_layer_indices"]
+
+    def test_loader_called_lazy(self, monkeypatch):
+        from olmlx.engine.reap import calibrate as cal_mod
+
+        model, _ = make_tiny_qwen3_moe()
+        calls = {}
+        def fake_load(path, lazy):
+            calls["lazy"] = lazy
+            return model, FakeTokenizer()
+        monkeypatch.setattr(cal_mod, "load_model_with_strict_fallback", fake_load)
+        cal_mod.calibrate_saliency_streaming("/fake", _tagged(1), max_tokens=8)
+        assert calls["lazy"] is True
+```
+
+Note: the tap-restoration and nullify-free steps mutate the shared `model` — order the streaming run AFTER the hooked run, and accept that `model` is consumed (nullified) by the streaming call; each test builds its own model.
+
+Caveat the test must respect: `_nullify_module_params` zeroes layer weights, so the streaming run must be last. If the equality fails only for `gpt_oss`, check mask handling first (sliding-window layers are configured as `full_attention` in the factory precisely to keep `_create_causal_mask` faithful).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_reap_calibrate.py::TestStreamingEqualsHooked -x -q`
+Expected: FAIL — `calibrate_saliency_streaming` not defined.
+
+- [ ] **Step 3: Implement** (append to `calibrate.py`)
+
+Add a module-level import at the top of `calibrate.py` so tests can patch the seam:
+
+```python
+from olmlx.engine.flash.prepare import load_model_with_strict_fallback
+```
+
+Then append:
+
+```python
+def _resolve_head(model, inner):
+    """Returns (norm, head_fn) for final logits; head_fn may use tied embeddings."""
+    norm = getattr(inner, "norm", None) or getattr(inner, "final_layernorm", None)
+    lm_head = getattr(model, "lm_head", None)
+    if lm_head is not None:
+        return norm, lm_head
+    return norm, inner.embed_tokens.as_linear
+
+
+def stream_layer_forward(model_path, tagged_texts, *, max_tokens=512,
+                         acc: SaliencyAccumulator | None = None,
+                         keep_head=False, per_sample_final=None,
+                         progress_callback=None):
+    """Layer-at-a-time streaming forward over a lazily-loaded model.
+
+    One disk pass; peak RAM ~= one layer + all sample hidden states. With `acc`
+    set, installs SaliencyTaps on MoE layers (calibration). With `keep_head`,
+    applies final norm + lm_head per sample and calls
+    per_sample_final(sample_idx, source, logits, token_ids) (perplexity).
+    Consumes the model (layers are nullified as it advances).
+    Returns the meta dict (same shape as collect_saliency's).
+    """
+    import gc
+
+    from mlx_lm.models.cache import make_prompt_cache
+
+    from olmlx.engine.flash.prepare import (
+        _create_causal_mask, _embed_normalizer, _get_backbone, _nullify_module_params,
+    )
+
+    model, tokenizer = load_model_with_strict_fallback(model_path, lazy=True)
+    inner = _get_backbone(model)
+    layers = inner.layers
+    moe_layer_indices, num_experts, top_k = _moe_scan(layers)
+
+    embed = inner.embed_tokens
+    mx.eval(embed.parameters())
+    hidden_size = getattr(getattr(model, "args", None), "hidden_size", 0) or 1
+    scale = _embed_normalizer(model, inner, hidden_size)
+    hidden, token_ids, sample_sources = [], [], []
+    for source, text in tagged_texts:
+        ids = _encode(tokenizer, text, max_tokens)
+        if not ids:
+            continue
+        h = embed(mx.array([ids])) * scale
+        mx.eval(h)
+        hidden.append(h)
+        token_ids.append(ids)
+        sample_sources.append(source)
+
+    tied = bool(getattr(getattr(model, "args", None), "tie_word_embeddings", False))
+    if not keep_head:
+        head = getattr(model, "lm_head", None)
+        if head is not None:
+            _nullify_module_params(head)
+        if not tied:
+            _nullify_module_params(embed)
+    # keep_head: embed must survive when tied (it IS the head); norm+lm_head stay.
+    gc.collect()
+    mx.clear_cache()
+
+    source_ref = {"idx": 0}
+    layer_pos = 0
+    for li, layer in enumerate(layers):
+        mx.eval(layer.parameters())
+        tap_installed: list[tuple[int, Any, str]] = []
+        if acc is not None:
+            tap_installed = install_taps([layer], acc, source_ref)
+            if tap_installed:
+                tap = getattr(layer, tap_installed[0][2])
+                tap._layer_pos = layer_pos     # renumber from per-call 0 to global ordinal
+                layer_pos += 1
+        for si in range(len(hidden)):
+            if tap_installed:
+                source_ref["idx"] = acc.sources.index(sample_sources[si])
+            cache_i = make_prompt_cache(model)[li]   # fresh per (sample, layer): GDN-safe
+            out = layer(hidden[si], mask=_create_causal_mask(hidden[si]), cache=cache_i)
+            hidden[si] = out[0] if isinstance(out, (tuple, list)) else out
+            mx.eval(hidden[si])
+        if tap_installed:
+            remove_taps([layer], tap_installed)
+        _nullify_module_params(layer)
+        gc.collect()
+        mx.clear_cache()
+        if progress_callback:
+            progress_callback(f"Processed layer {li + 1}/{len(layers)}",
+                              0.05 + (li + 1) / len(layers) * 0.9)
+
+    if keep_head and per_sample_final is not None:
+        norm, head = _resolve_head(model, inner)
+        for si in range(len(hidden)):
+            h = norm(hidden[si]) if norm is not None else hidden[si]
+            per_sample_final(si, sample_sources[si], head(h), token_ids[si])
+
+    return {
+        "model_type": getattr(getattr(model, "args", None), "model_type", "unknown"),
+        "num_experts": num_experts, "top_k": top_k,
+        "moe_layer_indices": moe_layer_indices,
+        "sources": list(dict.fromkeys(sample_sources)),
+        "num_samples": len(hidden), "max_tokens": max_tokens,
+        "prepared_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
+def calibrate_saliency_streaming(model_path, tagged_texts, *, max_tokens=512,
+                                 progress_callback=None):
+    sources = list(dict.fromkeys(s for s, _ in tagged_texts))
+    # geometry probe on a throwaway lazy skeleton is avoided: stream_layer_forward
+    # scans MoE geometry itself, but the accumulator needs dims up front — so size
+    # it lazily on first add via a thin pre-scan of the same lazy load.
+    model, _tok = load_model_with_strict_fallback(model_path, lazy=True)
+    from olmlx.engine.flash.prepare import _get_backbone
+    moe_layer_indices, num_experts, _top_k = _moe_scan(_get_backbone(model).layers)
+    del model
+    acc = SaliencyAccumulator(len(moe_layer_indices), num_experts, sources)
+    meta = stream_layer_forward(model_path, list(tagged_texts), max_tokens=max_tokens,
+                                acc=acc, progress_callback=progress_callback)
+    return acc, meta
+```
+
+The two lazy loads in `calibrate_saliency_streaming` are acceptable: `lazy=True` materializes nothing, so the skeleton probe is metadata-only (same reasoning as `_stream_record_activations`'s dim probe). Invariants the tests pin:
+- `SaliencyTap` layer positions are global MoE ordinals (0..n_moe−1), identical to `collect_saliency`'s numbering;
+- `source_ref["idx"]` is set per sample before that sample's forward through a tapped layer;
+- meta dict shape identical to `collect_saliency`'s;
+- tests patch `olmlx.engine.reap.calibrate.load_model_with_strict_fallback` — both entry points must route through that module-level name.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_reap_calibrate.py -q`
+Expected: PASS (all, including invariant 5).
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+uv run ruff check --fix olmlx tests && uv run ruff format olmlx tests
+git add olmlx/engine/reap/calibrate.py tests/test_reap_calibrate.py
+git commit -m "feat(reap): streaming layer-at-a-time calibration (invariant: streaming==hooked) (#701)"
+```
+
+---
+
+### Task 5: `plan.py` — uniform / global / graded planners
+
+**Files:**
+- Create: `olmlx/engine/reap/plan.py`
+- Create: `tests/test_reap_plan.py`
+
+**Interfaces (Produces):**
+```python
+@dataclass
+class ReapPlan:
+    mode: str                          # "uniform" | "global" | "graded"
+    moe_layer_indices: list[int]
+    keep: dict[int, list[int]]         # actual layer idx -> kept old expert ids, ASCENDING
+    bank_high: dict[int, list[int]] | None   # graded only: kept ids in the high-precision bank
+    high_bits: int | None
+    low_bits: int | None
+    num_experts_orig: int
+    top_k: int
+    meta: dict
+
+def plan_uniform(saliency: np.ndarray, moe_layer_indices: list[int], keep_count: int, *,
+                 top_k: int, num_experts: int) -> ReapPlan
+def plan_global(saliency: np.ndarray, moe_layer_indices: list[int], keep_fraction: float, *,
+                top_k: int, num_experts: int, floor_multiple: int = 4) -> ReapPlan
+def plan_graded(saliency: np.ndarray, moe_layer_indices: list[int], keep_fraction: float, *,
+                high_fraction: float, high_bits: int, low_bits: int,
+                top_k: int, num_experts: int, floor_multiple: int = 4) -> ReapPlan
+def save_plan(plan: ReapPlan, path: Path) -> None
+def load_plan(path: Path) -> ReapPlan
+```
+Semantics:
+- `keep` lists are sorted ascending — new expert index `i` = `keep[i]` (stable renumber; the apply-side invariant).
+- uniform: same `keep_count` every layer, top-`keep_count` by per-layer saliency; requires `top_k <= keep_count <= num_experts` (raise `ValueError` otherwise).
+- global: per-layer saliency normalized to sum 1 (layers have incomparable scales), all `(layer, expert)` pairs ranked globally; floors first — every layer is guaranteed `min(floor_multiple * top_k, num_experts)` experts — then remaining budget (`round(keep_fraction * L * E)` total) filled by global rank. Deterministic tie-break `(−score, layer, expert)`.
+- graded: keep set = `plan_global(keep_fraction)`; within each layer's kept set, the top `ceil(high_fraction * len(kept))` by saliency form `bank_high`. Plan-only in phase 1 (`apply` rejects it until phase 3).
+- JSON schema (`save_plan`): `{"version": 1, "mode", "moe_layer_indices", "keep": {str(layer): [...]}, "bank_high": {...}|null, "high_bits", "low_bits", "num_experts_orig", "top_k", "meta"}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_reap_plan.py`:
+
+```python
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from olmlx.engine.reap.plan import (
+    ReapPlan, load_plan, plan_global, plan_graded, plan_uniform, save_plan,
+)
+
+
+def _saliency(L=3, E=8, seed=0):
+    rng = np.random.RandomState(seed)
+    return rng.rand(L, E) * np.array([1.0, 10.0, 0.1])[:, None]  # wildly different layer scales
+
+
+class TestUniform:
+    def test_keeps_top_k_per_layer_ascending(self):
+        sal = np.array([[0.1, 0.9, 0.5, 0.7]])
+        p = plan_uniform(sal, [2], 2, top_k=1, num_experts=4)
+        assert p.keep == {2: [1, 3]}          # top-2 by saliency, ascending order
+        assert p.mode == "uniform" and p.bank_high is None
+
+    def test_rejects_keep_below_top_k(self):
+        with pytest.raises(ValueError, match="top_k"):
+            plan_uniform(_saliency(), [0, 1, 2], 1, top_k=2, num_experts=8)
+
+    def test_rejects_keep_above_num_experts(self):
+        with pytest.raises(ValueError):
+            plan_uniform(_saliency(), [0, 1, 2], 9, top_k=2, num_experts=8)
+
+    def test_identity_keep(self):
+        p = plan_uniform(_saliency(), [0, 1, 2], 8, top_k=2, num_experts=8)
+        assert all(p.keep[i] == list(range(8)) for i in [0, 1, 2])
+
+
+class TestGlobal:
+    def test_floor_enforced_despite_layer_scale(self):
+        sal = _saliency()   # layer 2 has 100x smaller scores
+        p = plan_global(sal, [0, 1, 2], 0.5, top_k=1, num_experts=8, floor_multiple=4)
+        assert all(len(p.keep[i]) >= 4 for i in [0, 1, 2])   # floor = 4*top_k
+
+    def test_normalization_makes_layers_comparable(self):
+        # without per-layer normalization, layer 1 (10x scale) would swallow the budget
+        sal = _saliency()
+        p = plan_global(sal, [0, 1, 2], 0.5, top_k=1, num_experts=8, floor_multiple=1)
+        sizes = [len(p.keep[i]) for i in [0, 1, 2]]
+        assert max(sizes) - min(sizes) <= 4   # roughly balanced, not 8/2/2
+
+    def test_total_budget(self):
+        p = plan_global(_saliency(), [0, 1, 2], 0.5, top_k=1, num_experts=8, floor_multiple=1)
+        assert sum(len(v) for v in p.keep.values()) == round(0.5 * 3 * 8)
+
+    def test_deterministic(self):
+        a = plan_global(_saliency(), [0, 1, 2], 0.5, top_k=1, num_experts=8)
+        b = plan_global(_saliency(), [0, 1, 2], 0.5, top_k=1, num_experts=8)
+        assert a.keep == b.keep
+
+
+class TestGraded:
+    def test_bank_high_is_subset_and_sized(self):
+        p = plan_graded(_saliency(), [0, 1, 2], 0.75, high_fraction=0.25,
+                        high_bits=8, low_bits=4, top_k=1, num_experts=8)
+        for layer, kept in p.keep.items():
+            high = p.bank_high[layer]
+            assert set(high) <= set(kept)
+            assert len(high) == -(-len(kept) * 25 // 100)   # ceil(0.25*kept)
+        assert (p.high_bits, p.low_bits) == (8, 4)
+
+    def test_high_bank_has_top_saliency(self):
+        sal = np.array([[0.1, 0.9, 0.5, 0.7, 0.2, 0.8, 0.3, 0.6]])
+        p = plan_graded(sal, [0], 1.0, high_fraction=0.25, high_bits=8, low_bits=4,
+                        top_k=1, num_experts=8)
+        assert set(p.bank_high[0]) == {1, 5}   # ceil(8*0.25)=2 top experts
+
+
+class TestPlanIO:
+    def test_roundtrip(self, tmp_path):
+        p = plan_graded(_saliency(), [0, 1, 2], 0.75, high_fraction=0.25,
+                        high_bits=8, low_bits=4, top_k=1, num_experts=8)
+        save_plan(p, tmp_path / "reap_plan.json")
+        q = load_plan(tmp_path / "reap_plan.json")
+        assert q.keep == p.keep and q.bank_high == p.bank_high
+        assert (q.mode, q.top_k, q.num_experts_orig) == (p.mode, p.top_k, p.num_experts_orig)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_reap_plan.py -x -q`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `plan.py`**
+
+```python
+"""REAP keep/drop (+bank) planning from calibrated saliency."""
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+PLAN_VERSION = 1
+
+
+@dataclass
+class ReapPlan:
+    mode: str
+    moe_layer_indices: list[int]
+    keep: dict[int, list[int]]
+    bank_high: dict[int, list[int]] | None
+    high_bits: int | None
+    low_bits: int | None
+    num_experts_orig: int
+    top_k: int
+    meta: dict = field(default_factory=dict)
+
+
+def _validate(saliency: np.ndarray, moe_layer_indices, num_experts: int) -> None:
+    if saliency.shape != (len(moe_layer_indices), num_experts):
+        raise ValueError(f"saliency shape {saliency.shape} != "
+                         f"({len(moe_layer_indices)}, {num_experts})")
+
+
+def _top_ascending(scores: np.ndarray, k: int) -> list[int]:
+    order = np.lexsort((np.arange(len(scores)), -scores))  # score desc, index asc tiebreak
+    return sorted(int(i) for i in order[:k])
+
+
+def plan_uniform(saliency, moe_layer_indices, keep_count, *, top_k, num_experts):
+    _validate(saliency, moe_layer_indices, num_experts)
+    if not top_k <= keep_count <= num_experts:
+        raise ValueError(f"keep_count={keep_count} must satisfy "
+                         f"top_k={top_k} <= keep <= num_experts={num_experts}")
+    keep = {layer: _top_ascending(saliency[pos], keep_count)
+            for pos, layer in enumerate(moe_layer_indices)}
+    return ReapPlan("uniform", list(moe_layer_indices), keep, None, None, None,
+                    num_experts, top_k)
+
+
+def plan_global(saliency, moe_layer_indices, keep_fraction, *, top_k, num_experts,
+                floor_multiple: int = 4):
+    _validate(saliency, moe_layer_indices, num_experts)
+    L = len(moe_layer_indices)
+    budget = round(keep_fraction * L * num_experts)
+    floor = min(floor_multiple * top_k, num_experts)
+    if budget < floor * L:
+        raise ValueError(f"budget {budget} below floor {floor}*{L} layers")
+    norm = saliency / np.maximum(saliency.sum(axis=1, keepdims=True), 1e-12)
+    keep_sets: list[set[int]] = []
+    for pos in range(L):
+        keep_sets.append(set(_top_ascending(norm[pos], floor)))
+    remaining = budget - sum(len(s) for s in keep_sets)
+    flat = [(-norm[pos, e], pos, e) for pos in range(L) for e in range(num_experts)
+            if e not in keep_sets[pos]]
+    flat.sort()
+    for _, pos, e in flat[:remaining]:
+        keep_sets[pos].add(e)
+    keep = {layer: sorted(keep_sets[pos]) for pos, layer in enumerate(moe_layer_indices)}
+    return ReapPlan("global", list(moe_layer_indices), keep, None, None, None,
+                    num_experts, top_k)
+
+
+def plan_graded(saliency, moe_layer_indices, keep_fraction, *, high_fraction,
+                high_bits, low_bits, top_k, num_experts, floor_multiple: int = 4):
+    base = plan_global(saliency, moe_layer_indices, keep_fraction, top_k=top_k,
+                       num_experts=num_experts, floor_multiple=floor_multiple)
+    bank_high: dict[int, list[int]] = {}
+    for pos, layer in enumerate(moe_layer_indices):
+        kept = base.keep[layer]
+        n_high = math.ceil(high_fraction * len(kept))
+        kept_scores = saliency[pos, kept]
+        order = np.lexsort((np.arange(len(kept)), -kept_scores))
+        bank_high[layer] = sorted(int(kept[i]) for i in order[:n_high])
+    return ReapPlan("graded", base.moe_layer_indices, base.keep, bank_high,
+                    high_bits, low_bits, num_experts, top_k)
+
+
+def save_plan(plan: ReapPlan, path: Path) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = asdict(plan)
+    payload["version"] = PLAN_VERSION
+    payload["keep"] = {str(k): v for k, v in plan.keep.items()}
+    if plan.bank_high is not None:
+        payload["bank_high"] = {str(k): v for k, v in plan.bank_high.items()}
+    path.write_text(json.dumps(payload, indent=2))
+
+
+def load_plan(path: Path) -> ReapPlan:
+    raw = json.loads(Path(path).read_text())
+    if raw.get("version") != PLAN_VERSION:
+        raise ValueError(f"unsupported reap plan version {raw.get('version')}")
+    keep = {int(k): list(v) for k, v in raw["keep"].items()}
+    bank_high = ({int(k): list(v) for k, v in raw["bank_high"].items()}
+                 if raw.get("bank_high") else None)
+    return ReapPlan(raw["mode"], list(raw["moe_layer_indices"]), keep, bank_high,
+                    raw.get("high_bits"), raw.get("low_bits"),
+                    raw["num_experts_orig"], raw["top_k"], raw.get("meta", {}))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_reap_plan.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+uv run ruff check --fix olmlx tests && uv run ruff format olmlx tests
+git add olmlx/engine/reap/plan.py tests/test_reap_plan.py
+git commit -m "feat(reap): uniform/global/graded pruning planners (#701)"
+```
+
+---
+
+### Task 6: `apply.py` — shard-by-shard pruning surgery (invariant test 1)
+
+**Files:**
+- Create: `olmlx/engine/reap/apply.py`
+- Create: `tests/test_reap_apply.py`
+
+**Interfaces:**
+- Consumes: `ReapPlan`/`load_plan` (Task 5); `_detect_expert_format`, `_ExpertFormat` from `olmlx.engine.flash.moe_bundler`; `collect_non_weight_files` from `olmlx.engine.pre_shard`; `save_tiny_model`/factories (Task 1).
+- Produces:
+```python
+class ReapApplyError(RuntimeError): ...
+
+def apply_plan(model_dir: Path, plan: ReapPlan, output_dir: Path, *,
+               progress_callback=None) -> Path
+def rewrite_config_num_experts(config: dict, new_count: int) -> str
+    # mutates in place (unwraps text_config), returns the alias key it rewrote
+```
+Surgery rules (the load-bearing part — the misrouting trap from #701):
+- Expert-stacked tensors (any key `{layer_prefix}.{L}.{expert_prefix}.{proj}.{weight|scales|biases|bias}`): slice axis 0 with `keep[L]`.
+- Router tensors, matched by suffix regex **relative to the MoE module prefix** (`fmt.expert_prefix.split(".")[0]`, e.g. `mlp`): `gate.(weight|scales|biases|bias)`, `gate.gate.(weight|scales|biases)` (Step-3.5 inner linear), `gate.e_score_correction_bias`, `gate.router_bias`, `e_score_correction_bias` (MiniMax block-level), `router.(weight|scales|biases|bias)` (gpt-oss). Slice axis 0 with the SAME `keep[L]` list. QuantizedLinear packs along the LAST axis, so axis-0 row slicing is always safe.
+- **The guard that makes the trap an error, not silent misrouting**: after classifying, any tensor under the MoE module prefix of a pruned layer whose `shape[0] == num_experts_orig` that was NOT sliced (excluding keys containing `shared_expert`) → raise `ReapApplyError` naming the key. This is the "asserted, not guarded" requirement.
+- Non-MoE / shared-expert / dense-layer tensors: copied through byte-identical.
+- Only `mode="uniform"` accepted; `global`/`graded` → `ReapApplyError` mentioning phase 3.
+- Config rewrite: probe `n_routed_experts` → `num_local_experts` → `num_experts` → `moe_num_experts` (unwrap `text_config`); set to `keep_count`. Refuse if `num_experts_per_tok > keep_count`.
+- One input shard → one output shard, same filename; `model.safetensors.index.json` regenerated when the input had one OR when output has >1 shard (`{"metadata": {"total_size": N}, "weight_map": {...}}`) — nothing else in the repo writes an index, build it here.
+- Copy non-weight files (`collect_non_weight_files`); write `reap_provenance.json` (`{"pruned_from", "plan_mode", "keep_count", "num_experts_orig", "moe_layer_indices", "prepared_at"}`).
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_reap_apply.py`:
+
+```python
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from mlx.utils import tree_flatten
+
+from olmlx.engine.reap.apply import ReapApplyError, apply_plan, rewrite_config_num_experts
+from olmlx.engine.reap.plan import ReapPlan
+from tests.reap_factories import (
+    make_tiny_deepseek_v3, make_tiny_gpt_oss, make_tiny_qwen3_moe,
+    save_tiny_model, tiny_config_dict,
+)
+
+
+def _uniform_plan(moe_layers, keep, num_experts=8, top_k=2):
+    return ReapPlan("uniform", list(moe_layers), {l: list(keep) for l in moe_layers},
+                    None, None, None, num_experts, top_k)
+
+
+def _save(factory, model_type, tmp_path, name="src"):
+    model, args = factory()
+    cfg = tiny_config_dict(args, model_type)
+    return save_tiny_model(model, cfg, tmp_path / name), model
+
+
+class TestIdentityNoOp:
+    """Invariant 1: identity prune is bit-for-bit a no-op."""
+
+    @pytest.mark.parametrize("factory,model_type,moe_layers", [
+        (make_tiny_qwen3_moe, "qwen3_moe", [0, 1]),
+        (make_tiny_gpt_oss, "gpt_oss", [0, 1]),
+        (make_tiny_deepseek_v3, "deepseek_v3", [1]),
+    ])
+    def test_identity(self, tmp_path, factory, model_type, moe_layers):
+        src, _ = _save(factory, model_type, tmp_path)
+        plan = _uniform_plan(moe_layers, list(range(8)))
+        out = apply_plan(src, plan, tmp_path / "out")
+        a = mx.load(str(src / "model.safetensors"))
+        b = mx.load(str(out / "model.safetensors"))
+        assert set(a) == set(b)
+        for k in a:
+            assert a[k].dtype == b[k].dtype, k
+            assert mx.array_equal(a[k], b[k]), k
+        cfg_a = json.loads((src / "config.json").read_text())
+        cfg_b = json.loads((out / "config.json").read_text())
+        assert cfg_a == cfg_b
+
+
+class TestUniformPrune:
+    def test_shapes_config_and_router_rows(self, tmp_path):
+        src, model = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        keep = [0, 2, 5, 7]
+        plan = _uniform_plan([0, 1], keep)
+        out = apply_plan(src, plan, tmp_path / "out")
+        w = mx.load(str(out / "model.safetensors"))
+        orig = mx.load(str(src / "model.safetensors"))
+        for layer in (0, 1):
+            for proj in ("gate_proj", "up_proj", "down_proj"):
+                key = f"model.layers.{layer}.mlp.switch_mlp.{proj}.weight"
+                assert w[key].shape[0] == 4
+                assert mx.array_equal(w[key], orig[key][mx.array(keep)])
+            gate = f"model.layers.{layer}.mlp.gate.weight"
+            assert w[gate].shape[0] == 4
+            assert mx.array_equal(w[gate], orig[gate][mx.array(keep)])
+        cfg = json.loads((out / "config.json").read_text())
+        assert cfg["num_experts"] == 4
+
+    def test_gpt_oss_router_bias_and_expert_bias(self, tmp_path):
+        src, _ = _save(make_tiny_gpt_oss, "gpt_oss", tmp_path)
+        keep = [1, 3, 4, 6]
+        out = apply_plan(src, _uniform_plan([0, 1], keep), tmp_path / "out")
+        w = mx.load(str(out / "model.safetensors"))
+        orig = mx.load(str(src / "model.safetensors"))
+        rb = "model.layers.0.mlp.router.bias"
+        assert mx.array_equal(w[rb], orig[rb][mx.array(keep)])
+        eb = "model.layers.0.mlp.experts.gate_proj.bias"
+        assert w[eb].shape[0] == 4
+        cfg = json.loads((out / "config.json").read_text())
+        assert cfg["num_local_experts"] == 4
+
+    def test_deepseek_bias_and_shared_experts_untouched(self, tmp_path):
+        src, _ = _save(make_tiny_deepseek_v3, "deepseek_v3", tmp_path)
+        keep = [0, 1, 2, 3, 4, 5]
+        out = apply_plan(src, _uniform_plan([1], keep), tmp_path / "out")
+        w = mx.load(str(out / "model.safetensors"))
+        orig = mx.load(str(src / "model.safetensors"))
+        bias = "model.layers.1.mlp.gate.e_score_correction_bias"
+        assert w[bias].shape[0] == 6
+        shared = [k for k in orig if "shared_experts" in k]
+        assert shared, "factory should produce shared experts"
+        for k in shared:
+            assert mx.array_equal(w[k], orig[k]), k
+        cfg = json.loads((out / "config.json").read_text())
+        assert cfg["n_routed_experts"] == 6
+
+    def test_provenance_and_non_weight_copy(self, tmp_path):
+        src, _ = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        (src / "tokenizer_config.json").write_text("{}")
+        out = apply_plan(src, _uniform_plan([0, 1], [0, 1, 2, 3]), tmp_path / "out")
+        prov = json.loads((out / "reap_provenance.json").read_text())
+        assert prov["keep_count"] == 4 and prov["num_experts_orig"] == 8
+        assert (out / "tokenizer_config.json").exists()
+
+    def test_pruned_model_reloads_and_runs(self, tmp_path):
+        from mlx_lm.models import qwen3_moe
+        src, _ = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        out = apply_plan(src, _uniform_plan([0, 1], [0, 2, 5, 7]), tmp_path / "out")
+        cfg = json.loads((out / "config.json").read_text())
+        args = qwen3_moe.ModelArgs.from_dict(cfg)
+        pruned = qwen3_moe.Model(args)
+        pruned.load_weights(str(out / "model.safetensors"), strict=True)
+        logits = pruned(mx.array([[1, 2, 3]]))
+        assert logits.shape == (1, 3, cfg["vocab_size"])
+
+
+class TestGuards:
+    def test_rejects_non_uniform_plan(self, tmp_path):
+        src, _ = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        plan = ReapPlan("global", [0, 1], {0: [0, 1], 1: [0, 1]}, None, None, None, 8, 2)
+        with pytest.raises(ReapApplyError, match="phase 3"):
+            apply_plan(src, plan, tmp_path / "out")
+
+    def test_rejects_top_k_above_keep(self, tmp_path):
+        src, _ = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        plan = ReapPlan("uniform", [0, 1], {0: [0], 1: [0]}, None, None, None, 8, 2)
+        with pytest.raises(ReapApplyError, match="num_experts_per_tok"):
+            apply_plan(src, plan, tmp_path / "out")
+
+    def test_unknown_expert_sized_tensor_is_error(self, tmp_path):
+        """The misrouting trap: an unrecognized E-sized tensor under the MoE prefix
+        must be a hard error, never a silent copy-through."""
+        src, model = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        w = mx.load(str(src / "model.safetensors"))
+        w["model.layers.0.mlp.mystery_bias"] = mx.zeros((8,))
+        mx.save_safetensors(str(src / "model.safetensors"), w)
+        with pytest.raises(ReapApplyError, match="mystery_bias"):
+            apply_plan(src, _uniform_plan([0, 1], [0, 1, 2, 3]), tmp_path / "out")
+
+
+class TestQuantizedSlicing:
+    def test_quantized_triple_sliced_together(self, tmp_path):
+        """Packed uint32 weight + scales + biases all slice on axis 0."""
+        import numpy as np
+        from safetensors.numpy import save_file
+
+        E, out_dim, in_dim, gs = 8, 16, 32, 32
+        d = tmp_path / "qsrc"
+        d.mkdir()
+        rng = np.random.RandomState(0)
+        tensors = {}
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            base = f"model.layers.0.mlp.switch_mlp.{proj}"
+            tensors[f"{base}.weight"] = rng.randint(0, 2**31, (E, out_dim, in_dim * 4 // 32),
+                                                    dtype=np.uint32)
+            tensors[f"{base}.scales"] = rng.rand(E, out_dim, in_dim // gs).astype(np.float16)
+            tensors[f"{base}.biases"] = rng.rand(E, out_dim, in_dim // gs).astype(np.float16)
+        tensors["model.layers.0.mlp.gate.weight"] = rng.rand(E, 64).astype(np.float16)
+        save_file(tensors, str(d / "model.safetensors"))
+        (d / "config.json").write_text(json.dumps({
+            "model_type": "qwen3_moe", "num_experts": E, "num_experts_per_tok": 2,
+            "num_hidden_layers": 1, "hidden_size": 64,
+            "quantization": {"bits": 4, "group_size": gs},
+        }))
+        keep = [0, 3, 6]
+        out = apply_plan(d, _uniform_plan([0], keep, num_experts=E), tmp_path / "qout")
+        w = mx.load(str(out / "model.safetensors"))
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            for comp in ("weight", "scales", "biases"):
+                key = f"model.layers.0.mlp.switch_mlp.{proj}.{comp}"
+                assert w[key].shape[0] == 3, key
+                assert w[key].dtype == mx.load(str(d / "model.safetensors"))[key].dtype
+
+
+class TestShardedIndex:
+    def test_multi_shard_with_index(self, tmp_path):
+        src, _ = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        # split the single file into two shards + index
+        w = mx.load(str(src / "model.safetensors"))
+        keys = sorted(w)
+        half = len(keys) // 2
+        s1 = {k: w[k] for k in keys[:half]}
+        s2 = {k: w[k] for k in keys[half:]}
+        mx.save_safetensors(str(src / "model-00001-of-00002.safetensors"), s1)
+        mx.save_safetensors(str(src / "model-00002-of-00002.safetensors"), s2)
+        (src / "model.safetensors").unlink()
+        index = {"metadata": {"total_size": 0},
+                 "weight_map": {k: "model-00001-of-00002.safetensors" for k in keys[:half]}}
+        index["weight_map"].update({k: "model-00002-of-00002.safetensors" for k in keys[half:]})
+        (src / "model.safetensors.index.json").write_text(json.dumps(index))
+
+        out = apply_plan(src, _uniform_plan([0, 1], [0, 1, 2, 3]), tmp_path / "out")
+        new_index = json.loads((out / "model.safetensors.index.json").read_text())
+        assert set(new_index["weight_map"]) == set(keys)
+        shard_files = set(new_index["weight_map"].values())
+        assert len(shard_files) == 2
+        assert new_index["metadata"]["total_size"] == sum(
+            (out / f).stat().st_size for f in shard_files)
+        merged = {}
+        for shard in set(new_index["weight_map"].values()):
+            merged.update(mx.load(str(out / shard)))
+        assert merged["model.layers.0.mlp.switch_mlp.gate_proj.weight"].shape[0] == 4
+
+
+class TestRewriteConfig:
+    def test_alias_probing_order(self):
+        cfg = {"num_experts": 8, "num_experts_per_tok": 2}
+        assert rewrite_config_num_experts(cfg, 4) == "num_experts"
+        assert cfg["num_experts"] == 4
+
+    def test_text_config_unwrap(self):
+        cfg = {"text_config": {"n_routed_experts": 8}}
+        assert rewrite_config_num_experts(cfg, 4) == "n_routed_experts"
+        assert cfg["text_config"]["n_routed_experts"] == 4
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_reap_apply.py -x -q`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `apply.py`**
+
+```python
+"""REAP pruning surgery: streaming shard-by-shard restack of kept experts.
+
+The trap (#701): pruning renumbers experts, so router rows
+(gate.weight / e_score_correction_bias / router.bias / ...) MUST be sliced with
+the same keep list as the expert stacks — and any expert-count-sized tensor we
+do not recognize is a hard error, because a missed one produces a model that
+loads, runs, and routes every token to the wrong expert.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import time
+from pathlib import Path
+from typing import Callable
+
+import mlx.core as mx
+
+from olmlx.engine.reap.plan import ReapPlan
+
+_EXPERT_COUNT_KEYS = ("n_routed_experts", "num_local_experts", "num_experts",
+                      "moe_num_experts")
+
+# Router-tensor suffixes relative to the MoE module (e.g. "mlp"). Axis 0 is the
+# expert axis in every one; QuantizedLinear packs along the last axis so row
+# slicing is always safe.
+_ROUTER_SUFFIXES = (
+    r"gate\.(weight|scales|biases|bias)",
+    r"gate\.gate\.(weight|scales|biases)",       # Step-3.5 inner linear
+    r"gate\.e_score_correction_bias",
+    r"gate\.router_bias",                         # Step-3.5
+    r"e_score_correction_bias",                   # MiniMax block-level
+    r"router\.(weight|scales|biases|bias)",       # gpt-oss
+)
+_EXPERT_COMPONENTS = ("weight", "scales", "biases", "bias")
+
+
+class ReapApplyError(RuntimeError):
+    pass
+
+
+def rewrite_config_num_experts(config: dict, new_count: int) -> str:
+    target = config.get("text_config", config)
+    for key in _EXPERT_COUNT_KEYS:
+        if key in target:
+            target[key] = new_count
+            return key
+    raise ReapApplyError(f"no expert-count key in config (tried {_EXPERT_COUNT_KEYS})")
+
+
+def _classify(name: str, fmt, keep_map: dict[int, list[int]], num_experts_orig: int,
+              arr_shape: tuple, layer_re: re.Pattern, router_res: list[re.Pattern],
+              expert_re: re.Pattern) -> tuple[str, int | None]:
+    """Returns ("expert"|"router"|"copy"|"error", layer_idx)."""
+    m = layer_re.match(name)
+    if not m:
+        return "copy", None
+    layer_idx = int(m.group(1))
+    if layer_idx not in keep_map:
+        return "copy", None
+    rest = m.group(2)
+    if expert_re.match(rest):
+        return "expert", layer_idx
+    for rre in router_res:
+        if rre.match(rest):
+            return "router", layer_idx
+    if "shared_expert" not in rest and arr_shape and arr_shape[0] == num_experts_orig:
+        return "error", layer_idx
+    return "copy", None
+
+
+def apply_plan(model_dir: Path, plan: ReapPlan, output_dir: Path, *,
+               progress_callback: Callable[[str, float], None] | None = None) -> Path:
+    from olmlx.engine.flash.moe_bundler import _detect_expert_format
+    from olmlx.engine.pre_shard import collect_non_weight_files
+
+    model_dir, output_dir = Path(model_dir), Path(output_dir)
+    if plan.mode != "uniform":
+        raise ReapApplyError(
+            f"apply supports uniform plans only for now; {plan.mode!r} plans need the "
+            f"phase 3 serving-side support (per-layer expert_counts / bank_split)")
+    keep_counts = {len(v) for v in plan.keep.values()}
+    if len(keep_counts) != 1:
+        raise ReapApplyError("uniform plan has non-uniform keep counts")
+    keep_count = keep_counts.pop()
+
+    config = json.loads((model_dir / "config.json").read_text())
+    cfg_view = config.get("text_config", config)
+    top_k = cfg_view.get("num_experts_per_tok", plan.top_k)
+    if top_k > keep_count:
+        raise ReapApplyError(f"num_experts_per_tok={top_k} > keep_count={keep_count}")
+
+    index_path = model_dir / "model.safetensors.index.json"
+    index = json.loads(index_path.read_text()) if index_path.exists() else None
+    fmt = _detect_expert_format(model_dir, plan.moe_layer_indices[0], index)
+    moe_prefix = fmt.expert_prefix.split(".")[0]           # e.g. "mlp"
+    container_rel = fmt.expert_prefix[len(moe_prefix) + 1:]  # e.g. "switch_mlp"
+
+    layer_re = re.compile(rf"^{re.escape(fmt.layer_prefix)}\.(\d+)\.({re.escape(moe_prefix)}\..+)$")
+    proj_alt = "|".join(re.escape(p) for p in fmt.projections)
+    comp_alt = "|".join(_EXPERT_COMPONENTS)
+    expert_re = re.compile(
+        rf"^{re.escape(moe_prefix)}\.{re.escape(container_rel)}\.({proj_alt})\.({comp_alt})$")
+    router_res = [re.compile(rf"^{re.escape(moe_prefix)}\.{suffix}$")
+                  for suffix in _ROUTER_SUFFIXES]
+
+    shards = (sorted(set(index["weight_map"].values())) if index
+              else ["model.safetensors"])
+    output_dir.mkdir(parents=True, exist_ok=True)
+    weight_map: dict[str, str] = {}
+    total_size = 0
+
+    for si, shard in enumerate(shards):
+        tensors = mx.load(str(model_dir / shard))
+        out: dict[str, mx.array] = {}
+        for name, arr in tensors.items():
+            kind, layer_idx = _classify(name, fmt, plan.keep, plan.num_experts_orig,
+                                        tuple(arr.shape), layer_re, router_res, expert_re)
+            if kind == "error":
+                raise ReapApplyError(
+                    f"unrecognized expert-count-sized tensor {name!r}: refusing to "
+                    f"copy it through unsliced (would silently misroute)")
+            if kind in ("expert", "router"):
+                out[name] = arr[mx.array(plan.keep[layer_idx])]
+            else:
+                out[name] = arr
+        mx.eval(*out.values())
+        mx.save_safetensors(str(output_dir / shard), out)
+        for name in out:
+            weight_map[name] = shard
+        total_size += (output_dir / shard).stat().st_size
+        del tensors, out
+        mx.clear_cache()
+        if progress_callback:
+            progress_callback(f"Pruned shard {si + 1}/{len(shards)}", (si + 1) / len(shards))
+
+    rewrite_config_num_experts(config, keep_count)
+    (output_dir / "config.json").write_text(json.dumps(config, indent=2, ensure_ascii=False))
+    if index is not None or len(shards) > 1:
+        (output_dir / "model.safetensors.index.json").write_text(json.dumps(
+            {"metadata": {"total_size": total_size}, "weight_map": weight_map}, indent=2))
+    for f in collect_non_weight_files(model_dir):
+        if f.name != "config.json":
+            shutil.copy2(f, output_dir / f.name)
+    (output_dir / "reap_provenance.json").write_text(json.dumps({
+        "pruned_from": str(model_dir), "plan_mode": plan.mode,
+        "keep_count": keep_count, "num_experts_orig": plan.num_experts_orig,
+        "moe_layer_indices": plan.moe_layer_indices,
+        "prepared_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }, indent=2))
+    return output_dir
+```
+
+Check `collect_non_weight_files`'s actual signature/return (pre_shard.py:68) at implementation time — if it returns relative names or excludes config differently, adapt the copy loop (the tests pin the observable behavior).
+
+Identity bit-for-bit note: `arr[mx.array(range(E))]` must preserve dtype (mx `take` does); the identity test compares config dicts too, so `rewrite_config_num_experts` writing the same value back is fine, but key order must survive — `json.dumps(config, indent=2)` of the loaded dict preserves insertion order.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_reap_apply.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+uv run ruff check --fix olmlx tests && uv run ruff format olmlx tests
+git add olmlx/engine/reap/apply.py tests/test_reap_apply.py
+git commit -m "feat(reap): uniform pruning surgery with misrouting guard (#701)"
+```
+
+---
+
+### Task 7: `verify.py` + equivalence & rotation invariants (tests 2 + 3)
+
+**Files:**
+- Create: `olmlx/engine/reap/verify.py`
+- Create: `tests/test_reap_equivalence.py`
+
+**Interfaces:**
+- Consumes: factories + `save_tiny_model` (Task 1), `collect_saliency` (Task 2), `plan_uniform` (Task 5), `apply_plan` (Task 6), `find_moe_module` (Task 1).
+- Produces:
+```python
+def mask_dropped_experts(model, keep: dict[int, list[int]]) -> Callable[[], None]
+    # Forces dropped experts unroutable IN PLACE on the full model; returns restore().
+    # Linear-gate + gpt-oss styles: wrap gate/router with an additive -inf mask on
+    # dropped logits. DeepSeek style: set gate.e_score_correction_bias rows to -inf
+    # (bias affects selection only — the issue's stated equivalence form).
+def max_logit_divergence(model_a, model_b, batches: list[mx.array]) -> float
+    # max |logits_a - logits_b| over the batches (float32 compare)
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_reap_equivalence.py`:
+
+```python
+from __future__ import annotations
+
+import json
+
+import mlx.core as mx
+import pytest
+
+from olmlx.engine.reap.apply import apply_plan
+from olmlx.engine.reap.plan import ReapPlan
+from olmlx.engine.reap.verify import mask_dropped_experts, max_logit_divergence
+from tests.reap_factories import (
+    make_tiny_deepseek_v3, make_tiny_gpt_oss, make_tiny_qwen3_moe,
+    save_tiny_model, tiny_config_dict,
+)
+
+_CASES = [
+    (make_tiny_qwen3_moe, "qwen3_moe", [0, 1]),
+    (make_tiny_gpt_oss, "gpt_oss", [0, 1]),
+    (make_tiny_deepseek_v3, "deepseek_v3", [1]),
+]
+
+
+def _reload_pruned(model_type, out_dir):
+    import importlib
+    module = importlib.import_module(f"mlx_lm.models.{model_type}")
+    cfg = json.loads((out_dir / "config.json").read_text())
+    args = module.ModelArgs.from_dict(cfg)
+    model = module.Model(args)
+    model.load_weights(str(out_dir / "model.safetensors"), strict=True)
+    mx.eval(model.parameters())
+    return model
+
+
+def _batches():
+    mx.random.seed(7)
+    return [mx.random.randint(1, 100, (2, 16)) for _ in range(3)]
+
+
+@pytest.mark.parametrize("factory,model_type,moe_layers", _CASES)
+class TestPrunedEquivalence:
+    """Invariant 2: pruned model == full model with dropped experts made unroutable."""
+
+    def test_equivalence(self, tmp_path, factory, model_type, moe_layers):
+        mx.random.seed(11)
+        full, args = factory()
+        keep = [0, 2, 4, 5, 6, 7]
+        src = save_tiny_model(full, tiny_config_dict(args, model_type), tmp_path / "src")
+        plan = ReapPlan("uniform", moe_layers, {l: keep for l in moe_layers},
+                        None, None, None, 8, 2)
+        pruned = _reload_pruned(model_type, apply_plan(src, plan, tmp_path / "out"))
+
+        restore = mask_dropped_experts(full, {l: keep for l in moe_layers})
+        try:
+            # remap: pruned token routing uses new indices; outputs must agree
+            diff = max_logit_divergence(full, pruned, _batches())
+        finally:
+            restore()
+        assert diff < 1e-3
+
+    def test_restore_undoes_mask(self, tmp_path, factory, model_type, moe_layers):
+        mx.random.seed(12)
+        full, _ = factory()
+        batch = _batches()[:1]
+        ref = full(batch[0])
+        restore = mask_dropped_experts(full, {l: [0, 1] for l in moe_layers})
+        restore()
+        assert mx.allclose(full(batch[0]), ref, atol=1e-6)
+
+
+@pytest.mark.parametrize("factory,model_type,moe_layers", _CASES)
+class TestRotation:
+    """Invariant 3: permuting router rows WITHOUT permuting experts must be detected —
+    proves the equivalence check is not vacuous."""
+
+    def test_rotated_router_diverges(self, tmp_path, factory, model_type, moe_layers):
+        mx.random.seed(13)
+        full, args = factory()
+        keep = [0, 2, 4, 5, 6, 7]
+        src = save_tiny_model(full, tiny_config_dict(args, model_type), tmp_path / "src")
+        plan = ReapPlan("uniform", moe_layers, {l: keep for l in moe_layers},
+                        None, None, None, 8, 2)
+        out = apply_plan(src, plan, tmp_path / "out")
+
+        # sabotage: rotate the pruned router rows by one position
+        w = mx.load(str(out / "model.safetensors"))
+        rotated = False
+        for l in moe_layers:
+            for cand in (f"model.layers.{l}.mlp.gate.weight",
+                         f"model.layers.{l}.mlp.router.weight"):
+                if cand in w:
+                    perm = mx.array(list(range(1, w[cand].shape[0])) + [0])
+                    w[cand] = w[cand][perm]
+                    rotated = True
+        assert rotated
+        mx.save_safetensors(str(out / "model.safetensors"), w)
+        pruned = _reload_pruned(model_type, out)
+
+        restore = mask_dropped_experts(full, {l: keep for l in moe_layers})
+        try:
+            diff = max_logit_divergence(full, pruned, _batches())
+        finally:
+            restore()
+        assert diff > 1e-2
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_reap_equivalence.py -x -q`
+Expected: FAIL — `olmlx.engine.reap.verify` missing.
+
+- [ ] **Step 3: Implement `verify.py`**
+
+```python
+"""Equivalence checking for REAP pruning: mask dropped experts on the full model
+and compare against the pruned artifact.
+
+Also the runtime backbone of `reap report`'s sanity check. The rotation test in
+tests/test_reap_equivalence.py proves this check can detect misrouting; keep it
+sensitive (max-abs on logits, no mean-pooling)."""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from olmlx.engine.reap.arch import (
+    STYLE_DEEPSEEK, find_moe_module,
+)
+
+
+class _MaskedGate(nn.Module):
+    """Additive -inf on dropped experts' logits; exact removal from softmax mass."""
+
+    def __init__(self, inner: Any, mask_vec: mx.array) -> None:
+        super().__init__()
+        self.inner = inner
+        self._mask_vec = mask_vec
+
+    def __call__(self, x):
+        return self.inner(x) + self._mask_vec
+
+
+def mask_dropped_experts(model, keep: dict[int, list[int]]) -> Callable[[], None]:
+    inner = getattr(model, "model", model)
+    layers = inner.layers
+    restores: list[Callable[[], None]] = []
+    for layer_idx, kept in keep.items():
+        info = find_moe_module(layers[layer_idx])
+        if info is None:
+            raise ValueError(f"layer {layer_idx} has no MoE module")
+        kept_mask = mx.zeros((info.num_experts,))
+        dropped = [e for e in range(info.num_experts) if e not in set(kept)]
+        if not dropped:
+            continue
+        neg = mx.full((info.num_experts,), 0.0)
+        neg[mx.array(dropped)] = -mx.inf  # if item-assign unsupported: build via mx.where
+        if info.style == STYLE_DEEPSEEK:
+            gate = info.module.gate
+            orig_bias = gate.e_score_correction_bias
+            gate.e_score_correction_bias = orig_bias + neg
+            def _restore(g=gate, b=orig_bias):
+                g.e_score_correction_bias = b
+            restores.append(_restore)
+        else:
+            gate = getattr(info.module, info.gate_attr)
+            setattr(info.module, info.gate_attr, _MaskedGate(gate, neg))
+            def _restore(m=info.module, a=info.gate_attr, g=gate):
+                setattr(m, a, g)
+            restores.append(_restore)
+
+    def restore_all() -> None:
+        for r in reversed(restores):
+            r()
+    return restore_all
+
+
+def max_logit_divergence(model_a, model_b, batches: list[mx.array]) -> float:
+    worst = 0.0
+    for batch in batches:
+        la = model_a(batch).astype(mx.float32)
+        lb = model_b(batch).astype(mx.float32)
+        worst = max(worst, float(mx.max(mx.abs(la - lb))))
+    return worst
+```
+
+Implementation notes:
+- mlx arrays don't support item assignment — build `neg` with `mx.where(one_hot_dropped, -mx.inf, 0.0)` (e.g. `mask = mx.zeros((E,)); mask = mx.where(mx.array([e in dropped_set for e in range(E)]), -mx.inf, mask)`). The comment in the sketch flags this; write the `mx.where` form.
+- DeepSeek `-inf` bias: `sigmoid(logit) + (-inf) = -inf` in the *selection* score, so dropped experts are never picked, while weighting uses the untouched `orig_scores` — exactly the issue's "dropped experts' correction bias at −inf" equivalence. If `-inf` arithmetic produces NaN in the group-select path, use `-1e9` (documented fallback; tolerance 1e-3 already absorbs the ~e-9 leakage).
+- gpt-oss softmax-after-top-k: `-inf` logits are never selected by `argpartition(-logits)` when at least `top_k` kept experts exist (guaranteed: keep ≥ top_k).
+- The equivalence holds *exactly* for softmax-before-top-k styles too, because `-inf` removes dropped experts from the softmax denominator — the router-renormalization argument from the issue.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_reap_equivalence.py -q`
+Expected: PASS. If the qwen3 equivalence diff is ~1e-6 but deepseek fails: check whether `e_score_correction_bias` is consumed pre- or post-sigmoid in the installed `group_expert_select` (deepseek_v3.py:193-222) and mask accordingly.
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+uv run ruff check --fix olmlx tests && uv run ruff format olmlx tests
+git add olmlx/engine/reap/verify.py tests/test_reap_equivalence.py
+git commit -m "feat(reap): -inf-mask equivalence check + rotation invariant (#701)"
+```
+
+---
+
+### Task 8: `report.py` — per-source overlap analysis + held-out perplexity gate
+
+**Files:**
+- Create: `olmlx/engine/reap/report.py`
+- Create: `tests/test_reap_report.py`
+
+**Interfaces:**
+- Consumes: `SaliencyAccumulator`/`load_saliency` (Task 2), the streaming driver (Task 4: whatever shared helper Task 4 extracted — reuse it with `keep_head=True` and no taps), `build_calibration_corpus` (Task 3).
+- Produces:
+```python
+def source_overlap(acc: SaliencyAccumulator, keep_count: int) -> dict
+    # {"pairs": {"a|b": {"mean_overlap": float, "per_layer": [...]}},
+    #  "chance": keep_count / num_experts, "keep_count": int}
+    # overlap(a,b) per layer = |topK(a) ∩ topK(b)| / keep_count
+def streaming_perplexity(model_path: str, tagged_texts: list[tuple[str, str]], *,
+                         max_tokens: int = 512, progress_callback=None) -> dict[str, float]
+    # per-source held-out ppl = exp(total_nll / total_tokens), one streaming pass
+def build_report(saliency_path: Path, *, keep_count: int,
+                 full_model_dir: str | None = None, pruned_model_dir: str | None = None,
+                 held_out_texts: list[tuple[str, str]] | None = None,
+                 max_tokens: int = 512, progress_callback=None) -> dict
+    # {"overlap": ..., "perplexity": {"full": {...}, "pruned": {...}, "ratio": {...}} | None,
+    #  "meta": saliency meta}
+```
+Perplexity math: for each sample, logits from the streaming head; `nll += cross_entropy(logits[:, :-1], ids[1:])` summed over positions; per-source aggregation. Skip samples shorter than 2 tokens.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_reap_report.py`:
+
+```python
+from __future__ import annotations
+
+import math
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from olmlx.engine.reap.calibrate import SaliencyAccumulator
+from olmlx.engine.reap.report import build_report, source_overlap, streaming_perplexity
+from tests.reap_factories import make_tiny_qwen3_moe
+from tests.test_reap_calibrate import FakeTokenizer
+
+
+class TestSourceOverlap:
+    def _acc(self):
+        acc = SaliencyAccumulator(1, 8, ["a", "b"])
+        # source a favors experts 0-3, source b favors 2-5 -> top4 overlap = {2,3} = 0.5
+        for e, v in enumerate([9, 8, 7, 6, 1, 1, 1, 1]):
+            acc.add(0, 0, np.array([e]), np.array([float(v)]))
+        for e, v in enumerate([1, 1, 9, 8, 7, 6, 1, 1]):
+            acc.add(0, 1, np.array([e]), np.array([float(v)]))
+        return acc
+
+    def test_pairwise_overlap(self):
+        rep = source_overlap(self._acc(), keep_count=4)
+        assert rep["pairs"]["a|b"]["mean_overlap"] == pytest.approx(0.5)
+        assert rep["chance"] == pytest.approx(0.5)
+
+    def test_identical_sources_full_overlap(self):
+        acc = SaliencyAccumulator(2, 8, ["a", "b"])
+        for src in (0, 1):
+            for layer in (0, 1):
+                acc.add(layer, src, np.arange(8), np.arange(8, dtype=np.float64))
+        rep = source_overlap(acc, keep_count=3)
+        assert rep["pairs"]["a|b"]["mean_overlap"] == pytest.approx(1.0)
+
+
+class TestStreamingPerplexity:
+    def test_matches_direct_forward(self, monkeypatch):
+        from olmlx.engine.reap import calibrate as cal_mod
+
+        mx.random.seed(21)
+        model, _ = make_tiny_qwen3_moe()
+        tok = FakeTokenizer()
+        texts = [("english", "hello world example " * 4), ("code", "def f(): pass " * 4)]
+
+        # direct reference on the same (fresh) model
+        expected: dict[str, list[float]] = {}
+        for source, text in texts:
+            ids = tok.encode(text)[:16]
+            logits = model(mx.array([ids])).astype(mx.float32)
+            logprobs = logits[:, :-1] - mx.logsumexp(logits[:, :-1], axis=-1, keepdims=True)
+            tgt = mx.array([ids[1:]])
+            nll = -mx.take_along_axis(logprobs, tgt[..., None], axis=-1).sum()
+            expected.setdefault(source, []).append((float(nll), len(ids) - 1))
+
+        monkeypatch.setattr(cal_mod, "load_model_with_strict_fallback",
+                            lambda path, lazy: (model, tok))
+        ppl = streaming_perplexity("/fake", texts, max_tokens=16)
+        for source in ("english", "code"):
+            nll, n = expected[source][0]
+            assert ppl[source] == pytest.approx(math.exp(nll / n), rel=1e-3)
+
+
+class TestBuildReport:
+    def test_overlap_only_when_no_models(self, tmp_path):
+        from olmlx.engine.reap.calibrate import save_saliency
+        acc = SaliencyAccumulator(1, 8, ["a", "b"])
+        acc.add(0, 0, np.arange(8), np.linspace(1, 8, 8))
+        acc.add(0, 1, np.arange(8), np.linspace(8, 1, 8))
+        meta = {"model_type": "qwen3_moe", "num_experts": 8, "top_k": 2,
+                "moe_layer_indices": [0], "sources": ["a", "b"]}
+        save_saliency(tmp_path / "s.npz", acc, meta)
+        rep = build_report(tmp_path / "s.npz", keep_count=4)
+        assert rep["perplexity"] is None
+        assert "a|b" in rep["overlap"]["pairs"]
+        assert rep["meta"]["model_type"] == "qwen3_moe"
+```
+
+Note the tied-embeddings caveat from Task 4: the streaming driver must NOT nullify `embed_tokens` when `keep_head=True` and embeddings are tied, or perplexity becomes garbage. The `test_matches_direct_forward` test catches this on any factory with `tie_word_embeddings=True` — if the qwen3_moe factory sets it False, add one extra assertion run with a tied variant if cheap, otherwise leave the invariant to the driver's own logic (documented).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_reap_report.py -x -q`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `report.py`**
+
+```python
+"""REAP reporting: per-source expert-overlap analysis and the held-out
+perplexity gate the kimi-k3-mlx repo explicitly lacked."""
+from __future__ import annotations
+
+import itertools
+import math
+from pathlib import Path
+from typing import Callable
+
+import mlx.core as mx
+import numpy as np
+
+from olmlx.engine.reap.calibrate import SaliencyAccumulator, load_saliency
+
+
+def source_overlap(acc: SaliencyAccumulator, keep_count: int) -> dict:
+    num_layers, _, num_experts = acc.sum.shape
+    tops: dict[str, list[set[int]]] = {}
+    for source in acc.sources:
+        sal = acc.saliency([source])
+        tops[source] = [set(np.argsort(-sal[layer])[:keep_count].tolist())
+                        for layer in range(num_layers)]
+    pairs = {}
+    for a, b in itertools.combinations(acc.sources, 2):
+        per_layer = [len(tops[a][layer] & tops[b][layer]) / keep_count
+                     for layer in range(num_layers)]
+        pairs[f"{a}|{b}"] = {"mean_overlap": float(np.mean(per_layer)),
+                             "per_layer": per_layer}
+    return {"pairs": pairs, "chance": keep_count / num_experts, "keep_count": keep_count}
+
+
+def streaming_perplexity(model_path: str, tagged_texts, *, max_tokens: int = 512,
+                         progress_callback: Callable[[str, float], None] | None = None,
+                         ) -> dict[str, float]:
+    from olmlx.engine.reap import calibrate as cal_mod
+
+    totals: dict[str, list[float]] = {}
+
+    def on_final(sample_idx: int, source: str, logits: mx.array, ids: list[int]) -> None:
+        if len(ids) < 2:
+            return
+        lg = logits.astype(mx.float32)[:, :-1]
+        logprobs = lg - mx.logsumexp(lg, axis=-1, keepdims=True)
+        tgt = mx.array([ids[1:]])
+        nll = float(-mx.take_along_axis(logprobs, tgt[..., None], axis=-1).sum())
+        acc = totals.setdefault(source, [0.0, 0])
+        acc[0] += nll
+        acc[1] += len(ids) - 1
+
+    cal_mod.stream_layer_forward(model_path, list(tagged_texts), max_tokens=max_tokens,
+                                 keep_head=True, per_sample_final=on_final,
+                                 progress_callback=progress_callback)
+    return {source: math.exp(nll / max(n, 1)) for source, (nll, n) in totals.items()}
+
+
+def build_report(saliency_path: Path, *, keep_count: int,
+                 full_model_dir: str | None = None, pruned_model_dir: str | None = None,
+                 held_out_texts=None, max_tokens: int = 512,
+                 progress_callback=None) -> dict:
+    acc, meta = load_saliency(saliency_path)
+    report: dict = {"overlap": source_overlap(acc, keep_count), "meta": meta,
+                    "perplexity": None}
+    if full_model_dir and pruned_model_dir and held_out_texts:
+        full = streaming_perplexity(full_model_dir, held_out_texts,
+                                    max_tokens=max_tokens,
+                                    progress_callback=progress_callback)
+        pruned = streaming_perplexity(pruned_model_dir, held_out_texts,
+                                      max_tokens=max_tokens,
+                                      progress_callback=progress_callback)
+        ratio = {s: pruned[s] / full[s] for s in full if s in pruned}
+        report["perplexity"] = {"full": full, "pruned": pruned, "ratio": ratio}
+    return report
+```
+
+(Exact `stream_layer_forward` call shape follows whatever Task 4 finalized — the test patches `calibrate.load_model_with_strict_fallback`, so `streaming_perplexity` must route through the same seam.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_reap_report.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+uv run ruff check --fix olmlx tests && uv run ruff format olmlx tests
+git add olmlx/engine/reap/report.py tests/test_reap_report.py
+git commit -m "feat(reap): source-overlap analysis + held-out perplexity gate (#701)"
+```
+
+---
+
+### Task 9: CLI family `olmlx reap` + docs
+
+**Files:**
+- Create: `olmlx/cli/reap_cmd.py`
+- Modify: `olmlx/cli/parser.py` (add `reap` subparser group, `dest="reap_command"`)
+- Modify: `olmlx/cli/__init__.py` (import handlers before `_COMMAND_HANDLERS`; add 4 entries)
+- Modify: `CLAUDE.md` (project tree: `engine/reap/` line + cli mention)
+- Create: `tests/test_reap_cli.py`
+
+**Interfaces:**
+- Consumes: everything above. All handler signatures `def cmd_reap_*(args): -> None`, sync, engine imports function-local, `_configure_logging()` first, `_resolve_and_download` for the model arg, `_flash_progress` as the progress callback, `raise SystemExit("...")` for arg validation BEFORE download.
+- CLI surface:
+```
+olmlx reap calibrate MODEL [--sources english,code,chinese] [--samples-per-source 256]
+                            [--max-tokens 512] [--output PATH]
+olmlx reap plan MODEL [--mode uniform|global|graded] [--keep N] [--keep-fraction F]
+                      [--sources SUBSET] [--floor-multiple 4] [--high-fraction 0.25]
+                      [--high-bits 8] [--low-bits 4] [--saliency PATH] [--output PATH]
+olmlx reap apply MODEL --plan PATH [--output-dir PATH]
+olmlx reap report MODEL [--saliency PATH] [--keep N] [--pruned-dir PATH]
+                        [--samples-per-source 32] [--skip-ppl]
+```
+- Defaults: saliency `<model_dir>/reap/saliency.npz`; plan `<model_dir>/reap/reap_plan.json`; apply output `<model_dir>/reap/pruned-<mode><keep_count>`; `--keep` for report defaults to the plan's keep count if a plan exists, else required.
+- `plan` validation: `uniform` requires `--keep`; `global`/`graded` require `--keep-fraction`; mutually exclusive otherwise → `SystemExit`.
+- Each handler ends by echoing the artifact path and the next command to run (calibrate → plan → apply → report chain).
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_reap_cli.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+import olmlx.cli as cli
+from olmlx.cli.parser import build_parser
+
+
+class TestParser:
+    def test_calibrate_defaults(self):
+        args = build_parser().parse_args(["reap", "calibrate", "some-model"])
+        assert args.command == "reap" and args.reap_command == "calibrate"
+        assert args.model == "some-model"
+        assert args.sources == "english,code,chinese"
+        assert args.samples_per_source == 256 and args.max_tokens == 512
+        assert args.output is None
+
+    def test_plan_modes(self):
+        args = build_parser().parse_args(
+            ["reap", "plan", "m", "--mode", "graded", "--keep-fraction", "0.75",
+             "--high-fraction", "0.25"])
+        assert args.mode == "graded" and args.keep_fraction == 0.75
+        assert args.high_bits == 8 and args.low_bits == 4
+
+    def test_apply_requires_plan(self):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["reap", "apply", "m"])
+
+    def test_report_flags(self):
+        args = build_parser().parse_args(
+            ["reap", "report", "m", "--skip-ppl", "--keep", "64"])
+        assert args.skip_ppl is True and args.keep == 64
+
+
+class TestDispatch:
+    def test_handlers_registered(self):
+        for sub in ("calibrate", "plan", "apply", "report"):
+            assert (("reap", sub) in cli._COMMAND_HANDLERS)
+            name = cli._COMMAND_HANDLERS[("reap", sub)]
+            assert callable(getattr(cli, name))
+
+    def test_cli_main_routes(self, monkeypatch):
+        called = {}
+        monkeypatch.setattr("olmlx.cli.cmd_reap_plan", lambda args: called.setdefault("args", args))
+        monkeypatch.setattr("sys.argv", ["olmlx", "reap", "plan", "m", "--keep", "8"])
+        cli.cli_main()
+        assert called["args"].model == "m"
+
+
+class TestPlanHandlerValidation:
+    def test_uniform_requires_keep(self, monkeypatch):
+        import olmlx.cli.reap_cmd as reap_cmd
+        args = build_parser().parse_args(["reap", "plan", "m", "--mode", "uniform"])
+        # validation must fire BEFORE any resolve/download
+        monkeypatch.setattr(reap_cmd, "_resolve_and_download",
+                            lambda *a, **k: pytest.fail("resolved before validation"))
+        with pytest.raises(SystemExit):
+            reap_cmd.cmd_reap_plan(args)
+```
+
+(Adjust the last test's patch target to wherever `reap_cmd` imports `_resolve_and_download` from — module-level import in `reap_cmd.py` makes this seam patchable; follow `prepare_cmd.py`'s import of `_resolve_and_download` from `models_cmd`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_reap_cli.py -x -q`
+Expected: FAIL — parser has no `reap` command.
+
+- [ ] **Step 3: Implement**
+
+`olmlx/cli/reap_cmd.py` (handler skeletons; engine imports function-local):
+
+```python
+"""olmlx reap: REAP expert pruning CLI (calibrate -> plan -> apply -> report)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from olmlx.cli.config_cmd import _configure_logging
+from olmlx.cli.models_cmd import _resolve_and_download
+from olmlx.cli.prepare_cmd import _flash_progress
+
+
+def _reap_dir(local_dir: Path) -> Path:
+    return Path(local_dir) / "reap"
+
+
+def cmd_reap_calibrate(args):
+    _configure_logging()
+    sources = [s.strip() for s in args.sources.split(",") if s.strip()]
+    if not sources:
+        raise SystemExit("--sources must name at least one source")
+    _store, local_dir = _resolve_and_download(args.model)
+    from olmlx.engine.reap.calibrate import calibrate_saliency_streaming, save_saliency
+    from olmlx.engine.reap.corpus import build_calibration_corpus
+
+    print(f"Calibrating REAP saliency for {args.model}")
+    print(f"  Sources: {', '.join(sources)}  samples/source: {args.samples_per_source}"
+          f"  max tokens: {args.max_tokens}")
+    texts = build_calibration_corpus(sources, args.samples_per_source,
+                                     progress_callback=_flash_progress)
+    acc, meta = calibrate_saliency_streaming(str(local_dir), texts,
+                                             max_tokens=args.max_tokens,
+                                             progress_callback=_flash_progress)
+    output = Path(args.output) if args.output else _reap_dir(local_dir) / "saliency.npz"
+    save_saliency(output, acc, meta)
+    print("\nCalibration complete!")
+    print(f"  Saliency: {output}")
+    print(f"\nNext: olmlx reap plan {args.model} --keep <n>   (num_experts={meta['num_experts']})")
+
+
+def cmd_reap_plan(args):
+    _configure_logging()
+    if args.mode == "uniform" and args.keep is None:
+        raise SystemExit("--mode uniform requires --keep")
+    if args.mode in ("global", "graded") and args.keep_fraction is None:
+        raise SystemExit(f"--mode {args.mode} requires --keep-fraction")
+    _store, local_dir = _resolve_and_download(args.model, download=False)
+    from olmlx.engine.reap.calibrate import load_saliency
+    from olmlx.engine.reap.plan import plan_global, plan_graded, plan_uniform, save_plan
+
+    saliency_path = Path(args.saliency) if args.saliency else _reap_dir(local_dir) / "saliency.npz"
+    acc, meta = load_saliency(saliency_path)
+    sources = [s.strip() for s in args.sources.split(",")] if args.sources else None
+    sal = acc.saliency(sources)
+    common = dict(top_k=meta["top_k"], num_experts=meta["num_experts"])
+    if args.mode == "uniform":
+        plan = plan_uniform(sal, meta["moe_layer_indices"], args.keep, **common)
+    elif args.mode == "global":
+        plan = plan_global(sal, meta["moe_layer_indices"], args.keep_fraction,
+                           floor_multiple=args.floor_multiple, **common)
+    else:
+        plan = plan_graded(sal, meta["moe_layer_indices"], args.keep_fraction,
+                           high_fraction=args.high_fraction, high_bits=args.high_bits,
+                           low_bits=args.low_bits, floor_multiple=args.floor_multiple,
+                           **common)
+    plan.meta = {"sources": sources or acc.sources, "saliency": str(saliency_path)}
+    output = Path(args.output) if args.output else _reap_dir(local_dir) / "reap_plan.json"
+    save_plan(plan, output)
+    kept = sum(len(v) for v in plan.keep.values())
+    total = len(plan.keep) * meta["num_experts"]
+    print(f"\nPlan written: {output}")
+    print(f"  Mode: {plan.mode}  kept experts: {kept}/{total}")
+    print(f"\nNext: olmlx reap apply {args.model} --plan {output}")
+
+
+def cmd_reap_apply(args):
+    _configure_logging()
+    _store, local_dir = _resolve_and_download(args.model, download=True)
+    from olmlx.engine.reap.apply import apply_plan
+    from olmlx.engine.reap.plan import load_plan
+
+    plan = load_plan(Path(args.plan))
+    keep_count = len(next(iter(plan.keep.values())))
+    output_dir = (Path(args.output_dir) if args.output_dir
+                  else _reap_dir(local_dir) / f"pruned-{plan.mode}{keep_count}")
+    out = apply_plan(Path(local_dir), plan, output_dir, progress_callback=_flash_progress)
+    print("\nPruning complete!")
+    print(f"  Output: {out}")
+    print(f"\nRegister it in models.json with a path entry, then: olmlx reap report "
+          f"{args.model} --pruned-dir {out}")
+
+
+def cmd_reap_report(args):
+    _configure_logging()
+    _store, local_dir = _resolve_and_download(args.model, download=not args.skip_ppl)
+    from olmlx.engine.reap.calibrate import load_saliency
+    from olmlx.engine.reap.corpus import build_calibration_corpus
+    from olmlx.engine.reap.report import build_report
+
+    saliency_path = Path(args.saliency) if args.saliency else _reap_dir(local_dir) / "saliency.npz"
+    keep = args.keep
+    if keep is None:
+        plan_path = _reap_dir(local_dir) / "reap_plan.json"
+        if plan_path.exists():
+            from olmlx.engine.reap.plan import load_plan
+            keep = len(next(iter(load_plan(plan_path).keep.values())))
+        else:
+            raise SystemExit("--keep required (no reap_plan.json to infer it from)")
+    held_out = None
+    if not args.skip_ppl and args.pruned_dir:
+        _acc, meta = load_saliency(saliency_path)
+        held_out = build_calibration_corpus(meta["sources"], args.samples_per_source,
+                                            skip=meta.get("num_samples", 256))
+    rep = build_report(saliency_path, keep_count=keep,
+                       full_model_dir=str(local_dir) if held_out else None,
+                       pruned_model_dir=args.pruned_dir if held_out else None,
+                       held_out_texts=held_out, progress_callback=_flash_progress)
+    print(f"\nREAP report (keep={keep}, chance overlap={rep['overlap']['chance']:.2f}):")
+    for pair, stats in rep["overlap"]["pairs"].items():
+        print(f"  {pair}: mean keep-set overlap {stats['mean_overlap']:.2f}")
+    if rep["perplexity"]:
+        print("\n  Held-out perplexity (pruned/full):")
+        for source, ratio in rep["perplexity"]["ratio"].items():
+            full = rep["perplexity"]["full"][source]
+            pruned = rep["perplexity"]["pruned"][source]
+            print(f"    {source}: {pruned:.2f} / {full:.2f}  (x{ratio:.3f})")
+    out_json = _reap_dir(local_dir) / "reap_report.json"
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(rep, indent=2))
+    print(f"\n  Report JSON: {out_json}")
+```
+
+`parser.py` — add after the last prepare-family group, following the flash/spectral template:
+
+```python
+    reap = sub.add_parser("reap", help="REAP expert pruning for MoE models")
+    reap_sub = reap.add_subparsers(dest="reap_command")
+
+    reap_cal = reap_sub.add_parser("calibrate", help="Streaming saliency calibration")
+    reap_cal.add_argument("model")
+    reap_cal.add_argument("--sources", type=str, default="english,code,chinese",
+                          help="Comma-separated calibration sources (default: english,code,chinese)")
+    reap_cal.add_argument("--samples-per-source", type=_positive_int, default=256,
+                          help="Calibration samples per source (default: 256)")
+    reap_cal.add_argument("--max-tokens", type=_positive_int, default=512,
+                          help="Max tokens per sample (default: 512)")
+    reap_cal.add_argument("--output", type=str, default=None,
+                          help="Saliency output path (default: <model>/reap/saliency.npz)")
+
+    reap_plan = reap_sub.add_parser("plan", help="Keep/drop (+bank) planning")
+    reap_plan.add_argument("model")
+    reap_plan.add_argument("--mode", choices=["uniform", "global", "graded"],
+                           default="uniform", help="Plan mode (default: uniform)")
+    reap_plan.add_argument("--keep", type=_positive_int, default=None,
+                           help="Experts to keep per layer (uniform mode)")
+    reap_plan.add_argument("--keep-fraction", type=float, default=None,
+                           help="Fraction of all experts to keep (global/graded)")
+    reap_plan.add_argument("--sources", type=str, default=None,
+                           help="Comma-separated source subset for domain builds")
+    reap_plan.add_argument("--floor-multiple", type=_positive_int, default=4,
+                           help="Per-layer floor = multiple * top_k (default: 4)")
+    reap_plan.add_argument("--high-fraction", type=float, default=0.25,
+                           help="Graded: fraction of kept experts in the high bank (default: 0.25)")
+    reap_plan.add_argument("--high-bits", type=int, choices=[4, 5, 6, 8], default=8,
+                           help="Graded: high-bank bits (default: 8)")
+    reap_plan.add_argument("--low-bits", type=int, choices=[2, 3, 4], default=4,
+                           help="Graded: low-bank bits (default: 4)")
+    reap_plan.add_argument("--saliency", type=str, default=None,
+                           help="Saliency npz path (default: <model>/reap/saliency.npz)")
+    reap_plan.add_argument("--output", type=str, default=None,
+                           help="Plan output path (default: <model>/reap/reap_plan.json)")
+
+    reap_apply = reap_sub.add_parser("apply", help="Prune the checkpoint per plan")
+    reap_apply.add_argument("model")
+    reap_apply.add_argument("--plan", type=str, required=True, help="reap_plan.json path")
+    reap_apply.add_argument("--output-dir", type=str, default=None,
+                            help="Output dir (default: <model>/reap/pruned-<mode><keep>)")
+
+    reap_rep = reap_sub.add_parser("report", help="Overlap analysis + held-out perplexity")
+    reap_rep.add_argument("model")
+    reap_rep.add_argument("--saliency", type=str, default=None,
+                          help="Saliency npz path (default: <model>/reap/saliency.npz)")
+    reap_rep.add_argument("--keep", type=_positive_int, default=None,
+                          help="Keep count for overlap analysis (default: from reap_plan.json)")
+    reap_rep.add_argument("--pruned-dir", type=str, default=None,
+                          help="Pruned model dir for the perplexity gate")
+    reap_rep.add_argument("--samples-per-source", type=_positive_int, default=32,
+                          help="Held-out samples per source for perplexity (default: 32)")
+    reap_rep.add_argument("--skip-ppl", action="store_true", default=False,
+                          help="Skip the perplexity gate (overlap analysis only)")
+```
+
+`cli/__init__.py` — add to the `prepare_cmd` import block region:
+
+```python
+from olmlx.cli.reap_cmd import (
+    cmd_reap_apply,
+    cmd_reap_calibrate,
+    cmd_reap_plan,
+    cmd_reap_report,
+)
+```
+and to `_COMMAND_HANDLERS`:
+```python
+    ("reap", "calibrate"): "cmd_reap_calibrate",
+    ("reap", "plan"): "cmd_reap_plan",
+    ("reap", "apply"): "cmd_reap_apply",
+    ("reap", "report"): "cmd_reap_report",
+```
+(`_validate_command_handlers()` at import will catch wiring mistakes.)
+
+`CLAUDE.md` project tree — add under `engine/`:
+```
+│   ├── reap/           # REAP expert pruning: calibrate/plan/apply/report (olmlx reap *)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_reap_cli.py tests/test_cli.py tests/test_cli_coverage.py -q`
+Expected: PASS (including the existing CLI suites — the new family must not break `_validate_command_handlers` or help output assertions).
+
+- [ ] **Step 5: Full suite + ruff + commit**
+
+Run: `uv run pytest -m "not real_model" -q` — full offline suite green.
+
+```bash
+uv run ruff check --fix olmlx tests && uv run ruff format olmlx tests
+git add olmlx/cli/ tests/test_reap_cli.py CLAUDE.md
+git commit -m "feat(reap): olmlx reap CLI family + docs (#701)"
+```
+
+---
+
+## Verification (whole plan)
+
+1. `uv run pytest tests/test_reap_*.py -q` — all REAP suites green.
+2. `uv run pytest -m "not real_model" -q` — no regressions.
+3. Invariants delivered: (1) identity no-op — `TestIdentityNoOp`; (2) pruned ≡ −inf-masked full — `TestPrunedEquivalence`; (3) rotation detected — `TestRotation`; (5) streaming ≡ hooked — `TestStreamingEqualsHooked`. Invariant (4) deferred to phase 3 by design.
+4. Optional live smoke (Metal machine, not CI): `uv run olmlx reap calibrate <small-moe-model> --samples-per-source 8 --max-tokens 128` then `plan --keep <n>` / `apply` / `report --skip-ppl` end-to-end on a real small MoE (e.g. a 4-bit Qwen3-30B-A3B) before attempting Qwen3-235B.
+
+## Follow-ups (explicitly out of scope here)
+
+- **Phase 3 plan**: Flash-MoE integration — per-layer expert counts in bundler/store/`flash_moe_config.json`, graded two-bank `gather_qmm` split in `FlashMoE.__call__`, invariant test 4 (two banks with identical weights ≡ single bank), `apply` support for `global`/`graded` plans + `expert_counts`/`bank_split` config keys.
+- **Phase 4 plan**: in-RAM TwoBankSwitchGLU for pruned-to-fit models (GLM-4.5-Air class).
+- Open questions from #701 to resolve during phase 3 planning: graded artifact portability (registerable model file vs olmlx-only), pinned corpus artifact vs on-the-fly HF datasets.
+

--- a/olmlx/cli/__init__.py
+++ b/olmlx/cli/__init__.py
@@ -102,6 +102,12 @@ from olmlx.cli.prepare_cmd import (  # noqa: F401
     _show_flash_moe_info,
     _show_flash_dense_info,
 )
+from olmlx.cli.reap_cmd import (  # noqa: F401
+    cmd_reap_apply,
+    cmd_reap_calibrate,
+    cmd_reap_plan,
+    cmd_reap_report,
+)
 from olmlx.cli.parser import (  # noqa: F401
     build_parser,
 )
@@ -136,6 +142,10 @@ _COMMAND_HANDLERS: dict[tuple[str, str | None], str] = {
     ("bench", "compare"): "cmd_bench_compare",
     ("bench", "list"): "cmd_bench_list",
     ("bench", "leaderboard"): "cmd_bench_leaderboard",
+    ("reap", "calibrate"): "cmd_reap_calibrate",
+    ("reap", "plan"): "cmd_reap_plan",
+    ("reap", "apply"): "cmd_reap_apply",
+    ("reap", "report"): "cmd_reap_report",
     ("config", "show"): "cmd_config_show",
 }
 

--- a/olmlx/cli/parser.py
+++ b/olmlx/cli/parser.py
@@ -719,6 +719,149 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    # REAP expert pruning (#701)
+    reap = sub.add_parser("reap", help="REAP expert pruning for MoE models")
+    reap_sub = reap.add_subparsers(dest="reap_command")
+
+    reap_cal = reap_sub.add_parser("calibrate", help="Streaming saliency calibration")
+    reap_cal.add_argument("model")
+    reap_cal.add_argument(
+        "--sources",
+        type=str,
+        default="english,code,chinese",
+        help="Comma-separated calibration sources (default: english,code,chinese)",
+    )
+    reap_cal.add_argument(
+        "--samples-per-source",
+        type=_positive_int,
+        default=256,
+        help="Calibration samples per source (default: 256)",
+    )
+    reap_cal.add_argument(
+        "--max-tokens",
+        type=_positive_int,
+        default=512,
+        help="Max tokens per sample (default: 512)",
+    )
+    reap_cal.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Saliency output path (default: <model>/reap/saliency.npz)",
+    )
+
+    reap_plan = reap_sub.add_parser("plan", help="Keep/drop (+bank) planning")
+    reap_plan.add_argument("model")
+    reap_plan.add_argument(
+        "--mode",
+        choices=["uniform", "global", "graded"],
+        default="uniform",
+        help="Plan mode (default: uniform)",
+    )
+    reap_plan.add_argument(
+        "--keep",
+        type=_positive_int,
+        default=None,
+        help="Experts to keep per layer (uniform mode)",
+    )
+    reap_plan.add_argument(
+        "--keep-fraction",
+        type=float,
+        default=None,
+        help="Fraction of all experts to keep (global/graded)",
+    )
+    reap_plan.add_argument(
+        "--sources",
+        type=str,
+        default=None,
+        help="Comma-separated source subset for domain builds",
+    )
+    reap_plan.add_argument(
+        "--floor-multiple",
+        type=_positive_int,
+        default=4,
+        help="Per-layer floor = multiple * top_k (default: 4)",
+    )
+    reap_plan.add_argument(
+        "--high-fraction",
+        type=float,
+        default=0.25,
+        help="Graded: fraction of kept experts in the high bank (default: 0.25)",
+    )
+    reap_plan.add_argument(
+        "--high-bits",
+        type=int,
+        choices=[4, 5, 6, 8],
+        default=8,
+        help="Graded: high-bank bits (default: 8)",
+    )
+    reap_plan.add_argument(
+        "--low-bits",
+        type=int,
+        choices=[2, 3, 4],
+        default=4,
+        help="Graded: low-bank bits (default: 4)",
+    )
+    reap_plan.add_argument(
+        "--saliency",
+        type=str,
+        default=None,
+        help="Saliency npz path (default: <model>/reap/saliency.npz)",
+    )
+    reap_plan.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Plan output path (default: <model>/reap/reap_plan.json)",
+    )
+
+    reap_apply = reap_sub.add_parser("apply", help="Prune the checkpoint per plan")
+    reap_apply.add_argument("model")
+    reap_apply.add_argument(
+        "--plan", type=str, required=True, help="reap_plan.json path"
+    )
+    reap_apply.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Output dir (default: <model>/reap/pruned-<mode><keep>)",
+    )
+
+    reap_rep = reap_sub.add_parser(
+        "report", help="Overlap analysis + held-out perplexity"
+    )
+    reap_rep.add_argument("model")
+    reap_rep.add_argument(
+        "--saliency",
+        type=str,
+        default=None,
+        help="Saliency npz path (default: <model>/reap/saliency.npz)",
+    )
+    reap_rep.add_argument(
+        "--keep",
+        type=_positive_int,
+        default=None,
+        help="Keep count for overlap analysis (default: from reap_plan.json)",
+    )
+    reap_rep.add_argument(
+        "--pruned-dir",
+        type=str,
+        default=None,
+        help="Pruned model dir for the perplexity gate",
+    )
+    reap_rep.add_argument(
+        "--samples-per-source",
+        type=_positive_int,
+        default=32,
+        help="Held-out samples per source for perplexity (default: 32)",
+    )
+    reap_rep.add_argument(
+        "--skip-ppl",
+        action="store_true",
+        default=False,
+        help="Skip the perplexity gate (overlap analysis only)",
+    )
+
     # Bench (benchmarking)
     bench = sub.add_parser("bench", help="Benchmarking and functional tests")
     bench_sub = bench.add_subparsers(dest="bench_command")

--- a/olmlx/cli/reap_cmd.py
+++ b/olmlx/cli/reap_cmd.py
@@ -61,7 +61,11 @@ def cmd_reap_plan(args):
         Path(args.saliency) if args.saliency else _reap_dir(local_dir) / "saliency.npz"
     )
     acc, meta = load_saliency(saliency_path)
-    sources = [s.strip() for s in args.sources.split(",")] if args.sources else None
+    sources = (
+        [s.strip() for s in args.sources.split(",") if s.strip()]
+        if args.sources
+        else None
+    )
     sal = acc.saliency(sources)
     common = dict(top_k=meta["top_k"], num_experts=meta["num_experts"])
     if args.mode == "uniform":

--- a/olmlx/cli/reap_cmd.py
+++ b/olmlx/cli/reap_cmd.py
@@ -1,0 +1,171 @@
+"""olmlx reap: REAP expert pruning CLI (calibrate -> plan -> apply -> report)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from olmlx.cli.config_cmd import _configure_logging
+from olmlx.cli.models_cmd import _resolve_and_download
+from olmlx.cli.prepare_cmd import _flash_progress
+
+
+def _reap_dir(local_dir: Path) -> Path:
+    return Path(local_dir) / "reap"
+
+
+def cmd_reap_calibrate(args):
+    _configure_logging()
+    sources = [s.strip() for s in args.sources.split(",") if s.strip()]
+    if not sources:
+        raise SystemExit("--sources must name at least one source")
+    _store, local_dir = _resolve_and_download(args.model)
+    from olmlx.engine.reap.calibrate import calibrate_saliency_streaming, save_saliency
+    from olmlx.engine.reap.corpus import build_calibration_corpus
+
+    print(f"Calibrating REAP saliency for {args.model}")
+    print(
+        f"  Sources: {', '.join(sources)}  samples/source: {args.samples_per_source}"
+        f"  max tokens: {args.max_tokens}"
+    )
+    texts = build_calibration_corpus(
+        sources, args.samples_per_source, progress_callback=_flash_progress
+    )
+    acc, meta = calibrate_saliency_streaming(
+        str(local_dir),
+        texts,
+        max_tokens=args.max_tokens,
+        progress_callback=_flash_progress,
+    )
+    output = Path(args.output) if args.output else _reap_dir(local_dir) / "saliency.npz"
+    save_saliency(output, acc, meta)
+    print("\nCalibration complete!")
+    print(f"  Saliency: {output}")
+    print(
+        f"\nNext: olmlx reap plan {args.model} --keep <n>   "
+        f"(num_experts={meta['num_experts']})"
+    )
+
+
+def cmd_reap_plan(args):
+    _configure_logging()
+    if args.mode == "uniform" and args.keep is None:
+        raise SystemExit("--mode uniform requires --keep")
+    if args.mode in ("global", "graded") and args.keep_fraction is None:
+        raise SystemExit(f"--mode {args.mode} requires --keep-fraction")
+    _store, local_dir = _resolve_and_download(args.model, download=False)
+    from olmlx.engine.reap.calibrate import load_saliency
+    from olmlx.engine.reap.plan import plan_global, plan_graded, plan_uniform, save_plan
+
+    saliency_path = (
+        Path(args.saliency) if args.saliency else _reap_dir(local_dir) / "saliency.npz"
+    )
+    acc, meta = load_saliency(saliency_path)
+    sources = [s.strip() for s in args.sources.split(",")] if args.sources else None
+    sal = acc.saliency(sources)
+    common = dict(top_k=meta["top_k"], num_experts=meta["num_experts"])
+    if args.mode == "uniform":
+        plan = plan_uniform(sal, meta["moe_layer_indices"], args.keep, **common)
+    elif args.mode == "global":
+        plan = plan_global(
+            sal,
+            meta["moe_layer_indices"],
+            args.keep_fraction,
+            floor_multiple=args.floor_multiple,
+            **common,
+        )
+    else:
+        plan = plan_graded(
+            sal,
+            meta["moe_layer_indices"],
+            args.keep_fraction,
+            high_fraction=args.high_fraction,
+            high_bits=args.high_bits,
+            low_bits=args.low_bits,
+            floor_multiple=args.floor_multiple,
+            **common,
+        )
+    plan.meta = {"sources": sources or acc.sources, "saliency": str(saliency_path)}
+    output = (
+        Path(args.output) if args.output else _reap_dir(local_dir) / "reap_plan.json"
+    )
+    save_plan(plan, output)
+    kept = sum(len(v) for v in plan.keep.values())
+    total = len(plan.keep) * meta["num_experts"]
+    print(f"\nPlan written: {output}")
+    print(f"  Mode: {plan.mode}  kept experts: {kept}/{total}")
+    print(f"\nNext: olmlx reap apply {args.model} --plan {output}")
+
+
+def cmd_reap_apply(args):
+    _configure_logging()
+    _store, local_dir = _resolve_and_download(args.model, download=True)
+    from olmlx.engine.reap.apply import apply_plan
+    from olmlx.engine.reap.plan import load_plan
+
+    plan = load_plan(Path(args.plan))
+    keep_count = len(next(iter(plan.keep.values())))
+    output_dir = (
+        Path(args.output_dir)
+        if args.output_dir
+        else _reap_dir(local_dir) / f"pruned-{plan.mode}{keep_count}"
+    )
+    out = apply_plan(
+        Path(local_dir), plan, output_dir, progress_callback=_flash_progress
+    )
+    print("\nPruning complete!")
+    print(f"  Output: {out}")
+    print(
+        f"\nRegister it in models.json with a path entry, then: olmlx reap report "
+        f"{args.model} --pruned-dir {out}"
+    )
+
+
+def cmd_reap_report(args):
+    _configure_logging()
+    _store, local_dir = _resolve_and_download(args.model, download=not args.skip_ppl)
+    from olmlx.engine.reap.calibrate import load_saliency
+    from olmlx.engine.reap.corpus import build_calibration_corpus
+    from olmlx.engine.reap.report import build_report
+
+    saliency_path = (
+        Path(args.saliency) if args.saliency else _reap_dir(local_dir) / "saliency.npz"
+    )
+    keep = args.keep
+    if keep is None:
+        plan_path = _reap_dir(local_dir) / "reap_plan.json"
+        if plan_path.exists():
+            from olmlx.engine.reap.plan import load_plan
+
+            keep = len(next(iter(load_plan(plan_path).keep.values())))
+        else:
+            raise SystemExit("--keep required (no reap_plan.json to infer it from)")
+    held_out = None
+    if not args.skip_ppl and args.pruned_dir:
+        _acc, meta = load_saliency(saliency_path)
+        held_out = build_calibration_corpus(
+            meta["sources"], args.samples_per_source, skip=meta.get("num_samples", 256)
+        )
+    rep = build_report(
+        saliency_path,
+        keep_count=keep,
+        full_model_dir=str(local_dir) if held_out else None,
+        pruned_model_dir=args.pruned_dir if held_out else None,
+        held_out_texts=held_out,
+        progress_callback=_flash_progress,
+    )
+    print(
+        f"\nREAP report (keep={keep}, chance overlap={rep['overlap']['chance']:.2f}):"
+    )
+    for pair, stats in rep["overlap"]["pairs"].items():
+        print(f"  {pair}: mean keep-set overlap {stats['mean_overlap']:.2f}")
+    if rep["perplexity"]:
+        print("\n  Held-out perplexity (pruned/full):")
+        for source, ratio in rep["perplexity"]["ratio"].items():
+            full = rep["perplexity"]["full"][source]
+            pruned = rep["perplexity"]["pruned"][source]
+            print(f"    {source}: {pruned:.2f} / {full:.2f}  (x{ratio:.3f})")
+    out_json = _reap_dir(local_dir) / "reap_report.json"
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(rep, indent=2))
+    print(f"\n  Report JSON: {out_json}")

--- a/olmlx/engine/reap/__init__.py
+++ b/olmlx/engine/reap/__init__.py
@@ -1,0 +1,1 @@
+"""REAP expert pruning: calibration, planning, pruning surgery, and reporting (#701)."""

--- a/olmlx/engine/reap/apply.py
+++ b/olmlx/engine/reap/apply.py
@@ -109,6 +109,42 @@ def apply_plan(
 
     config = json.loads((model_dir / "config.json").read_text())
     cfg_view = config.get("text_config", config)
+
+    actual_num_experts = None
+    for key in _EXPERT_COUNT_KEYS:
+        if key in cfg_view:
+            actual_num_experts = cfg_view[key]
+            break
+    if actual_num_experts is not None and actual_num_experts != plan.num_experts_orig:
+        raise ReapApplyError(
+            f"plan.num_experts_orig={plan.num_experts_orig} does not match the "
+            f"checkpoint config's expert count ({actual_num_experts}); refusing "
+            f"to apply a stale/mismatched plan (the misrouting guard keys off "
+            f"num_experts_orig, so a mismatch would silently weaken it)"
+        )
+
+    n_group = cfg_view.get("n_group")
+    if n_group is not None and n_group > 1:
+        raise ReapApplyError(
+            f"group-routed config (n_group={n_group}) is not supported by "
+            f"apply_plan yet; a uniform prune leaves n_group/topk_group "
+            f"untouched, which either breaks MoEGate's group reshape or "
+            f"silently shifts group partition boundaries (phase 3 territory)"
+        )
+
+    num_hidden_layers = cfg_view.get("num_hidden_layers")
+    if num_hidden_layers is not None:
+        bad_layers = sorted(
+            idx
+            for idx in set(plan.keep) | set(plan.moe_layer_indices)
+            if not (0 <= idx < num_hidden_layers)
+        )
+        if bad_layers:
+            raise ReapApplyError(
+                f"plan references layer index/indices {bad_layers} outside "
+                f"num_hidden_layers={num_hidden_layers}"
+            )
+
     top_k = cfg_view.get("num_experts_per_tok", plan.top_k)
     if top_k > keep_count:
         raise ReapApplyError(f"num_experts_per_tok={top_k} > keep_count={keep_count}")

--- a/olmlx/engine/reap/apply.py
+++ b/olmlx/engine/reap/apply.py
@@ -1,0 +1,203 @@
+"""REAP pruning surgery: streaming shard-by-shard restack of kept experts.
+
+The trap (#701): pruning renumbers experts, so router rows
+(gate.weight / e_score_correction_bias / router.bias / ...) MUST be sliced with
+the same keep list as the expert stacks — and any expert-count-sized tensor we
+do not recognize is a hard error, because a missed one produces a model that
+loads, runs, and routes every token to the wrong expert.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import time
+from pathlib import Path
+from typing import Callable
+
+import mlx.core as mx
+
+from olmlx.engine.reap.plan import ReapPlan
+
+_EXPERT_COUNT_KEYS = (
+    "n_routed_experts",
+    "num_local_experts",
+    "num_experts",
+    "moe_num_experts",
+)
+
+# Router-tensor suffixes relative to the MoE module (e.g. "mlp"). Axis 0 is the
+# expert axis in every one; QuantizedLinear packs along the last axis so row
+# slicing is always safe.
+_ROUTER_SUFFIXES = (
+    r"gate\.(weight|scales|biases|bias)",
+    r"gate\.gate\.(weight|scales|biases)",  # Step-3.5 inner linear
+    r"gate\.e_score_correction_bias",
+    r"gate\.router_bias",  # Step-3.5
+    r"e_score_correction_bias",  # MiniMax block-level
+    r"router\.(weight|scales|biases|bias)",  # gpt-oss
+)
+_EXPERT_COMPONENTS = ("weight", "scales", "biases", "bias")
+
+
+class ReapApplyError(RuntimeError):
+    pass
+
+
+def rewrite_config_num_experts(config: dict, new_count: int) -> str:
+    """Mutate `config` in place, setting the expert-count key to `new_count`.
+
+    Unwraps `text_config` (VLM-style nested text config) if present. Returns
+    the alias key that was rewritten.
+    """
+    target = config.get("text_config", config)
+    for key in _EXPERT_COUNT_KEYS:
+        if key in target:
+            target[key] = new_count
+            return key
+    raise ReapApplyError(f"no expert-count key in config (tried {_EXPERT_COUNT_KEYS})")
+
+
+def _classify(
+    name: str,
+    keep_map: dict[int, list[int]],
+    num_experts_orig: int,
+    arr_shape: tuple,
+    layer_re: re.Pattern,
+    router_res: list[re.Pattern],
+    expert_re: re.Pattern,
+) -> tuple[str, int | None]:
+    """Returns ("expert"|"router"|"copy"|"error", layer_idx)."""
+    m = layer_re.match(name)
+    if not m:
+        return "copy", None
+    layer_idx = int(m.group(1))
+    if layer_idx not in keep_map:
+        return "copy", None
+    rest = m.group(2)
+    if expert_re.match(rest):
+        return "expert", layer_idx
+    for rre in router_res:
+        if rre.match(rest):
+            return "router", layer_idx
+    if "shared_expert" not in rest and arr_shape and arr_shape[0] == num_experts_orig:
+        return "error", layer_idx
+    return "copy", None
+
+
+def apply_plan(
+    model_dir: Path,
+    plan: ReapPlan,
+    output_dir: Path,
+    *,
+    progress_callback: Callable[[str, float], None] | None = None,
+) -> Path:
+    from olmlx.engine.flash.moe_bundler import _detect_expert_format
+    from olmlx.engine.pre_shard import collect_non_weight_files
+
+    model_dir, output_dir = Path(model_dir), Path(output_dir)
+    if plan.mode != "uniform":
+        raise ReapApplyError(
+            f"apply supports uniform plans only for now; {plan.mode!r} plans need "
+            f"the phase 3 serving-side support (per-layer expert_counts / bank_split)"
+        )
+    keep_counts = {len(v) for v in plan.keep.values()}
+    if len(keep_counts) != 1:
+        raise ReapApplyError("uniform plan has non-uniform keep counts")
+    keep_count = keep_counts.pop()
+
+    config = json.loads((model_dir / "config.json").read_text())
+    cfg_view = config.get("text_config", config)
+    top_k = cfg_view.get("num_experts_per_tok", plan.top_k)
+    if top_k > keep_count:
+        raise ReapApplyError(f"num_experts_per_tok={top_k} > keep_count={keep_count}")
+
+    index_path = model_dir / "model.safetensors.index.json"
+    index = json.loads(index_path.read_text()) if index_path.exists() else None
+    fmt = _detect_expert_format(model_dir, plan.moe_layer_indices[0], index)
+    moe_prefix = fmt.expert_prefix.split(".")[0]  # e.g. "mlp"
+    container_rel = fmt.expert_prefix[len(moe_prefix) + 1 :]  # e.g. "switch_mlp"
+
+    layer_re = re.compile(
+        rf"^{re.escape(fmt.layer_prefix)}\.(\d+)\.({re.escape(moe_prefix)}\..+)$"
+    )
+    proj_alt = "|".join(re.escape(p) for p in fmt.projections)
+    comp_alt = "|".join(_EXPERT_COMPONENTS)
+    expert_re = re.compile(
+        rf"^{re.escape(moe_prefix)}\.{re.escape(container_rel)}\.({proj_alt})\.({comp_alt})$"
+    )
+    router_res = [
+        re.compile(rf"^{re.escape(moe_prefix)}\.{suffix}$")
+        for suffix in _ROUTER_SUFFIXES
+    ]
+
+    shards = (
+        sorted(set(index["weight_map"].values())) if index else ["model.safetensors"]
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    weight_map: dict[str, str] = {}
+    total_size = 0
+
+    for si, shard in enumerate(shards):
+        tensors = mx.load(str(model_dir / shard))
+        out: dict[str, mx.array] = {}
+        for name, arr in tensors.items():
+            kind, layer_idx = _classify(
+                name,
+                plan.keep,
+                plan.num_experts_orig,
+                tuple(arr.shape),
+                layer_re,
+                router_res,
+                expert_re,
+            )
+            if kind == "error":
+                raise ReapApplyError(
+                    f"unrecognized expert-count-sized tensor {name!r}: refusing to "
+                    f"copy it through unsliced (would silently misroute)"
+                )
+            if kind in ("expert", "router"):
+                out[name] = arr[mx.array(plan.keep[layer_idx])]
+            else:
+                out[name] = arr
+        mx.eval(*out.values())
+        mx.save_safetensors(str(output_dir / shard), out)
+        for name in out:
+            weight_map[name] = shard
+        total_size += (output_dir / shard).stat().st_size
+        del tensors, out
+        mx.clear_cache()
+        if progress_callback:
+            progress_callback(
+                f"Pruned shard {si + 1}/{len(shards)}", (si + 1) / len(shards)
+            )
+
+    rewrite_config_num_experts(config, keep_count)
+    (output_dir / "config.json").write_text(
+        json.dumps(config, indent=2, ensure_ascii=False)
+    )
+    if index is not None or len(shards) > 1:
+        (output_dir / "model.safetensors.index.json").write_text(
+            json.dumps(
+                {"metadata": {"total_size": total_size}, "weight_map": weight_map},
+                indent=2,
+            )
+        )
+    for f in collect_non_weight_files(model_dir):
+        if f.name != "config.json":
+            shutil.copy2(f, output_dir / f.name)
+    (output_dir / "reap_provenance.json").write_text(
+        json.dumps(
+            {
+                "pruned_from": str(model_dir),
+                "plan_mode": plan.mode,
+                "keep_count": keep_count,
+                "num_experts_orig": plan.num_experts_orig,
+                "moe_layer_indices": plan.moe_layer_indices,
+                "prepared_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            },
+            indent=2,
+        )
+    )
+    return output_dir

--- a/olmlx/engine/reap/apply.py
+++ b/olmlx/engine/reap/apply.py
@@ -151,6 +151,20 @@ def apply_plan(
 
     index_path = model_dir / "model.safetensors.index.json"
     index = json.loads(index_path.read_text()) if index_path.exists() else None
+    if index:
+        shards = sorted(set(index["weight_map"].values()))
+    else:
+        # Without an index, format detection and the shard loop below both
+        # assume the single-file layout — refuse anything else explicitly
+        # rather than failing later with a confusing FileNotFoundError.
+        shards = sorted(p.name for p in model_dir.glob("*.safetensors"))
+        if not shards:
+            raise ReapApplyError(f"no .safetensors files found in {model_dir}")
+        if shards != ["model.safetensors"]:
+            raise ReapApplyError(
+                f"multi-file checkpoint without model.safetensors.index.json "
+                f"is unsupported (found {shards}); regenerate the index"
+            )
     fmt = _detect_expert_format(model_dir, plan.moe_layer_indices[0], index)
     moe_prefix = fmt.expert_prefix.split(".")[0]  # e.g. "mlp"
     container_rel = fmt.expert_prefix[len(moe_prefix) + 1 :]  # e.g. "switch_mlp"
@@ -168,9 +182,6 @@ def apply_plan(
         for suffix in _ROUTER_SUFFIXES
     ]
 
-    shards = (
-        sorted(set(index["weight_map"].values())) if index else ["model.safetensors"]
-    )
     output_dir.mkdir(parents=True, exist_ok=True)
     weight_map: dict[str, str] = {}
     total_size = 0

--- a/olmlx/engine/reap/arch.py
+++ b/olmlx/engine/reap/arch.py
@@ -1,0 +1,155 @@
+"""Per-architecture MoE introspection for REAP.
+
+Mirrors the router-style dispatch chain in flash/flash_moe_model.py
+_replace_moe_layers (detection order is load-bearing there and here).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+STYLE_QWEN3 = "qwen3"  # plain linear gate, softmax before top-k
+STYLE_QWEN3_NEXT = "qwen3_next"  # linear gate + shared_expert_gate
+STYLE_MINIMAX = "minimax"  # linear gate + block-level e_score_correction_bias
+STYLE_DEEPSEEK = "deepseek"  # custom gate module returning (inds, scores)
+STYLE_GPT_OSS = "gpt_oss"  # `router` linear + `experts` container
+
+_MOE_ATTRS = ("mlp", "block_sparse_moe", "mixer")
+_CONTAINER_ATTRS = ("switch_mlp", "experts")
+_PROJ_PROBES = ("gate_proj", "fc1")
+
+
+@dataclass
+class MoeModuleInfo:
+    attr_name: str
+    module: Any
+    container_name: str
+    gate_attr: str
+    style: str
+    num_experts: int
+    top_k: int
+
+
+def _gate_is_linear(gate: Any) -> bool:
+    linear_types: tuple[type, ...] = (nn.Linear,)
+    if hasattr(nn, "QuantizedLinear"):
+        linear_types = (nn.Linear, nn.QuantizedLinear)
+    return isinstance(gate, linear_types)
+
+
+def detect_router_style(moe_module: Any) -> str:
+    gate = getattr(moe_module, "gate", None)
+    if _gate_is_linear(gate) and hasattr(moe_module, "shared_expert_gate"):
+        return STYLE_QWEN3_NEXT
+    if _gate_is_linear(gate) and hasattr(moe_module, "e_score_correction_bias"):
+        return STYLE_MINIMAX
+    if _gate_is_linear(gate):
+        return STYLE_QWEN3
+    if gate is not None:
+        return STYLE_DEEPSEEK
+    if getattr(moe_module, "router", None) is not None:
+        return STYLE_GPT_OSS
+    raise ValueError("unrecognized MoE router layout")
+
+
+def _find_container(moe_module: Any) -> tuple[str, Any] | None:
+    for name in _CONTAINER_ATTRS:
+        cont = getattr(moe_module, name, None)
+        if cont is None:
+            continue
+        for probe in _PROJ_PROBES:
+            proj = getattr(cont, probe, None)
+            if proj is not None and getattr(proj, "weight", None) is not None:
+                return name, cont
+    return None
+
+
+def _top_k_of(moe_module: Any) -> int | None:
+    for owner in (moe_module, getattr(moe_module, "gate", None)):
+        if owner is None:
+            continue
+        for attr in ("top_k", "num_experts_per_tok", "num_local_experts_per_tok"):
+            val = getattr(owner, attr, None)
+            if isinstance(val, int) and val > 0:
+                return val
+    config = getattr(getattr(moe_module, "gate", None), "config", None)
+    val = getattr(config, "num_experts_per_tok", None)
+    return val if isinstance(val, int) else None
+
+
+def find_moe_module(
+    layer: Any, *, top_k_hint: int | None = None
+) -> MoeModuleInfo | None:
+    for attr in _MOE_ATTRS:
+        moe = getattr(layer, attr, None)
+        if moe is None:
+            continue
+        found = _find_container(moe)
+        if found is None:
+            continue
+        container_name, container = found
+        try:
+            style = detect_router_style(moe)
+        except ValueError:
+            continue
+        # gpt-oss keeps experts under the same attr the container probe found;
+        # in that layout `moe` IS the block and `container` its SwitchGLU.
+        proj = getattr(container, "gate_proj", None) or getattr(container, "fc1", None)
+        num_experts = int(proj.weight.shape[0])
+        top_k = _top_k_of(moe) or top_k_hint
+        if top_k is None:
+            raise ValueError(f"cannot determine top_k for MoE module {attr!r}")
+        gate_attr = "router" if style == STYLE_GPT_OSS else "gate"
+        return MoeModuleInfo(
+            attr_name=attr,
+            module=moe,
+            container_name=container_name,
+            gate_attr=gate_attr,
+            style=style,
+            num_experts=num_experts,
+            top_k=int(top_k),
+        )
+    return None
+
+
+def applied_scores(
+    style: str, moe_module: Any, gate_out: Any, inds: mx.array
+) -> mx.array:
+    """Routing weight actually applied to each selected expert's output.
+
+    gate_out is the raw gate/router output: logits for linear styles, the
+    (inds, scores) tuple for DeepSeek-style custom gates.
+
+    Score math mirrors the installed mlx-lm model sources exactly:
+    - qwen3_moe.py / qwen3_next.py: softmax(precise=True) over the full
+      logits *before* top-k selection, then renormalize the selected
+      scores if norm_topk_prob is set.
+    - gpt_oss.py: softmax(precise=True) over only the *selected* logits
+      (no renorm — softmax over top-k already sums to one).
+    - minimax.py: sigmoid over the full (unbiased) logits, select, then
+      renormalize with a 1e-20 epsilon (top-k selection itself uses a
+      bias-corrected score, but the values taken and renormalized are the
+      unbiased sigmoid scores).
+    - deepseek_v3.py: MoEGate already returns (inds, scores) with all
+      selection/renorm/scaling baked in — pure passthrough.
+    """
+    if style == STYLE_DEEPSEEK:
+        return gate_out[1]
+    if style in (STYLE_QWEN3, STYLE_QWEN3_NEXT):
+        probs = mx.softmax(gate_out.astype(mx.float32), axis=-1, precise=True)
+        scores = mx.take_along_axis(probs, inds, axis=-1)
+        if getattr(moe_module, "norm_topk_prob", False):
+            scores = scores / mx.sum(scores, axis=-1, keepdims=True)
+        return scores
+    if style == STYLE_MINIMAX:
+        probs = mx.sigmoid(gate_out.astype(mx.float32))
+        scores = mx.take_along_axis(probs, inds, axis=-1)
+        return scores / (mx.sum(scores, axis=-1, keepdims=True) + 1e-20)
+    if style == STYLE_GPT_OSS:
+        selected = mx.take_along_axis(gate_out, inds, axis=-1)
+        return mx.softmax(selected, axis=-1, precise=True)
+    raise ValueError(f"unknown router style {style!r}")

--- a/olmlx/engine/reap/calibrate.py
+++ b/olmlx/engine/reap/calibrate.py
@@ -248,6 +248,42 @@ def _resolve_head(model, inner):
     return norm, inner.embed_tokens.as_linear
 
 
+def _layer_window_size(inner, args, li: int, layer) -> int | None:
+    """Best-effort per-layer sliding-window size, mirroring how the model's own
+    full-forward decides it, so the streaming mask matches the hooked one exactly.
+
+    Returns None for global/full-attention layers (plain causal, unbounded).
+    Two conventions are checked (covers gpt_oss/olmo3-style backbones and
+    gemma3/cohere2-style layers; falls back to full causal if neither applies —
+    still correct for archs with no sliding attention, e.g. qwen3_moe/deepseek_v3):
+    - a backbone- or args-level `layer_types` list, indexed by `li`, where any
+      value other than "full_attention" means sliding (gpt_oss, olmo3);
+    - a boolean `is_sliding`/`use_sliding_window` flag on the layer or its
+      `self_attn` (gemma3_text, cohere2).
+    """
+    layer_types = getattr(inner, "layer_types", None) or getattr(
+        args, "layer_types", None
+    )
+    if layer_types is not None and li < len(layer_types):
+        is_sliding = layer_types[li] != "full_attention"
+    else:
+        is_sliding = False
+        attn = getattr(layer, "self_attn", None)
+        for holder in (attn, layer):
+            if holder is None:
+                continue
+            for attr in ("is_sliding", "use_sliding_window"):
+                flag = getattr(holder, attr, None)
+                if flag is not None:
+                    is_sliding = bool(flag)
+                    break
+            if is_sliding:
+                break
+    if not is_sliding:
+        return None
+    return getattr(inner, "window_size", None) or getattr(args, "sliding_window", None)
+
+
 def stream_layer_forward(
     model_path,
     tagged_texts,
@@ -280,12 +316,18 @@ def stream_layer_forward(
 
     model, tokenizer = load_model_with_strict_fallback(model_path, lazy=True)
     inner = _get_backbone(model)
+    args = getattr(model, "args", None)
     layers = inner.layers
     moe_layer_indices, num_experts, top_k = _moe_scan(layers)
 
+    # Derived up front from every tagged text (not the post-encode-filter
+    # sample list below) so a source whose samples all encode to empty still
+    # shows up in meta, matching collect_saliency's up-front `sources`.
+    all_sources = list(dict.fromkeys(s for s, _ in tagged_texts))
+
     embed = inner.embed_tokens
     mx.eval(embed.parameters())
-    hidden_size = getattr(getattr(model, "args", None), "hidden_size", 0) or 1
+    hidden_size = getattr(args, "hidden_size", 0) or 1
     scale = _embed_normalizer(model, inner, hidden_size)
     hidden, token_ids, sample_sources = [], [], []
     for source, text in tagged_texts:
@@ -298,7 +340,7 @@ def stream_layer_forward(
         token_ids.append(ids)
         sample_sources.append(source)
 
-    tied = bool(getattr(getattr(model, "args", None), "tie_word_embeddings", False))
+    tied = bool(getattr(args, "tie_word_embeddings", False))
     if not keep_head:
         head = getattr(model, "lm_head", None)
         if head is not None:
@@ -334,7 +376,13 @@ def stream_layer_forward(
             # which applies the mask via mx.where(mask, scores, min) — an
             # additive float mask is nonzero (truthy) exactly where it should
             # be falsy, inverting the causal direction. See task-4-report.md.
-            mask = create_causal_mask(seq_len) if seq_len > 1 else None
+            # Per-layer window_size mirrors sliding-attention layers (gpt_oss
+            # etc.) — a global unwindowed mask silently over-attends on those
+            # layers once seq_len exceeds the window. See task-4-report.md.
+            window = _layer_window_size(inner, args, li, layer)
+            mask = (
+                create_causal_mask(seq_len, window_size=window) if seq_len > 1 else None
+            )
             out = layer(hidden[si], mask=mask, cache=cache_i)
             hidden[si] = out[0] if isinstance(out, (tuple, list)) else out
             mx.eval(hidden[si])
@@ -356,11 +404,11 @@ def stream_layer_forward(
             per_sample_final(si, sample_sources[si], head(h), token_ids[si])
 
     return {
-        "model_type": getattr(getattr(model, "args", None), "model_type", "unknown"),
+        "model_type": getattr(args, "model_type", "unknown"),
         "num_experts": num_experts,
         "top_k": top_k,
         "moe_layer_indices": moe_layer_indices,
-        "sources": list(dict.fromkeys(sample_sources)),
+        "sources": all_sources,
         "num_samples": len(hidden),
         "max_tokens": max_tokens,
         "prepared_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),

--- a/olmlx/engine/reap/calibrate.py
+++ b/olmlx/engine/reap/calibrate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
 from pathlib import Path
 from typing import Any, Callable
@@ -13,6 +14,8 @@ import numpy as np
 
 from olmlx.engine.flash.prepare import load_model_with_strict_fallback
 from olmlx.engine.reap.arch import MoeModuleInfo, applied_scores, find_moe_module
+
+logger = logging.getLogger(__name__)
 
 
 class SaliencyAccumulator:
@@ -317,6 +320,24 @@ def stream_layer_forward(
     layers = inner.layers
     moe_layer_indices, num_experts, top_k = _moe_scan(layers)
 
+    # Window detection is best-effort (known conventions only). If the config
+    # advertises a sliding window but no layer matched any convention, the
+    # masks below would silently over-attend past the window — make it loud.
+    layer_windows = [
+        _layer_window_size(inner, args, li, layer) for li, layer in enumerate(layers)
+    ]
+    if getattr(args, "sliding_window", None) and not any(
+        w is not None for w in layer_windows
+    ):
+        logger.warning(
+            "config advertises sliding_window=%s but no layer matched a known "
+            "sliding-attention convention (layer_types / is_sliding / "
+            "use_sliding_window); streaming calibration will use full causal "
+            "masks and its saliency may diverge from the model's real "
+            "attention pattern",
+            getattr(args, "sliding_window", None),
+        )
+
     # Derived up front from every tagged text (not the post-encode-filter
     # sample list below) so a source whose samples all encode to empty still
     # shows up in meta, matching collect_saliency's up-front `sources`.
@@ -376,7 +397,7 @@ def stream_layer_forward(
             # Per-layer window_size mirrors sliding-attention layers (gpt_oss
             # etc.) — a global unwindowed mask silently over-attends on those
             # layers once seq_len exceeds the window. See task-4-report.md.
-            window = _layer_window_size(inner, args, li, layer)
+            window = layer_windows[li]
             mask = (
                 create_causal_mask(seq_len, window_size=window) if seq_len > 1 else None
             )

--- a/olmlx/engine/reap/calibrate.py
+++ b/olmlx/engine/reap/calibrate.py
@@ -369,6 +369,13 @@ def stream_layer_forward(
     gc.collect()
     mx.clear_cache()
 
+    # One cache list per sample, built once (O(S*L) constructions instead of
+    # O(S*L^2) from calling make_prompt_cache inside the double loop). Each
+    # entry is still used exactly once — fresh per (sample, layer), the
+    # GDN-safety requirement — and dropped right after its forward so live KV
+    # state never exceeds one forward's worth.
+    sample_caches = [make_prompt_cache(model) for _ in hidden]
+
     source_ref = {"idx": 0}
     layer_pos = 0
     for li, layer in enumerate(layers):
@@ -385,7 +392,7 @@ def stream_layer_forward(
                 source_ref["idx"] = acc.sources.index(sample_sources[si])
             # Fresh per (sample, layer) cache: GDN-safe (recurrent state must
             # not carry across independent forward passes at this layer).
-            cache_i = make_prompt_cache(model)[li]
+            cache_i = sample_caches[si][li]
             seq_len = hidden[si].shape[1]
             # Boolean mask (True=attend), matching what each arch's own
             # full-forward builds via create_attention_mask(..., return_array=True)
@@ -404,6 +411,7 @@ def stream_layer_forward(
             out = layer(hidden[si], mask=mask, cache=cache_i)
             hidden[si] = out[0] if isinstance(out, (tuple, list)) else out
             mx.eval(hidden[si])
+            sample_caches[si][li] = None  # drop this cache's KV state now
         if tap_installed:
             remove_taps([layer], tap_installed)
         _nullify_module_params(layer)

--- a/olmlx/engine/reap/calibrate.py
+++ b/olmlx/engine/reap/calibrate.py
@@ -323,9 +323,9 @@ def stream_layer_forward(
         for si in range(len(hidden)):
             if tap_installed:
                 source_ref["idx"] = acc.sources.index(sample_sources[si])
-            cache_i = make_prompt_cache(model)[
-                li
-            ]  # fresh per (sample, layer): GDN-safe
+            # Fresh per (sample, layer) cache: GDN-safe (recurrent state must
+            # not carry across independent forward passes at this layer).
+            cache_i = make_prompt_cache(model)[li]
             seq_len = hidden[si].shape[1]
             # Boolean mask (True=attend), matching what each arch's own
             # full-forward builds via create_attention_mask(..., return_array=True)

--- a/olmlx/engine/reap/calibrate.py
+++ b/olmlx/engine/reap/calibrate.py
@@ -360,7 +360,7 @@ def stream_layer_forward(
                 tap._layer_pos = layer_pos  # renumber from per-call 0 to global ordinal
                 layer_pos += 1
         for si in range(len(hidden)):
-            if tap_installed:
+            if tap_installed and acc is not None:
                 source_ref["idx"] = acc.sources.index(sample_sources[si])
             # Fresh per (sample, layer) cache: GDN-safe (recurrent state must
             # not carry across independent forward passes at this layer).

--- a/olmlx/engine/reap/calibrate.py
+++ b/olmlx/engine/reap/calibrate.py
@@ -12,6 +12,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
+from olmlx.engine.flash.prepare import load_model_with_strict_fallback
 from olmlx.engine.reap.arch import MoeModuleInfo, applied_scores, find_moe_module
 
 logger = logging.getLogger(__name__)
@@ -235,4 +236,155 @@ def collect_saliency(
         "max_tokens": max_tokens,
         "prepared_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
+    return acc, meta
+
+
+def _resolve_head(model, inner):
+    """Returns (norm, head_fn) for final logits; head_fn may use tied embeddings."""
+    norm = getattr(inner, "norm", None) or getattr(inner, "final_layernorm", None)
+    lm_head = getattr(model, "lm_head", None)
+    if lm_head is not None:
+        return norm, lm_head
+    return norm, inner.embed_tokens.as_linear
+
+
+def stream_layer_forward(
+    model_path,
+    tagged_texts,
+    *,
+    max_tokens=512,
+    acc: SaliencyAccumulator | None = None,
+    keep_head=False,
+    per_sample_final=None,
+    progress_callback=None,
+):
+    """Layer-at-a-time streaming forward over a lazily-loaded model.
+
+    One disk pass; peak RAM ~= one layer + all sample hidden states. With `acc`
+    set, installs SaliencyTaps on MoE layers (calibration). With `keep_head`,
+    applies final norm + lm_head per sample and calls
+    per_sample_final(sample_idx, source, logits, token_ids) (perplexity).
+    Consumes the model (layers are nullified as it advances).
+    Returns the meta dict (same shape as collect_saliency's).
+    """
+    import gc
+
+    from mlx_lm.models.base import create_causal_mask
+    from mlx_lm.models.cache import make_prompt_cache
+
+    from olmlx.engine.flash.prepare import (
+        _embed_normalizer,
+        _get_backbone,
+        _nullify_module_params,
+    )
+
+    model, tokenizer = load_model_with_strict_fallback(model_path, lazy=True)
+    inner = _get_backbone(model)
+    layers = inner.layers
+    moe_layer_indices, num_experts, top_k = _moe_scan(layers)
+
+    embed = inner.embed_tokens
+    mx.eval(embed.parameters())
+    hidden_size = getattr(getattr(model, "args", None), "hidden_size", 0) or 1
+    scale = _embed_normalizer(model, inner, hidden_size)
+    hidden, token_ids, sample_sources = [], [], []
+    for source, text in tagged_texts:
+        ids = _encode(tokenizer, text, max_tokens)
+        if not ids:
+            continue
+        h = embed(mx.array([ids])) * scale
+        mx.eval(h)
+        hidden.append(h)
+        token_ids.append(ids)
+        sample_sources.append(source)
+
+    tied = bool(getattr(getattr(model, "args", None), "tie_word_embeddings", False))
+    if not keep_head:
+        head = getattr(model, "lm_head", None)
+        if head is not None:
+            _nullify_module_params(head)
+        if not tied:
+            _nullify_module_params(embed)
+    # keep_head: embed must survive when tied (it IS the head); norm+lm_head stay.
+    gc.collect()
+    mx.clear_cache()
+
+    source_ref = {"idx": 0}
+    layer_pos = 0
+    for li, layer in enumerate(layers):
+        mx.eval(layer.parameters())
+        tap_installed: list[tuple[int, Any, str]] = []
+        if acc is not None:
+            tap_installed = install_taps([layer], acc, source_ref)
+            if tap_installed:
+                tap = getattr(layer, tap_installed[0][2])
+                tap._layer_pos = layer_pos  # renumber from per-call 0 to global ordinal
+                layer_pos += 1
+        for si in range(len(hidden)):
+            if tap_installed:
+                source_ref["idx"] = acc.sources.index(sample_sources[si])
+            cache_i = make_prompt_cache(model)[
+                li
+            ]  # fresh per (sample, layer): GDN-safe
+            seq_len = hidden[si].shape[1]
+            # Boolean mask (True=attend), matching what each arch's own
+            # full-forward builds via create_attention_mask(..., return_array=True)
+            # (or the equivalent "causal" fast-path for seq_len <= window_size).
+            # A float additive mask (0/-1e9) breaks DeepSeek-V3's MLA attention,
+            # which applies the mask via mx.where(mask, scores, min) — an
+            # additive float mask is nonzero (truthy) exactly where it should
+            # be falsy, inverting the causal direction. See task-4-report.md.
+            mask = create_causal_mask(seq_len) if seq_len > 1 else None
+            out = layer(hidden[si], mask=mask, cache=cache_i)
+            hidden[si] = out[0] if isinstance(out, (tuple, list)) else out
+            mx.eval(hidden[si])
+        if tap_installed:
+            remove_taps([layer], tap_installed)
+        _nullify_module_params(layer)
+        gc.collect()
+        mx.clear_cache()
+        if progress_callback:
+            progress_callback(
+                f"Processed layer {li + 1}/{len(layers)}",
+                0.05 + (li + 1) / len(layers) * 0.9,
+            )
+
+    if keep_head and per_sample_final is not None:
+        norm, head = _resolve_head(model, inner)
+        for si in range(len(hidden)):
+            h = norm(hidden[si]) if norm is not None else hidden[si]
+            per_sample_final(si, sample_sources[si], head(h), token_ids[si])
+
+    return {
+        "model_type": getattr(getattr(model, "args", None), "model_type", "unknown"),
+        "num_experts": num_experts,
+        "top_k": top_k,
+        "moe_layer_indices": moe_layer_indices,
+        "sources": list(dict.fromkeys(sample_sources)),
+        "num_samples": len(hidden),
+        "max_tokens": max_tokens,
+        "prepared_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
+def calibrate_saliency_streaming(
+    model_path, tagged_texts, *, max_tokens=512, progress_callback=None
+):
+    sources = list(dict.fromkeys(s for s, _ in tagged_texts))
+    # geometry probe on a throwaway lazy skeleton is avoided: stream_layer_forward
+    # scans MoE geometry itself, but the accumulator needs dims up front — so size
+    # it lazily on first add via a thin pre-scan of the same lazy load.
+    model, _tok = load_model_with_strict_fallback(model_path, lazy=True)
+    from olmlx.engine.flash.prepare import _get_backbone
+
+    moe_layer_indices, num_experts, _top_k = _moe_scan(_get_backbone(model).layers)
+    del model
+    acc = SaliencyAccumulator(len(moe_layer_indices), num_experts, sources)
+    meta = stream_layer_forward(
+        model_path,
+        list(tagged_texts),
+        max_tokens=max_tokens,
+        acc=acc,
+        progress_callback=progress_callback,
+    )
     return acc, meta

--- a/olmlx/engine/reap/calibrate.py
+++ b/olmlx/engine/reap/calibrate.py
@@ -1,0 +1,238 @@
+"""REAP saliency calibration: taps, accumulator, full-forward + streaming drivers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from olmlx.engine.reap.arch import MoeModuleInfo, applied_scores, find_moe_module
+
+logger = logging.getLogger(__name__)
+
+
+class SaliencyAccumulator:
+    def __init__(
+        self, num_moe_layers: int, num_experts: int, sources: list[str]
+    ) -> None:
+        self.sources = list(sources)
+        self.sum = np.zeros(
+            (num_moe_layers, len(self.sources), num_experts), dtype=np.float64
+        )
+        self.count = np.zeros_like(self.sum, dtype=np.int64)
+
+    def add(
+        self,
+        layer_pos: int,
+        source_idx: int,
+        expert_ids: np.ndarray,
+        contribs: np.ndarray,
+    ) -> None:
+        np.add.at(self.sum[layer_pos, source_idx], expert_ids, contribs)
+        np.add.at(self.count[layer_pos, source_idx], expert_ids, 1)
+
+    def _source_indices(self, sources: list[str] | None) -> list[int]:
+        if sources is None:
+            return list(range(len(self.sources)))
+        missing = [s for s in sources if s not in self.sources]
+        if missing:
+            raise ValueError(
+                f"unknown sources {missing}; calibrated sources: {self.sources}"
+            )
+        return [self.sources.index(s) for s in sources]
+
+    def saliency(self, sources: list[str] | None = None) -> np.ndarray:
+        idx = self._source_indices(sources)
+        s = self.sum[:, idx].sum(axis=1)
+        c = self.count[:, idx].sum(axis=1)
+        return s / np.maximum(c, 1)
+
+    def frequency(self, sources: list[str] | None = None) -> np.ndarray:
+        idx = self._source_indices(sources)
+        return self.count[:, idx].sum(axis=1)
+
+
+def save_saliency(path: Path, acc: SaliencyAccumulator, meta: dict) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(
+        path,
+        sum=acc.sum,
+        count=acc.count,
+        sources=np.array(acc.sources),
+        meta=json.dumps(meta),
+    )
+
+
+def load_saliency(path: Path) -> tuple[SaliencyAccumulator, dict]:
+    data = np.load(path, allow_pickle=False)
+    sources = [str(s) for s in data["sources"]]
+    acc = SaliencyAccumulator(data["sum"].shape[0], data["sum"].shape[2], sources)
+    acc.sum = data["sum"].astype(np.float64)
+    acc.count = data["count"].astype(np.int64)
+    return acc, json.loads(str(data["meta"]))
+
+
+class _CaptureContainer(nn.Module):
+    def __init__(self, inner: Any, captured: dict) -> None:
+        super().__init__()
+        self.inner = inner
+        self._captured = captured
+
+    def __call__(self, x, inds, **kwargs):
+        out = self.inner(x, inds, **kwargs)
+        self._captured["inds"] = inds
+        self._captured["expert_outs"] = out
+        return out
+
+
+class _CaptureGate(nn.Module):
+    def __init__(self, inner: Any, captured: dict) -> None:
+        super().__init__()
+        self.inner = inner
+        self._captured = captured
+
+    def __call__(self, x):
+        out = self.inner(x)
+        self._captured["gate_out"] = out
+        return out
+
+
+class SaliencyTap(nn.Module):
+    """Replaces a MoE block attr on a decoder layer; records REAP contributions
+    from the block's own forward (no routing reimplementation on the hot path)."""
+
+    def __init__(
+        self,
+        info: MoeModuleInfo,
+        layer_pos: int,
+        acc: SaliencyAccumulator,
+        source_ref: dict[str, int],
+    ) -> None:
+        super().__init__()
+        self.inner = info.module
+        self._info = info
+        self._layer_pos = layer_pos
+        self._acc = acc
+        self._source_ref = source_ref
+
+    def __call__(self, x, *args, **kwargs):
+        info = self._info
+        container = getattr(self.inner, info.container_name)
+        gate = getattr(self.inner, info.gate_attr)
+        captured: dict = {}
+        setattr(self.inner, info.container_name, _CaptureContainer(container, captured))
+        setattr(self.inner, info.gate_attr, _CaptureGate(gate, captured))
+        try:
+            y = self.inner(x, *args, **kwargs)
+        finally:
+            setattr(self.inner, info.container_name, container)
+            setattr(self.inner, info.gate_attr, gate)
+        inds = captured["inds"]
+        scores = applied_scores(info.style, self.inner, captured["gate_out"], inds)
+        norms = mx.linalg.norm(captured["expert_outs"].astype(mx.float32), axis=-1)
+        contribs = np.asarray((scores * norms).reshape(-1), dtype=np.float64)
+        experts = np.asarray(inds.reshape(-1))
+        self._acc.add(self._layer_pos, self._source_ref["idx"], experts, contribs)
+        return y
+
+
+def install_taps(
+    model_layers,
+    acc: SaliencyAccumulator,
+    source_ref: dict[str, int],
+    *,
+    top_k_hint: int | None = None,
+) -> list[tuple[int, Any, str]]:
+    installed: list[tuple[int, Any, str]] = []
+    layer_pos = 0
+    for i, layer in enumerate(model_layers):
+        info = find_moe_module(layer, top_k_hint=top_k_hint)
+        if info is None:
+            continue
+        tap = SaliencyTap(info, layer_pos, acc, source_ref)
+        installed.append((i, info.module, info.attr_name))
+        setattr(layer, info.attr_name, tap)
+        layer_pos += 1
+    return installed
+
+
+def remove_taps(model_layers, installed: list[tuple[int, Any, str]]) -> None:
+    for i, original, attr in installed:
+        setattr(model_layers[i], attr, original)
+
+
+def _encode(tokenizer, text: str, max_tokens: int) -> list[int]:
+    tokens = tokenizer.encode(text)
+    if isinstance(tokens, dict):
+        tokens = tokens["input_ids"]
+    return list(tokens)[:max_tokens]
+
+
+def _moe_scan(layers, top_k_hint=None) -> tuple[list[int], int, int]:
+    indices, num_experts, top_k = [], 0, 0
+    for i, layer in enumerate(layers):
+        info = find_moe_module(layer, top_k_hint=top_k_hint)
+        if info is not None:
+            indices.append(i)
+            num_experts, top_k = info.num_experts, info.top_k
+    if not indices:
+        raise ValueError(
+            "model has no recognized MoE layers; REAP requires an MoE model"
+        )
+    return indices, num_experts, top_k
+
+
+def _backbone(model):
+    from olmlx.engine.flash.prepare import _get_backbone
+
+    return _get_backbone(model)
+
+
+def collect_saliency(
+    model,
+    tokenizer,
+    tagged_texts: list[tuple[str, str]],
+    *,
+    max_tokens: int = 512,
+    progress_callback: Callable[[str, float], None] | None = None,
+) -> tuple[SaliencyAccumulator, dict]:
+    """Full-forward (non-streaming) saliency collection for models that fit in RAM."""
+    inner = _backbone(model)
+    layers = inner.layers
+    moe_layer_indices, num_experts, top_k = _moe_scan(layers)
+    sources = list(dict.fromkeys(s for s, _ in tagged_texts))
+    acc = SaliencyAccumulator(len(moe_layer_indices), num_experts, sources)
+    source_ref = {"idx": 0}
+    installed = install_taps(layers, acc, source_ref)
+    try:
+        for n, (source, text) in enumerate(tagged_texts):
+            source_ref["idx"] = sources.index(source)
+            ids = _encode(tokenizer, text, max_tokens)
+            if not ids:
+                continue
+            mx.eval(model(mx.array([ids])))
+            if progress_callback:
+                progress_callback(
+                    f"Calibrated {n + 1}/{len(tagged_texts)} samples",
+                    (n + 1) / len(tagged_texts),
+                )
+    finally:
+        remove_taps(layers, installed)
+    meta = {
+        "model_type": getattr(getattr(model, "args", None), "model_type", "unknown"),
+        "num_experts": num_experts,
+        "top_k": top_k,
+        "moe_layer_indices": moe_layer_indices,
+        "sources": sources,
+        "num_samples": len(tagged_texts),
+        "max_tokens": max_tokens,
+        "prepared_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    return acc, meta

--- a/olmlx/engine/reap/calibrate.py
+++ b/olmlx/engine/reap/calibrate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import time
 from pathlib import Path
 from typing import Any, Callable
@@ -14,8 +13,6 @@ import numpy as np
 
 from olmlx.engine.flash.prepare import load_model_with_strict_fallback
 from olmlx.engine.reap.arch import MoeModuleInfo, applied_scores, find_moe_module
-
-logger = logging.getLogger(__name__)
 
 
 class SaliencyAccumulator:

--- a/olmlx/engine/reap/corpus.py
+++ b/olmlx/engine/reap/corpus.py
@@ -1,0 +1,166 @@
+"""Calibration corpus builder: per-source tagging, CJK filter, round-robin interleave.
+
+Ports the kimi-k3-mlx corpus lessons: per-language C4 configs (pooled multilingual
+C4 is ~97% Latin script), sources interleaved not concatenated (calibration reads
+a prefix), and a CJK-fraction filter to drop mojibake documents.
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+from dataclasses import dataclass
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+_CJK_RANGES = (
+    (0x4E00, 0x9FFF),
+    (0x3400, 0x4DBF),  # CJK unified + ext A
+    (0x3040, 0x30FF),  # hiragana + katakana
+    (0xAC00, 0xD7AF),  # hangul
+)
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    name: str
+    dataset: str
+    config: str | None
+    split: str
+    text_key: str
+    min_chars: int = 100
+    min_cjk_fraction: float = 0.0
+    data_dir: str | None = None
+
+
+BUILTIN_SOURCES: dict[str, SourceSpec] = {
+    "english": SourceSpec("english", "allenai/c4", "en", "train", "text"),
+    "chinese": SourceSpec(
+        "chinese", "allenai/c4", "zh", "train", "text", min_cjk_fraction=0.3
+    ),
+    "code": SourceSpec(
+        "code",
+        "bigcode/the-stack-smol",
+        None,
+        "train",
+        "content",
+        data_dir="data/python",
+    ),
+}
+
+
+def cjk_fraction(text: str) -> float:
+    if not text:
+        return 0.0
+    hits = sum(1 for ch in text if any(lo <= ord(ch) <= hi for lo, hi in _CJK_RANGES))
+    return hits / len(text)
+
+
+_SYNTH_TEMPLATES = {
+    "english": "The {0} of {1} is a widely studied subject in modern research. ",
+    "chinese": "关于{0}与{1}的研究是现代学术领域的重要课题。",
+    "code": "def process_{0}(data):\n    result = [x for x in data if x.{1}]\n    return result\n",
+}
+_SYNTH_TOPICS = [
+    "history",
+    "structure",
+    "analysis",
+    "theory",
+    "design",
+    "behavior",
+    "origin",
+    "measurement",
+    "classification",
+    "evolution",
+    "dynamics",
+    "composition",
+]
+
+
+def synthetic_source_texts(source: str, n: int) -> list[str]:
+    template = _SYNTH_TEMPLATES.get(source, _SYNTH_TEMPLATES["english"])
+    texts = []
+    for i in range(n):
+        a = _SYNTH_TOPICS[i % len(_SYNTH_TOPICS)]
+        b = _SYNTH_TOPICS[(i + 7) % len(_SYNTH_TOPICS)]
+        texts.append((template.format(a, b)) * 12)
+    return texts
+
+
+def _stream_source(spec: SourceSpec, n: int, *, skip: int, char_cap: int) -> list[str]:
+    import datasets
+
+    kwargs = {"split": spec.split, "streaming": True}
+    if spec.data_dir:
+        kwargs["data_dir"] = spec.data_dir
+    stream = (
+        datasets.load_dataset(spec.dataset, spec.config, **kwargs)
+        if spec.config
+        else datasets.load_dataset(spec.dataset, **kwargs)
+    )
+    accepted: list[str] = []
+    to_skip = skip
+    try:
+        for row in stream:
+            text = row.get(spec.text_key, "")
+            if len(text) < spec.min_chars:
+                continue
+            if spec.min_cjk_fraction and cjk_fraction(text) < spec.min_cjk_fraction:
+                continue
+            if to_skip > 0:
+                to_skip -= 1
+                continue
+            accepted.append(text[:char_cap])
+            if len(accepted) >= n:
+                break
+    finally:
+        close = getattr(stream, "close", None)
+        if close is not None:
+            close()
+    if len(accepted) < n:
+        raise RuntimeError(
+            f"source {spec.name!r} yielded only {len(accepted)}/{n} samples"
+        )
+    return accepted
+
+
+def build_calibration_corpus(
+    sources: list[str],
+    samples_per_source: int,
+    *,
+    skip: int = 0,
+    char_cap: int = 4096,
+    progress_callback: Callable[[str, float], None] | None = None,
+) -> list[tuple[str, str]]:
+    unknown = [s for s in sources if s not in BUILTIN_SOURCES]
+    if unknown:
+        raise ValueError(
+            f"unknown calibration sources {unknown}; "
+            f"available: {sorted(BUILTIN_SOURCES)}"
+        )
+    per_source: dict[str, list[str]] = {}
+    for i, name in enumerate(sources):
+        spec = BUILTIN_SOURCES[name]
+        try:
+            per_source[name] = _stream_source(
+                spec, samples_per_source, skip=skip, char_cap=char_cap
+            )
+        except Exception as exc:  # noqa: BLE001 — mirror _get_c4_calibration_data
+            logger.warning(
+                "calibration source %s unavailable (%s); using synthetic fallback",
+                name,
+                exc,
+            )
+            per_source[name] = [
+                t[:char_cap] for t in synthetic_source_texts(name, samples_per_source)
+            ]
+        if progress_callback:
+            progress_callback(f"Fetched source {name}", (i + 1) / len(sources))
+    # round-robin interleave so a prefix read still covers every source
+    tagged: list[tuple[str, str]] = []
+    for row in itertools.zip_longest(
+        *([(name, t) for t in per_source[name]] for name in sources)
+    ):
+        tagged.extend(item for item in row if item is not None)
+    return tagged

--- a/olmlx/engine/reap/plan.py
+++ b/olmlx/engine/reap/plan.py
@@ -1,0 +1,166 @@
+"""REAP keep/drop (+bank) planning from calibrated saliency."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+PLAN_VERSION = 1
+
+
+@dataclass
+class ReapPlan:
+    mode: str
+    moe_layer_indices: list[int]
+    keep: dict[int, list[int]]
+    bank_high: dict[int, list[int]] | None
+    high_bits: int | None
+    low_bits: int | None
+    num_experts_orig: int
+    top_k: int
+    meta: dict = field(default_factory=dict)
+
+
+def _validate(saliency: np.ndarray, moe_layer_indices, num_experts: int) -> None:
+    if saliency.shape != (len(moe_layer_indices), num_experts):
+        raise ValueError(
+            f"saliency shape {saliency.shape} != "
+            f"({len(moe_layer_indices)}, {num_experts})"
+        )
+
+
+def _top_ascending(scores: np.ndarray, k: int) -> list[int]:
+    order = np.lexsort(
+        (np.arange(len(scores)), -scores)
+    )  # score desc, index asc tiebreak
+    return sorted(int(i) for i in order[:k])
+
+
+def plan_uniform(saliency, moe_layer_indices, keep_count, *, top_k, num_experts):
+    _validate(saliency, moe_layer_indices, num_experts)
+    if not top_k <= keep_count <= num_experts:
+        raise ValueError(
+            f"keep_count={keep_count} must satisfy "
+            f"top_k={top_k} <= keep <= num_experts={num_experts}"
+        )
+    keep = {
+        layer: _top_ascending(saliency[pos], keep_count)
+        for pos, layer in enumerate(moe_layer_indices)
+    }
+    return ReapPlan(
+        "uniform", list(moe_layer_indices), keep, None, None, None, num_experts, top_k
+    )
+
+
+def plan_global(
+    saliency,
+    moe_layer_indices,
+    keep_fraction,
+    *,
+    top_k,
+    num_experts,
+    floor_multiple: int = 4,
+):
+    _validate(saliency, moe_layer_indices, num_experts)
+    L = len(moe_layer_indices)
+    budget = round(keep_fraction * L * num_experts)
+    floor = min(floor_multiple * top_k, num_experts)
+    if budget < floor * L:
+        raise ValueError(f"budget {budget} below floor {floor}*{L} layers")
+    norm = saliency / np.maximum(saliency.sum(axis=1, keepdims=True), 1e-12)
+    keep_sets: list[set[int]] = []
+    for pos in range(L):
+        keep_sets.append(set(_top_ascending(norm[pos], floor)))
+    remaining = budget - sum(len(s) for s in keep_sets)
+    flat = [
+        (-norm[pos, e], pos, e)
+        for pos in range(L)
+        for e in range(num_experts)
+        if e not in keep_sets[pos]
+    ]
+    flat.sort()
+    for _, pos, e in flat[:remaining]:
+        keep_sets[pos].add(e)
+    keep = {
+        layer: sorted(keep_sets[pos]) for pos, layer in enumerate(moe_layer_indices)
+    }
+    return ReapPlan(
+        "global", list(moe_layer_indices), keep, None, None, None, num_experts, top_k
+    )
+
+
+def plan_graded(
+    saliency,
+    moe_layer_indices,
+    keep_fraction,
+    *,
+    high_fraction,
+    high_bits,
+    low_bits,
+    top_k,
+    num_experts,
+    floor_multiple: int = 4,
+):
+    base = plan_global(
+        saliency,
+        moe_layer_indices,
+        keep_fraction,
+        top_k=top_k,
+        num_experts=num_experts,
+        floor_multiple=floor_multiple,
+    )
+    bank_high: dict[int, list[int]] = {}
+    for pos, layer in enumerate(moe_layer_indices):
+        kept = base.keep[layer]
+        n_high = math.ceil(high_fraction * len(kept))
+        kept_scores = saliency[pos, kept]
+        order = np.lexsort((np.arange(len(kept)), -kept_scores))
+        bank_high[layer] = sorted(int(kept[i]) for i in order[:n_high])
+    return ReapPlan(
+        "graded",
+        base.moe_layer_indices,
+        base.keep,
+        bank_high,
+        high_bits,
+        low_bits,
+        num_experts,
+        top_k,
+    )
+
+
+def save_plan(plan: ReapPlan, path: Path) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = asdict(plan)
+    payload["version"] = PLAN_VERSION
+    payload["keep"] = {str(k): v for k, v in plan.keep.items()}
+    if plan.bank_high is not None:
+        payload["bank_high"] = {str(k): v for k, v in plan.bank_high.items()}
+    path.write_text(json.dumps(payload, indent=2))
+
+
+def load_plan(path: Path) -> ReapPlan:
+    raw = json.loads(Path(path).read_text())
+    if raw.get("version") != PLAN_VERSION:
+        raise ValueError(f"unsupported reap plan version {raw.get('version')}")
+    keep = {int(k): list(v) for k, v in raw["keep"].items()}
+    bank_high = (
+        {int(k): list(v) for k, v in raw["bank_high"].items()}
+        if raw.get("bank_high")
+        else None
+    )
+    return ReapPlan(
+        raw["mode"],
+        list(raw["moe_layer_indices"]),
+        keep,
+        bank_high,
+        raw.get("high_bits"),
+        raw.get("low_bits"),
+        raw["num_experts_orig"],
+        raw["top_k"],
+        raw.get("meta", {}),
+    )

--- a/olmlx/engine/reap/report.py
+++ b/olmlx/engine/reap/report.py
@@ -1,0 +1,109 @@
+"""REAP reporting: per-source expert-overlap analysis and the held-out
+perplexity gate the kimi-k3-mlx repo explicitly lacked."""
+
+from __future__ import annotations
+
+import itertools
+import math
+from pathlib import Path
+from typing import Callable
+
+import mlx.core as mx
+import numpy as np
+
+from olmlx.engine.reap.calibrate import SaliencyAccumulator, load_saliency
+
+
+def source_overlap(acc: SaliencyAccumulator, keep_count: int) -> dict:
+    num_layers, _, num_experts = acc.sum.shape
+    tops: dict[str, list[set[int]]] = {}
+    for source in acc.sources:
+        sal = acc.saliency([source])
+        tops[source] = [
+            set(np.argsort(-sal[layer])[:keep_count].tolist())
+            for layer in range(num_layers)
+        ]
+    pairs = {}
+    for a, b in itertools.combinations(acc.sources, 2):
+        per_layer = [
+            len(tops[a][layer] & tops[b][layer]) / keep_count
+            for layer in range(num_layers)
+        ]
+        pairs[f"{a}|{b}"] = {
+            "mean_overlap": float(np.mean(per_layer)),
+            "per_layer": per_layer,
+        }
+    return {
+        "pairs": pairs,
+        "chance": keep_count / num_experts,
+        "keep_count": keep_count,
+    }
+
+
+def streaming_perplexity(
+    model_path: str,
+    tagged_texts,
+    *,
+    max_tokens: int = 512,
+    progress_callback: Callable[[str, float], None] | None = None,
+) -> dict[str, float]:
+    from olmlx.engine.reap import calibrate as cal_mod
+
+    totals: dict[str, list[float]] = {}
+
+    def on_final(
+        sample_idx: int, source: str, logits: mx.array, ids: list[int]
+    ) -> None:
+        if len(ids) < 2:
+            return
+        lg = logits.astype(mx.float32)[:, :-1]
+        logprobs = lg - mx.logsumexp(lg, axis=-1, keepdims=True)
+        tgt = mx.array([ids[1:]])
+        nll = float(-mx.take_along_axis(logprobs, tgt[..., None], axis=-1).sum())
+        acc = totals.setdefault(source, [0.0, 0])
+        acc[0] += nll
+        acc[1] += len(ids) - 1
+
+    cal_mod.stream_layer_forward(
+        model_path,
+        list(tagged_texts),
+        max_tokens=max_tokens,
+        keep_head=True,
+        per_sample_final=on_final,
+        progress_callback=progress_callback,
+    )
+    return {source: math.exp(nll / max(n, 1)) for source, (nll, n) in totals.items()}
+
+
+def build_report(
+    saliency_path: Path,
+    *,
+    keep_count: int,
+    full_model_dir: str | None = None,
+    pruned_model_dir: str | None = None,
+    held_out_texts=None,
+    max_tokens: int = 512,
+    progress_callback=None,
+) -> dict:
+    acc, meta = load_saliency(saliency_path)
+    report: dict = {
+        "overlap": source_overlap(acc, keep_count),
+        "meta": meta,
+        "perplexity": None,
+    }
+    if full_model_dir and pruned_model_dir and held_out_texts:
+        full = streaming_perplexity(
+            full_model_dir,
+            held_out_texts,
+            max_tokens=max_tokens,
+            progress_callback=progress_callback,
+        )
+        pruned = streaming_perplexity(
+            pruned_model_dir,
+            held_out_texts,
+            max_tokens=max_tokens,
+            progress_callback=progress_callback,
+        )
+        ratio = {s: pruned[s] / full[s] for s in full if s in pruned}
+        report["perplexity"] = {"full": full, "pruned": pruned, "ratio": ratio}
+    return report

--- a/olmlx/engine/reap/verify.py
+++ b/olmlx/engine/reap/verify.py
@@ -1,7 +1,8 @@
 """Equivalence checking for REAP pruning: mask dropped experts on the full model
 and compare against the pruned artifact.
 
-Also the runtime backbone of `reap report`'s sanity check. The rotation test in
+Exercised today by the invariant tests only (no runtime callers); wiring it
+into `reap report`'s sanity check is phase-3 territory. The rotation test in
 tests/test_reap_equivalence.py proves this check can detect misrouting; keep it
 sensitive (max-abs on logits, no mean-pooling).
 

--- a/olmlx/engine/reap/verify.py
+++ b/olmlx/engine/reap/verify.py
@@ -75,10 +75,10 @@ def mask_dropped_experts(model, keep: dict[int, list[int]]) -> Callable[[], None
             orig_bias = gate.e_score_correction_bias
             gate.e_score_correction_bias = orig_bias + neg
 
-            def _restore(g=gate, b=orig_bias):
+            def _restore_gate_bias(g=gate, b=orig_bias):
                 g.e_score_correction_bias = b
 
-            restores.append(_restore)
+            restores.append(_restore_gate_bias)
         elif info.style == STYLE_MINIMAX:
             # bias lives on the MoE block itself, not under a nested gate
             # module (structural difference from DeepSeek) — same
@@ -87,18 +87,18 @@ def mask_dropped_experts(model, keep: dict[int, list[int]]) -> Callable[[], None
             orig_bias = block.e_score_correction_bias
             block.e_score_correction_bias = orig_bias + neg
 
-            def _restore(m=block, b=orig_bias):
+            def _restore_block_bias(m=block, b=orig_bias):
                 m.e_score_correction_bias = b
 
-            restores.append(_restore)
+            restores.append(_restore_block_bias)
         else:
             gate = getattr(info.module, info.gate_attr)
             setattr(info.module, info.gate_attr, _MaskedGate(gate, neg))
 
-            def _restore(m=info.module, a=info.gate_attr, g=gate):
+            def _restore_wrapped_gate(m=info.module, a=info.gate_attr, g=gate):
                 setattr(m, a, g)
 
-            restores.append(_restore)
+            restores.append(_restore_wrapped_gate)
 
     def restore_all() -> None:
         for r in reversed(restores):

--- a/olmlx/engine/reap/verify.py
+++ b/olmlx/engine/reap/verify.py
@@ -1,0 +1,88 @@
+"""Equivalence checking for REAP pruning: mask dropped experts on the full model
+and compare against the pruned artifact.
+
+Also the runtime backbone of `reap report`'s sanity check. The rotation test in
+tests/test_reap_equivalence.py proves this check can detect misrouting; keep it
+sensitive (max-abs on logits, no mean-pooling)."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from olmlx.engine.reap.arch import STYLE_DEEPSEEK, find_moe_module
+
+
+class _MaskedGate(nn.Module):
+    """Additive -inf on dropped experts' logits; exact removal from softmax mass."""
+
+    def __init__(self, inner: Any, mask_vec: mx.array) -> None:
+        super().__init__()
+        self.inner = inner
+        self._mask_vec = mask_vec
+
+    def __call__(self, x):
+        return self.inner(x) + self._mask_vec
+
+
+def _dropped_mask(num_experts: int, kept: list[int]) -> mx.array:
+    """-inf (additive) at dropped expert positions, 0.0 at kept ones.
+
+    mlx arrays don't support item assignment, so build this via mx.where over
+    a boolean membership array rather than in-place indexed writes.
+    """
+    kept_set = set(kept)
+    is_dropped = mx.array([e not in kept_set for e in range(num_experts)])
+    mask = mx.where(is_dropped, mx.array(-mx.inf), mx.array(0.0))
+    return mask
+
+
+def mask_dropped_experts(model, keep: dict[int, list[int]]) -> Callable[[], None]:
+    """Forces dropped experts unroutable IN PLACE on the full model; returns restore()."""
+    inner = getattr(model, "model", model)
+    layers = inner.layers
+    restores: list[Callable[[], None]] = []
+    for layer_idx, kept in keep.items():
+        info = find_moe_module(layers[layer_idx])
+        if info is None:
+            raise ValueError(f"layer {layer_idx} has no MoE module")
+        dropped = [e for e in range(info.num_experts) if e not in set(kept)]
+        if not dropped:
+            continue
+        neg = _dropped_mask(info.num_experts, kept)
+
+        if info.style == STYLE_DEEPSEEK:
+            gate = info.module.gate
+            orig_bias = gate.e_score_correction_bias
+            gate.e_score_correction_bias = orig_bias + neg
+
+            def _restore(g=gate, b=orig_bias):
+                g.e_score_correction_bias = b
+
+            restores.append(_restore)
+        else:
+            gate = getattr(info.module, info.gate_attr)
+            setattr(info.module, info.gate_attr, _MaskedGate(gate, neg))
+
+            def _restore(m=info.module, a=info.gate_attr, g=gate):
+                setattr(m, a, g)
+
+            restores.append(_restore)
+
+    def restore_all() -> None:
+        for r in reversed(restores):
+            r()
+
+    return restore_all
+
+
+def max_logit_divergence(model_a, model_b, batches: list[mx.array]) -> float:
+    """max |logits_a - logits_b| over the batches (float32 compare)."""
+    worst = 0.0
+    for batch in batches:
+        la = model_a(batch).astype(mx.float32)
+        lb = model_b(batch).astype(mx.float32)
+        worst = max(worst, float(mx.max(mx.abs(la - lb))))
+    return worst

--- a/olmlx/engine/reap/verify.py
+++ b/olmlx/engine/reap/verify.py
@@ -3,7 +3,21 @@ and compare against the pruned artifact.
 
 Also the runtime backbone of `reap report`'s sanity check. The rotation test in
 tests/test_reap_equivalence.py proves this check can detect misrouting; keep it
-sensitive (max-abs on logits, no mean-pooling)."""
+sensitive (max-abs on logits, no mean-pooling).
+
+Two masking mechanisms, chosen per router style:
+- Plain linear-gate / gpt-oss styles select straight off the gate/router's raw
+  logits, so an additive -inf on those logits (`_MaskedGate`) removes dropped
+  experts from the softmax mass exactly.
+- DeepSeek and MiniMax select off a *bias-corrected sigmoid* score
+  (`sigmoid(logits) + e_score_correction_bias`) while still *weighting* by the
+  uncorrected sigmoid — sigmoid(-inf) is exactly 0, so masking the logits
+  would be washed out by the correction bias and a dropped expert could still
+  win selection. Both instead mask the correction bias itself
+  (selection-only, matching the issue's stated equivalence form). The two
+  differ structurally in *where* that bias lives: DeepSeek's is nested under
+  a separate gate module (`gate.e_score_correction_bias`); MiniMax's sits
+  directly on the MoE block (`block.e_score_correction_bias`)."""
 
 from __future__ import annotations
 
@@ -12,11 +26,14 @@ from typing import Any, Callable
 import mlx.core as mx
 import mlx.nn as nn
 
-from olmlx.engine.reap.arch import STYLE_DEEPSEEK, find_moe_module
+from olmlx.engine.reap.arch import STYLE_DEEPSEEK, STYLE_MINIMAX, find_moe_module
 
 
 class _MaskedGate(nn.Module):
-    """Additive -inf on dropped experts' logits; exact removal from softmax mass."""
+    """Additive -inf on dropped experts' logits; exact removal from softmax mass.
+
+    Only sound for router styles that select directly off these logits (no
+    intervening bias-corrected score) — see module docstring."""
 
     def __init__(self, inner: Any, mask_vec: mx.array) -> None:
         super().__init__()
@@ -27,13 +44,12 @@ class _MaskedGate(nn.Module):
         return self.inner(x) + self._mask_vec
 
 
-def _dropped_mask(num_experts: int, kept: list[int]) -> mx.array:
+def _dropped_mask(num_experts: int, kept_set: set[int]) -> mx.array:
     """-inf (additive) at dropped expert positions, 0.0 at kept ones.
 
     mlx arrays don't support item assignment, so build this via mx.where over
     a boolean membership array rather than in-place indexed writes.
     """
-    kept_set = set(kept)
     is_dropped = mx.array([e not in kept_set for e in range(num_experts)])
     mask = mx.where(is_dropped, mx.array(-mx.inf), mx.array(0.0))
     return mask
@@ -48,10 +64,10 @@ def mask_dropped_experts(model, keep: dict[int, list[int]]) -> Callable[[], None
         info = find_moe_module(layers[layer_idx])
         if info is None:
             raise ValueError(f"layer {layer_idx} has no MoE module")
-        dropped = [e for e in range(info.num_experts) if e not in set(kept)]
-        if not dropped:
-            continue
-        neg = _dropped_mask(info.num_experts, kept)
+        kept_set = set(kept)
+        if len(kept_set) >= info.num_experts:
+            continue  # nothing dropped at this layer
+        neg = _dropped_mask(info.num_experts, kept_set)
 
         if info.style == STYLE_DEEPSEEK:
             gate = info.module.gate
@@ -60,6 +76,18 @@ def mask_dropped_experts(model, keep: dict[int, list[int]]) -> Callable[[], None
 
             def _restore(g=gate, b=orig_bias):
                 g.e_score_correction_bias = b
+
+            restores.append(_restore)
+        elif info.style == STYLE_MINIMAX:
+            # bias lives on the MoE block itself, not under a nested gate
+            # module (structural difference from DeepSeek) — same
+            # selection-only masking mechanism otherwise.
+            block = info.module
+            orig_bias = block.e_score_correction_bias
+            block.e_score_correction_bias = orig_bias + neg
+
+            def _restore(m=block, b=orig_bias):
+                m.e_score_correction_bias = b
 
             restores.append(_restore)
         else:

--- a/tests/reap_factories.py
+++ b/tests/reap_factories.py
@@ -1,0 +1,129 @@
+"""Tiny in-process MoE models for REAP tests. Never touches mlx_lm.load."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+
+def _build(module, args):
+    model = module.Model(args)
+    mx.eval(model.parameters())
+    return model, args
+
+
+def make_tiny_qwen3_moe(*, num_experts=8, top_k=2, num_layers=2, hidden=64, vocab=128):
+    from mlx_lm.models import qwen3_moe
+
+    args = qwen3_moe.ModelArgs(
+        model_type="qwen3_moe",
+        hidden_size=hidden,
+        num_hidden_layers=num_layers,
+        intermediate_size=hidden * 2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=hidden // 4,
+        rms_norm_eps=1e-5,
+        vocab_size=vocab,
+        rope_theta=10000.0,
+        max_position_embeddings=2048,
+        tie_word_embeddings=False,
+        num_experts=num_experts,
+        num_experts_per_tok=top_k,
+        moe_intermediate_size=hidden // 2,
+        decoder_sparse_step=1,
+        mlp_only_layers=[],
+        norm_topk_prob=True,
+    )
+    return _build(qwen3_moe, args)
+
+
+def make_tiny_gpt_oss(*, num_experts=8, top_k=2, num_layers=2, hidden=64, vocab=128):
+    from mlx_lm.models import gpt_oss
+
+    # GptOssMoeModel.__init__ requires both "sliding_attention" and
+    # "full_attention" to appear in layer_types (it indexes .index() on
+    # each), so an all-"full_attention" list (as sketched in the brief)
+    # raises ValueError. Alternate the two so both are always present.
+    layer_types = (["sliding_attention", "full_attention"] * ((num_layers + 1) // 2))[
+        :num_layers
+    ]
+
+    args = gpt_oss.ModelArgs(
+        model_type="gpt_oss",
+        hidden_size=hidden,
+        num_hidden_layers=num_layers,
+        intermediate_size=hidden // 2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=hidden // 4,
+        rms_norm_eps=1e-5,
+        vocab_size=vocab,
+        num_local_experts=num_experts,
+        num_experts_per_tok=top_k,
+        sliding_window=4096,
+        rope_theta=10000.0,
+        layer_types=layer_types,
+    )
+    return _build(gpt_oss, args)
+
+
+def make_tiny_deepseek_v3(
+    *, num_experts=8, top_k=2, num_layers=2, hidden=64, vocab=128
+):
+    from mlx_lm.models import deepseek_v3
+
+    args = deepseek_v3.ModelArgs(
+        model_type="deepseek_v3",
+        hidden_size=hidden,
+        num_hidden_layers=num_layers,
+        intermediate_size=hidden * 2,
+        moe_intermediate_size=hidden // 2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        vocab_size=vocab,
+        n_routed_experts=num_experts,
+        n_shared_experts=1,
+        num_experts_per_tok=top_k,
+        routed_scaling_factor=1.0,
+        topk_method="noaux_tc",
+        n_group=1,
+        topk_group=1,
+        norm_topk_prob=True,
+        first_k_dense_replace=1,
+        moe_layer_freq=1,
+        kv_lora_rank=16,
+        # DeepseekV3Attention branches on `q_lora_rank is None` to decide
+        # whether to build the low-rank query projection at all; 0 (as
+        # sketched in the brief) falls into the "build it" branch and
+        # nn.Linear(hidden_size, 0, ...) divides by zero in its scale
+        # calculation. None means "no q-LoRA", matching real dense-query
+        # configs.
+        q_lora_rank=None,
+        qk_rope_head_dim=16,
+        qk_nope_head_dim=16,
+        v_head_dim=16,
+        max_position_embeddings=2048,
+        rms_norm_eps=1e-5,
+        rope_theta=10000.0,
+    )
+    return _build(deepseek_v3, args)
+
+
+def tiny_config_dict(args, model_type: str) -> dict:
+    cfg = dataclasses.asdict(args)
+    cfg["model_type"] = model_type
+    return cfg
+
+
+def save_tiny_model(model, config: dict, out_dir: Path) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    weights = dict(tree_flatten(model.parameters()))
+    mx.eval(*weights.values())
+    mx.save_safetensors(str(out_dir / "model.safetensors"), weights)
+    (out_dir / "config.json").write_text(json.dumps(config, indent=2))
+    return out_dir

--- a/tests/reap_factories.py
+++ b/tests/reap_factories.py
@@ -42,7 +42,15 @@ def make_tiny_qwen3_moe(*, num_experts=8, top_k=2, num_layers=2, hidden=64, voca
     return _build(qwen3_moe, args)
 
 
-def make_tiny_gpt_oss(*, num_experts=8, top_k=2, num_layers=2, hidden=64, vocab=128):
+def make_tiny_gpt_oss(
+    *,
+    num_experts=8,
+    top_k=2,
+    num_layers=2,
+    hidden=64,
+    vocab=128,
+    sliding_window=4096,
+):
     from mlx_lm.models import gpt_oss
 
     # GptOssMoeModel.__init__ requires both "sliding_attention" and
@@ -53,6 +61,10 @@ def make_tiny_gpt_oss(*, num_experts=8, top_k=2, num_layers=2, hidden=64, vocab=
         :num_layers
     ]
 
+    # sliding_window defaults to 4096, which dwarfs the tests' 16-token
+    # sequences (sliding-window semantics can't diverge from full causal at
+    # that length). Callers that need real windowed-attention behavior (e.g.
+    # a streaming-vs-hooked regression test) pass a small value explicitly.
     args = gpt_oss.ModelArgs(
         model_type="gpt_oss",
         hidden_size=hidden,
@@ -65,7 +77,7 @@ def make_tiny_gpt_oss(*, num_experts=8, top_k=2, num_layers=2, hidden=64, vocab=
         vocab_size=vocab,
         num_local_experts=num_experts,
         num_experts_per_tok=top_k,
-        sliding_window=4096,
+        sliding_window=sliding_window,
         rope_theta=10000.0,
         layer_types=layer_types,
     )

--- a/tests/reap_factories.py
+++ b/tests/reap_factories.py
@@ -123,7 +123,23 @@ def make_tiny_deepseek_v3(
         rms_norm_eps=1e-5,
         rope_theta=10000.0,
     )
-    return _build(deepseek_v3, args)
+    model, args = _build(deepseek_v3, args)
+    # MoEGate.weight is a bare `mx.zeros(...)` attribute in mlx-lm's
+    # deepseek_v3.py (not an nn.Linear, so it's never touched by mlx's
+    # default random-init policy) — real usage always overwrites it via
+    # checkpoint load. Left at zero, `x @ weight.T` is identically 0 for
+    # every token, so top-k selection degenerates into a pure tie broken by
+    # argpartition's *unstable* tie-break, which is sensitive to incidental
+    # array memory layout (e.g. contiguous-after-eval vs a lazy gather) and
+    # produced flaky/order-dependent equivalence & rotation-detection
+    # results. Give it a small random draw so routing actually depends on
+    # the input, matching every other (nn.Linear-backed) router style.
+    for layer in model.model.layers:
+        gate = getattr(getattr(layer, "mlp", None), "gate", None)
+        if gate is not None and hasattr(gate, "weight"):
+            gate.weight = mx.random.normal(gate.weight.shape) * 0.02
+    mx.eval(model.parameters())
+    return model, args
 
 
 def tiny_config_dict(args, model_type: str) -> dict:

--- a/tests/test_reap_apply.py
+++ b/tests/test_reap_apply.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from olmlx.engine.reap.apply import (
+    ReapApplyError,
+    apply_plan,
+    rewrite_config_num_experts,
+)
+from olmlx.engine.reap.plan import ReapPlan
+from tests.reap_factories import (
+    make_tiny_deepseek_v3,
+    make_tiny_gpt_oss,
+    make_tiny_qwen3_moe,
+    save_tiny_model,
+    tiny_config_dict,
+)
+
+
+def _uniform_plan(moe_layers, keep, num_experts=8, top_k=2):
+    return ReapPlan(
+        "uniform",
+        list(moe_layers),
+        {layer: list(keep) for layer in moe_layers},
+        None,
+        None,
+        None,
+        num_experts,
+        top_k,
+    )
+
+
+def _save(factory, model_type, tmp_path, name="src"):
+    model, args = factory()
+    cfg = tiny_config_dict(args, model_type)
+    return save_tiny_model(model, cfg, tmp_path / name), model
+
+
+class TestIdentityNoOp:
+    """Invariant 1: identity prune is bit-for-bit a no-op."""
+
+    @pytest.mark.parametrize(
+        "factory,model_type,moe_layers",
+        [
+            (make_tiny_qwen3_moe, "qwen3_moe", [0, 1]),
+            (make_tiny_gpt_oss, "gpt_oss", [0, 1]),
+            (make_tiny_deepseek_v3, "deepseek_v3", [1]),
+        ],
+    )
+    def test_identity(self, tmp_path, factory, model_type, moe_layers):
+        src, _ = _save(factory, model_type, tmp_path)
+        plan = _uniform_plan(moe_layers, list(range(8)))
+        out = apply_plan(src, plan, tmp_path / "out")
+        a = mx.load(str(src / "model.safetensors"))
+        b = mx.load(str(out / "model.safetensors"))
+        assert set(a) == set(b)
+        for k in a:
+            assert a[k].dtype == b[k].dtype, k
+            assert mx.array_equal(a[k], b[k]), k
+        cfg_a = json.loads((src / "config.json").read_text())
+        cfg_b = json.loads((out / "config.json").read_text())
+        assert cfg_a == cfg_b
+
+
+class TestUniformPrune:
+    def test_shapes_config_and_router_rows(self, tmp_path):
+        src, model = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        keep = [0, 2, 5, 7]
+        plan = _uniform_plan([0, 1], keep)
+        out = apply_plan(src, plan, tmp_path / "out")
+        w = mx.load(str(out / "model.safetensors"))
+        orig = mx.load(str(src / "model.safetensors"))
+        for layer in (0, 1):
+            for proj in ("gate_proj", "up_proj", "down_proj"):
+                key = f"model.layers.{layer}.mlp.switch_mlp.{proj}.weight"
+                assert w[key].shape[0] == 4
+                assert mx.array_equal(w[key], orig[key][mx.array(keep)])
+            gate = f"model.layers.{layer}.mlp.gate.weight"
+            assert w[gate].shape[0] == 4
+            assert mx.array_equal(w[gate], orig[gate][mx.array(keep)])
+        cfg = json.loads((out / "config.json").read_text())
+        assert cfg["num_experts"] == 4
+
+    def test_gpt_oss_router_bias_and_expert_bias(self, tmp_path):
+        src, _ = _save(make_tiny_gpt_oss, "gpt_oss", tmp_path)
+        keep = [1, 3, 4, 6]
+        out = apply_plan(src, _uniform_plan([0, 1], keep), tmp_path / "out")
+        w = mx.load(str(out / "model.safetensors"))
+        orig = mx.load(str(src / "model.safetensors"))
+        rb = "model.layers.0.mlp.router.bias"
+        assert mx.array_equal(w[rb], orig[rb][mx.array(keep)])
+        eb = "model.layers.0.mlp.experts.gate_proj.bias"
+        assert w[eb].shape[0] == 4
+        cfg = json.loads((out / "config.json").read_text())
+        assert cfg["num_local_experts"] == 4
+
+    def test_deepseek_bias_and_shared_experts_untouched(self, tmp_path):
+        src, _ = _save(make_tiny_deepseek_v3, "deepseek_v3", tmp_path)
+        keep = [0, 1, 2, 3, 4, 5]
+        out = apply_plan(src, _uniform_plan([1], keep), tmp_path / "out")
+        w = mx.load(str(out / "model.safetensors"))
+        orig = mx.load(str(src / "model.safetensors"))
+        bias = "model.layers.1.mlp.gate.e_score_correction_bias"
+        assert w[bias].shape[0] == 6
+        shared = [k for k in orig if "shared_experts" in k]
+        assert shared, "factory should produce shared experts"
+        for k in shared:
+            assert mx.array_equal(w[k], orig[k]), k
+        cfg = json.loads((out / "config.json").read_text())
+        assert cfg["n_routed_experts"] == 6
+
+    def test_provenance_and_non_weight_copy(self, tmp_path):
+        src, _ = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        (src / "tokenizer_config.json").write_text("{}")
+        out = apply_plan(src, _uniform_plan([0, 1], [0, 1, 2, 3]), tmp_path / "out")
+        prov = json.loads((out / "reap_provenance.json").read_text())
+        assert prov["keep_count"] == 4 and prov["num_experts_orig"] == 8
+        assert (out / "tokenizer_config.json").exists()
+
+    def test_pruned_model_reloads_and_runs(self, tmp_path):
+        from mlx_lm.models import qwen3_moe
+
+        src, _ = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        out = apply_plan(src, _uniform_plan([0, 1], [0, 2, 5, 7]), tmp_path / "out")
+        cfg = json.loads((out / "config.json").read_text())
+        args = qwen3_moe.ModelArgs.from_dict(cfg)
+        pruned = qwen3_moe.Model(args)
+        pruned.load_weights(str(out / "model.safetensors"), strict=True)
+        logits = pruned(mx.array([[1, 2, 3]]))
+        assert logits.shape == (1, 3, cfg["vocab_size"])
+
+
+class TestGuards:
+    def test_rejects_non_uniform_plan(self, tmp_path):
+        src, _ = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        plan = ReapPlan(
+            "global", [0, 1], {0: [0, 1], 1: [0, 1]}, None, None, None, 8, 2
+        )
+        with pytest.raises(ReapApplyError, match="phase 3"):
+            apply_plan(src, plan, tmp_path / "out")
+
+    def test_rejects_top_k_above_keep(self, tmp_path):
+        src, _ = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        plan = ReapPlan("uniform", [0, 1], {0: [0], 1: [0]}, None, None, None, 8, 2)
+        with pytest.raises(ReapApplyError, match="num_experts_per_tok"):
+            apply_plan(src, plan, tmp_path / "out")
+
+    def test_unknown_expert_sized_tensor_is_error(self, tmp_path):
+        """The misrouting trap: an unrecognized E-sized tensor under the MoE prefix
+        must be a hard error, never a silent copy-through."""
+        src, model = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        w = mx.load(str(src / "model.safetensors"))
+        w["model.layers.0.mlp.mystery_bias"] = mx.zeros((8,))
+        mx.save_safetensors(str(src / "model.safetensors"), w)
+        with pytest.raises(ReapApplyError, match="mystery_bias"):
+            apply_plan(src, _uniform_plan([0, 1], [0, 1, 2, 3]), tmp_path / "out")
+
+
+class TestQuantizedSlicing:
+    def test_quantized_triple_sliced_together(self, tmp_path):
+        """Packed uint32 weight + scales + biases all slice on axis 0."""
+        from safetensors.numpy import save_file
+
+        E, out_dim, in_dim, gs = 8, 16, 32, 32
+        d = tmp_path / "qsrc"
+        d.mkdir()
+        rng = np.random.RandomState(0)
+        tensors = {}
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            base = f"model.layers.0.mlp.switch_mlp.{proj}"
+            tensors[f"{base}.weight"] = rng.randint(
+                0, 2**31, (E, out_dim, in_dim * 4 // 32), dtype=np.uint32
+            )
+            tensors[f"{base}.scales"] = rng.rand(E, out_dim, in_dim // gs).astype(
+                np.float16
+            )
+            tensors[f"{base}.biases"] = rng.rand(E, out_dim, in_dim // gs).astype(
+                np.float16
+            )
+        tensors["model.layers.0.mlp.gate.weight"] = rng.rand(E, 64).astype(np.float16)
+        save_file(tensors, str(d / "model.safetensors"))
+        (d / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "qwen3_moe",
+                    "num_experts": E,
+                    "num_experts_per_tok": 2,
+                    "num_hidden_layers": 1,
+                    "hidden_size": 64,
+                    "quantization": {"bits": 4, "group_size": gs},
+                }
+            )
+        )
+        keep = [0, 3, 6]
+        out = apply_plan(d, _uniform_plan([0], keep, num_experts=E), tmp_path / "qout")
+        w = mx.load(str(out / "model.safetensors"))
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            for comp in ("weight", "scales", "biases"):
+                key = f"model.layers.0.mlp.switch_mlp.{proj}.{comp}"
+                assert w[key].shape[0] == 3, key
+                assert w[key].dtype == mx.load(str(d / "model.safetensors"))[key].dtype
+
+
+class TestShardedIndex:
+    def test_multi_shard_with_index(self, tmp_path):
+        src, _ = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        # split the single file into two shards + index
+        w = mx.load(str(src / "model.safetensors"))
+        keys = sorted(w)
+        half = len(keys) // 2
+        s1 = {k: w[k] for k in keys[:half]}
+        s2 = {k: w[k] for k in keys[half:]}
+        mx.save_safetensors(str(src / "model-00001-of-00002.safetensors"), s1)
+        mx.save_safetensors(str(src / "model-00002-of-00002.safetensors"), s2)
+        (src / "model.safetensors").unlink()
+        index = {
+            "metadata": {"total_size": 0},
+            "weight_map": {k: "model-00001-of-00002.safetensors" for k in keys[:half]},
+        }
+        index["weight_map"].update(
+            {k: "model-00002-of-00002.safetensors" for k in keys[half:]}
+        )
+        (src / "model.safetensors.index.json").write_text(json.dumps(index))
+
+        out = apply_plan(src, _uniform_plan([0, 1], [0, 1, 2, 3]), tmp_path / "out")
+        new_index = json.loads((out / "model.safetensors.index.json").read_text())
+        assert set(new_index["weight_map"]) == set(keys)
+        shard_files = set(new_index["weight_map"].values())
+        assert len(shard_files) == 2
+        assert new_index["metadata"]["total_size"] == sum(
+            (out / f).stat().st_size for f in shard_files
+        )
+        merged = {}
+        for shard in set(new_index["weight_map"].values()):
+            merged.update(mx.load(str(out / shard)))
+        assert merged["model.layers.0.mlp.switch_mlp.gate_proj.weight"].shape[0] == 4
+
+
+class TestRewriteConfig:
+    def test_alias_probing_order(self):
+        cfg = {"num_experts": 8, "num_experts_per_tok": 2}
+        assert rewrite_config_num_experts(cfg, 4) == "num_experts"
+        assert cfg["num_experts"] == 4
+
+    def test_text_config_unwrap(self):
+        cfg = {"text_config": {"n_routed_experts": 8}}
+        assert rewrite_config_num_experts(cfg, 4) == "n_routed_experts"
+        assert cfg["text_config"]["n_routed_experts"] == 4

--- a/tests/test_reap_apply.py
+++ b/tests/test_reap_apply.py
@@ -284,3 +284,28 @@ class TestRewriteConfig:
         cfg = {"text_config": {"n_routed_experts": 8}}
         assert rewrite_config_num_experts(cfg, 4) == "n_routed_experts"
         assert cfg["text_config"]["n_routed_experts"] == 4
+
+
+class TestIndexlessLayouts:
+    def test_multi_shard_without_index_rejected(self, tmp_path):
+        src, _ = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        w = mx.load(str(src / "model.safetensors"))
+        keys = sorted(w)
+        half = len(keys) // 2
+        mx.save_safetensors(
+            str(src / "model-00001-of-00002.safetensors"),
+            {k: w[k] for k in keys[:half]},
+        )
+        mx.save_safetensors(
+            str(src / "model-00002-of-00002.safetensors"),
+            {k: w[k] for k in keys[half:]},
+        )
+        (src / "model.safetensors").unlink()
+        with pytest.raises(ReapApplyError, match="index"):
+            apply_plan(src, _uniform_plan([0, 1], [0, 1, 2, 3]), tmp_path / "out")
+
+    def test_no_safetensors_rejected(self, tmp_path):
+        src, _ = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        (src / "model.safetensors").unlink()
+        with pytest.raises(ReapApplyError, match="no .safetensors"):
+            apply_plan(src, _uniform_plan([0, 1], [0, 1, 2, 3]), tmp_path / "out")

--- a/tests/test_reap_apply.py
+++ b/tests/test_reap_apply.py
@@ -159,6 +159,40 @@ class TestGuards:
         with pytest.raises(ReapApplyError, match="mystery_bias"):
             apply_plan(src, _uniform_plan([0, 1], [0, 1, 2, 3]), tmp_path / "out")
 
+    def test_rejects_plan_num_experts_orig_mismatch(self, tmp_path):
+        """A stale/mismatched plan.num_experts_orig must be rejected up front —
+        otherwise _classify's error branch keys off the wrong count and an
+        unrecognized tensor sized to the checkpoint's ACTUAL expert count gets
+        copied through instead of erroring (the exact misrouting trap)."""
+        src, _ = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)  # actual: 8 experts
+        plan = _uniform_plan([0, 1], [0, 1, 2, 3], num_experts=4)  # stale: plan says 4
+        with pytest.raises(ReapApplyError, match="num_experts_orig"):
+            apply_plan(src, plan, tmp_path / "out")
+
+    def test_rejects_out_of_range_layer_index(self, tmp_path):
+        """Plan layers must be plausible against the checkpoint's
+        num_hidden_layers, or a typo'd layer index silently no-ops."""
+        src, _ = _save(
+            make_tiny_qwen3_moe, "qwen3_moe", tmp_path
+        )  # num_hidden_layers=2
+        plan = _uniform_plan([0, 5], [0, 1, 2, 3])
+        with pytest.raises(ReapApplyError, match="layer"):
+            apply_plan(src, plan, tmp_path / "out")
+
+    def test_rejects_grouped_routing_config(self, tmp_path):
+        """Uniform prune leaves n_group/topk_group untouched; on a
+        group-routed checkpoint that either breaks MoEGate's group reshape or
+        silently shifts group partition boundaries. Not supported yet."""
+        src, _ = _save(make_tiny_deepseek_v3, "deepseek_v3", tmp_path)
+        cfg_path = src / "config.json"
+        cfg = json.loads(cfg_path.read_text())
+        cfg["n_group"] = 4
+        cfg["topk_group"] = 2
+        cfg_path.write_text(json.dumps(cfg))
+        plan = _uniform_plan([1], list(range(6)), num_experts=8)
+        with pytest.raises(ReapApplyError, match="n_group"):
+            apply_plan(src, plan, tmp_path / "out")
+
 
 class TestQuantizedSlicing:
     def test_quantized_triple_sliced_together(self, tmp_path):

--- a/tests/test_reap_arch.py
+++ b/tests/test_reap_arch.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from olmlx.engine.reap.arch import (
+    STYLE_DEEPSEEK,
+    STYLE_GPT_OSS,
+    STYLE_MINIMAX,
+    STYLE_QWEN3,
+    STYLE_QWEN3_NEXT,
+    applied_scores,
+    detect_router_style,
+    find_moe_module,
+)
+from tests.reap_factories import (
+    make_tiny_deepseek_v3,
+    make_tiny_gpt_oss,
+    make_tiny_qwen3_moe,
+)
+
+
+class TestDetectRouterStyle:
+    def test_qwen3_moe(self):
+        model, _ = make_tiny_qwen3_moe()
+        assert detect_router_style(model.model.layers[0].mlp) == STYLE_QWEN3
+
+    def test_gpt_oss(self):
+        model, _ = make_tiny_gpt_oss()
+        assert detect_router_style(model.model.layers[0].mlp) == STYLE_GPT_OSS
+
+    def test_deepseek_v3_moe_layer(self):
+        model, args = make_tiny_deepseek_v3()
+        # first_k_dense_replace=1 -> layer 0 dense, layer 1 MoE
+        assert detect_router_style(model.model.layers[1].mlp) == STYLE_DEEPSEEK
+
+    def test_qwen3_next_style_via_fake(self):
+        class Fake(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.gate = nn.Linear(8, 4, bias=False)
+                self.shared_expert_gate = nn.Linear(8, 1, bias=False)
+
+        assert detect_router_style(Fake()) == STYLE_QWEN3_NEXT
+
+    def test_minimax_style_via_fake(self):
+        class Fake(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.gate = nn.Linear(8, 4, bias=False)
+                self.e_score_correction_bias = mx.zeros((4,))
+
+        assert detect_router_style(Fake()) == STYLE_MINIMAX
+
+
+class TestFindMoeModule:
+    def test_qwen3_moe(self):
+        model, args = make_tiny_qwen3_moe(num_experts=8, top_k=2)
+        info = find_moe_module(model.model.layers[0])
+        assert info is not None
+        assert (info.attr_name, info.container_name, info.gate_attr) == (
+            "mlp",
+            "switch_mlp",
+            "gate",
+        )
+        assert info.num_experts == 8 and info.top_k == 2
+
+    def test_gpt_oss_container_is_experts(self):
+        model, _ = make_tiny_gpt_oss()
+        info = find_moe_module(model.model.layers[0])
+        assert (info.container_name, info.gate_attr) == ("experts", "router")
+
+    def test_dense_layer_returns_none(self):
+        model, _ = make_tiny_deepseek_v3()
+        assert (
+            find_moe_module(model.model.layers[0]) is None
+        )  # dense (first_k_dense_replace=1)
+        assert find_moe_module(model.model.layers[1]) is not None
+
+
+class TestAppliedScores:
+    def test_qwen3_matches_block_math(self):
+        model, _ = make_tiny_qwen3_moe(num_experts=8, top_k=2)
+        moe = model.model.layers[0].mlp
+        x = mx.random.normal((3, 5, 64))
+        logits = moe.gate(x)
+        probs = mx.softmax(logits.astype(mx.float32), axis=-1)
+        inds = mx.stop_gradient(mx.argpartition(-probs, kth=1, axis=-1)[..., :2])
+        scores = applied_scores(STYLE_QWEN3, moe, logits, inds)
+        expected = mx.take_along_axis(probs, inds, axis=-1)
+        expected = expected / mx.sum(
+            expected, axis=-1, keepdims=True
+        )  # norm_topk_prob=True
+        assert mx.allclose(scores, expected, atol=1e-6)
+
+    def test_scores_sum_to_one_when_renormed(self):
+        model, _ = make_tiny_qwen3_moe()
+        moe = model.model.layers[0].mlp
+        x = mx.random.normal((2, 4, 64))
+        logits = moe.gate(x)
+        inds = mx.argpartition(-logits, kth=1, axis=-1)[..., :2]
+        s = applied_scores(STYLE_QWEN3, moe, logits, inds)
+        assert mx.allclose(mx.sum(s, axis=-1), mx.ones(s.shape[:-1]), atol=1e-5)
+
+    def test_gpt_oss_softmax_over_selected(self):
+        model, _ = make_tiny_gpt_oss(num_experts=8, top_k=2)
+        moe = model.model.layers[0].mlp
+        x = mx.random.normal((2, 4, 64))
+        logits = moe.router(x)
+        inds = mx.argpartition(-logits, kth=1, axis=-1)[..., :2]
+        s = applied_scores(STYLE_GPT_OSS, moe, logits, inds)
+        assert mx.allclose(
+            s, mx.softmax(mx.take_along_axis(logits, inds, axis=-1), axis=-1), atol=1e-6
+        )
+
+    def test_deepseek_passthrough(self):
+        model, _ = make_tiny_deepseek_v3()
+        moe = model.model.layers[1].mlp
+        x = mx.random.normal((2, 4, 64))
+        gate_out = moe.gate(x)  # (inds, scores)
+        s = applied_scores(STYLE_DEEPSEEK, moe, gate_out, gate_out[0])
+        assert mx.array_equal(s, gate_out[1])

--- a/tests/test_reap_calibrate.py
+++ b/tests/test_reap_calibrate.py
@@ -215,3 +215,42 @@ class TestStreamingEqualsHooked:
         monkeypatch.setattr(cal_mod, "load_model_with_strict_fallback", fake_load)
         cal_mod.calibrate_saliency_streaming("/fake", _tagged(1), max_tokens=8)
         assert calls["lazy"] is True
+
+
+class TestUnrecognizedSlidingWindowWarning:
+    """A config that advertises sliding_window without any known per-layer
+    convention must warn loudly (masks would silently over-attend otherwise)."""
+
+    def test_warns_when_no_convention_matches(self, monkeypatch, caplog):
+        import logging
+
+        from olmlx.engine.reap import calibrate as cal_mod
+
+        model, args = make_tiny_qwen3_moe()
+        args.sliding_window = 8  # advertised, but qwen3_moe has no layer_types/flags
+        monkeypatch.setattr(
+            cal_mod,
+            "load_model_with_strict_fallback",
+            lambda p, lazy: (model, FakeTokenizer()),
+        )
+        with caplog.at_level(logging.WARNING, logger="olmlx.engine.reap.calibrate"):
+            cal_mod.calibrate_saliency_streaming("/fake", _tagged(1), max_tokens=8)
+        assert any("sliding-attention convention" in r.message for r in caplog.records)
+
+    def test_no_warning_when_convention_matches(self, monkeypatch, caplog):
+        import logging
+
+        from olmlx.engine.reap import calibrate as cal_mod
+        from tests.reap_factories import make_tiny_gpt_oss
+
+        model, _ = make_tiny_gpt_oss(sliding_window=8)
+        monkeypatch.setattr(
+            cal_mod,
+            "load_model_with_strict_fallback",
+            lambda p, lazy: (model, FakeTokenizer()),
+        )
+        with caplog.at_level(logging.WARNING, logger="olmlx.engine.reap.calibrate"):
+            cal_mod.calibrate_saliency_streaming("/fake", _tagged(1), max_tokens=8)
+        assert not any(
+            "sliding-attention convention" in r.message for r in caplog.records
+        )

--- a/tests/test_reap_calibrate.py
+++ b/tests/test_reap_calibrate.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from olmlx.engine.reap.calibrate import (
+    SaliencyAccumulator,
+    collect_saliency,
+    load_saliency,
+    save_saliency,
+)
+from tests.reap_factories import (
+    make_tiny_deepseek_v3,
+    make_tiny_gpt_oss,
+    make_tiny_qwen3_moe,
+)
+
+
+class FakeTokenizer:
+    """Maps each character to a token id; enough for tiny-vocab models."""
+
+    def encode(self, text):
+        return [ord(c) % 100 + 1 for c in text]
+
+
+def _tagged(n_per_source=3):
+    return [("english", "hello world " * 8), ("code", "def f(x): return x " * 6)][
+        :2
+    ] * n_per_source
+
+
+class TestAccumulator:
+    def test_add_and_mean(self):
+        acc = SaliencyAccumulator(2, 4, ["a", "b"])
+        acc.add(0, 0, np.array([1, 1, 3]), np.array([2.0, 4.0, 6.0]))
+        sal = acc.saliency(["a"])
+        assert sal.shape == (2, 4)
+        assert sal[0, 1] == pytest.approx(3.0)  # mean of 2,4
+        assert sal[0, 3] == pytest.approx(6.0)
+        assert sal[0, 0] == 0.0 and sal[1, 1] == 0.0
+
+    def test_source_combination(self):
+        acc = SaliencyAccumulator(1, 4, ["a", "b"])
+        acc.add(0, 0, np.array([0]), np.array([1.0]))
+        acc.add(0, 1, np.array([0]), np.array([3.0]))
+        assert acc.saliency(["a"])[0, 0] == pytest.approx(1.0)
+        assert acc.saliency(None)[0, 0] == pytest.approx(2.0)  # pooled mean
+
+    def test_npz_roundtrip(self, tmp_path):
+        acc = SaliencyAccumulator(1, 4, ["a"])
+        acc.add(0, 0, np.array([2]), np.array([5.0]))
+        meta = {
+            "model_type": "qwen3_moe",
+            "num_experts": 4,
+            "top_k": 2,
+            "moe_layer_indices": [0],
+            "sources": ["a"],
+        }
+        save_saliency(tmp_path / "s.npz", acc, meta)
+        acc2, meta2 = load_saliency(tmp_path / "s.npz")
+        np.testing.assert_array_equal(acc.sum, acc2.sum)
+        np.testing.assert_array_equal(acc.count, acc2.count)
+        assert acc2.sources == ["a"] and meta2["model_type"] == "qwen3_moe"
+
+
+@pytest.mark.parametrize(
+    "factory", [make_tiny_qwen3_moe, make_tiny_gpt_oss, make_tiny_deepseek_v3]
+)
+class TestCollectSaliency:
+    def test_counts_and_meta(self, factory):
+        mx.random.seed(0)
+        model, args = factory()
+        acc, meta = collect_saliency(model, FakeTokenizer(), _tagged(), max_tokens=16)
+        n_moe = len(meta["moe_layer_indices"])
+        assert acc.sum.shape == (n_moe, 2, 8)
+        # every routed token contributes exactly top_k slots per MoE layer
+        total_tokens = sum(
+            min(len(FakeTokenizer().encode(t)), 16) for _, t in _tagged()
+        )
+        assert acc.count.sum() == n_moe * total_tokens * meta["top_k"]
+        assert (acc.sum >= 0).all()
+        assert meta["num_experts"] == 8 and meta["top_k"] == 2
+
+    def test_taps_removed_after_collect(self, factory):
+        model, _ = factory()
+        layers = model.model.layers
+        before = [type(getattr(layer, "mlp", None)).__name__ for layer in layers]
+        collect_saliency(model, FakeTokenizer(), _tagged(1), max_tokens=8)
+        after = [type(getattr(layer, "mlp", None)).__name__ for layer in layers]
+        assert before == after
+
+    def test_forward_unchanged_by_tap(self, factory):
+        mx.random.seed(1)
+        model, _ = factory()
+        ids = mx.array([[1, 2, 3, 4, 5]])
+        ref = np.array(model(ids), copy=True)
+        collect_saliency(model, FakeTokenizer(), _tagged(1), max_tokens=8)
+        out = np.array(model(ids))
+        np.testing.assert_allclose(out, ref, atol=1e-5)
+
+
+class TestSaliencyMatchesManualReference:
+    def test_qwen3_hand_computed(self):
+        """Independent reimplementation of REAP S_j for one batch pins the tap."""
+        mx.random.seed(2)
+        model, _ = make_tiny_qwen3_moe(num_layers=1)
+        text = "abcdefghij"
+        acc, meta = collect_saliency(
+            model, FakeTokenizer(), [("src", text)], max_tokens=32
+        )
+
+        moe = model.model.layers[0].mlp
+        ids = mx.array([FakeTokenizer().encode(text)])
+        # reference: run the pre-MoE part by calling the layer's attention manually is
+        # overkill; instead recompute routing on the *hidden states the MoE saw* by
+        # re-running the model with a capture of the MoE input.
+        seen = {}
+        orig_call = type(moe).__call__
+
+        def capture(self_, x):
+            seen["x"] = x
+            return orig_call(self_, x)
+
+        type(moe).__call__ = capture
+        try:
+            model(ids)
+        finally:
+            type(moe).__call__ = orig_call
+        x = seen["x"].reshape(-1, seen["x"].shape[-1])
+        probs = mx.softmax(moe.gate(x).astype(mx.float32), axis=-1, precise=True)
+        inds = mx.argpartition(-probs, kth=1, axis=-1)[..., :2]
+        scores = mx.take_along_axis(probs, inds, axis=-1)
+        scores = scores / mx.sum(scores, axis=-1, keepdims=True)
+        ys = moe.switch_mlp(x, inds)
+        norms = mx.linalg.norm(ys.astype(mx.float32), axis=-1)
+        expected = np.zeros(8)
+        counts = np.zeros(8)
+        np.add.at(
+            expected,
+            np.array(inds).reshape(-1),
+            np.array(scores * norms, dtype=np.float64).reshape(-1),
+        )
+        np.add.at(counts, np.array(inds).reshape(-1), 1)
+        np.testing.assert_allclose(acc.sum[0, 0], expected, rtol=1e-4)
+        np.testing.assert_array_equal(acc.count[0, 0], counts)

--- a/tests/test_reap_calibrate.py
+++ b/tests/test_reap_calibrate.py
@@ -144,3 +144,47 @@ class TestSaliencyMatchesManualReference:
         np.add.at(counts, np.array(inds).reshape(-1), 1)
         np.testing.assert_allclose(acc.sum[0, 0], expected, rtol=1e-4)
         np.testing.assert_array_equal(acc.count[0, 0], counts)
+
+
+class TestStreamingEqualsHooked:
+    """Invariant 5: streaming layer-at-a-time saliency == full-forward hooked saliency."""
+
+    @pytest.mark.parametrize(
+        "factory", [make_tiny_qwen3_moe, make_tiny_gpt_oss, make_tiny_deepseek_v3]
+    )
+    def test_streaming_matches_hooked(self, factory, monkeypatch):
+        from olmlx.engine.reap import calibrate as cal_mod
+
+        mx.random.seed(3)
+        model, args = factory()
+        tok = FakeTokenizer()
+        texts = _tagged(2)
+
+        hooked_acc, hooked_meta = collect_saliency(model, tok, texts, max_tokens=16)
+
+        monkeypatch.setattr(
+            cal_mod,
+            "load_model_with_strict_fallback",
+            lambda path, lazy: (model, tok),
+        )
+        stream_acc, stream_meta = cal_mod.calibrate_saliency_streaming(
+            "/fake/path", texts, max_tokens=16
+        )
+
+        np.testing.assert_allclose(stream_acc.sum, hooked_acc.sum, rtol=1e-3, atol=1e-6)
+        np.testing.assert_array_equal(stream_acc.count, hooked_acc.count)
+        assert stream_meta["moe_layer_indices"] == hooked_meta["moe_layer_indices"]
+
+    def test_loader_called_lazy(self, monkeypatch):
+        from olmlx.engine.reap import calibrate as cal_mod
+
+        model, _ = make_tiny_qwen3_moe()
+        calls = {}
+
+        def fake_load(path, lazy):
+            calls["lazy"] = lazy
+            return model, FakeTokenizer()
+
+        monkeypatch.setattr(cal_mod, "load_model_with_strict_fallback", fake_load)
+        cal_mod.calibrate_saliency_streaming("/fake", _tagged(1), max_tokens=8)
+        assert calls["lazy"] is True

--- a/tests/test_reap_calibrate.py
+++ b/tests/test_reap_calibrate.py
@@ -175,6 +175,33 @@ class TestStreamingEqualsHooked:
         np.testing.assert_array_equal(stream_acc.count, hooked_acc.count)
         assert stream_meta["moe_layer_indices"] == hooked_meta["moe_layer_indices"]
 
+    def test_streaming_matches_hooked_gpt_oss_narrow_sliding_window(self, monkeypatch):
+        """Regression: a per-arch-uniform mask silently ignores gpt_oss's
+        sliding_attention layers. With window << seq_len the sliding layers
+        must only attend to the last `window` positions, same as the real
+        full-forward's create_attention_mask(..., window_size=...) path."""
+        from olmlx.engine.reap import calibrate as cal_mod
+
+        mx.random.seed(3)
+        model, args = make_tiny_gpt_oss(sliding_window=8)
+        tok = FakeTokenizer()
+        texts = _tagged(2)
+
+        hooked_acc, hooked_meta = collect_saliency(model, tok, texts, max_tokens=40)
+
+        monkeypatch.setattr(
+            cal_mod,
+            "load_model_with_strict_fallback",
+            lambda path, lazy: (model, tok),
+        )
+        stream_acc, stream_meta = cal_mod.calibrate_saliency_streaming(
+            "/fake/path", texts, max_tokens=40
+        )
+
+        np.testing.assert_allclose(stream_acc.sum, hooked_acc.sum, rtol=1e-3, atol=1e-6)
+        np.testing.assert_array_equal(stream_acc.count, hooked_acc.count)
+        assert stream_meta["moe_layer_indices"] == hooked_meta["moe_layer_indices"]
+
     def test_loader_called_lazy(self, monkeypatch):
         from olmlx.engine.reap import calibrate as cal_mod
 

--- a/tests/test_reap_cli.py
+++ b/tests/test_reap_cli.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+
+import olmlx.cli as cli
+from olmlx.cli.parser import build_parser
+
+
+class TestParser:
+    def test_calibrate_defaults(self):
+        args = build_parser().parse_args(["reap", "calibrate", "some-model"])
+        assert args.command == "reap" and args.reap_command == "calibrate"
+        assert args.model == "some-model"
+        assert args.sources == "english,code,chinese"
+        assert args.samples_per_source == 256 and args.max_tokens == 512
+        assert args.output is None
+
+    def test_plan_modes(self):
+        args = build_parser().parse_args(
+            [
+                "reap",
+                "plan",
+                "m",
+                "--mode",
+                "graded",
+                "--keep-fraction",
+                "0.75",
+                "--high-fraction",
+                "0.25",
+            ]
+        )
+        assert args.mode == "graded" and args.keep_fraction == 0.75
+        assert args.high_bits == 8 and args.low_bits == 4
+
+    def test_apply_requires_plan(self):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["reap", "apply", "m"])
+
+    def test_report_flags(self):
+        args = build_parser().parse_args(
+            ["reap", "report", "m", "--skip-ppl", "--keep", "64"]
+        )
+        assert args.skip_ppl is True and args.keep == 64
+
+
+class TestDispatch:
+    def test_handlers_registered(self):
+        for sub in ("calibrate", "plan", "apply", "report"):
+            assert ("reap", sub) in cli._COMMAND_HANDLERS
+            name = cli._COMMAND_HANDLERS[("reap", sub)]
+            assert callable(getattr(cli, name))
+
+    def test_cli_main_routes(self, monkeypatch):
+        called = {}
+        monkeypatch.setattr(
+            "olmlx.cli.cmd_reap_plan", lambda args: called.setdefault("args", args)
+        )
+        monkeypatch.setattr("sys.argv", ["olmlx", "reap", "plan", "m", "--keep", "8"])
+        cli.cli_main()
+        assert called["args"].model == "m"
+
+
+class TestPlanHandlerValidation:
+    def test_uniform_requires_keep(self, monkeypatch):
+        import olmlx.cli.reap_cmd as reap_cmd
+
+        args = build_parser().parse_args(["reap", "plan", "m", "--mode", "uniform"])
+        # validation must fire BEFORE any resolve/download
+        monkeypatch.setattr(
+            reap_cmd,
+            "_resolve_and_download",
+            lambda *a, **k: pytest.fail("resolved before validation"),
+        )
+        with pytest.raises(SystemExit):
+            reap_cmd.cmd_reap_plan(args)

--- a/tests/test_reap_corpus.py
+++ b/tests/test_reap_corpus.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from olmlx.engine.reap import corpus as corpus_mod
 from olmlx.engine.reap.corpus import (
     BUILTIN_SOURCES,
     build_calibration_corpus,
@@ -46,10 +47,25 @@ def _fake_load_dataset(rows_by_key):
 
 
 class TestBuildCorpus:
-    def _patch(self, monkeypatch, rows_by_key):
+    def _patch(self, monkeypatch, rows_by_key, block_fallback=False):
         import datasets
 
         monkeypatch.setattr(datasets, "load_dataset", _fake_load_dataset(rows_by_key))
+        # For content-asserting tests, block synthetic fallback to detect suite pollution:
+        # if datasets is poisoned and the fallback is triggered, the test fails loudly
+        # instead of silently getting wrong content from synthetic text.
+        if block_fallback:
+
+            def raise_fallback_blocked(*args, **kwargs):
+                raise RuntimeError(
+                    "synthetic_source_texts was called (datasets fallback triggered); "
+                    "this indicates the datasets module was poisoned by an earlier test. "
+                    "Check test ordering and sys.modules state."
+                )
+
+            monkeypatch.setattr(
+                corpus_mod, "synthetic_source_texts", raise_fallback_blocked
+            )
 
     def test_interleaved_and_tagged(self, monkeypatch):
         en = [{"text": f"english document number {i} " * 10} for i in range(5)]
@@ -60,6 +76,7 @@ class TestBuildCorpus:
                 ("allenai/c4", "en"): en,
                 (BUILTIN_SOURCES["code"].dataset, BUILTIN_SOURCES["code"].config): code,
             },
+            block_fallback=True,
         )
         out = build_calibration_corpus(["english", "code"], 3)
         assert len(out) == 6
@@ -69,21 +86,25 @@ class TestBuildCorpus:
 
     def test_min_chars_filter(self, monkeypatch):
         rows = [{"text": "short"}] + [{"text": "x" * 200}] * 3
-        self._patch(monkeypatch, {("allenai/c4", "en"): rows})
+        self._patch(monkeypatch, {("allenai/c4", "en"): rows}, block_fallback=True)
         out = build_calibration_corpus(["english"], 2)
         assert all(len(t) >= 100 for _, t in out)
 
     def test_cjk_filter_for_chinese(self, monkeypatch):
         mojibake = {"text": "a" * 200}  # claims zh, no CJK
         good = {"text": "中文测试" * 60}
-        self._patch(monkeypatch, {("allenai/c4", "zh"): [mojibake, good, good]})
+        self._patch(
+            monkeypatch,
+            {("allenai/c4", "zh"): [mojibake, good, good]},
+            block_fallback=True,
+        )
         out = build_calibration_corpus(["chinese"], 2)
         assert len(out) == 2
         assert all(cjk_fraction(t) >= 0.3 for _, t in out)
 
     def test_skip_reserves_held_out(self, monkeypatch):
         rows = [{"text": f"document number {i:03d} " * 10} for i in range(10)]
-        self._patch(monkeypatch, {("allenai/c4", "en"): rows})
+        self._patch(monkeypatch, {("allenai/c4", "en"): rows}, block_fallback=True)
         cal = build_calibration_corpus(["english"], 3)
         held = build_calibration_corpus(["english"], 2, skip=3)
         cal_texts = {t for _, t in cal}
@@ -91,7 +112,7 @@ class TestBuildCorpus:
 
     def test_char_cap(self, monkeypatch):
         rows = [{"text": "y" * 10_000}] * 2
-        self._patch(monkeypatch, {("allenai/c4", "en"): rows})
+        self._patch(monkeypatch, {("allenai/c4", "en"): rows}, block_fallback=True)
         out = build_calibration_corpus(["english"], 2, char_cap=1000)
         assert all(len(t) == 1000 for _, t in out)
 

--- a/tests/test_reap_corpus.py
+++ b/tests/test_reap_corpus.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import pytest
+
+from olmlx.engine.reap.corpus import (
+    BUILTIN_SOURCES,
+    build_calibration_corpus,
+    cjk_fraction,
+    synthetic_source_texts,
+)
+
+
+class TestCjkFraction:
+    def test_pure_ascii(self):
+        assert cjk_fraction("hello world") == 0.0
+
+    def test_pure_cjk(self):
+        assert cjk_fraction("你好世界") == 1.0
+
+    def test_mixed(self):
+        assert 0.4 < cjk_fraction("abc你好中文字") < 0.8
+
+    def test_empty(self):
+        assert cjk_fraction("") == 0.0
+
+
+class _FakeStream:
+    """Stands in for datasets.load_dataset(..., streaming=True)."""
+
+    def __init__(self, rows):
+        self.rows = rows
+        self.closed = False
+
+    def __iter__(self):
+        return iter(self.rows)
+
+    def close(self):
+        self.closed = True
+
+
+def _fake_load_dataset(rows_by_key):
+    def load_dataset(dataset, config=None, split=None, streaming=False, data_dir=None):
+        return _FakeStream(rows_by_key[(dataset, config)])
+
+    return load_dataset
+
+
+class TestBuildCorpus:
+    def _patch(self, monkeypatch, rows_by_key):
+        import datasets
+
+        monkeypatch.setattr(datasets, "load_dataset", _fake_load_dataset(rows_by_key))
+
+    def test_interleaved_and_tagged(self, monkeypatch):
+        en = [{"text": f"english document number {i} " * 10} for i in range(5)]
+        code = [{"content": f"def fn_{i}(): return {i} " * 10} for i in range(5)]
+        self._patch(
+            monkeypatch,
+            {
+                ("allenai/c4", "en"): en,
+                (BUILTIN_SOURCES["code"].dataset, BUILTIN_SOURCES["code"].config): code,
+            },
+        )
+        out = build_calibration_corpus(["english", "code"], 3)
+        assert len(out) == 6
+        # round-robin: e, c, e, c, e, c
+        assert [s for s, _ in out] == ["english", "code"] * 3
+        assert "english document" in out[0][1] and "def fn_" in out[1][1]
+
+    def test_min_chars_filter(self, monkeypatch):
+        rows = [{"text": "short"}] + [{"text": "x" * 200}] * 3
+        self._patch(monkeypatch, {("allenai/c4", "en"): rows})
+        out = build_calibration_corpus(["english"], 2)
+        assert all(len(t) >= 100 for _, t in out)
+
+    def test_cjk_filter_for_chinese(self, monkeypatch):
+        mojibake = {"text": "a" * 200}  # claims zh, no CJK
+        good = {"text": "中文测试" * 60}
+        self._patch(monkeypatch, {("allenai/c4", "zh"): [mojibake, good, good]})
+        out = build_calibration_corpus(["chinese"], 2)
+        assert len(out) == 2
+        assert all(cjk_fraction(t) >= 0.3 for _, t in out)
+
+    def test_skip_reserves_held_out(self, monkeypatch):
+        rows = [{"text": f"document number {i:03d} " * 10} for i in range(10)]
+        self._patch(monkeypatch, {("allenai/c4", "en"): rows})
+        cal = build_calibration_corpus(["english"], 3)
+        held = build_calibration_corpus(["english"], 2, skip=3)
+        cal_texts = {t for _, t in cal}
+        assert all(t not in cal_texts for _, t in held)
+
+    def test_char_cap(self, monkeypatch):
+        rows = [{"text": "y" * 10_000}] * 2
+        self._patch(monkeypatch, {("allenai/c4", "en"): rows})
+        out = build_calibration_corpus(["english"], 2, char_cap=1000)
+        assert all(len(t) == 1000 for _, t in out)
+
+    def test_fallback_to_synthetic_on_error(self, monkeypatch):
+        import datasets
+
+        def boom(*a, **k):
+            raise ConnectionError("offline")
+
+        monkeypatch.setattr(datasets, "load_dataset", boom)
+        out = build_calibration_corpus(["english"], 4)
+        assert len(out) == 4 and all(s == "english" for s, _ in out)
+
+    def test_unknown_source_raises(self):
+        with pytest.raises(ValueError, match="klingon"):
+            build_calibration_corpus(["klingon"], 2)
+
+
+class TestSynthetic:
+    def test_deterministic_and_distinct(self):
+        a = synthetic_source_texts("code", 5)
+        b = synthetic_source_texts("code", 5)
+        assert a == b and len(set(a)) == 5
+        assert synthetic_source_texts("english", 3) != synthetic_source_texts("code", 3)

--- a/tests/test_reap_corpus.py
+++ b/tests/test_reap_corpus.py
@@ -2,6 +2,14 @@ from __future__ import annotations
 
 import pytest
 
+# Import datasets at module level to avoid PyArrow extension type re-registration
+# errors when multiple tests import it (ArrowKeyError: type already defined).
+# This happens in full-suite runs where earlier tests have already imported it.
+try:
+    import datasets
+except ImportError:
+    datasets = None
+
 from olmlx.engine.reap import corpus as corpus_mod
 from olmlx.engine.reap.corpus import (
     BUILTIN_SOURCES,
@@ -48,8 +56,8 @@ def _fake_load_dataset(rows_by_key):
 
 class TestBuildCorpus:
     def _patch(self, monkeypatch, rows_by_key, block_fallback=False):
-        import datasets
-
+        if datasets is None:
+            pytest.skip("datasets not installed")
         monkeypatch.setattr(datasets, "load_dataset", _fake_load_dataset(rows_by_key))
         # For content-asserting tests, block synthetic fallback to detect suite pollution:
         # if datasets is poisoned and the fallback is triggered, the test fails loudly
@@ -117,7 +125,8 @@ class TestBuildCorpus:
         assert all(len(t) == 1000 for _, t in out)
 
     def test_fallback_to_synthetic_on_error(self, monkeypatch):
-        import datasets
+        if datasets is None:
+            pytest.skip("datasets not installed")
 
         def boom(*a, **k):
             raise ConnectionError("offline")

--- a/tests/test_reap_equivalence.py
+++ b/tests/test_reap_equivalence.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+
+import mlx.core as mx
+import pytest
+
+from olmlx.engine.reap.apply import apply_plan
+from olmlx.engine.reap.plan import ReapPlan
+from olmlx.engine.reap.verify import mask_dropped_experts, max_logit_divergence
+from tests.reap_factories import (
+    make_tiny_deepseek_v3,
+    make_tiny_gpt_oss,
+    make_tiny_qwen3_moe,
+    save_tiny_model,
+    tiny_config_dict,
+)
+
+_CASES = [
+    (make_tiny_qwen3_moe, "qwen3_moe", [0, 1]),
+    (make_tiny_gpt_oss, "gpt_oss", [0, 1]),
+    (make_tiny_deepseek_v3, "deepseek_v3", [1]),
+]
+
+
+def _reload_pruned(model_type, out_dir):
+    import importlib
+
+    module = importlib.import_module(f"mlx_lm.models.{model_type}")
+    cfg = json.loads((out_dir / "config.json").read_text())
+    args = module.ModelArgs.from_dict(cfg)
+    model = module.Model(args)
+    model.load_weights(str(out_dir / "model.safetensors"), strict=True)
+    mx.eval(model.parameters())
+    return model
+
+
+def _batches():
+    mx.random.seed(7)
+    return [mx.random.randint(1, 100, (2, 16)) for _ in range(3)]
+
+
+@pytest.mark.parametrize("factory,model_type,moe_layers", _CASES)
+class TestPrunedEquivalence:
+    """Invariant 2: pruned model == full model with dropped experts made unroutable."""
+
+    def test_equivalence(self, tmp_path, factory, model_type, moe_layers):
+        mx.random.seed(11)
+        full, args = factory()
+        keep = [0, 2, 4, 5, 6, 7]
+        src = save_tiny_model(
+            full, tiny_config_dict(args, model_type), tmp_path / "src"
+        )
+        plan = ReapPlan(
+            "uniform",
+            moe_layers,
+            {layer_idx: keep for layer_idx in moe_layers},
+            None,
+            None,
+            None,
+            8,
+            2,
+        )
+        pruned = _reload_pruned(model_type, apply_plan(src, plan, tmp_path / "out"))
+
+        restore = mask_dropped_experts(
+            full, {layer_idx: keep for layer_idx in moe_layers}
+        )
+        try:
+            # remap: pruned token routing uses new indices; outputs must agree
+            diff = max_logit_divergence(full, pruned, _batches())
+        finally:
+            restore()
+        assert diff < 1e-3
+
+    def test_restore_undoes_mask(self, tmp_path, factory, model_type, moe_layers):
+        mx.random.seed(12)
+        full, _ = factory()
+        batch = _batches()[:1]
+        ref = full(batch[0])
+        restore = mask_dropped_experts(
+            full, {layer_idx: [0, 1] for layer_idx in moe_layers}
+        )
+        restore()
+        assert mx.allclose(full(batch[0]), ref, atol=1e-6)
+
+
+@pytest.mark.parametrize("factory,model_type,moe_layers", _CASES)
+class TestRotation:
+    """Invariant 3: permuting router rows WITHOUT permuting experts must be detected —
+    proves the equivalence check is not vacuous."""
+
+    def test_rotated_router_diverges(self, tmp_path, factory, model_type, moe_layers):
+        mx.random.seed(13)
+        full, args = factory()
+        keep = [0, 2, 4, 5, 6, 7]
+        src = save_tiny_model(
+            full, tiny_config_dict(args, model_type), tmp_path / "src"
+        )
+        plan = ReapPlan(
+            "uniform",
+            moe_layers,
+            {layer_idx: keep for layer_idx in moe_layers},
+            None,
+            None,
+            None,
+            8,
+            2,
+        )
+        out = apply_plan(src, plan, tmp_path / "out")
+
+        # sabotage: rotate the pruned router rows by one position
+        w = mx.load(str(out / "model.safetensors"))
+        rotated = False
+        for layer_idx in moe_layers:
+            for cand in (
+                f"model.layers.{layer_idx}.mlp.gate.weight",
+                f"model.layers.{layer_idx}.mlp.router.weight",
+            ):
+                if cand in w:
+                    perm = mx.array(list(range(1, w[cand].shape[0])) + [0])
+                    w[cand] = w[cand][perm]
+                    rotated = True
+        assert rotated
+        mx.eval(*w.values())
+        mx.save_safetensors(str(out / "model.safetensors"), w)
+        pruned = _reload_pruned(model_type, out)
+
+        restore = mask_dropped_experts(
+            full, {layer_idx: keep for layer_idx in moe_layers}
+        )
+        try:
+            diff = max_logit_divergence(full, pruned, _batches())
+        finally:
+            restore()
+        assert diff > 1e-2

--- a/tests/test_reap_equivalence.py
+++ b/tests/test_reap_equivalence.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import json
 
 import mlx.core as mx
+import mlx.nn as nn
 import pytest
 
 from olmlx.engine.reap.apply import apply_plan
+from olmlx.engine.reap.arch import STYLE_MINIMAX, find_moe_module
 from olmlx.engine.reap.plan import ReapPlan
 from olmlx.engine.reap.verify import mask_dropped_experts, max_logit_divergence
 from tests.reap_factories import (
@@ -134,3 +136,107 @@ class TestRotation:
         finally:
             restore()
         assert diff > 1e-2
+
+
+class _FakeExpertContainer(nn.Module):
+    """Minimal SwitchGLU stand-in: only .gate_proj.weight.shape[0] matters to
+    find_moe_module's expert-count probe -- it's never called."""
+
+    def __init__(self, num_experts: int, hidden: int) -> None:
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden, num_experts, bias=False)
+
+
+class _FakeMiniMaxBlock(nn.Module):
+    """Mirrors mlx_lm.models.minimax.MiniMaxSparseMoeBlock's attribute layout:
+    linear .gate, block-level .e_score_correction_bias (NOT nested under the
+    gate, unlike DeepSeek's MoEGate), and a switch_mlp expert container."""
+
+    def __init__(self, hidden: int, num_experts: int, bias_init: list[float]) -> None:
+        super().__init__()
+        self.gate = nn.Linear(hidden, num_experts, bias=False)
+        self.e_score_correction_bias = mx.array(bias_init)
+        self.switch_mlp = _FakeExpertContainer(num_experts, hidden)
+        self.num_experts_per_tok = 2
+
+
+class _FakeMiniMaxModel(nn.Module):
+    def __init__(
+        self,
+        hidden: int = 8,
+        num_experts: int = 4,
+        bias_init: list[float] | None = None,
+    ) -> None:
+        super().__init__()
+        bias_init = bias_init if bias_init is not None else [0.0] * num_experts
+
+        class _Inner(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+
+                class _Layer(nn.Module):
+                    def __init__(self) -> None:
+                        super().__init__()
+                        self.mlp = _FakeMiniMaxBlock(hidden, num_experts, bias_init)
+
+                self.layers = [_Layer()]
+
+        self.model = _Inner()
+
+
+class TestMiniMaxMasking:
+    """MiniMax selects off sigmoid(logits) + e_score_correction_bias (see
+    arch.py's applied_scores docstring; mlx-lm minimax.py:174-188), while
+    still *weighting* by the uncorrected sigmoid. A generic additive -inf on
+    the raw gate logits (the mechanism used for plain linear-gate styles)
+    washes out here: sigmoid(-inf) == 0 exactly, so a dropped expert with a
+    large correction bias can still win selection. The fix masks the
+    correction bias itself -- and MiniMax's bias lives directly on the MoE
+    *block*, not nested under a separate gate module like DeepSeek's."""
+
+    def test_dropped_experts_excluded_from_selection(self):
+        mx.random.seed(21)
+        hidden, num_experts = 8, 4
+        # A deliberately large bias on a dropped index (1): under the old
+        # gate-wrapping approach this would still win top-k selection over
+        # legitimately kept experts despite sigmoid(-inf) == 0 for its own
+        # logit -- exactly the wash-out bug this test guards against.
+        bias_init = [2.0, 50.0, -3.0, 7.0]
+        model = _FakeMiniMaxModel(hidden, num_experts, bias_init)
+        block = model.model.layers[0].mlp
+
+        info = find_moe_module(model.model.layers[0])
+        assert info is not None
+        assert info.style == STYLE_MINIMAX
+        assert info.gate_attr == "gate"
+
+        orig_gate = block.gate
+        orig_bias = mx.array(bias_init)
+        keep = [0, 2]  # drop 1 and 3
+
+        restore = mask_dropped_experts(model, {0: keep})
+
+        # the block-bias branch must have fired, not the generic gate-wrap:
+        # the gate module itself is untouched.
+        assert block.gate is orig_gate
+
+        masked_bias = block.e_score_correction_bias
+        assert float(masked_bias[1]) == float("-inf")
+        assert float(masked_bias[3]) == float("-inf")
+        assert mx.array_equal(masked_bias[mx.array(keep)], orig_bias[mx.array(keep)])
+
+        # recompute MiniMax's actual selection math (minimax.py:178-188) and
+        # confirm a dropped expert is never selected, for arbitrary input --
+        # deterministic here since exactly `top_k` finite candidates remain.
+        x = mx.random.normal((3, 5, hidden))
+        logits = block.gate(x.astype(mx.float32))
+        scores = mx.sigmoid(logits) + block.e_score_correction_bias
+        inds = mx.argpartition(-scores, kth=block.num_experts_per_tok - 1, axis=-1)[
+            ..., : block.num_experts_per_tok
+        ]
+        selected = set(inds.reshape(-1).tolist())
+        assert selected.isdisjoint({1, 3})
+        assert selected == {0, 2}
+
+        restore()
+        assert mx.array_equal(block.e_score_correction_bias, orig_bias)

--- a/tests/test_reap_plan.py
+++ b/tests/test_reap_plan.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from olmlx.engine.reap.plan import (
+    load_plan,
+    plan_global,
+    plan_graded,
+    plan_uniform,
+    save_plan,
+)
+
+
+def _saliency(L=3, E=8, seed=0):
+    rng = np.random.RandomState(seed)
+    return (
+        rng.rand(L, E) * np.array([1.0, 10.0, 0.1])[:, None]
+    )  # wildly different layer scales
+
+
+class TestUniform:
+    def test_keeps_top_k_per_layer_ascending(self):
+        sal = np.array([[0.1, 0.9, 0.5, 0.7]])
+        p = plan_uniform(sal, [2], 2, top_k=1, num_experts=4)
+        assert p.keep == {2: [1, 3]}  # top-2 by saliency, ascending order
+        assert p.mode == "uniform" and p.bank_high is None
+
+    def test_rejects_keep_below_top_k(self):
+        with pytest.raises(ValueError, match="top_k"):
+            plan_uniform(_saliency(), [0, 1, 2], 1, top_k=2, num_experts=8)
+
+    def test_rejects_keep_above_num_experts(self):
+        with pytest.raises(ValueError):
+            plan_uniform(_saliency(), [0, 1, 2], 9, top_k=2, num_experts=8)
+
+    def test_identity_keep(self):
+        p = plan_uniform(_saliency(), [0, 1, 2], 8, top_k=2, num_experts=8)
+        assert all(p.keep[i] == list(range(8)) for i in [0, 1, 2])
+
+
+class TestGlobal:
+    def test_floor_enforced_despite_layer_scale(self):
+        sal = _saliency()  # layer 2 has 100x smaller scores
+        p = plan_global(sal, [0, 1, 2], 0.5, top_k=1, num_experts=8, floor_multiple=4)
+        assert all(len(p.keep[i]) >= 4 for i in [0, 1, 2])  # floor = 4*top_k
+
+    def test_normalization_makes_layers_comparable(self):
+        # without per-layer normalization, layer 1 (10x scale) would swallow the budget
+        sal = _saliency()
+        p = plan_global(sal, [0, 1, 2], 0.5, top_k=1, num_experts=8, floor_multiple=1)
+        sizes = [len(p.keep[i]) for i in [0, 1, 2]]
+        assert max(sizes) - min(sizes) <= 4  # roughly balanced, not 8/2/2
+
+    def test_total_budget(self):
+        p = plan_global(
+            _saliency(), [0, 1, 2], 0.5, top_k=1, num_experts=8, floor_multiple=1
+        )
+        assert sum(len(v) for v in p.keep.values()) == round(0.5 * 3 * 8)
+
+    def test_deterministic(self):
+        a = plan_global(_saliency(), [0, 1, 2], 0.5, top_k=1, num_experts=8)
+        b = plan_global(_saliency(), [0, 1, 2], 0.5, top_k=1, num_experts=8)
+        assert a.keep == b.keep
+
+
+class TestGraded:
+    def test_bank_high_is_subset_and_sized(self):
+        p = plan_graded(
+            _saliency(),
+            [0, 1, 2],
+            0.75,
+            high_fraction=0.25,
+            high_bits=8,
+            low_bits=4,
+            top_k=1,
+            num_experts=8,
+        )
+        for layer, kept in p.keep.items():
+            high = p.bank_high[layer]
+            assert set(high) <= set(kept)
+            assert len(high) == -(-len(kept) * 25 // 100)  # ceil(0.25*kept)
+        assert (p.high_bits, p.low_bits) == (8, 4)
+
+    def test_high_bank_has_top_saliency(self):
+        sal = np.array([[0.1, 0.9, 0.5, 0.7, 0.2, 0.8, 0.3, 0.6]])
+        p = plan_graded(
+            sal,
+            [0],
+            1.0,
+            high_fraction=0.25,
+            high_bits=8,
+            low_bits=4,
+            top_k=1,
+            num_experts=8,
+        )
+        assert set(p.bank_high[0]) == {1, 5}  # ceil(8*0.25)=2 top experts
+
+
+class TestPlanIO:
+    def test_roundtrip(self, tmp_path):
+        p = plan_graded(
+            _saliency(),
+            [0, 1, 2],
+            0.75,
+            high_fraction=0.25,
+            high_bits=8,
+            low_bits=4,
+            top_k=1,
+            num_experts=8,
+        )
+        save_plan(p, tmp_path / "reap_plan.json")
+        q = load_plan(tmp_path / "reap_plan.json")
+        assert q.keep == p.keep and q.bank_high == p.bank_high
+        assert (q.mode, q.top_k, q.num_experts_orig) == (
+            p.mode,
+            p.top_k,
+            p.num_experts_orig,
+        )

--- a/tests/test_reap_report.py
+++ b/tests/test_reap_report.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import math
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from olmlx.engine.reap.calibrate import SaliencyAccumulator
+from olmlx.engine.reap.report import build_report, source_overlap, streaming_perplexity
+from tests.reap_factories import make_tiny_qwen3_moe
+from tests.test_reap_calibrate import FakeTokenizer
+
+
+class TestSourceOverlap:
+    def _acc(self):
+        acc = SaliencyAccumulator(1, 8, ["a", "b"])
+        # source a favors experts 0-3, source b favors 2-5 -> top4 overlap = {2,3} = 0.5
+        for e, v in enumerate([9, 8, 7, 6, 1, 1, 1, 1]):
+            acc.add(0, 0, np.array([e]), np.array([float(v)]))
+        for e, v in enumerate([1, 1, 9, 8, 7, 6, 1, 1]):
+            acc.add(0, 1, np.array([e]), np.array([float(v)]))
+        return acc
+
+    def test_pairwise_overlap(self):
+        rep = source_overlap(self._acc(), keep_count=4)
+        assert rep["pairs"]["a|b"]["mean_overlap"] == pytest.approx(0.5)
+        assert rep["chance"] == pytest.approx(0.5)
+
+    def test_identical_sources_full_overlap(self):
+        acc = SaliencyAccumulator(2, 8, ["a", "b"])
+        for src in (0, 1):
+            for layer in (0, 1):
+                acc.add(layer, src, np.arange(8), np.arange(8, dtype=np.float64))
+        rep = source_overlap(acc, keep_count=3)
+        assert rep["pairs"]["a|b"]["mean_overlap"] == pytest.approx(1.0)
+
+
+class TestStreamingPerplexity:
+    def test_matches_direct_forward(self, monkeypatch):
+        from olmlx.engine.reap import calibrate as cal_mod
+
+        mx.random.seed(21)
+        model, _ = make_tiny_qwen3_moe()
+        tok = FakeTokenizer()
+        texts = [
+            ("english", "hello world example " * 4),
+            ("code", "def f(): pass " * 4),
+        ]
+
+        # direct reference on the same (fresh) model
+        expected: dict[str, list[float]] = {}
+        for source, text in texts:
+            ids = tok.encode(text)[:16]
+            logits = model(mx.array([ids])).astype(mx.float32)
+            logprobs = logits[:, :-1] - mx.logsumexp(
+                logits[:, :-1], axis=-1, keepdims=True
+            )
+            tgt = mx.array([ids[1:]])
+            nll = -mx.take_along_axis(logprobs, tgt[..., None], axis=-1).sum()
+            expected.setdefault(source, []).append((float(nll), len(ids) - 1))
+
+        monkeypatch.setattr(
+            cal_mod, "load_model_with_strict_fallback", lambda path, lazy: (model, tok)
+        )
+        ppl = streaming_perplexity("/fake", texts, max_tokens=16)
+        for source in ("english", "code"):
+            nll, n = expected[source][0]
+            assert ppl[source] == pytest.approx(math.exp(nll / n), rel=1e-3)
+
+
+class TestBuildReport:
+    def test_overlap_only_when_no_models(self, tmp_path):
+        from olmlx.engine.reap.calibrate import save_saliency
+
+        acc = SaliencyAccumulator(1, 8, ["a", "b"])
+        acc.add(0, 0, np.arange(8), np.linspace(1, 8, 8))
+        acc.add(0, 1, np.arange(8), np.linspace(8, 1, 8))
+        meta = {
+            "model_type": "qwen3_moe",
+            "num_experts": 8,
+            "top_k": 2,
+            "moe_layer_indices": [0],
+            "sources": ["a", "b"],
+        }
+        save_saliency(tmp_path / "s.npz", acc, meta)
+        rep = build_report(tmp_path / "s.npz", keep_count=4)
+        assert rep["perplexity"] is None
+        assert "a|b" in rep["overlap"]["pairs"]
+        assert rep["meta"]["model_type"] == "qwen3_moe"


### PR DESCRIPTION
Implements phases 1–2 of #701: REAP expert pruning for MoE models.

## What's here

New `olmlx/engine/reap/` package + `olmlx reap calibrate|plan|apply|report` CLI family. Nothing in the serving path changes.

- **`reap calibrate`** — streaming layer-at-a-time saliency calibration (`S_j = mean(score · ‖expert_out‖₂)`): lazy load, materialize one layer at a time, per-source tagging accumulated in the same pass → `saliency.npz`. Router taps read routing from the model's own forward (per-arch dispatch mirroring Flash-MoE's chain: qwen3-moe, qwen3-next, deepseek/glm, minimax, gpt-oss). Per-layer sliding-window masks honored (gpt-oss regression-tested at window ≪ context); hybrid-GDN layers get fresh per-(sample, layer) caches.
- **`reap plan`** — `uniform` (stock-mlx-lm-loadable target), `global` (per-layer-normalized global ranking with a 4·top_k routable floor), `graded` (adds per-layer high-precision bank assignment) → versioned `reap_plan.json`. Domain builds via `--sources`.
- **`reap apply`** — shard-by-shard safetensors surgery (uniform plans; global/graded await phase 3 serving support). The #701 misrouting trap is *asserted*: router rows (`gate.weight`, `e_score_correction_bias`, `router.bias`, Step-3.5 inner-gate keys, …) are sliced with the same keep list as the expert stacks, any unrecognized expert-count-sized tensor is a hard error, the plan is validated against the checkpoint's expert count, and grouped-routing (`n_group > 1`) configs are rejected. Rewrites config + regenerated safetensors index + provenance.
- **`reap report`** — per-source keep-set overlap vs chance, plus the held-out per-domain perplexity gate (streaming, so it runs on models larger than RAM).
- **Corpus builder** — per-language C4 configs + code source, round-robin interleaved, CJK mojibake filter, per-source tagging, deterministic offline fallback.

## Invariant suite (per the proposal's testing section)

1. Identity prune is bit-for-bit a no-op (qwen3-moe / gpt-oss / deepseek-v3 tiny models).
2. Pruned ≡ full model with dropped experts' logits/correction-bias at −inf (max logit divergence < 1e-3).
3. Rotation test: permuted router rows are detected (divergence > 1e-2) — the equivalence check is not vacuous.
4. *(Two-bank ≡ single-bank — deferred to phase 3 with the graded execution path.)*
5. Streaming calibration ≡ full-forward hooked calibration, including a narrow-sliding-window gpt-oss case.

92 new tests across 8 files; full offline suite green (2 pre-existing environment failures unrelated to this branch: rerank SDPA numeric reference, ffmpeg-not-on-PATH).

## Notes

- CLI shape is `olmlx reap <sub>` (family-first, matching `flash prepare` conventions) rather than the issue's literal `olmlx prepare reap-*` — there is no top-level `prepare` command; trivial to alias if preferred.
- Found & worked around an mlx-lm quirk: `deepseek_v3.MoEGate.weight` is a bare `mx.zeros` attribute (never randomly initialized), which made tie-broken routing flaky in tests.
- Phases 3 (Flash-MoE per-layer counts + two-bank `gather_qmm`) and 4 (in-RAM TwoBankSwitchGLU) are planned as follow-ups; plan doc included in-branch at `docs/superpowers/plans/2026-07-28-reap-phase1-2.md`.

Closes nothing yet — #701 stays open for phases 3–4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)