### PR TITLE
fix(reap): resolve lm_head through VLM language towers; refuse untied embed fallback

### DIFF
--- a/olmlx/engine/reap/calibrate.py
+++ b/olmlx/engine/reap/calibrate.py
@@ -239,13 +239,40 @@ def collect_saliency(
     return acc, meta
 
 
+def _find_lm_head(model):
+    """lm_head on the model or its VLM language tower (qwen3_5_moe-style)."""
+    for holder in (model, getattr(model, "language_model", None)):
+        head = getattr(holder, "lm_head", None) if holder is not None else None
+        if head is not None:
+            return head
+    return None
+
+
+def _is_tied(model) -> bool:
+    for holder in (model, getattr(model, "language_model", None)):
+        args = getattr(holder, "args", None) if holder is not None else None
+        if args is not None and getattr(args, "tie_word_embeddings", False):
+            return True
+    return False
+
+
 def _resolve_head(model, inner):
-    """Returns (norm, head_fn) for final logits; head_fn may use tied embeddings."""
+    """Returns (norm, head_fn) for final logits.
+
+    Falls back to the embedding matrix ONLY for genuinely tied models —
+    scoring an untied model through embed.as_linear yields random-quality
+    logits (worse-than-uniform perplexity), so that case is a hard error.
+    """
     norm = getattr(inner, "norm", None) or getattr(inner, "final_layernorm", None)
-    lm_head = getattr(model, "lm_head", None)
+    lm_head = _find_lm_head(model)
     if lm_head is not None:
         return norm, lm_head
-    return norm, inner.embed_tokens.as_linear
+    if _is_tied(model):
+        return norm, inner.embed_tokens.as_linear
+    raise ValueError(
+        "no lm_head found on the model or its language_model, and embeddings "
+        "are not tied — refusing to compute logits with the embedding matrix"
+    )
 
 
 def _layer_types(inner, args) -> list[str] | None:
@@ -381,7 +408,7 @@ def stream_layer_forward(
 
     tied = bool(getattr(args, "tie_word_embeddings", False))
     if not keep_head:
-        head = getattr(model, "lm_head", None)
+        head = _find_lm_head(model)
         if head is not None:
             _nullify_module_params(head)
         if not tied:

--- a/tests/test_reap_calibrate.py
+++ b/tests/test_reap_calibrate.py
@@ -281,3 +281,54 @@ class TestStreamingHybridGdn:
         np.testing.assert_allclose(stream_acc.sum, hooked_acc.sum, rtol=1e-3, atol=1e-6)
         np.testing.assert_array_equal(stream_acc.count, hooked_acc.count)
         assert stream_meta["moe_layer_indices"] == hooked_meta["moe_layer_indices"]
+
+
+class TestResolveHead:
+    """_resolve_head must find lm_head on VLM wrappers (model.language_model)
+    and must never silently score with the embedding matrix when untied."""
+
+    @staticmethod
+    def _backbone():
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            norm=lambda x: x,
+            embed_tokens=SimpleNamespace(as_linear=lambda x: x),
+        )
+
+    def test_outer_lm_head(self):
+        from types import SimpleNamespace
+
+        from olmlx.engine.reap.calibrate import _resolve_head
+
+        head = lambda x: x  # noqa: E731
+        model = SimpleNamespace(lm_head=head)
+        assert _resolve_head(model, self._backbone())[1] is head
+
+    def test_vlm_nested_lm_head(self):
+        from types import SimpleNamespace
+
+        from olmlx.engine.reap.calibrate import _resolve_head
+
+        head = lambda x: x  # noqa: E731
+        model = SimpleNamespace(language_model=SimpleNamespace(lm_head=head))
+        assert _resolve_head(model, self._backbone())[1] is head
+
+    def test_tied_falls_back_to_embedding(self):
+        from types import SimpleNamespace
+
+        from olmlx.engine.reap.calibrate import _resolve_head
+
+        inner = self._backbone()
+        model = SimpleNamespace(args=SimpleNamespace(tie_word_embeddings=True))
+        norm, head = _resolve_head(model, inner)
+        assert head is inner.embed_tokens.as_linear
+
+    def test_untied_without_head_raises(self):
+        from types import SimpleNamespace
+
+        from olmlx.engine.reap.calibrate import _resolve_head
+
+        model = SimpleNamespace(args=SimpleNamespace(tie_word_embeddings=False))
+        with pytest.raises(ValueError, match="lm_head"):
+            _resolve_head(model, self._backbone())


### PR DESCRIPTION
Second bug found by the Qwen3.6-35B-A3B hybrid smoke run (follow-up to #705): `reap report`'s perplexity gate produced worse-than-uniform numbers (full-model ppl ~258k) on the VLM-wrapped `qwen3_5_moe` checkpoint.

**Root cause:** `_resolve_head` only looked for `lm_head` on the outer model. On qwen3_5_moe-style wrappers it lives on `model.language_model`, so the resolver silently fell back to `embed_tokens.as_linear` — which is only valid for tied embeddings; this checkpoint is untied, so every logit was computed against the wrong matrix.

**Fix:**
- `_find_lm_head` probes the model and its `language_model` tower.
- The embedding fallback now requires `tie_word_embeddings=True` (checked on both holders); an untied model with no findable head is a hard `ValueError` instead of silent garbage.
- The `keep_head=False` nullification path uses the same resolution, so nested heads are freed during calibration too.

**Tests:** 4 new unit tests on `_resolve_head` (outer head, nested VLM head, tied fallback, untied-raises). 101 reap tests green, pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)