### PR TITLE
fix(reap): GDN linear-attention layers get the ssm mask in streaming calibration

### DIFF
--- a/olmlx/engine/reap/calibrate.py
+++ b/olmlx/engine/reap/calibrate.py
@@ -248,6 +248,27 @@ def _resolve_head(model, inner):
     return norm, inner.embed_tokens.as_linear
 
 
+def _layer_types(inner, args) -> list[str] | None:
+    return getattr(inner, "layer_types", None) or getattr(args, "layer_types", None)
+
+
+def _is_linear_attention(inner, args, li: int, layer) -> bool:
+    """True for GDN/SSM linear-attention layers (qwen3_5/qwen3_next hybrids).
+
+    These take an ssm mask (a (B, S) padding mask, None when unpadded) — never
+    the (S, S) causal matrix, which their `mx.where(mask[..., None], qkv, 0)`
+    would broadcast batch-ways into a shape crash.
+    """
+    if getattr(layer, "is_linear", None):
+        return True
+    layer_types = _layer_types(inner, args)
+    return (
+        layer_types is not None
+        and li < len(layer_types)
+        and layer_types[li] == "linear_attention"
+    )
+
+
 def _layer_window_size(inner, args, li: int, layer) -> int | None:
     """Best-effort per-layer sliding-window size, mirroring how the model's own
     full-forward decides it, so the streaming mask matches the hooked one exactly.
@@ -261,11 +282,11 @@ def _layer_window_size(inner, args, li: int, layer) -> int | None:
     - a boolean `is_sliding`/`use_sliding_window` flag on the layer or its
       `self_attn` (gemma3_text, cohere2).
     """
-    layer_types = getattr(inner, "layer_types", None) or getattr(
-        args, "layer_types", None
-    )
+    layer_types = _layer_types(inner, args)
     if layer_types is not None and li < len(layer_types):
-        is_sliding = layer_types[li] != "full_attention"
+        # "linear_attention" (GDN) is neither full nor sliding — handled by
+        # _is_linear_attention; only genuinely windowed types count here.
+        is_sliding = layer_types[li] not in ("full_attention", "linear_attention")
     else:
         is_sliding = False
         attn = getattr(layer, "self_attn", None)
