### PR TITLE
fix(reap): don't copy store metadata into pruned artifacts

### DIFF
--- a/olmlx/engine/reap/apply.py
+++ b/olmlx/engine/reap/apply.py
@@ -231,8 +231,12 @@ def apply_plan(
                 indent=2,
             )
         )
+    # config.json is rewritten above; manifest.json / .downloading are olmlx
+    # store metadata for the SOURCE dir — copying a stale manifest makes the
+    # pruned artifact masquerade as the unpruned base model.
+    skip_copy = {"config.json", "manifest.json", ".downloading"}
     for f in collect_non_weight_files(model_dir):
-        if f.name != "config.json":
+        if f.name not in skip_copy:
             shutil.copy2(f, output_dir / f.name)
     (output_dir / "reap_provenance.json").write_text(
         json.dumps(

--- a/tests/test_reap_apply.py
+++ b/tests/test_reap_apply.py
@@ -121,6 +121,17 @@ class TestUniformPrune:
         assert prov["keep_count"] == 4 and prov["num_experts_orig"] == 8
         assert (out / "tokenizer_config.json").exists()
 
+    def test_store_internal_artifacts_not_copied(self, tmp_path):
+        """A stale manifest.json / .downloading marker in the source (olmlx
+        store metadata) must not leak into the pruned artifact — a copied
+        manifest misidentifies the output as the unpruned base model."""
+        src, _ = _save(make_tiny_qwen3_moe, "qwen3_moe", tmp_path)
+        (src / "manifest.json").write_text('{"name": "base:latest", "size": 1}')
+        (src / ".downloading").write_text("")
+        out = apply_plan(src, _uniform_plan([0, 1], [0, 1, 2, 3]), tmp_path / "out")
+        assert not (out / "manifest.json").exists()
+        assert not (out / ".downloading").exists()
+
     def test_pruned_model_reloads_and_runs(self, tmp_path):
         from mlx_lm.models import qwen3_moe
 


### PR DESCRIPTION
Found while registering the pruned Qwen3.6-35B-A3B: `reap apply` copies all non-weight files from the source dir, including olmlx store metadata. A stale `manifest.json` copied into the pruned artifact made `olmlx models show` report the pruned model as the unpruned base (wrong name/size). `.downloading` markers would similarly poison `is_downloaded()` on the output.

Fix: exclude `manifest.json` and `.downloading` from the copy (config.json was already excluded — it's rewritten). Test pins both exclusions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)