@@ -305,7 +326,7 @@ def stream_layer_forward(
     """
     import gc
 
-    from mlx_lm.models.base import create_causal_mask
+    from mlx_lm.models.base import create_causal_mask, create_ssm_mask
     from mlx_lm.models.cache import make_prompt_cache
 
     from olmlx.engine.flash.prepare import (
@@ -404,10 +425,18 @@ def stream_layer_forward(
             # Per-layer window_size mirrors sliding-attention layers (gpt_oss
             # etc.) — a global unwindowed mask silently over-attends on those
             # layers once seq_len exceeds the window. See task-4-report.md.
-            window = layer_windows[li]
-            mask = (
-                create_causal_mask(seq_len, window_size=window) if seq_len > 1 else None
-            )
+            # GDN linear-attention layers instead get the model's own ssm mask
+            # (None for unpadded batches), mirroring e.g. Qwen3_5TextModel:
+            # `mask = ssm_mask if layer.is_linear else fa_mask`.
+            if _is_linear_attention(inner, args, li, layer):
+                mask = create_ssm_mask(hidden[si], cache_i)
+            else:
+                window = layer_windows[li]
+                mask = (
+                    create_causal_mask(seq_len, window_size=window)
+                    if seq_len > 1
+                    else None
+                )
             out = layer(hidden[si], mask=mask, cache=cache_i)
             hidden[si] = out[0] if isinstance(out, (tuple, list)) else out
             mx.eval(hidden[si])

--- a/tests/reap_factories.py
+++ b/tests/reap_factories.py
@@ -155,3 +155,42 @@ def save_tiny_model(model, config: dict, out_dir: Path) -> Path:
     mx.save_safetensors(str(out_dir / "model.safetensors"), weights)
     (out_dir / "config.json").write_text(json.dumps(config, indent=2))
     return out_dir
+
+
+def make_tiny_qwen3_5_hybrid(
+    *, num_experts=8, top_k=2, num_layers=4, hidden=64, vocab=128
+):
+    """Hybrid GDN + MoE (qwen3_5): layers 0-2 linear attention, layer 3 full.
+
+    Exercises the streaming driver's per-layer mask dispatch — GDN layers must
+    receive an ssm mask (None for unpadded batches), never the causal matrix.
+    """
+    from mlx_lm.models import qwen3_5
+
+    args = qwen3_5.TextModelArgs(
+        model_type="qwen3_5",
+        hidden_size=hidden,
+        intermediate_size=hidden * 2,
+        num_hidden_layers=num_layers,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        rms_norm_eps=1e-5,
+        vocab_size=vocab,
+        full_attention_interval=4,
+        linear_num_value_heads=4,
+        linear_num_key_heads=2,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_conv_kernel_dim=4,
+        num_experts=num_experts,
+        num_experts_per_tok=top_k,
+        decoder_sparse_step=1,
+        moe_intermediate_size=hidden // 2,
+        shared_expert_intermediate_size=hidden // 2,
+        norm_topk_prob=True,
+        tie_word_embeddings=False,
+    )
+    model = qwen3_5.TextModel(args)
+    mx.eval(model.parameters())
+    return model, args

--- a/tests/test_reap_calibrate.py
+++ b/tests/test_reap_calibrate.py
@@ -254,3 +254,30 @@ class TestUnrecognizedSlidingWindowWarning:
         assert not any(
             "sliding-attention convention" in r.message for r in caplog.records
         )
+
+
+class TestStreamingHybridGdn:
+    """Streaming == hooked must hold on hybrid GDN models (qwen3_5): GDN layers
+    take an ssm mask (None when unpadded), never the (S, S) causal matrix —
+    passing the causal matrix broadcasts qkv batch-ways and crashes."""
+
+    def test_streaming_matches_hooked_hybrid(self, monkeypatch):
+        from olmlx.engine.reap import calibrate as cal_mod
+        from tests.reap_factories import make_tiny_qwen3_5_hybrid
+
+        mx.random.seed(23)
+        model, _ = make_tiny_qwen3_5_hybrid()
+        tok = FakeTokenizer()
+        texts = _tagged(2)
+
+        hooked_acc, hooked_meta = collect_saliency(model, tok, texts, max_tokens=24)
+
+        monkeypatch.setattr(
+            cal_mod, "load_model_with_strict_fallback", lambda p, lazy: (model, tok)
+        )
+        stream_acc, stream_meta = cal_mod.calibrate_saliency_streaming(
+            "/fake", texts, max_tokens=24
+        )
+        np.testing.assert_allclose(stream_acc.sum, hooked_acc.sum, rtol=1e-3, atol=1e-6)
+        np.testing.assert_array_equal(stream_acc.count, hooked_acc.count)
+        assert stream_meta["moe_layer_indices"] == hooked_meta["moe_layer_indices"]


### PR DESCRIPTION
Found by the first real hybrid smoke run (Qwen3.6-35B-A3B-4bit, #701 follow-up): streaming calibration crashed in the first GDN layer with a shape error at the conv-state concatenation.

**Root cause:** hybrid qwen3_5/qwen3_next GDN layers interpret `mask` as a `(B, S)` padding mask (`mx.where(mask[..., None], qkv, 0)`); the streaming driver handed every layer its `(S, S)` causal matrix, which broadcasts `qkv` batch-ways into `(S, S, dim)`. The model's own forward dispatches `ssm_mask if layer.is_linear else fa_mask`.

**Fix:**
- `stream_layer_forward` now mirrors that dispatch: linear-attention layers (detected via `layer.is_linear` or a `layer_types` entry of `"linear_attention"`) get mlx-lm's own `create_ssm_mask(h, cache)`; attention layers keep the windowed causal mask.
- `_layer_window_size` no longer classifies `"linear_attention"` entries as sliding-window.

**Test:** new tiny qwen3_5 hybrid GDN+MoE factory (3 linear + 1 full-attention layers, qwen3_next-style routing) joins the streaming≡hooked invariant matrix; the test reproduces the exact production crash before the fix.

Verified: 97 reap tests green, pyright clean; the real Qwen3.6-35B-A3B calibration run proceeds past the crash with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)